### PR TITLE
Add close button in email input screen

### DIFF
--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -180,6 +180,7 @@
         {#if state === "needs-auth-info"}
           <StateNeedsAuthInfo
             onContinue={handleContinue}
+            onClose={handleClose}
           />
         {/if}
         {#if state === "needs-payment-info" && paymentInfoCollectionMetadata}

--- a/src/ui/states/state-needs-auth-info.svelte
+++ b/src/ui/states/state-needs-auth-info.svelte
@@ -2,14 +2,18 @@
   import Button from "../button.svelte";
   import ModalFooter from "../modal-footer.svelte";
   import ModalSection from "../modal-section.svelte";
+  import RowLayout from "../layout/row-layout.svelte";
 
   export let onContinue: any;
+  export let onClose: () => void;
 
   $: email = "";
 
   const handleContinue = async () => {
     onContinue({ email });
   };
+
+
 </script>
 
 <div>
@@ -30,7 +34,10 @@
       </div>
     </ModalSection>
     <ModalFooter>
-      <Button>Continue</Button>
+      <RowLayout>
+        <Button>Continue</Button>
+        <Button intent="secondary" on:click={onClose}>Close</Button>
+      </RowLayout>
     </ModalFooter>
   </form>
 </div>


### PR DESCRIPTION
## Motivation / Description
We didn't have a way to close the purchase flow while inputting the email. We want to join this step together with the payment details step in the future, but for now, it's separate and it couldn't be closed, which was not a great UX.

## Changes introduced

## Linear ticket (if any)

## Additional comments
<img width="826" alt="image" src="https://github.com/RevenueCat/purchases-js/assets/808417/f13a702a-3784-40d1-a35f-c5a8415bd26a">
