### PR TITLE
Add processed `period` to `PricingPhase`

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -2428,6 +2428,79 @@
           ]
         },
         {
+          "kind": "Interface",
+          "canonicalReference": "@revenuecat/purchases-js!Period:interface",
+          "docComment": "/**\n * Represents a period of time.\n *\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare interface Period "
+            }
+          ],
+          "fileUrlPath": "dist/Purchases.es.d.ts",
+          "releaseTag": "Public",
+          "name": "Period",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!Period#number:member",
+              "docComment": "/**\n * The number of units in the period.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "number: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "number"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "number",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!Period#unit:member",
+              "docComment": "/**\n * The unit of time.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "unit: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PeriodUnit",
+                  "canonicalReference": "@revenuecat/purchases-js!PeriodUnit:enum"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "unit",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
+          "extendsTokenRanges": []
+        },
+        {
           "kind": "TypeAlias",
           "canonicalReference": "@revenuecat/purchases-js!PeriodType:type",
           "docComment": "/**\n * Supported period types for an entitlement. - \"normal\" If the entitlement is not under an introductory or trial period. - \"intro\" If the entitlement is under an introductory period. - \"trial\" If the entitlement is under a trial period.\n *\n * @public\n */\n",
@@ -2452,6 +2525,107 @@
             "startIndex": 1,
             "endIndex": 2
           }
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "@revenuecat/purchases-js!PeriodUnit:enum",
+          "docComment": "/**\n * Represents a unit of time.\n *\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare enum PeriodUnit "
+            }
+          ],
+          "fileUrlPath": "dist/Purchases.es.d.ts",
+          "releaseTag": "Public",
+          "name": "PeriodUnit",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "@revenuecat/purchases-js!PeriodUnit.Day:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Day = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"day\""
+                }
+              ],
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "name": "Day"
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "@revenuecat/purchases-js!PeriodUnit.Month:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Month = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"month\""
+                }
+              ],
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "name": "Month"
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "@revenuecat/purchases-js!PeriodUnit.Week:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Week = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"week\""
+                }
+              ],
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "name": "Week"
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "@revenuecat/purchases-js!PeriodUnit.Year:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Year = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"year\""
+                }
+              ],
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "name": "Year"
+            }
+          ]
         },
         {
           "kind": "Interface",
@@ -2596,8 +2770,40 @@
             },
             {
               "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PricingPhase#period:member",
+              "docComment": "/**\n * The duration of the phase as a {@link Period}.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly period: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Period",
+                  "canonicalReference": "@revenuecat/purchases-js!Period:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | null"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "period",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              }
+            },
+            {
+              "kind": "PropertySignature",
               "canonicalReference": "@revenuecat/purchases-js!PricingPhase#periodDuration:member",
-              "docComment": "/**\n * The duration of the purchase option price in ISO 8601 format. For applicable options (trials, initial/promotional prices), otherwise null\n */\n",
+              "docComment": "/**\n * The duration of the phase in ISO 8601 format.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -164,7 +164,25 @@ export enum PackageType {
 }
 
 // @public
+export interface Period {
+    number: number;
+    unit: PeriodUnit;
+}
+
+// @public
 export type PeriodType = "normal" | "intro" | "trial";
