### PR TITLE
Fix side info not showing when not specifying purchase option

### DIFF
--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -191,16 +191,16 @@
                                 <IconCart/>
                             {/if}
                         </ModalHeader>
-                        {#if productDetails && purchaseOption}
-                            <StatePresentOffer productDetails={productDetails} purchaseOption={purchaseOption}/>
+                        {#if productDetails && purchaseOptionToUse}
+                            <StatePresentOffer productDetails={productDetails} purchaseOption={purchaseOptionToUse}/>
                         {/if}
                     </Shell>
                 </div>
             {/if}
             <div class="rcb-ui-main">
                 <Shell>
-                    {#if state === "present-offer" && productDetails && purchaseOption}
-                        <StatePresentOffer productDetails={productDetails} purchaseOption={purchaseOption}/>
+                    {#if state === "present-offer" && productDetails && purchaseOptionToUse}
+                        <StatePresentOffer productDetails={productDetails} purchaseOption={purchaseOptionToUse}/>
                     {/if}
                     {#if state === "present-offer" && !productDetails}
                         <StateLoading/>


### PR DESCRIPTION
## Motivation / Description
The sidebar info was not displaying the product information when the `purchaseOption` was not specified as part of the `purchasePackage` parameters. We should be automatically be picking up the default option in that case. 

This fixes that default case so it shows the correct info.

## Changes introduced

## Linear ticket (if any)

## Additional comments
