### PR TITLE
Added support for SubscriptionPurchaseOptions in ProductResponses

### DIFF
--- a/src/networking/responses/products-response.ts
+++ b/src/networking/responses/products-response.ts
@@ -19,10 +19,7 @@ export interface SubscriptionPurchaseOption extends PurchaseOption {
 }
 
 export interface ProductResponse {
-  current_price: {
-    amount: number;
-    currency: string;
-  };
+  current_price: Price;
   identifier: string;
   normal_period_duration: string;
   product_type: string;

--- a/src/networking/responses/products-response.ts
+++ b/src/networking/responses/products-response.ts
@@ -1,3 +1,23 @@
+export interface Price {
+  amount: number;
+  currency: string;
+}
+
+export interface PurchaseOptionPrice {
+  period_duration: string | null;
+  price: Price | null;
+  cycle_count: number;
+}
+
+export interface PurchaseOption {
+  id: string;
+}
+
+export interface SubscriptionPurchaseOption extends PurchaseOption {
+  base_price: PurchaseOptionPrice;
+  trial: PurchaseOptionPrice | null;
+}
+
 export interface ProductResponse {
   current_price: {
     amount: number;
@@ -7,6 +27,8 @@ export interface ProductResponse {
   normal_period_duration: string;
   product_type: string;
   title: string;
+  default_subscription_purchase_option_id: string | null;
+  subscription_purchase_options: Map<string, SubscriptionPurchaseOption>;
 }
 
 export interface ProductsResponse {

--- a/src/tests/test-responses.ts
+++ b/src/tests/test-responses.ts
@@ -9,6 +9,19 @@ const monthlyProductResponse = {
   normal_period_duration: "PT1H",
   product_type: "subscription",
   title: "Monthly test",
+  default_subscription_purchase_option_id: "base_option",
+  subscription_purchase_options: {
+    base_option: {
+      base_price: {
+        period_duration: null,
+        cycle_count: 1,
+        price: {
+          amount: 300,
+          currency: "USD",
+        },
+      },
+    },
+  },
 };
 
 const monthly2ProductResponse = {
@@ -20,6 +33,24 @@ const monthly2ProductResponse = {
   normal_period_duration: "PT1H",
   product_type: "subscription",
   title: "Monthly test 2",
+  default_subscription_purchase_option_id: "offer_12345",
+  subscription_purchase_options: {
+    offer_12345: {
+      base_price: {
+        period_duration: null,
+        cycle_count: 1,
+        price: {
+          amount: 500,
+          currency: "USD",
+        },
+      },
+      trial: {
+        period_duration: "P1W",
+        cycle_count: 1,
+        price: null,
+      },
+    },
+  },
 };
 
 export const productsResponse = {


### PR DESCRIPTION
## Motivation / Description
We updated the /products endpoint to return purchase options that include, as example, trial offers.
This PR adds the necessary interfaces to support the data returned by Khepri as of now.

## Changes introduced
* Added the new interfaces in product-responses.ts
* Updated the test response from the endpoint with a trial offer and a base option


## Linear ticket
BIL-502