### PR TITLE
[EXTERNAL] Fix storybook development mode (#145) contributed by @AbraaoAlves

### DIFF
--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { onMount } from "svelte";
-    import { type Package, Product, PurchaseOption, Purchases } from "../main";
+    import type { Package, Product, PurchaseOption, Purchases } from "../main";
     import StatePresentOffer from "./states/state-present-offer.svelte";
     import StateLoading from "./states/state-loading.svelte";
     import StateError from "./states/state-error.svelte";

--- a/src/ui/states/state-present-offer.svelte
+++ b/src/ui/states/state-present-offer.svelte
@@ -2,7 +2,7 @@
     import ModalSection from "../modal-section.svelte";
     import {formatPrice, getRenewsLabel} from "../../helpers/price-labels";
     import {getTrialsLabel} from "../../helpers/price-labels.js";
-    import { Product, PurchaseOption, SubscriptionOption } from "../../entities/offerings";
+    import type { Product, PurchaseOption, SubscriptionOption } from "../../entities/offerings";
 
     export let productDetails: Product;
     export let purchaseOption: PurchaseOption;


### PR DESCRIPTION
## Motivation / Description

Storybook dev mode is broken


![image](https://github.com/RevenueCat/purchases-js/assets/608731/9a05249a-17ab-4c62-a5d4-547bd62760dc)

To reproduce, just run:

``` bash
npm install
npm run storybook
```

Storybook breaks because some svelte files are importing types from ts files like runtime code, not just `types`.

## Changes introduced

## Linear ticket (if any)

## Additional comments

## Motivation / Description

## Changes introduced

## Linear ticket (if any)

## Additional comments

This was contributed by @AbraaoAlves in #145
