### PR TITLE
Add support for adding additional headers on http requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To avoid publishing the package you can set it up as a local dependency.
 In your testing project install the library as.
 
 ```bash
-npm i /path/to/rcbilling-js
+npm i /path/to/purchases-js
 ```
 
 ## Running tests

--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -1522,6 +1522,51 @@
           ]
         },
         {
+          "kind": "Interface",
+          "canonicalReference": "@revenuecat/purchases-js!HttpConfig:interface",
+          "docComment": "/**\n * Parameters used to customise the http requests executed by purchases-js.\n *\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare interface HttpConfig "
+            }
+          ],
+          "fileUrlPath": "dist/Purchases.es.d.ts",
+          "releaseTag": "Public",
+          "name": "HttpConfig",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!HttpConfig#includeCredentials:member",
+              "docComment": "/**\n * If true uses credentials:'include' when executing XHR requests.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "includeCredentials?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "includeCredentials",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
+          "extendsTokenRanges": []
+        },
+        {
           "kind": "Enum",
           "canonicalReference": "@revenuecat/purchases-js!LogLevel:enum",
           "docComment": "/**\n * Possible levels to log in the console.\n *\n * @public\n */\n",
@@ -3449,7 +3494,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@revenuecat/purchases-js!Purchases.configure:member(1)",
-              "docComment": "/**\n * Configures the Purchases SDK. This should be called as soon as your app has a unique user id for your user. You should only call this once, and keep the returned instance around for use throughout your application.\n *\n * @param apiKey - RevenueCat API Key. Can be obtained from the RevenueCat dashboard.\n *\n * @param appUserId - Your unique id for identifying the user.\n *\n * @throws\n *\n * {@link PurchasesError} if the API key or user id are invalid.\n */\n",
+              "docComment": "/**\n * Configures the Purchases SDK. This should be called as soon as your app has a unique user id for your user. You should only call this once, and keep the returned instance around for use throughout your application.\n *\n * @param apiKey - RevenueCat API Key. Can be obtained from the RevenueCat dashboard.\n *\n * @param appUserId - Your unique id for identifying the user.\n *\n * @param httpConfig - Advanced http configuration to customise the SDK usage {@link HttpConfig}.\n *\n * @throws\n *\n * {@link PurchasesError} if the API key or user id are invalid.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -3469,6 +3514,15 @@
                 },
                 {
                   "kind": "Content",
+                  "text": ", httpConfig?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "HttpConfig",
+                  "canonicalReference": "@revenuecat/purchases-js!HttpConfig:interface"
+                },
+                {
+                  "kind": "Content",
                   "text": "): "
                 },
                 {
@@ -3483,8 +3537,8 @@
               ],
               "isStatic": true,
               "returnTypeTokenRange": {
-                "startIndex": 5,
-                "endIndex": 6
+                "startIndex": 7,
+                "endIndex": 8
               },
               "releaseTag": "Public",
               "isProtected": false,
@@ -3505,6 +3559,14 @@
                     "endIndex": 4
                   },
                   "isOptional": false
+                },
+                {
+                  "parameterName": "httpConfig",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 5,
+                    "endIndex": 6
+                  },
+                  "isOptional": true
                 }
               ],
               "isOptional": false,

--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -1567,33 +1567,6 @@
                 "startIndex": 1,
                 "endIndex": 3
               }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!HttpConfig#includeCredentials:member",
-              "docComment": "/**\n * If true uses credentials:'include' when executing XHR requests.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "includeCredentials?: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "boolean"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "includeCredentials",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
             }
           ],
           "extendsTokenRanges": []

