### PR TITLE
Fix deployment of library after moving to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,15 @@ jobs:
           cache-version: v1
       - revenuecat/trust-github-key
       - run:
+          name: Install node dependencies
+          command: npm ci
+      - run:
+          name: Build
+          command: npm run build
+      - run:
+          name: Pack
+          command: npm pack
+      - run:
           name: release
           command: bundle exec fastlane release
 


### PR DESCRIPTION
## Motivation / Description
We moved to CircleCI in #70 but the release job gets executed in a different container that doesn't have the built library, so it's not part of the published library. That broke the 0.0.17 release. This makes sure we build the library before publishing 

## Changes introduced

## Linear ticket (if any)

## Additional comments
