### PR TITLE
Add `X-Is-Sandbox` header to all requests

### DIFF
--- a/src/helpers/api-key-helper.ts
+++ b/src/helpers/api-key-helper.ts
@@ -1,3 +1,3 @@
-export function isApiKeySandbox(apiKey: string): boolean {
+export function isSandboxApiKey(apiKey: string): boolean {
   return apiKey ? apiKey.startsWith("rcb_sb_") : false;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ import { ProductsResponse } from "./networking/responses/products-response";
 import { EntitlementResponse } from "./networking/responses/entitlements-response";
 import { RC_ENDPOINT } from "./helpers/constants";
 import { Backend } from "./networking/backend";
-import { isApiKeySandbox } from "./helpers/api-key-helper";
+import { isSandboxApiKey } from "./helpers/api-key-helper";
 
 export type Offerings = InnerOfferings;
 export type Offering = InnerOffering;
@@ -240,6 +240,6 @@ export class Purchases {
   }
 
   public isSandbox(): boolean {
-    return isApiKeySandbox(this._API_KEY);
+    return isSandboxApiKey(this._API_KEY);
   }
 }

--- a/src/networking/http-client.ts
+++ b/src/networking/http-client.ts
@@ -7,7 +7,7 @@ import {
 } from "../entities/errors";
 import { VERSION } from "../helpers/constants";
 import { StatusCodes } from "http-status-codes";
-import { isApiKeySandbox } from "../helpers/api-key-helper";
+import { isSandboxApiKey } from "../helpers/api-key-helper";
 
 export async function performRequest<RequestBody, ResponseType>(
   endpoint: SupportedEndpoint,
@@ -81,7 +81,7 @@ function getHeaders(
     Accept: "application/json",
     "X-Platform": "web",
     "X-Version": VERSION,
-    "X-Is-Sandbox": `${isApiKeySandbox(apiKey)}`,
+    "X-Is-Sandbox": `${isSandboxApiKey(apiKey)}`,
   };
   if (headers != null) {
     all_headers = { ...all_headers, ...headers };


### PR DESCRIPTION
## Motivation / Description
This PR adds the `X-Is-Sandbox` header to all requests to the backend. This will fix some issues where entitlements where not showing in the requests to the `/subscribers` endpoint. We need to apply a proper fix in the servers so we don't rely on the information from the SDK in this case, but this should work for now.

## Changes introduced

## Linear ticket (if any)
https://linear.app/revenuecat/issue/BIL-237/v1subscribers-response-not-updated-after-a-purchase-through-rcbilling

## Additional comments
