### PR TITLE
Send `presented_offering_identifier` in `POST /subscribe`

### DIFF
--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -42,11 +42,13 @@ export class PurchaseOperationHelper {
     appUserId: string,
     productId: string,
     email: string,
+    offeringIdentifier: string,
   ): Promise<SubscribeResponse> {
     const subscribeResponse = await this.backend.postSubscribe(
       appUserId,
       productId,
       email,
+      offeringIdentifier,
     );
     this.operationSessionId = subscribeResponse.operation_session_id;
     return subscribeResponse;

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -56,11 +56,13 @@ export class Backend {
     appUserId: string,
     productId: string,
     email: string,
+    offeringIdentifier: string,
   ): Promise<SubscribeResponse> {
     type SubscribeRequestBody = {
       app_user_id: string;
       product_id: string;
       email: string;
+      presented_offering_identifier: string;
     };
 
     return await performRequest<SubscribeRequestBody, SubscribeResponse>(
@@ -70,6 +72,7 @@ export class Backend {
         app_user_id: appUserId,
         product_id: productId,
         email: email,
+        presented_offering_identifier: offeringIdentifier,
       },
     );
   }

--- a/src/tests/helpers/purchase-operation-helper.test.ts
+++ b/src/tests/helpers/purchase-operation-helper.test.ts
@@ -70,6 +70,7 @@ describe("PurchaseOperationHelper", () => {
         "test-app-user-id",
         "test-product-id",
         "test-email",
+        "test-offering-id",
       ),
       new PurchasesError(
         ErrorCode.UnknownBackendError,
@@ -102,6 +103,7 @@ describe("PurchaseOperationHelper", () => {
       "test-app-user-id",
       "test-product-id",
       "test-email",
+      "test-offering-id",
     );
     await expectPromiseToPurchaseFlowError(
       purchaseOperationHelper.pollCurrentPurchaseForCompletion(),
@@ -133,6 +135,7 @@ describe("PurchaseOperationHelper", () => {
       "test-app-user-id",
       "test-product-id",
       "test-email",
+      "test-offering-id",
     );
     await purchaseOperationHelper.pollCurrentPurchaseForCompletion();
   });
@@ -193,6 +196,7 @@ describe("PurchaseOperationHelper", () => {
       "test-app-user-id",
       "test-product-id",
       "test-email",
+      "test-offering-id",
     );
     await expectPromiseToPurchaseFlowError(
       purchaseOperationHelper.pollCurrentPurchaseForCompletion(),

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -245,6 +245,7 @@ describe("subscribe request", () => {
         "someAppUserId",
         "monthly",
         "testemail@revenuecat.com",
+        "offering_1",
       ),
     ).toEqual(subscribeResponse);
   });
@@ -258,6 +259,7 @@ describe("subscribe request", () => {
         "someAppUserId",
         "monthly",
         "testemail@revenuecat.com",
+        "offering_1",
       ),
       new PurchasesError(
         ErrorCode.UnknownBackendError,
@@ -281,6 +283,7 @@ describe("subscribe request", () => {
         "someAppUserId",
         "monthly",
         "testemail@revenuecat.com",
+        "offering_1",
       ),
       new PurchasesError(
         ErrorCode.InvalidCredentialsError,

--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -89,8 +89,12 @@
       return;
     }
 
-    purchaseOperationHelper.startPurchase(appUserId, productId, customerEmail)
-      .then((result) => {
+    purchaseOperationHelper.startPurchase(
+      appUserId,
+      productId,
+      customerEmail,
+      rcPackage.rcBillingProduct.presentedOfferingIdentifier,
+    ).then((result) => {
         if (result.next_action === "collect_payment_info") {
           state = "needs-payment-info";
           paymentInfoCollectionMetadata = result;


### PR DESCRIPTION
## Motivation / Description
For experiments and charts to work well, we need to send the backend the offering id used to obtain the purchased product.

## Changes introduced

## Linear ticket (if any)

## Additional comments
