### PR TITLE
Make `all` offerings a dictionary

### DIFF
--- a/src/entities/offerings.ts
+++ b/src/entities/offerings.ts
@@ -27,7 +27,7 @@ export interface Offering {
 }
 
 export interface OfferingsPage {
-  all: Offering[];
+  all: { [offeringId: string]: Offering };
   current: Offering | null;
   priceByPackageId: { [packageId: string]: number };
 }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -214,9 +214,9 @@ test("can get offerings", async () => {
   };
 
   expect(offerings).toEqual({
-    all: [
-      currentOffering,
-      {
+    all: {
+      offering_1: currentOffering,
+      offering_2: {
         displayName: "Offering 2",
         id: "offering_2",
         identifier: "offering_2",
@@ -237,7 +237,7 @@ test("can get offerings", async () => {
           },
         ],
       },
-    ],
+    },
     current: currentOffering,
     priceByPackageId: {
       package_1: {
@@ -255,8 +255,8 @@ test("can get offerings without current offering id", async () => {
   );
 
   expect(offerings).toEqual({
-    all: [
-      {
+    all: {
+      offering_1: {
         displayName: "Offering 1",
         id: "offering_1",
         identifier: "offering_1",
@@ -277,7 +277,7 @@ test("can get offerings without current offering id", async () => {
           },
         ],
       },
-      {
+      offering_2: {
         displayName: "Offering 2",
         id: "offering_2",
         identifier: "offering_2",
@@ -298,7 +298,7 @@ test("can get offerings without current offering id", async () => {
           },
         ],
       },
-    ],
+    },
     current: null,
     priceByPackageId: {},
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -73,10 +73,14 @@ export class Purchases {
         ? null
         : toOffering(currentOfferingServerResponse, productsMap);
 
+    const allOfferings: { [offeringId: string]: Offering } = {};
+    offeringsData.offerings.forEach(
+      (o: ServerResponse) =>
+        (allOfferings[o.identifier] = toOffering(o, productsMap)),
+    );
+
     return {
-      all: offeringsData.offerings.map((o: ServerResponse) =>
-        toOffering(o, productsMap),
-      ),
+      all: allOfferings,
       current: currentOffering,
       priceByPackageId: pricesByPackageId,
     };
@@ -233,7 +237,7 @@ export class Purchases {
   ): Promise<Package | null> {
     const offeringsPage = await this.listOfferings(appUserId);
     const packages: Package[] = [];
-    offeringsPage.all.forEach((offering) =>
+    Object.values(offeringsPage.all).forEach((offering) =>
       packages.push(...offering.packages),
     );
 


### PR DESCRIPTION
## Motivation / Description
We renamed the `offerings` field to `all` in #26. However, it was still an array of offerings. In the mobile SDKs, we return a dictionary by offering id. This modifies the SDK to return that.

## Changes introduced

## Linear ticket (if any)

## Additional comments
