### PR TITLE
Make demo app independent of entitlement ID

### DIFF
--- a/examples/rcbilling-demo/package-lock.json
+++ b/examples/rcbilling-demo/package-lock.json
@@ -32,7 +32,7 @@
     },
     "../..": {
       "name": "@revenuecat/purchases-js",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@stripe/stripe-js": "^2.2.0",

--- a/examples/rcbilling-demo/src/App.tsx
+++ b/examples/rcbilling-demo/src/App.tsx
@@ -12,8 +12,6 @@ import PaywallPage from "./pages/paywall";
 import SuccessPage from "./pages/success";
 import { loadPurchases } from "./util/PurchasesLoader";
 
-export const catServicesEntitlementId = "catServices";
-
 const router = createBrowserRouter([
   {
     path: "/",

--- a/examples/rcbilling-demo/src/App.tsx
+++ b/examples/rcbilling-demo/src/App.tsx
@@ -33,7 +33,7 @@ const router = createBrowserRouter([
     path: "/paywall/:app_user_id",
     loader: loadPurchases,
     element: (
-      <WithoutEntitlement entitlementId={catServicesEntitlementId}>
+      <WithoutEntitlement>
         <PaywallPage />
       </WithoutEntitlement>
     ),
@@ -42,7 +42,7 @@ const router = createBrowserRouter([
     path: "/success/:app_user_id",
     loader: loadPurchases,
     element: (
-      <WithEntitlement entitlementId={catServicesEntitlementId}>
+      <WithEntitlement>
         <SuccessPage />
       </WithEntitlement>
     ),

--- a/examples/rcbilling-demo/src/components/WithEntitlement.tsx
+++ b/examples/rcbilling-demo/src/components/WithEntitlement.tsx
@@ -1,27 +1,19 @@
-import React, { useEffect, useState } from "react";
-import IChildrenProps from "./IChildrenProps";
+import React, { PropsWithChildren, useEffect, useState } from "react";
 import { usePurchasesLoaderData } from "../util/PurchasesLoader";
 import { useNavigate } from "react-router-dom";
 
-interface IWithEntitlementProps extends IChildrenProps {
-  entitlementId: string;
-}
-
-const WithEntitlement: React.FC<IWithEntitlementProps> = ({
-  entitlementId,
-  children,
-}) => {
+const WithEntitlement: React.FC<PropsWithChildren> = ({ children }) => {
   const { customerInfo, purchases } = usePurchasesLoaderData();
   const [isLoading, setLoading] = useState<boolean>(true);
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!customerInfo.entitlements.active[entitlementId]) {
+    if (Object.keys(customerInfo.entitlements.active).length === 0) {
       navigate(`/paywall/${purchases.getAppUserId()}`);
     } else {
       setLoading(false);
     }
-  }, [customerInfo, purchases, entitlementId, navigate]);
+  }, [customerInfo, purchases, navigate]);
 
   return customerInfo && !isLoading ? <>{children}</> : null;
 };

--- a/examples/rcbilling-demo/src/components/WithoutEntitlement.tsx
+++ b/examples/rcbilling-demo/src/components/WithoutEntitlement.tsx
@@ -1,27 +1,19 @@
-import React, { useEffect, useState } from "react";
-import IChildrenProps from "./IChildrenProps";
+import React, { PropsWithChildren, useEffect, useState } from "react";
 import { usePurchasesLoaderData } from "../util/PurchasesLoader";
 import { useNavigate } from "react-router-dom";
 
-interface IWithoutEntitlementProps extends IChildrenProps {
-  entitlementId: string;
-}
-
-const WithoutEntitlement: React.FC<IWithoutEntitlementProps> = ({
-  entitlementId,
-  children,
-}) => {
+const WithoutEntitlement: React.FC<PropsWithChildren> = ({ children }) => {
   const { customerInfo, purchases } = usePurchasesLoaderData();
   const [isLoading, setLoading] = useState<boolean>(true);
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (customerInfo.entitlements.active[entitlementId]) {
+    if (Object.keys(customerInfo.entitlements.active).length > 0) {
       navigate(`/success/${purchases.getAppUserId()}`);
     } else {
       setLoading(false);
     }
-  }, [customerInfo, purchases, entitlementId, navigate]);
+  }, [customerInfo, purchases, navigate]);
 
   return customerInfo && !isLoading ? <>{children}</> : null;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@revenuecat/purchases-js",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@revenuecat/purchases-js",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@stripe/stripe-js": "^2.2.0",


### PR DESCRIPTION
## Motivation / Description

The demo app required a specific entitlement ID; this makes it independent of the entitlement ID that is being used

## Changes introduced

## Linear ticket (if any)

## Additional comments
