### PR TITLE
Add new `docs` and `api-report` folders to npmignore to avoid including them in published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,6 @@ pull_request_template.md
 src/*
 *.test.d.ts
 examples/*
+docs/
+api-report/
+temp/


### PR DESCRIPTION
## Motivation / Description
We didn't add these folders to npmignore in #61. This adds them so we don't publish them.

## Changes introduced

## Linear ticket (if any)

## Additional comments
