### PR TITLE
Add `presentedOfferingIdentifier` to `Product` type

### DIFF
--- a/src/entities/offerings.ts
+++ b/src/entities/offerings.ts
@@ -28,6 +28,7 @@ export interface Product {
   readonly identifier: string;
   readonly currentPrice: Price | null;
   readonly normalPeriodDuration: string | null;
+  readonly presentedOfferingIdentifier: string;
 }
 
 export interface Package {
@@ -57,17 +58,22 @@ export interface Offerings {
   readonly current: Offering | null;
 }
 
-export const toProduct = (productDetailsData: ProductResponse): Product => {
+const toProduct = (
+  productDetailsData: ProductResponse,
+  presentedOfferingIdentifier: string,
+): Product => {
   return {
     id: productDetailsData.identifier,
     identifier: productDetailsData.identifier,
     displayName: productDetailsData.title,
     currentPrice: productDetailsData.current_price as Price,
     normalPeriodDuration: productDetailsData.normal_period_duration,
+    presentedOfferingIdentifier: presentedOfferingIdentifier,
   };
 };
 
-export const toPackage = (
+const toPackage = (
+  presentedOfferingIdentifier: string,
   packageData: PackageResponse,
   productDetailsData: { [productId: string]: ProductResponse },
 ): Package | null => {
@@ -78,7 +84,7 @@ export const toPackage = (
   return {
     id: packageData.identifier,
     identifier: packageData.identifier,
-    rcBillingProduct: toProduct(rcBillingProduct),
+    rcBillingProduct: toProduct(rcBillingProduct, presentedOfferingIdentifier),
     packageType: getPackageType(packageData.identifier),
   };
 };
@@ -88,7 +94,9 @@ export const toOffering = (
   productDetailsData: { [productId: string]: ProductResponse },
 ): Offering | null => {
   const packages = offeringsData.packages
-    .map((p: PackageResponse) => toPackage(p, productDetailsData))
+    .map((p: PackageResponse) =>
+      toPackage(offeringsData.identifier, p, productDetailsData),
+    )
     .filter(notEmpty);
   const packagesById: { [packageId: string]: Package } = {};
   for (const p of packages) {

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -51,6 +51,7 @@ describe("getOfferings", () => {
       id: "monthly",
       identifier: "monthly",
       normalPeriodDuration: "PT1H",
+      presentedOfferingIdentifier: "offering_1",
     },
   };
   test("can get offerings", async () => {
@@ -96,6 +97,7 @@ describe("getOfferings", () => {
                 id: "monthly_2",
                 identifier: "monthly_2",
                 normalPeriodDuration: "PT1H",
+                presentedOfferingIdentifier: "offering_2",
               },
             },
           },
@@ -155,6 +157,7 @@ describe("getOfferings", () => {
                 id: "monthly_2",
                 identifier: "monthly_2",
                 normalPeriodDuration: "PT1H",
+                presentedOfferingIdentifier: "offering_2",
               },
             },
           },


### PR DESCRIPTION
## Motivation / Description
This adds a new field to the `Product` type: `presentedOfferingIdentifier`. This will correspond with the offering that was used to obtain that product. This will be used to post the offering id when posting a subscription in future PRs.

## Changes introduced

## Linear ticket (if any)

## Additional comments
