### PR TITLE
URL encode user defined parameters in urls

### DIFF
--- a/src/networking/endpoints.ts
+++ b/src/networking/endpoints.ts
@@ -22,7 +22,8 @@ export class GetOfferingsEndpoint implements Endpoint {
   name: string = "getOfferings";
 
   url(): string {
-    return `${RC_ENDPOINT}${SUBSCRIBERS_PATH}/${this.appUserId}/offerings`;
+    const encodedAppUserId = encodeURIComponent(this.appUserId);
+    return `${RC_ENDPOINT}${SUBSCRIBERS_PATH}/${encodedAppUserId}/offerings`;
   }
 }
 
@@ -47,7 +48,11 @@ export class GetProductsEndpoint implements Endpoint {
   }
 
   url(): string {
-    return `${RC_ENDPOINT}${RC_BILLING_PATH}/subscribers/${this.appUserId}/products?id=${this.productIds.join("&id=")}`;
+    const encodedAppUserId = encodeURIComponent(this.appUserId);
+    const encodedProductIds = this.productIds
+      .map(encodeURIComponent)
+      .join("&id=");
+    return `${RC_ENDPOINT}${RC_BILLING_PATH}/subscribers/${encodedAppUserId}/products?id=${encodedProductIds}`;
   }
 }
 
@@ -61,7 +66,8 @@ export class GetCustomerInfoEndpoint implements Endpoint {
   }
 
   url(): string {
-    return `${RC_ENDPOINT}${SUBSCRIBERS_PATH}/${this.appUserId}`;
+    const encodedAppUserId = encodeURIComponent(this.appUserId);
+    return `${RC_ENDPOINT}${SUBSCRIBERS_PATH}/${encodedAppUserId}`;
   }
 }
 

--- a/src/tests/networking/endpoints.test.ts
+++ b/src/tests/networking/endpoints.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "vitest";
+import {
+  GetBrandingInfoEndpoint,
+  GetCheckoutStatusEndpoint,
+  GetCustomerInfoEndpoint,
+  GetOfferingsEndpoint,
+  GetProductsEndpoint,
+  SubscribeEndpoint,
+} from "../../networking/endpoints";
+
+describe("getOfferings endpoint", () => {
+  const endpoint = new GetOfferingsEndpoint("someAppUserId");
+
+  test("uses correct method", () => {
+    expect(endpoint.method).toBe("GET");
+  });
+
+  test("has correct url for common app user id", () => {
+    expect(endpoint.url()).toBe(
+      "http://localhost:8000/v1/subscribers/someAppUserId/offerings",
+    );
+  });
+
+  test("correctly encodes app user id", () => {
+    expect(
+      new GetOfferingsEndpoint("some+User/id#That$Requires&Encoding").url(),
+    ).toBe(
+      "http://localhost:8000/v1/subscribers/some%2BUser%2Fid%23That%24Requires%26Encoding/offerings",
+    );
+  });
+});
+
+describe("subscribe endpoint", () => {
+  const endpoint = new SubscribeEndpoint();
+
+  test("uses correct method", () => {
+    expect(endpoint.method).toBe("POST");
+  });
+
+  test("has correct path", () => {
+    expect(endpoint.url()).toBe("http://localhost:8000/rcbilling/v1/subscribe");
+  });
+});
+
+describe("getProducts endpoint", () => {
+  const endpoint = new GetProductsEndpoint("someAppUserId", [
+    "monthly",
+    "annual",
+  ]);
+
+  test("uses correct method", () => {
+    expect(endpoint.method).toBe("GET");
+  });
+
+  test("has correct path for common app user id", () => {
+    expect(endpoint.url()).toBe(
+      "http://localhost:8000/rcbilling/v1/subscribers/someAppUserId/products?id=monthly&id=annual",
+    );
+  });
+
+  test("correctly encodes app user id and product ids", () => {
+    expect(
+      new GetProductsEndpoint("some+User/id#That$Requires&Encoding", [
+        "product+id/That$requires!Encoding",
+        "productIdWithoutEncoding",
+      ]).url(),
+    ).toBe(
+      "http://localhost:8000/rcbilling/v1/subscribers/some%2BUser%2Fid%23That%24Requires%26Encoding/products?id=product%2Bid%2FThat%24requires!Encoding&id=productIdWithoutEncoding",
+    );
+  });
+});
+
+describe("getCustomerInfo endpoint", () => {
+  const endpoint = new GetCustomerInfoEndpoint("someAppUserId");
+
+  test("uses correct method", () => {
+    expect(endpoint.method).toBe("GET");
+  });
+
+  test("has correct path for common app user id", () => {
+    expect(endpoint.url()).toBe(
+      "http://localhost:8000/v1/subscribers/someAppUserId",
+    );
+  });
+
+  test("correctly encodes app user id", () => {
+    expect(
+      new GetCustomerInfoEndpoint("some+User/id#That$Requires&Encoding").url(),
+    ).toBe(
+      "http://localhost:8000/v1/subscribers/some%2BUser%2Fid%23That%24Requires%26Encoding",
+    );
+  });
+});
+
+describe("getBrandingInfo endpoint", () => {
+  const endpoint = new GetBrandingInfoEndpoint();
+
+  test("uses correct method", () => {
+    expect(endpoint.method).toBe("GET");
+  });
+
+  test("has correct path", () => {
+    expect(endpoint.url()).toBe("http://localhost:8000/rcbilling/v1/branding");
+  });
+});
+
+describe("getCheckoutStatus endpoint", () => {
+  const endpoint = new GetCheckoutStatusEndpoint("someOperationSessionId");
+
+  test("uses correct method", () => {
+    expect(endpoint.method).toBe("GET");
+  });
+
+  test("has correct path", () => {
+    expect(endpoint.url()).toBe(
+      "http://localhost:8000/rcbilling/v1/checkout/someOperationSessionId",
+    );
+  });
+});


### PR DESCRIPTION
## Motivation / Description
We were not url-encoding some of the parameters in the urls which lead to incorrect requests. This fixes that issue.

## Changes introduced

## Linear ticket (if any)
https://linear.app/revenuecat/issue/BIL-397/sdk-should-url-encode-the-app-user-id-when-making-requests

## Additional comments
