### PR TITLE
Fix TypeScript autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,17 @@
   "private": false,
   "version": "0.0.5",
   "type": "module",
-  "types": "dist/main.d.ts",
-  "main": "dist/purchases-js.js",
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/Purchases.umd.js",
+  "module": "./dist/Purchases.es.js",
+  "exports": {
+    ".": {
+      "import": "./dist/Purchases.es.js",
+      "require": "./dist/Purchases.umd.js"
+    }
+  },
   "license": "MIT",
   "scripts": {
     "dev": "vite",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    // /* Bundler mode */
+    /* Bundler mode */
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,12 +4,15 @@ import dts from "vite-plugin-dts";
 
 export default defineConfig({
   build: {
-    target: "es2015",
     lib: {
       entry: resolve(__dirname, "src/main.ts"),
       name: "Purchases",
-      formats: ["es"],
+      fileName: (format) => `Purchases.${format}.js`,
     },
   },
-  plugins: [dts()],
+  plugins: [
+    dts({
+      rollupTypes: true,
+    }),
+  ],
 });


### PR DESCRIPTION
## Motivation / Description

- [x] Generate both UMD and ES Module output
- [x] Generate single `.d.ts` instead of one per file (which caused the autocomplete being missing since the name `main.d.ts` didn't match the code file `purchases-js.js`)

![image](https://github.com/RevenueCat/purchases-js/assets/4152942/3aa6ecd1-15fc-47e3-8c9f-3ed41c534f86)