+
+// @public
+export enum PeriodUnit {
+    // (undocumented)
+    Day = "day",
+    // (undocumented)
+    Month = "month",
+    // (undocumented)
+    Week = "week",
+    // (undocumented)
+    Year = "year"
+}
 
 // @public
 export interface Price {
@@ -176,6 +194,7 @@ export interface Price {
 // @public
 export interface PricingPhase {
     readonly cycleCount: number;
+    readonly period: Period | null;
     readonly periodDuration: string | null;
     readonly price: Price | null;
 }

--- a/src/entities/offerings.ts
+++ b/src/entities/offerings.ts
@@ -10,6 +10,7 @@ import {
 import { notEmpty } from "../helpers/type-helper";
 import { formatPrice } from "../helpers/price-labels";
 import { Logger } from "../helpers/logger";
+import { parseISODuration, type Period } from "../helpers/duration-helper";
 
 /**
  * Enumeration of all possible Package types.
@@ -82,10 +83,13 @@ export interface Price {
  */
 export interface PricingPhase {
   /**
-   * The duration of the purchase option price in ISO 8601 format.
-   * For applicable options (trials, initial/promotional prices), otherwise null
+   * The duration of the phase in ISO 8601 format.
    */
   readonly periodDuration: string | null;
+  /**
+   * The duration of the phase as a {@link Period}.
+   */
+  readonly period: Period | null;
   /**
    * The price for the purchase option.
    * Null in case of trials.
@@ -280,8 +284,10 @@ const toPrice = (priceData: { amount: number; currency: string }): Price => {
 };
 
 const toPricingPhase = (optionPhase: PricingPhaseResponse): PricingPhase => {
+  const periodDuration = optionPhase.period_duration;
   return {
-    periodDuration: optionPhase.period_duration,
+    periodDuration: periodDuration,
+    period: periodDuration ? parseISODuration(periodDuration) : null,
     cycleCount: optionPhase.cycle_count,
     price: optionPhase.price ? toPrice(optionPhase.price) : null,
   } as PricingPhase;

--- a/src/helpers/duration-helper.ts
+++ b/src/helpers/duration-helper.ts
@@ -1,5 +1,9 @@
 import { Logger } from "./logger";
 
+/**
+ * Represents a unit of time.
+ * @public
+ */
 export enum PeriodUnit {
   Year = "year",
   Month = "month",
@@ -7,8 +11,18 @@ export enum PeriodUnit {
   Day = "day",
 }
 
+/**
+ * Represents a period of time.
+ * @public
+ */
 export interface Period {
+  /**
+   * The number of units in the period.
+   */
   number: number;
+  /**
+   * The unit of time.
+   */
   unit: PeriodUnit;
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,6 +59,7 @@ export {
   PurchasesError,
   UninitializedPurchasesError,
 } from "./entities/errors";
+export type { Period, PeriodUnit } from "./helpers/duration-helper";
 export { LogLevel } from "./entities/log-level";
 export type { PurchaseParams } from "./entities/purchase-params";
 

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../main";
 import { getRequestHandlers } from "./test-responses";
 import { UninitializedPurchasesError } from "../entities/errors";
+import { PeriodUnit } from "../helpers/duration-helper";
 
 const server = setupServer(...getRequestHandlers());
 
@@ -142,6 +143,10 @@ describe("getOfferings", () => {
         base: {
           cycleCount: 1,
           periodDuration: "P1M",
+          period: {
+            number: 1,
+            unit: PeriodUnit.Month,
+          },
           price: {
             amount: 300,
             currency: "USD",
@@ -156,6 +161,10 @@ describe("getOfferings", () => {
           base: {
             cycleCount: 1,
             periodDuration: "P1M",
+            period: {
+              number: 1,
+              unit: PeriodUnit.Month,
+            },
             price: {
               amount: 300,
               currency: "USD",
@@ -194,6 +203,10 @@ describe("getOfferings", () => {
       base: {
         cycleCount: 1,
         periodDuration: "P1M",
+        period: {
+          number: 1,
+          unit: PeriodUnit.Month,
+        },
         price: {
           amount: 500,
           currency: "USD",
@@ -203,6 +216,10 @@ describe("getOfferings", () => {
       trial: {
         cycleCount: 1,
         periodDuration: "P1W",
+        period: {
+          number: 1,
+          unit: PeriodUnit.Week,
+        },
         price: null,
       },
     };
@@ -276,6 +293,10 @@ describe("getOfferings", () => {
           base: {
             cycleCount: 1,
             periodDuration: "P1M",
+            period: {
+              number: 1,
+              unit: PeriodUnit.Month,
+            },
             price: {
               amount: 500,
               currency: "USD",
@@ -285,6 +306,10 @@ describe("getOfferings", () => {
           trial: {
             cycleCount: 1,
             periodDuration: "P1W",
+            period: {
+              number: 1,
+              unit: PeriodUnit.Week,
+            },
             price: null,
           },
         },
@@ -294,6 +319,10 @@ describe("getOfferings", () => {
             base: {
               cycleCount: 1,
               periodDuration: "P1M",
+              period: {
+                number: 1,
+                unit: PeriodUnit.Month,
+              },
               price: {
                 amount: 500,
                 currency: "USD",
@@ -303,6 +332,10 @@ describe("getOfferings", () => {
             trial: {
               cycleCount: 1,
               periodDuration: "P1W",
+              period: {
+                number: 1,
+                unit: PeriodUnit.Week,
+              },
               price: null,
             },
           },


### PR DESCRIPTION
## Motivation / Description
Currently, we only expose the periodDuration as a ISO8601 string. While developers can parse that, we can also provide a parsed version of this duration in the `PricingPhase` which includes the duration of the trials and base phases for convenience. This is a followup of trial support in #117 

## Changes introduced

## Linear ticket (if any)

## Additional comments
