### PR TITLE
Remove `priceByPackageId` property from offerings

### DIFF
--- a/src/entities/offerings.ts
+++ b/src/entities/offerings.ts
@@ -29,7 +29,6 @@ export interface Offering {
 export interface OfferingsPage {
   offerings: Offering[];
   current: Offering | null;
-  priceByPackageId: { [packageId: string]: number };
 }
 
 export const toPrice = (priceData: ServerResponse) => {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -239,12 +239,6 @@ test("can get offerings", async () => {
       },
     ],
     current: currentOffering,
-    priceByPackageId: {
-      package_1: {
-        amount: 300,
-        currency: "USD",
-      },
-    },
   });
 });
 
@@ -300,7 +294,6 @@ test("can get offerings without current offering id", async () => {
       },
     ],
     current: null,
-    priceByPackageId: {},
   });
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,6 @@ import {
   OfferingsPage as InnerOfferingsPage,
   Package as InnerPackage,
   toOffering,
-  toPrice,
 } from "./entities/offerings";
 import {
   SubscribeResponse,
@@ -58,16 +57,6 @@ export class Purchases {
       productsMap[p.identifier] = p;
     });
 
-    const pricesByPackageId: ServerResponse = {};
-    if (currentOfferingServerResponse != null) {
-      currentOfferingServerResponse.packages.forEach(
-        (p: ServerResponse) =>
-          (pricesByPackageId[p.identifier] = toPrice(
-            productsMap[p.platform_product_identifier].current_price,
-          )),
-      );
-    }
-
     const currentOffering: InnerOffering | null =
       currentOfferingServerResponse == null
         ? null
@@ -78,7 +67,6 @@ export class Purchases {
         toOffering(o, productsMap),
       ),
       current: currentOffering,
-      priceByPackageId: pricesByPackageId,
     };
   };
 


### PR DESCRIPTION
## Motivation / Description
This removes the `priceByPackageId` property from the offerings type. The price is available inside the product, same as in mobile. Lmk if we needed this specifically for something (seems unused in the demo app)

## Changes introduced

## Linear ticket (if any)

## Additional comments
