### PR TITLE
Allow multiple configure calls to create new purchases

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 1e624200ff2ddf0d398ce072171db35d017c408b
+  revision: 8ec007234d81f7a17a09a7e9243983485fac84b2
   branch: main
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)

--- a/src/main.ts
+++ b/src/main.ts
@@ -119,9 +119,9 @@ export class Purchases {
   static configure(apiKey: string, appUserId: string): Purchases {
     if (Purchases.instance !== undefined) {
       Logger.warnLog(
-        "Purchases is already initialized. Ignoring and returning existing instance.",
+        "Purchases is already initialized. You normally should only configure Purchases once. " +
+          "Creating and returning new instance.",
       );
-      return Purchases.getSharedInstance();
     }
     validateApiKey(apiKey);
     validateAppUserId(appUserId);

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -56,13 +56,13 @@ describe("Purchases.configure()", () => {
     expect(purchases).toBeDefined();
   });
 
-  test("configure multiple times returns same instance", () => {
+  test("configure multiple times returns different instances", () => {
     const purchases = Purchases.configure(testApiKey, testUserId);
     const purchases2 = Purchases.configure(
       "rcb_another_api_key",
       "another_user_id",
     );
-    expect(purchases).toEqual(purchases2);
+    expect(purchases).not.toEqual(purchases2);
   });
 });
 


### PR DESCRIPTION
## Motivation / Description
Currently if the developer calls `configure` multiple times, we return the same instance of `Purchases` and ignore the call. This might be confusing if the developer changes the user id in the other call. 

Normally, the developer should only call configure once, and we indicate that with a log, but in case they do, a more sensible option is to recreate the purchases instance with the given parameters (api key and user id) if they have changed.

## Changes introduced

## Linear ticket (if any)

## Additional comments
