### PR TITLE
Handle network errors

### DIFF
--- a/src/networking/http-client.ts
+++ b/src/networking/http-client.ts
@@ -15,15 +15,27 @@ export async function performRequest<RequestBody, ResponseType>(
   body?: RequestBody,
   headers?: { [key: string]: string },
 ): Promise<ResponseType> {
-  const response = await fetch(endpoint.url(), {
-    method: endpoint.method,
-    headers: getHeaders(apiKey, headers),
-    body: getBody(body),
-  });
+  try {
+    const response = await fetch(endpoint.url(), {
+      method: endpoint.method,
+      headers: getHeaders(apiKey, headers),
+      body: getBody(body),
+    });
 
-  await handleErrors(response, endpoint);
+    await handleErrors(response, endpoint);
 
-  return (await response.json()) as ResponseType; // TODO: Validate response is correct.
+    return (await response.json()) as ResponseType; // TODO: Validate response is correct.
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw new PurchasesError(
+        ErrorCode.NetworkError,
+        ErrorCodeUtils.getPublicMessage(ErrorCode.NetworkError),
+        error.message,
+      );
+    } else {
+      throw error;
+    }
+  }
 }
 
 async function handleErrors(response: Response, endpoint: SupportedEndpoint) {

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -110,6 +110,18 @@ describe("getCustomerInfo request", () => {
       ),
     );
   });
+
+  test("throws network error if cannot reach server", async () => {
+    setCustomerInfoResponse(HttpResponse.error());
+    await expectPromiseToError(
+      backend.getCustomerInfo("someAppUserId"),
+      new PurchasesError(
+        ErrorCode.NetworkError,
+        "Error performing request.",
+        "Failed to fetch",
+      ),
+    );
+  });
 });
 
 describe("getOfferings request", () => {
@@ -167,6 +179,18 @@ describe("getOfferings request", () => {
       ),
     );
   });
+
+  test("throws network error if cannot reach server", async () => {
+    setOfferingsResponse(HttpResponse.error());
+    await expectPromiseToError(
+      backend.getOfferings("someAppUserId"),
+      new PurchasesError(
+        ErrorCode.NetworkError,
+        "Error performing request.",
+        "Failed to fetch",
+      ),
+    );
+  });
 });
 
 describe("getProducts request", () => {
@@ -217,6 +241,18 @@ describe("getProducts request", () => {
         ErrorCode.InvalidCredentialsError,
         "There was a credentials issue. Check the underlying error for more details.",
         "API key was wrong",
+      ),
+    );
+  });
+
+  test("throws network error if cannot reach server", async () => {
+    setProductsResponse(HttpResponse.error());
+    await expectPromiseToError(
+      backend.getProducts("someAppUserId", ["monthly", "monthly_2"]),
+      new PurchasesError(
+        ErrorCode.NetworkError,
+        "Error performing request.",
+        "Failed to fetch",
       ),
     );
   });
@@ -289,6 +325,23 @@ describe("subscribe request", () => {
         ErrorCode.InvalidCredentialsError,
         "There was a credentials issue. Check the underlying error for more details.",
         "API key was wrong",
+      ),
+    );
+  });
+
+  test("throws network error if cannot reach server", async () => {
+    setSubscribeResponse(HttpResponse.error());
+    await expectPromiseToError(
+      backend.postSubscribe(
+        "someAppUserId",
+        "monthly",
+        "testemail@revenuecat.com",
+        "offering_1",
+      ),
+      new PurchasesError(
+        ErrorCode.NetworkError,
+        "Error performing request.",
+        "Failed to fetch",
       ),
     );
   });


### PR DESCRIPTION
## Motivation / Description
To make a more flexible API, we shouldn't be returning the network error directly. Instead, this will wrap the error into our own `PurchasesError` type, with a `NetworkError` code.

## Changes introduced

## Linear ticket (if any)

## Additional comments
