### PR TITLE
Validate email in SDK

### DIFF
--- a/src/helpers/validators.ts
+++ b/src/helpers/validators.ts
@@ -1,0 +1,8 @@
+export function validateEmail(email: string): string | null {
+  if (email.trim() === "") {
+    return "You need to provide your email address to continue.";
+  } else if (!email.match(/^[^@]+@[^@]+\.[^@]+$/)) {
+    return "Email is not valid. Please provide a valid email address.";
+  }
+  return null;
+}

--- a/src/tests/helpers/validators.test.ts
+++ b/src/tests/helpers/validators.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "vitest";
+import { validateEmail } from "../../helpers/validators";
+
+describe("validateEmail", () => {
+  test("validates empty email correctly", () => {
+    expect(validateEmail("")).toEqual(
+      "You need to provide your email address to continue.",
+    );
+  });
+
+  test("validates invalid email correctly", () => {
+    expect(validateEmail("ajajdfljf@lkajd")).toEqual(
+      "Email is not valid. Please provide a valid email address.",
+    );
+  });
+
+  test("validates valid email correctly", () => {
+    expect(validateEmail("test123@revenuecat.com")).toEqual(null);
+  });
+});

--- a/src/ui/states/state-needs-auth-info.svelte
+++ b/src/ui/states/state-needs-auth-info.svelte
@@ -5,6 +5,7 @@
   import RowLayout from "../layout/row-layout.svelte";
   import ModalHeader from "../modal-header.svelte";
   import ProcessingAnimation from "../processing-animation.svelte";
+  import { validateEmail } from "../../helpers/validators";
 
   export let onContinue: any;
   export let onClose: () => void;
@@ -15,8 +16,9 @@
   $: inputClass = error ? "error" : "";
 
   const handleContinue = async () => {
-    if (email.trim() === "") {
-      error = "You need to provide your email address to continue.";
+    const verificationErrors = validateEmail(email);
+    if (verificationErrors) {
+      error = verificationErrors;
     } else {
       onContinue({ email });
     }


### PR DESCRIPTION
## Motivation / Description
We were relying on the backend to validate the email. We can add some initial validation in the SDK itself to make the response faster. Note that we don't validate the email if provided by the developer, we will still rely on the backend for that.

## Changes introduced

## Linear ticket (if any)

## Additional comments
<img width="1169" alt="image" src="https://github.com/RevenueCat/purchases-js/assets/808417/88d418f0-b1b0-4342-b75a-24ef8c5b2fb5">
