### PR TITLE
Add `current` to offerings response

### DIFF
--- a/src/entities/offerings.ts
+++ b/src/entities/offerings.ts
@@ -27,7 +27,7 @@ export interface Offering {
 }
 
 export interface OfferingsPage {
-  all: Offering[];
+  all: { [offeringId: string]: Offering };
   current: Offering | null;
 }
 

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -214,9 +214,9 @@ test("can get offerings", async () => {
   };
 
   expect(offerings).toEqual({
-    all: [
-      currentOffering,
-      {
+    all: {
+      offering_1: currentOffering,
+      offering_2: {
         displayName: "Offering 2",
         id: "offering_2",
         identifier: "offering_2",
@@ -237,7 +237,7 @@ test("can get offerings", async () => {
           },
         ],
       },
-    ],
+    },
     current: currentOffering,
   });
 });
@@ -249,8 +249,8 @@ test("can get offerings without current offering id", async () => {
   );
 
   expect(offerings).toEqual({
-    all: [
-      {
+    all: {
+      offering_1: {
         displayName: "Offering 1",
         id: "offering_1",
         identifier: "offering_1",
@@ -271,7 +271,7 @@ test("can get offerings without current offering id", async () => {
           },
         ],
       },
-      {
+      offering_2: {
         displayName: "Offering 2",
         id: "offering_2",
         identifier: "offering_2",
@@ -292,7 +292,7 @@ test("can get offerings without current offering id", async () => {
           },
         ],
       },
-    ],
+    },
     current: null,
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,10 +62,14 @@ export class Purchases {
         ? null
         : toOffering(currentOfferingServerResponse, productsMap);
 
+    const allOfferings: { [offeringId: string]: Offering } = {};
+    offeringsData.offerings.forEach(
+      (o: ServerResponse) =>
+        (allOfferings[o.identifier] = toOffering(o, productsMap)),
+    );
+
     return {
-      all: offeringsData.offerings.map((o: ServerResponse) =>
-        toOffering(o, productsMap),
-      ),
+      all: allOfferings,
       current: currentOffering,
     };
   };
@@ -221,7 +225,7 @@ export class Purchases {
   ): Promise<Package | null> {
     const offeringsPage = await this.listOfferings(appUserId);
     const packages: Package[] = [];
-    offeringsPage.all.forEach((offering) =>
+    Object.values(offeringsPage.all).forEach((offering) =>
       packages.push(...offering.packages),
     );
 


### PR DESCRIPTION
## Motivation / Description
The offerings response has a `current` property indicating the current offering as selected by khepri. This PR:
- Adds the `current` property
- Fixes `offerings` so it has all the offerings, not only the current.
- Supports not having a current offering id in the backend response 
- Renames `offerings` field to `all`

## Changes introduced

## Linear ticket (if any)

## Additional comments
