### PR TITLE
[BIL-292] Add `formattedPrice` to Price

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -2521,6 +2521,33 @@
                 "startIndex": 1,
                 "endIndex": 2
               }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!Price#formattedPrice:member",
+              "docComment": "/**\n * Formatted price string including price and currency.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly formattedPrice: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "formattedPrice",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
             }
           ],
           "extendsTokenRanges": []

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -170,6 +170,7 @@ export type PeriodType = "normal" | "intro" | "trial";
 export interface Price {
     readonly amount: number;
     readonly currency: string;
+    readonly formattedPrice: string;
 }
 
 // @public

--- a/examples/rcbilling-demo/src/pages/paywall/index.tsx
+++ b/examples/rcbilling-demo/src/pages/paywall/index.tsx
@@ -34,9 +34,7 @@ export const PackageCard: React.FC<IPackageCardProps> = ({ pkg, onClick }) => {
               justifyContent: "center",
             }}
           >
-            <h2>{`${(pkg.rcBillingProduct?.currentPrice?.amount / 100).toFixed(
-              2,
-            )} ${pkg.rcBillingProduct?.currentPrice?.currency}`}</h2>
+            <h2>{`${pkg.rcBillingProduct?.currentPrice?.formattedPrice}`}</h2>
 
             {pkg.rcBillingProduct.normalPeriodDuration && (
               <h3>

--- a/examples/rcbilling-demo/src/tests/main.test.ts
+++ b/examples/rcbilling-demo/src/tests/main.test.ts
@@ -8,9 +8,9 @@ test("Get offerings displays packages", async () => {
   const { browser, page } = await setupTest();
   const packageCards = await getPackageCards(page);
   expect(packageCards.length).toEqual(3);
-  await expectElementContainsText(packageCards[0], "3.00 USD");
-  await expectElementContainsText(packageCards[1], "9.99 USD");
-  await expectElementContainsText(packageCards[2], "19.99 USD");
+  await expectElementContainsText(packageCards[0], "$3.00");
+  await expectElementContainsText(packageCards[1], "$9.99");
+  await expectElementContainsText(packageCards[2], "$19.99");
   await browser.close();
 });
 

--- a/src/entities/offerings.ts
+++ b/src/entities/offerings.ts
@@ -4,6 +4,7 @@ import {
 } from "../networking/responses/offerings-response";
 import { type ProductResponse } from "../networking/responses/products-response";
 import { notEmpty } from "../helpers/type-helper";
+import { formatPrice } from "../helpers/price-labels";
 
 /**
  * Enumeration of all possible Package types.
@@ -64,6 +65,10 @@ export interface Price {
    * If currency code cannot be determined, currency symbol is returned.
    */
   readonly currency: string;
+  /**
+   * Formatted price string including price and currency.
+   */
+  readonly formattedPrice: string;
 }
 
 /**
@@ -185,6 +190,14 @@ export interface Offerings {
   readonly current: Offering | null;
 }
 
+const toPrice = (priceData: { amount: number; currency: string }): Price => {
+  return {
+    amount: priceData.amount,
+    currency: priceData.currency,
+    formattedPrice: formatPrice(priceData.amount, priceData.currency),
+  };
+};
+
 const toProduct = (
   productDetailsData: ProductResponse,
   presentedOfferingIdentifier: string,
@@ -192,7 +205,7 @@ const toProduct = (
   return {
     identifier: productDetailsData.identifier,
     displayName: productDetailsData.title,
-    currentPrice: productDetailsData.current_price as Price,
+    currentPrice: toPrice(productDetailsData.current_price),
     normalPeriodDuration: productDetailsData.normal_period_duration,
     presentedOfferingIdentifier: presentedOfferingIdentifier,
   };

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -126,6 +126,7 @@ describe("getOfferings", () => {
       currentPrice: {
         currency: "USD",
         amount: 300,
+        formattedPrice: "$3.00",
       },
       displayName: "Monthly test",
       identifier: "monthly",
@@ -161,6 +162,7 @@ describe("getOfferings", () => {
         currentPrice: {
           currency: "USD",
           amount: 500,
+          formattedPrice: "$5.00",
         },
         displayName: "Monthly test 2",
         identifier: "monthly_2",
@@ -203,6 +205,7 @@ describe("getOfferings", () => {
         currentPrice: {
           currency: "USD",
           amount: 500,
+          formattedPrice: "$5.00",
         },
         displayName: "Monthly test 2",
         identifier: "monthly_2",


### PR DESCRIPTION
## Motivation / Description
We want to have a precomputed label that developers can use to display the price. This will use the same formatter we use in our purchase form. This is currently using the hardcoded locale `en-US`, but we can change that once we support other locales.

## Changes introduced

## Linear ticket (if any)

## Additional comments

![image](https://github.com/RevenueCat/purchases-js/assets/808417/a705cc2f-e458-4bad-b573-437aa59985a9)

