### PR TITLE
Hide `isEntitledTo` from public API

### DIFF
--- a/examples/rcbilling-demo/src/components/WithEntitlement.tsx
+++ b/examples/rcbilling-demo/src/components/WithEntitlement.tsx
@@ -21,8 +21,10 @@ const WithEntitlement: React.FC<IWithEntitlementProps> = ({
 }) => {
   const [isEntitled, setIsEntitled] = useState<boolean | null>(null);
 
-  const doCheckEntitlement = useCallback((): Promise<boolean> => {
-    return purchases.isEntitledTo(appUserId, entitlementId);
+  const doCheckEntitlement = useCallback(async (): Promise<boolean> => {
+    const customerInfo = await purchases.getCustomerInfo(appUserId);
+
+    return entitlementId in customerInfo.entitlements.active;
   }, [purchases, appUserId, entitlementId]);
 
   useEffect(() => {

--- a/examples/rcbilling-demo/src/components/WithoutEntitlement.tsx
+++ b/examples/rcbilling-demo/src/components/WithoutEntitlement.tsx
@@ -21,8 +21,10 @@ const WithoutEntitlement: React.FC<IWithEntitlementProps> = ({
 }) => {
   const [isEntitled, setIsEntitled] = useState<boolean | null>(null);
 
-  const doCheckEntitlement = useCallback((): Promise<boolean> => {
-    return purchases.isEntitledTo(appUserId, entitlementId);
+  const doCheckEntitlement = useCallback(async (): Promise<boolean> => {
+    const customerInfo = await purchases.getCustomerInfo(appUserId);
+
+    return entitlementId in customerInfo.entitlements.active;
   }, [purchases, appUserId, entitlementId]);
 
   useEffect(() => {

--- a/src/helpers/entitlement-checking-helper.ts
+++ b/src/helpers/entitlement-checking-helper.ts
@@ -1,7 +1,8 @@
-import { Purchases } from "../main";
+import { EntitlementResponse } from "../networking/responses/entitlements-response";
+import { Backend } from "../networking/backend";
 
 export function waitForEntitlement(
-  purchases: Purchases,
+  backend: Backend,
   appUserId: string,
   entitlementIdentifier: string,
   maxAttempts: number = 10,
@@ -9,8 +10,7 @@ export function waitForEntitlement(
   const waitMSBetweenAttempts = 1000;
   return new Promise<boolean>((resolve, reject) => {
     const checkForEntitlement = (checkCount = 1) =>
-      purchases
-        .isEntitledTo(appUserId, entitlementIdentifier)
+      isEntitledTo(backend, appUserId, entitlementIdentifier)
         .then((hasEntitlement) => {
           if (checkCount > maxAttempts) {
             return resolve(false);
@@ -29,4 +29,17 @@ export function waitForEntitlement(
 
     checkForEntitlement();
   });
+}
+
+async function isEntitledTo(
+  backend: Backend,
+  appUserId: string,
+  entitlementIdentifier: string,
+): Promise<boolean> {
+  const entitlementsResponse = await backend.getEntitlements(appUserId);
+
+  const entitlements = entitlementsResponse.entitlements.map(
+    (ent: EntitlementResponse) => ent.lookup_key,
+  );
+  return entitlements.includes(entitlementIdentifier);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,6 @@ import {
   PackageResponse,
 } from "./networking/responses/offerings-response";
 import { ProductsResponse } from "./networking/responses/products-response";
-import { EntitlementResponse } from "./networking/responses/entitlements-response";
 import { RC_ENDPOINT } from "./helpers/constants";
 import { Backend } from "./networking/backend";
 import { isSandboxApiKey } from "./helpers/api-key-helper";
@@ -128,18 +127,6 @@ export class Purchases {
     return this.toOfferings(offeringsResponse, productsResponse);
   }
 
-  public async isEntitledTo(
-    appUserId: string,
-    entitlementIdentifier: string,
-  ): Promise<boolean> {
-    const entitlementsResponse = await this.backend.getEntitlements(appUserId);
-
-    const entitlements = entitlementsResponse.entitlements.map(
-      (ent: EntitlementResponse) => ent.lookup_key,
-    );
-    return entitlements.includes(entitlementIdentifier);
-  }
-
   public purchasePackage(
     appUserId: string,
     rcPackage: Package,
@@ -181,7 +168,7 @@ export class Purchases {
           customerEmail,
           onFinished: async () => {
             const hasEntitlement = await waitForEntitlement(
-              this,
+              this.backend,
               appUserId,
               entitlementId,
             );

--- a/src/tests/helpers/entitlement-checking-helper.test.ts
+++ b/src/tests/helpers/entitlement-checking-helper.test.ts
@@ -1,12 +1,8 @@
 import { beforeAll, expect, test } from "vitest";
-import { Purchases } from "../../main";
 import { waitForEntitlement } from "../../helpers/entitlement-checking-helper";
 import { setupServer } from "msw/node";
 import { getEntitlementsResponseHandlers } from "../test-responses";
-
-const STRIPE_TEST_DATA = {
-  stripe: { accountId: "acct_123", publishableKey: "pk_123" },
-} as const;
+import { Backend } from "../../networking/backend";
 
 const server = setupServer(...getEntitlementsResponseHandlers());
 
@@ -15,9 +11,9 @@ beforeAll(() => {
 });
 
 test("returns true if a user is entitled and uses waitForEntitlement", async () => {
-  const billing = new Purchases("test_api_key", STRIPE_TEST_DATA);
+  const backend = new Backend("test_api_key");
   const isEntitled = await waitForEntitlement(
-    billing,
+    backend,
     "someAppUserId",
     "someEntitlement",
     2,
@@ -26,9 +22,9 @@ test("returns true if a user is entitled and uses waitForEntitlement", async () 
 });
 
 test("returns false if a user is not entitled and uses waitForEntitlement", async () => {
-  const billing = new Purchases("test_api_key", STRIPE_TEST_DATA);
+  const backend = new Backend("test_api_key");
   const isEntitled = await waitForEntitlement(
-    billing,
+    backend,
     "someOtherAppUserId",
     "someEntitlement",
     2,

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -18,24 +18,6 @@ test("Purchases is defined", () => {
   expect(billing).toBeDefined();
 });
 
-test("returns true if a user is entitled", async () => {
-  const billing = new Purchases("test_api_key", STRIPE_TEST_DATA);
-  const isEntitled = await billing.isEntitledTo(
-    "someAppUserId",
-    "someEntitlement",
-  );
-  expect(isEntitled).toBeTruthy();
-});
-
-test("returns false if a user is not entitled", async () => {
-  const billing = new Purchases("test_api_key", STRIPE_TEST_DATA);
-  const isEntitled = await billing.isEntitledTo(
-    "someOtherAppUserId",
-    "someEntitlement",
-  );
-  expect(isEntitled).not.toBeTruthy();
-});
-
 test("can get offerings", async () => {
   const billing = new Purchases("test_api_key", STRIPE_TEST_DATA);
   const offerings = await billing.getOfferings("someAppUserId");


### PR DESCRIPTION
## Motivation / Description
The `isEntitledTo` function is used to poll for entitlements. That part doesn't need to be public either, so this hides that from the public API, in preparation of removing it once we have better track of the purchase status.

This also updates the demo app to use `getCustomerInfo` instead to check for the entitlement status.

## Changes introduced

## Linear ticket (if any)

## Additional comments
