### PR TITLE
Add backend email validation errors display to email screen

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -1101,6 +1101,27 @@
             },
             {
               "kind": "EnumMember",
+              "canonicalReference": "@revenuecat/purchases-js!ErrorCode.InvalidEmailError:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "InvalidEmailError = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "38"
+                }
+              ],
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "name": "InvalidEmailError"
+            },
+            {
+              "kind": "EnumMember",
               "canonicalReference": "@revenuecat/purchases-js!ErrorCode.InvalidReceiptError:member",
               "docComment": "",
               "excerptTokens": [

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -66,6 +66,8 @@ export enum ErrorCode {
     // (undocumented)
     InvalidCredentialsError = 11,
     // (undocumented)
+    InvalidEmailError = 38,
+    // (undocumented)
     InvalidReceiptError = 8,
     // (undocumented)
     InvalidSubscriberAttributesError = 21,

--- a/src/entities/errors.ts
+++ b/src/entities/errors.ts
@@ -35,6 +35,7 @@ export enum ErrorCode {
   EmptySubscriberAttributesError = 25,
   CustomerInfoError = 28,
   SignatureVerificationError = 36,
+  InvalidEmailError = 38,
 }
 
 export class ErrorCodeUtils {
@@ -101,6 +102,8 @@ export class ErrorCodeUtils {
         return "There was a problem related to the customer info.";
       case ErrorCode.SignatureVerificationError:
         return "Request failed signature verification. Please see https://rev.cat/trusted-entitlements for more info.";
+      case ErrorCode.InvalidEmailError:
+        return "Email is not valid. Please provide a valid email address.";
     }
   }
 
@@ -145,6 +148,9 @@ export class ErrorCodeUtils {
         return ErrorCode.UnexpectedBackendResponseError;
       case BackendErrorCode.BackendProductIDsMalformed:
         return ErrorCode.UnsupportedError;
+      case BackendErrorCode.BackendInvalidEmail:
+      case BackendErrorCode.BackendNoMXRecordsFound:
+        return ErrorCode.InvalidEmailError;
     }
   }
 
@@ -180,6 +186,7 @@ export class ErrorCodeUtils {
 
 export enum BackendErrorCode {
   BackendInvalidPlatform = 7000,
+  BackendInvalidEmail = 7012,
   BackendStoreProblem = 7101,
   BackendCannotTransferPurchase = 7102,
   BackendInvalidReceiptToken = 7103,
@@ -202,6 +209,7 @@ export enum BackendErrorCode {
   BackendProductIDsMalformed = 7662,
   BackendAlreadySubscribedError = 7772,
   BackendOfferNotFound = 7814,
+  BackendNoMXRecordsFound = 7834,
 }
 
 /**

--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -36,6 +36,8 @@ export class PurchaseFlowError extends Error {
     let errorCode: PurchaseFlowErrorCode;
     if (e.errorCode === ErrorCode.ProductAlreadyPurchasedError) {
       errorCode = PurchaseFlowErrorCode.AlreadySubscribedError;
+    } else if (e.errorCode === ErrorCode.InvalidEmailError) {
+      errorCode = PurchaseFlowErrorCode.MissingEmailError;
     } else {
       errorCode = defaultFlowErrorCode;
     }

--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -115,11 +115,13 @@
             )
             .then((result) => {
                 if (result.next_action === "collect_payment_info") {
+                    lastError = null;
                     state = "needs-payment-info";
                     paymentInfoCollectionMetadata = result;
                     return;
                 }
                 if (result.next_action === "completed") {
+                    lastError = null;
                     state = "success";
                     return;
                 }
@@ -162,6 +164,11 @@
     };
 
     const handleError = (e: PurchaseFlowError) => {
+        if (state === "processing-auth-info") {
+            lastError = e;
+            state = "needs-auth-info";
+            return;
+        }
         lastError = e;
         state = "error";
     };
@@ -210,6 +217,7 @@
                                 onContinue={handleContinue}
                                 onClose={handleClose}
                                 processing={state === "processing-auth-info"}
+                                lastError={lastError}
                         />
                     {/if}
                     {#if paymentInfoCollectionMetadata && (state === "needs-payment-info" || state === "polling-purchase-status")}

--- a/src/ui/states/state-needs-auth-info.svelte
+++ b/src/ui/states/state-needs-auth-info.svelte
@@ -6,10 +6,13 @@
   import ModalHeader from "../modal-header.svelte";
   import ProcessingAnimation from "../processing-animation.svelte";
   import { validateEmail } from "../../helpers/validators";
+  import { PurchaseFlowError } from "../../helpers/purchase-operation-helper";
+  import { beforeUpdate } from "svelte";
 
   export let onContinue: any;
   export let onClose: () => void;
   export let processing: boolean;
+  export let lastError: PurchaseFlowError | null;
 
   $: email = "";
   $: error = "";
@@ -23,6 +26,10 @@
       onContinue({ email });
     }
   };
+
+  beforeUpdate(async () => {
+    error = lastError?.message ?? "";
+  });
 </script>
 
 <form on:submit|preventDefault={handleContinue}>


### PR DESCRIPTION
## Motivation / Description
This makes any email validation errors from the backend display within the email input screen, instead of as a separate screen.

<img width="705" alt="image" src="https://github.com/RevenueCat/purchases-js/assets/808417/622c6162-cff6-4574-a308-1842ba958cf5">


## Changes introduced

## Linear ticket (if any)

## Additional comments
