### PR TITLE
Rename `listOfferings` to `getOfferings`, `OfferingsPage` to `Offerings` and remove `getPackage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ associated `rcBillingProduct` and price.
 ```typescript
 const purchases = new Purchases("your RC_PUBLISHABLE_API_KEY");
 
-purchases.listOfferings().then((offeringsPage) => {
-  offeringsPage.offerings.forEach((offering) => {
-    console.log(offering);
-  });
+purchases.getOfferings().then((offerings) => {
+  // Get current offering
+  console.log(offerings.current);
+  // Or a dictionary of all offerings
+  console.log(offerings.all);
 });
 ```
 
@@ -140,7 +141,7 @@ You built your paywall, and your user just clicked on the offer they want to sub
 ```tsx
 const purchases = new Purchases("your RC_PUBLISHABLE_API_KEY");
 // You can retrieve this from the offerings you downloaded, as example:
-// offeringsPage.offerings[0].packages[0].rcBillingProduct.identifier
+// offerings.current.packages[0].rcBillingProduct.identifier
 const rcBillingProductIndentifier =
   "the Product Identifier the user wants to buy";
 const appUserId =

--- a/examples/rcbilling-demo/src/pages/paywall/index.tsx
+++ b/examples/rcbilling-demo/src/pages/paywall/index.tsx
@@ -1,4 +1,4 @@
-import { OfferingsPage, Package, Purchases } from "@revenuecat/purchases-js";
+import { Offerings, Package, Purchases } from "@revenuecat/purchases-js";
 import React, { useEffect, useState } from "react";
 
 interface IPackageCardProps {
@@ -53,11 +53,11 @@ interface IPaywallPageProps {
 }
 
 const PaywallPage: React.FC<IPaywallPageProps> = ({ purchases, appUserId }) => {
-  const [offerings, setOfferings] = useState<OfferingsPage | null>(null);
+  const [offerings, setOfferings] = useState<Offerings | null>(null);
 
   useEffect(() => {
-    purchases.listOfferings(appUserId).then((offeringsPage) => {
-      setOfferings(offeringsPage);
+    purchases.getOfferings(appUserId).then((offerings) => {
+      setOfferings(offerings);
     });
   }, [purchases, appUserId]);
 

--- a/src/entities/offerings.ts
+++ b/src/entities/offerings.ts
@@ -26,7 +26,7 @@ export interface Offering {
   packages: Package[];
 }
 
-export interface OfferingsPage {
+export interface Offerings {
   all: { [offeringId: string]: Offering };
   current: Offering | null;
 }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -193,7 +193,7 @@ test("returns false if a user is not entitled and uses waitForEntitlement", asyn
 
 test("can get offerings", async () => {
   const billing = new Purchases("test_api_key", STRIPE_TEST_DATA);
-  const offerings = await billing.listOfferings("someAppUserId");
+  const offerings = await billing.getOfferings("someAppUserId");
 
   const currentOffering = {
     displayName: "Offering 1",
@@ -248,7 +248,7 @@ test("can get offerings", async () => {
 
 test("can get offerings without current offering id", async () => {
   const billing = new Purchases("test_api_key", STRIPE_TEST_DATA);
-  const offerings = await billing.listOfferings(
+  const offerings = await billing.getOfferings(
     "appUserIdWithoutCurrentOfferingId",
   );
 
@@ -315,17 +315,4 @@ test("can post to subscribe", async () => {
       clientSecret: "seti_123",
     },
   });
-});
-
-test("can get a specific Package", async () => {
-  const purchases = new Purchases("test_api_key", STRIPE_TEST_DATA);
-  const pkg = await purchases.getPackage("someAppUserId", "package_1");
-  expect(pkg).not.toBeNull();
-  expect(pkg?.identifier).toBe("package_1");
-});
-
-test("returns null for Package not found", async () => {
-  const purchases = new Purchases("test_api_key", STRIPE_TEST_DATA);
-  const pkg = await purchases.getPackage("someAppUserId", "package_not_there");
-  expect(pkg).toBeNull();
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import {
   Offering as InnerOffering,
-  OfferingsPage as InnerOfferingsPage,
+  Offerings as InnerOfferings,
   Package as InnerPackage,
   toOffering,
 } from "./entities/offerings";
@@ -20,7 +20,7 @@ import {
   UnknownServerError,
 } from "./entities/errors";
 
-export type OfferingsPage = InnerOfferingsPage;
+export type Offerings = InnerOfferings;
 export type Offering = InnerOffering;
 export type Package = InnerPackage;
 
@@ -64,10 +64,10 @@ export class Purchases {
     }
   }
 
-  private toOfferingsPage = (
+  private toOfferings = (
     offeringsData: ServerResponse,
     productsData: ServerResponse,
-  ): OfferingsPage => {
+  ): Offerings => {
     const currentOfferingServerResponse =
       offeringsData.offerings.find(
         (o: ServerResponse) =>
@@ -96,7 +96,7 @@ export class Purchases {
     };
   };
 
-  public async listOfferings(appUserId: string): Promise<OfferingsPage> {
+  public async getOfferings(appUserId: string): Promise<Offerings> {
     const offeringsResponse = await fetch(
       `${Purchases._RC_ENDPOINT}/v1/subscribers/${appUserId}/offerings`,
       {
@@ -131,7 +131,7 @@ export class Purchases {
 
     const productsData = await productsResponse.json();
     this.logMissingProductIds(productIds, productsData.product_details);
-    return this.toOfferingsPage(offeringsData, productsData);
+    return this.toOfferings(offeringsData, productsData);
   }
 
   public async isEntitledTo(
@@ -240,26 +240,6 @@ export class Purchases {
     }
 
     throw new UnknownServerError();
-  }
-
-  public async getPackage(
-    appUserId: string,
-    packageIdentifier: string,
-  ): Promise<Package | null> {
-    const offeringsPage = await this.listOfferings(appUserId);
-    const packages: Package[] = [];
-    Object.values(offeringsPage.all).forEach((offering) =>
-      packages.push(...offering.packages),
-    );
-
-    const filteredPackages: Package[] = packages.filter(
-      (pakg) => pakg.identifier === packageIdentifier,
-    );
-    if (filteredPackages.length === 0) {
-      return null;
-    }
-
-    return filteredPackages[0];
   }
 
   public purchasePackage(


### PR DESCRIPTION
## Motivation / Description
This PR has some changes to make the API resemble the one in the mobile SDKs more closely:
- Rename `listOfferings` to `getOfferings`
- Rename `OfferingsPage` to `Offerings`
- Remove `getPackage` (This shouldn't be needed since it can be obtained from the offering. We might need a `getProduct` method at some point, but the `getPackage` shouldn't be needed AFAIK)

## Changes introduced

## Linear ticket (if any)

## Additional comments