--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -1538,6 +1538,38 @@
           "members": [
             {
               "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!HttpConfig#additionalHeaders:member",
+              "docComment": "/**\n * Additional headers to include in all HTTP requests.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "additionalHeaders?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Record",
+                  "canonicalReference": "!Record:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<string, string>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "additionalHeaders",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              }
+            },
+            {
+              "kind": "PropertySignature",
               "canonicalReference": "@revenuecat/purchases-js!HttpConfig#includeCredentials:member",
               "docComment": "/**\n * If true uses credentials:'include' when executing XHR requests.\n */\n",
               "excerptTokens": [

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -109,6 +109,7 @@ export enum ErrorCode {
 
 // @public
 export interface HttpConfig {
+    additionalHeaders?: Record<string, string>;
     includeCredentials?: boolean;
 }
 

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -108,6 +108,11 @@ export enum ErrorCode {
 }
 
 // @public
+export interface HttpConfig {
+    includeCredentials?: boolean;
+}
+
+// @public
 export enum LogLevel {
     Debug = 4,
     Error = 1,
@@ -234,7 +239,7 @@ export interface PurchaseParams {
 export class Purchases {
     changeUser(newAppUserId: string): Promise<CustomerInfo>;
     close(): void;
-    static configure(apiKey: string, appUserId: string): Purchases;
+    static configure(apiKey: string, appUserId: string, httpConfig?: HttpConfig): Purchases;
     getAppUserId(): string;
     getCustomerInfo(): Promise<CustomerInfo>;
     getOfferings(): Promise<Offerings>;

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -110,7 +110,6 @@ export enum ErrorCode {
 // @public
 export interface HttpConfig {
     additionalHeaders?: Record<string, string>;
-    includeCredentials?: boolean;
 }
 
 // @public

--- a/src/entities/http-config.ts
+++ b/src/entities/http-config.ts
@@ -1,0 +1,10 @@
+/**
+ * Parameters used to customise the http requests executed by purchases-js.
+ * @public
+ */
+export interface HttpConfig {
+  /**
+   * If true uses credentials:'include' when executing XHR requests.
+   */
+  includeCredentials?: boolean;
+}

--- a/src/entities/http-config.ts
+++ b/src/entities/http-config.ts
@@ -7,6 +7,10 @@ export interface HttpConfig {
    * If true uses credentials:'include' when executing XHR requests.
    */
   includeCredentials?: boolean;
+  /**
+   * Additional headers to include in all HTTP requests.
+   */
+  additionalHeaders?: Record<string, string>;
 }
 
 export const defaultHttpConfig = { includeCredentials: false };

--- a/src/entities/http-config.ts
+++ b/src/entities/http-config.ts
@@ -8,3 +8,5 @@ export interface HttpConfig {
    */
   includeCredentials?: boolean;
 }
+
+export const defaultHttpConfig = { includeCredentials: false };

--- a/src/entities/http-config.ts
+++ b/src/entities/http-config.ts
@@ -4,13 +4,9 @@
  */
 export interface HttpConfig {
   /**
-   * If true uses credentials:'include' when executing XHR requests.
-   */
-  includeCredentials?: boolean;
-  /**
    * Additional headers to include in all HTTP requests.
    */
   additionalHeaders?: Record<string, string>;
 }
 
-export const defaultHttpConfig = { includeCredentials: false };
+export const defaultHttpConfig = {};

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ import {
   validateAppUserId,
 } from "./helpers/configuration-validators";
 import { type PurchaseParams } from "./entities/purchase-params";
-import { type HttpConfig } from "./entities/http-config";
+import { defaultHttpConfig, type HttpConfig } from "./entities/http-config";
 
 export type {
   Offering,
@@ -131,7 +131,7 @@ export class Purchases {
   static configure(
     apiKey: string,
     appUserId: string,
-    httpConfig?: HttpConfig,
+    httpConfig: HttpConfig = defaultHttpConfig,
   ): Purchases {
     if (Purchases.instance !== undefined) {
       Logger.warnLog(
@@ -149,11 +149,11 @@ export class Purchases {
   private constructor(
     apiKey: string,
     appUserId: string,
-    httpConfig?: HttpConfig,
+    httpConfig: HttpConfig = defaultHttpConfig,
   ) {
     this._API_KEY = apiKey;
     this._appUserId = appUserId;
-    this._httpConfig = httpConfig ? httpConfig : { includeCredentials: false };
+    this._httpConfig = httpConfig;
 
     if (RC_ENDPOINT === undefined) {
       Logger.errorLog(

--- a/src/main.ts
+++ b/src/main.ts
@@ -79,9 +79,6 @@ export class Purchases {
   private _appUserId: string;
 
   /** @internal */
-  private _httpConfig: HttpConfig;
-
-  /** @internal */
   private readonly backend: Backend;
 
   /** @internal */
@@ -153,7 +150,6 @@ export class Purchases {
   ) {
     this._API_KEY = apiKey;
     this._appUserId = appUserId;
-    this._httpConfig = httpConfig;
 
     if (RC_ENDPOINT === undefined) {
       Logger.errorLog(
@@ -163,7 +159,7 @@ export class Purchases {
     if (isSandboxApiKey(apiKey)) {
       Logger.debugLog("Initializing Purchases SDK with sandbox API Key");
     }
-    this.backend = new Backend(this._API_KEY, this._httpConfig);
+    this.backend = new Backend(this._API_KEY, httpConfig);
     this.purchaseOperationHelper = new PurchaseOperationHelper(this.backend);
   }
 

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -13,13 +13,13 @@ import { type SubscribeResponse } from "./responses/subscribe-response";
 import { type ProductsResponse } from "./responses/products-response";
 import { type BrandingInfoResponse } from "./responses/branding-response";
 import { type CheckoutStatusResponse } from "./responses/checkout-status-response";
-import { type HttpConfig } from "../entities/http-config";
+import { defaultHttpConfig, type HttpConfig } from "../entities/http-config";
 
 export class Backend {
   private readonly API_KEY: string;
   private readonly httpConfig: HttpConfig;
 
-  constructor(API_KEY: string, httpConfig: HttpConfig) {
+  constructor(API_KEY: string, httpConfig: HttpConfig = defaultHttpConfig) {
     this.API_KEY = API_KEY;
     this.httpConfig = httpConfig;
   }

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -13,25 +13,34 @@ import { type SubscribeResponse } from "./responses/subscribe-response";
 import { type ProductsResponse } from "./responses/products-response";
 import { type BrandingInfoResponse } from "./responses/branding-response";
 import { type CheckoutStatusResponse } from "./responses/checkout-status-response";
+import { type HttpConfig } from "../entities/http-config";
 
 export class Backend {
   private readonly API_KEY: string;
+  private readonly httpConfig: HttpConfig;
 
-  constructor(API_KEY: string) {
+  constructor(API_KEY: string, httpConfig: HttpConfig) {
     this.API_KEY = API_KEY;
+    this.httpConfig = httpConfig;
   }
 
   async getOfferings(appUserId: string): Promise<OfferingsResponse> {
     return await performRequest<null, OfferingsResponse>(
       new GetOfferingsEndpoint(appUserId),
-      this.API_KEY,
+      {
+        apiKey: this.API_KEY,
+        includeCredentials: this.httpConfig.includeCredentials,
+      },
     );
   }
 
   async getCustomerInfo(appUserId: string): Promise<SubscriberResponse> {
     return await performRequest<null, SubscriberResponse>(
       new GetCustomerInfoEndpoint(appUserId),
-      this.API_KEY,
+      {
+        apiKey: this.API_KEY,
+        includeCredentials: this.httpConfig.includeCredentials,
+      },
     );
   }
 
@@ -41,14 +50,20 @@ export class Backend {
   ): Promise<ProductsResponse> {
     return await performRequest<null, ProductsResponse>(
       new GetProductsEndpoint(appUserId, productIds),
-      this.API_KEY,
+      {
+        apiKey: this.API_KEY,
+        includeCredentials: this.httpConfig.includeCredentials,
+      },
     );
   }
 
   async getBrandingInfo(): Promise<BrandingInfoResponse> {
     return await performRequest<null, BrandingInfoResponse>(
       new GetBrandingInfoEndpoint(),
-      this.API_KEY,
+      {
+        apiKey: this.API_KEY,
+        includeCredentials: this.httpConfig.includeCredentials,
+      },
     );
   }
 
@@ -80,8 +95,11 @@ export class Backend {
 
     return await performRequest<SubscribeRequestBody, SubscribeResponse>(
       new SubscribeEndpoint(),
-      this.API_KEY,
-      requestBody,
+      {
+        apiKey: this.API_KEY,
+        body: requestBody,
+        includeCredentials: this.httpConfig.includeCredentials,
+      },
     );
   }
 
@@ -90,7 +108,10 @@ export class Backend {
   ): Promise<CheckoutStatusResponse> {
     return await performRequest<null, CheckoutStatusResponse>(
       new GetCheckoutStatusEndpoint(operationSessionId),
-      this.API_KEY,
+      {
+        apiKey: this.API_KEY,
+        includeCredentials: this.httpConfig.includeCredentials,
+      },
     );
   }
 }

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -29,7 +29,7 @@ export class Backend {
       new GetOfferingsEndpoint(appUserId),
       {
         apiKey: this.API_KEY,
-        includeCredentials: this.httpConfig.includeCredentials,
+        httpConfig: this.httpConfig,
       },
     );
   }
@@ -39,7 +39,7 @@ export class Backend {
       new GetCustomerInfoEndpoint(appUserId),
       {
         apiKey: this.API_KEY,
-        includeCredentials: this.httpConfig.includeCredentials,
+        httpConfig: this.httpConfig,
       },
     );
   }
@@ -52,7 +52,7 @@ export class Backend {
       new GetProductsEndpoint(appUserId, productIds),
       {
         apiKey: this.API_KEY,
-        includeCredentials: this.httpConfig.includeCredentials,
+        httpConfig: this.httpConfig,
       },
     );
   }
@@ -62,7 +62,7 @@ export class Backend {
       new GetBrandingInfoEndpoint(),
       {
         apiKey: this.API_KEY,
-        includeCredentials: this.httpConfig.includeCredentials,
+        httpConfig: this.httpConfig,
       },
     );
   }
@@ -98,7 +98,7 @@ export class Backend {
       {
         apiKey: this.API_KEY,
         body: requestBody,
-        includeCredentials: this.httpConfig.includeCredentials,
+        httpConfig: this.httpConfig,
       },
     );
   }
@@ -110,7 +110,7 @@ export class Backend {
       new GetCheckoutStatusEndpoint(operationSessionId),
       {
         apiKey: this.API_KEY,
-        includeCredentials: this.httpConfig.includeCredentials,
+        httpConfig: this.httpConfig,
       },
     );
   }

--- a/src/networking/http-client.ts
+++ b/src/networking/http-client.ts
@@ -109,6 +109,8 @@ function getHeaders(
     all_headers = { ...all_headers, ...headers };
   }
   if (additionalHeaders) {
+    // The order here is intentional, so we don't allow overriding the SDK
+    // headers with additional headers.
     all_headers = { ...additionalHeaders, ...all_headers };
   }
   return all_headers;

--- a/src/networking/http-client.ts
+++ b/src/networking/http-client.ts
@@ -9,15 +9,23 @@ import { VERSION } from "../helpers/constants";
 import { StatusCodes } from "http-status-codes";
 import { isSandboxApiKey } from "../helpers/api-key-helper";
 
+interface HttpRequestConfig<RequestBody> {
+  apiKey: string;
+  body?: RequestBody;
+  headers?: { [key: string]: string };
+  includeCredentials?: boolean;
+}
+
 export async function performRequest<RequestBody, ResponseType>(
   endpoint: SupportedEndpoint,
-  apiKey: string,
-  body?: RequestBody,
-  headers?: { [key: string]: string },
+  config: HttpRequestConfig<RequestBody>,
 ): Promise<ResponseType> {
+  const { apiKey, body, headers, includeCredentials } = config;
+
   try {
     const response = await fetch(endpoint.url(), {
       method: endpoint.method,
+      credentials: includeCredentials ? "include" : "omit",
       headers: getHeaders(apiKey, headers),
       body: getBody(body),
     });

--- a/src/networking/http-client.ts
+++ b/src/networking/http-client.ts
@@ -26,7 +26,6 @@ export async function performRequest<RequestBody, ResponseType>(
   try {
     const response = await fetch(endpoint.url(), {
       method: endpoint.method,
-      credentials: httpConfig?.includeCredentials ? "include" : "omit",
       headers: getHeaders(apiKey, headers, httpConfig?.additionalHeaders),
       body: getBody(body),
     });

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -37,7 +37,7 @@ describe("httpConfig is setup correctly", () => {
     );
   }
 
-  test("credentials is omit by default", async () => {
+  test("credentials is `omit` by default", async () => {
     setCustomerInfoResponse(
       HttpResponse.json(customerInfoResponse, { status: 200 }),
     );
@@ -51,7 +51,7 @@ describe("httpConfig is setup correctly", () => {
     expect(requestPerformed?.credentials).toEqual("omit");
   });
 
-  test("credentials is include if passing httpConfig parameter", async () => {
+  test("credentials is `include` if passing httpConfig parameter", async () => {
     setCustomerInfoResponse(
       HttpResponse.json(customerInfoResponse, { status: 200 }),
     );

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -37,35 +37,6 @@ describe("httpConfig is setup correctly", () => {
     );
   }
 
-  test("credentials is `omit` by default", async () => {
-    setCustomerInfoResponse(
-      HttpResponse.json(customerInfoResponse, { status: 200 }),
-    );
-
-    let requestPerformed: Request | undefined;
-    server.events.on("request:start", (req) => {
-      requestPerformed = req.request;
-    });
-    await backend.getCustomerInfo("someAppUserId");
-    expect(requestPerformed).not.toBeNull();
-    expect(requestPerformed?.credentials).toEqual("omit");
-  });
-
-  test("credentials is `include` if passing httpConfig parameter", async () => {
-    setCustomerInfoResponse(
-      HttpResponse.json(customerInfoResponse, { status: 200 }),
-    );
-
-    let requestPerformed: Request | undefined;
-    server.events.on("request:start", (req) => {
-      requestPerformed = req.request;
-    });
-    backend = new Backend("test_api_key", { includeCredentials: true });
-    await backend.getCustomerInfo("someAppUserId");
-    expect(requestPerformed).not.toBeNull();
-    expect(requestPerformed?.credentials).toEqual("include");
-  });
-
   test("additionalHeaders are included correctly", async () => {
     setCustomerInfoResponse(
       HttpResponse.json(customerInfoResponse, { status: 200 }),


### PR DESCRIPTION
## Motivation / Description
This adds support for adding additional headers to all http requests. This can be useful in some situations like when specifying a proxy url (to handle the connections yourself)

## Changes introduced

## Linear ticket (if any)

## Additional comments
