### PR TITLE
Fix version auto-bump automation

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,7 +1,8 @@
 files_with_version_number = {
   './package.json' => ['"version": "{x}"'],
   './scripts/docs/index.html' => ['purchases-js-docs/{x}/'],
-  './.version' => ['{x}']
+  './.version' => ['{x}'],
+  './src/helpers/constants.ts' => ['VERSION = "{x}"']
 }
 
 repo_name = 'purchases-js'

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -1,2 +1,2 @@
-export const VERSION = "0.0.10";
+export const VERSION = "0.0.18";
 export const RC_ENDPOINT = import.meta.env.VITE_RC_ENDPOINT as string;


### PR DESCRIPTION
## Motivation / Description
We need to bump the version sent as a header in all backend request on each version bump. This was missing from #70.

This adds that and bumps the version to the current version

## Changes introduced

## Linear ticket (if any)

## Additional comments
