### PR TITLE
Show better errors in purchase flow when user is subscribed

### DIFF
--- a/src/entities/errors.ts
+++ b/src/entities/errors.ts
@@ -122,6 +122,8 @@ export class ErrorCodeUtils {
       case BackendErrorCode.BackendProductIdForGoogleReceiptNotProvided:
       case BackendErrorCode.BackendOfferNotFound:
         return ErrorCode.PurchaseInvalidError;
+      case BackendErrorCode.BackendAlreadySubscribedError:
+        return ErrorCode.ProductAlreadyPurchasedError;
       case BackendErrorCode.BackendEmptyAppUserId:
         return ErrorCode.InvalidAppUserIdError;
       case BackendErrorCode.BackendPlayStoreQuotaExceeded:
@@ -170,6 +172,8 @@ export class ErrorCodeUtils {
         return ErrorCode.StoreProblemError;
       case PurchaseFlowErrorCode.UnknownError:
         return ErrorCode.UnknownError;
+      case PurchaseFlowErrorCode.AlreadySubscribedError:
+        return ErrorCode.ProductAlreadyPurchasedError;
     }
   }
 }
@@ -196,6 +200,7 @@ export enum BackendErrorCode {
   BackendInvalidSubscriberAttributes = 7263,
   BackendInvalidSubscriberAttributesBody = 7264,
   BackendProductIDsMalformed = 7662,
+  BackendAlreadySubscribedError = 7772,
   BackendOfferNotFound = 7814,
 }
 

--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-    import {onMount} from "svelte";
-    import { type Package, Product, PurchaseOption, Purchases, PurchasesError } from "../main";
+    import { onMount } from "svelte";
+    import { type Package, Product, PurchaseOption, Purchases } from "../main";
     import StatePresentOffer from "./states/state-present-offer.svelte";
     import StateLoading from "./states/state-loading.svelte";
     import StateError from "./states/state-error.svelte";
@@ -9,19 +9,19 @@
     import StateNeedsAuthInfo from "./states/state-needs-auth-info.svelte";
     import ConditionalFullScreen from "./conditional-full-screen.svelte";
     import Shell from "./shell.svelte";
-    import {type SubscribeResponse} from "../networking/responses/subscribe-response";
-    import {type BrandingInfoResponse} from "../networking/responses/branding-response";
+    import { type SubscribeResponse } from "../networking/responses/subscribe-response";
+    import { type BrandingInfoResponse } from "../networking/responses/branding-response";
     import {
         PurchaseFlowError,
         PurchaseFlowErrorCode,
         PurchaseOperationHelper,
     } from "../helpers/purchase-operation-helper";
-    import {Backend} from "../networking/backend";
+    import { Backend } from "../networking/backend";
     import ModalHeader from "./modal-header.svelte";
     import IconCart from "./assets/icon-cart.svelte";
     import BrandingInfoUI from "./branding-info-ui.svelte";
     import SandboxBanner from "./sandbox-banner.svelte";
-    import {Colors} from "../assets/colors";
+    import { Colors } from "../assets/colors";
 
     export let asModal = true;
     export let customerEmail: string | undefined;
@@ -124,14 +124,8 @@
                     return;
                 }
             })
-            .catch((e: PurchasesError) => {
-                handleError(
-                    new PurchaseFlowError(
-                        PurchaseFlowErrorCode.ErrorSettingUpPurchase,
-                        e.message,
-                        e.underlyingErrorMessage,
-                    ),
-                );
+            .catch((e: PurchaseFlowError) => {
+                handleError(e);
             });
     };
 

--- a/src/ui/states/state-error.svelte
+++ b/src/ui/states/state-error.svelte
@@ -37,7 +37,7 @@
       case PurchaseFlowErrorCode.MissingEmailError:
         return "Email is required to complete the purchase.";
       case PurchaseFlowErrorCode.AlreadySubscribedError:
-        return "This user is already subscribed to this product."
+        return "You are already subscribed to this product."
     }
     return lastError.message;
   }

--- a/src/ui/states/state-error.svelte
+++ b/src/ui/states/state-error.svelte
@@ -41,10 +41,19 @@
     }
     return lastError.message;
   }
+
+  function getErrorTitle(): string {
+    switch (lastError.errorCode) {
+      case PurchaseFlowErrorCode.AlreadySubscribedError:
+        return "Already subscribed";
+      default:
+        return "Something went wrong";
+    }
+  }
 </script>
 
 <MessageLayout
-  title="Something went wrong"
+  title={getErrorTitle()}
   {brandingInfo}
   {onContinue}
   type="error"

--- a/src/ui/states/state-error.svelte
+++ b/src/ui/states/state-error.svelte
@@ -36,6 +36,8 @@
         return lastError.message;
       case PurchaseFlowErrorCode.MissingEmailError:
         return "Email is required to complete the purchase.";
+      case PurchaseFlowErrorCode.AlreadySubscribedError:
+        return "This user is already subscribed to this product."
     }
     return lastError.message;
   }


### PR DESCRIPTION
## Motivation / Description
When a user tries to purchase a product they are already subscribed to, the backend returns an error, but the SDK wasn't handling that well and displayed a generic error. This modifies that to return a more readable error.

<img width="664" alt="image" src="https://github.com/RevenueCat/purchases-js/assets/808417/f2b6e9f2-fa74-4a8f-8861-fc77fb367544">



## Changes introduced

## Linear ticket (if any)

## Additional comments
