### PR TITLE
Add new `OfferNotFound` error parsing to backend request error processing

### DIFF
--- a/src/entities/errors.ts
+++ b/src/entities/errors.ts
@@ -120,6 +120,7 @@ export class ErrorCodeUtils {
         return ErrorCode.InvalidCredentialsError;
       case BackendErrorCode.BackendInvalidPaymentModeOrIntroPriceNotProvided:
       case BackendErrorCode.BackendProductIdForGoogleReceiptNotProvided:
+      case BackendErrorCode.BackendOfferNotFound:
         return ErrorCode.PurchaseInvalidError;
       case BackendErrorCode.BackendEmptyAppUserId:
         return ErrorCode.InvalidAppUserIdError;
@@ -195,6 +196,7 @@ export enum BackendErrorCode {
   BackendInvalidSubscriberAttributes = 7263,
   BackendInvalidSubscriberAttributesBody = 7264,
   BackendProductIDsMalformed = 7662,
+  BackendOfferNotFound = 7814,
 }
 
 /**

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -332,6 +332,32 @@ describe("subscribe request", () => {
     );
   });
 
+  test("throws a PurchaseInvalidError if the backend returns with a offer not found error", async () => {
+    setSubscribeResponse(
+      HttpResponse.json(
+        {
+          code: BackendErrorCode.BackendOfferNotFound,
+          message: "Offer not available",
+        },
+        { status: StatusCodes.NOT_FOUND },
+      ),
+    );
+    await expectPromiseToError(
+      backend.postSubscribe(
+        "someAppUserId",
+        "monthly",
+        "testemail@revenuecat.com",
+        "offering_1",
+        undefined,
+      ),
+      new PurchasesError(
+        ErrorCode.PurchaseInvalidError,
+        "One or more of the arguments provided are invalid.",
+        "Offer not available",
+      ),
+    );
+  });
+
   test("throws network error if cannot reach server", async () => {
     setSubscribeResponse(HttpResponse.error());
     await expectPromiseToError(


### PR DESCRIPTION
## Motivation / Description
There is a new error the backend can return when the SDK tries to purchase an offer and that offer is not available anymore for the customer. This improves the processing of that error so it's a more meaningful error.

## Changes introduced

## Linear ticket (if any)

## Additional comments
