### PR TITLE
Add support for `proxyURL` to redirect requests

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -1567,6 +1567,33 @@
                 "startIndex": 1,
                 "endIndex": 3
               }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!HttpConfig#proxyURL:member",
+              "docComment": "/**\n * Set this property to your proxy URL *only* if you've received a proxy key value from your RevenueCat contact. This value should never end with a trailing slash.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "proxyURL?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "proxyURL",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
             }
           ],
           "extendsTokenRanges": []

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -110,6 +110,7 @@ export enum ErrorCode {
 // @public
 export interface HttpConfig {
     additionalHeaders?: Record<string, string>;
+    proxyURL?: string;
 }
 
 // @public

--- a/src/entities/http-config.ts
+++ b/src/entities/http-config.ts
@@ -7,6 +7,12 @@ export interface HttpConfig {
    * Additional headers to include in all HTTP requests.
    */
   additionalHeaders?: Record<string, string>;
+  /**
+   * Set this property to your proxy URL *only* if you've received a proxy
+   * key value from your RevenueCat contact. This value should never end with
+   * a trailing slash.
+   */
+  proxyURL?: string;
 }
 
 export const defaultHttpConfig = {};

--- a/src/helpers/configuration-validators.ts
+++ b/src/helpers/configuration-validators.ts
@@ -33,3 +33,12 @@ export function validateAppUserId(appUserId: string) {
     );
   }
 }
+
+export function validateProxyUrl(proxyUrl?: string) {
+  if (proxyUrl?.endsWith("/")) {
+    throw new PurchasesError(
+      ErrorCode.ConfigurationError,
+      "Invalid proxy URL. The proxy URL should not end with a trailing slash.",
+    );
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,7 @@ import { Logger } from "./helpers/logger";
 import {
   validateApiKey,
   validateAppUserId,
+  validateProxyUrl,
 } from "./helpers/configuration-validators";
 import { type PurchaseParams } from "./entities/purchase-params";
 import { defaultHttpConfig, type HttpConfig } from "./entities/http-config";
@@ -138,6 +139,7 @@ export class Purchases {
     }
     validateApiKey(apiKey);
     validateAppUserId(appUserId);
+    validateProxyUrl(httpConfig.proxyURL);
     Purchases.instance = new Purchases(apiKey, appUserId, httpConfig);
     return Purchases.getSharedInstance();
   }

--- a/src/networking/endpoints.ts
+++ b/src/networking/endpoints.ts
@@ -1,5 +1,3 @@
-import { RC_ENDPOINT } from "../helpers/constants";
-
 type HttpMethodType = "GET" | "POST";
 
 const SUBSCRIBERS_PATH = "/v1/subscribers";
@@ -8,7 +6,7 @@ const RC_BILLING_PATH = "/rcbilling/v1";
 interface Endpoint {
   method: HttpMethodType;
   name: string;
-  url(): string;
+  urlPath(): string;
 }
 
 export class GetOfferingsEndpoint implements Endpoint {
@@ -21,9 +19,9 @@ export class GetOfferingsEndpoint implements Endpoint {
   method: HttpMethodType = "GET";
   name: string = "getOfferings";
 
-  url(): string {
+  urlPath(): string {
     const encodedAppUserId = encodeURIComponent(this.appUserId);
-    return `${RC_ENDPOINT}${SUBSCRIBERS_PATH}/${encodedAppUserId}/offerings`;
+    return `${SUBSCRIBERS_PATH}/${encodedAppUserId}/offerings`;
   }
 }
 
@@ -31,8 +29,8 @@ export class SubscribeEndpoint implements Endpoint {
   method: HttpMethodType = "POST";
   name: string = "subscribe";
 
-  url(): string {
-    return `${RC_ENDPOINT}${RC_BILLING_PATH}/subscribe`;
+  urlPath(): string {
+    return `${RC_BILLING_PATH}/subscribe`;
   }
 }
 
@@ -47,12 +45,12 @@ export class GetProductsEndpoint implements Endpoint {
     this.productIds = productIds;
   }
 
-  url(): string {
+  urlPath(): string {
     const encodedAppUserId = encodeURIComponent(this.appUserId);
     const encodedProductIds = this.productIds
       .map(encodeURIComponent)
       .join("&id=");
-    return `${RC_ENDPOINT}${RC_BILLING_PATH}/subscribers/${encodedAppUserId}/products?id=${encodedProductIds}`;
+    return `${RC_BILLING_PATH}/subscribers/${encodedAppUserId}/products?id=${encodedProductIds}`;
   }
 }
 
@@ -65,9 +63,9 @@ export class GetCustomerInfoEndpoint implements Endpoint {
     this.appUserId = appUserId;
   }
 
-  url(): string {
+  urlPath(): string {
     const encodedAppUserId = encodeURIComponent(this.appUserId);
-    return `${RC_ENDPOINT}${SUBSCRIBERS_PATH}/${encodedAppUserId}`;
+    return `${SUBSCRIBERS_PATH}/${encodedAppUserId}`;
   }
 }
 
@@ -75,8 +73,8 @@ export class GetBrandingInfoEndpoint implements Endpoint {
   method: HttpMethodType = "GET";
   name: string = "getBrandingInfo";
 
-  url(): string {
-    return `${RC_ENDPOINT}${RC_BILLING_PATH}/branding`;
+  urlPath(): string {
+    return `${RC_BILLING_PATH}/branding`;
   }
 }
 
@@ -89,8 +87,8 @@ export class GetCheckoutStatusEndpoint implements Endpoint {
     this.operationSessionId = operationSessionId;
   }
 
-  url(): string {
-    return `${RC_ENDPOINT}${RC_BILLING_PATH}/checkout/${this.operationSessionId}`;
+  urlPath(): string {
+    return `${RC_BILLING_PATH}/checkout/${this.operationSessionId}`;
   }
 }
 

--- a/src/networking/http-client.ts
+++ b/src/networking/http-client.ts
@@ -5,7 +5,7 @@ import {
   ErrorCodeUtils,
   PurchasesError,
 } from "../entities/errors";
-import { VERSION } from "../helpers/constants";
+import { RC_ENDPOINT, VERSION } from "../helpers/constants";
 import { StatusCodes } from "http-status-codes";
 import { isSandboxApiKey } from "../helpers/api-key-helper";
 import type { HttpConfig } from "../entities/http-config";
@@ -22,9 +22,11 @@ export async function performRequest<RequestBody, ResponseType>(
   config: HttpRequestConfig<RequestBody>,
 ): Promise<ResponseType> {
   const { apiKey, body, headers, httpConfig } = config;
+  const baseUrl = httpConfig?.proxyURL ?? RC_ENDPOINT;
+  const url = `${baseUrl}${endpoint.urlPath()}`;
 
   try {
-    const response = await fetch(endpoint.url(), {
+    const response = await fetch(url, {
       method: endpoint.method,
       headers: getHeaders(apiKey, headers, httpConfig?.additionalHeaders),
       body: getBody(body),

--- a/src/tests/networking/endpoints.test.ts
+++ b/src/tests/networking/endpoints.test.ts
@@ -15,17 +15,15 @@ describe("getOfferings endpoint", () => {
     expect(endpoint.method).toBe("GET");
   });
 
-  test("has correct url for common app user id", () => {
-    expect(endpoint.url()).toBe(
-      "http://localhost:8000/v1/subscribers/someAppUserId/offerings",
-    );
+  test("has correct urlPath for common app user id", () => {
+    expect(endpoint.urlPath()).toBe("/v1/subscribers/someAppUserId/offerings");
   });
 
   test("correctly encodes app user id", () => {
     expect(
-      new GetOfferingsEndpoint("some+User/id#That$Requires&Encoding").url(),
+      new GetOfferingsEndpoint("some+User/id#That$Requires&Encoding").urlPath(),
     ).toBe(
-      "http://localhost:8000/v1/subscribers/some%2BUser%2Fid%23That%24Requires%26Encoding/offerings",
+      "/v1/subscribers/some%2BUser%2Fid%23That%24Requires%26Encoding/offerings",
     );
   });
 });
@@ -37,8 +35,8 @@ describe("subscribe endpoint", () => {
     expect(endpoint.method).toBe("POST");
   });
 
-  test("has correct path", () => {
-    expect(endpoint.url()).toBe("http://localhost:8000/rcbilling/v1/subscribe");
+  test("has correct urlPath", () => {
+    expect(endpoint.urlPath()).toBe("/rcbilling/v1/subscribe");
   });
 });
 
@@ -52,9 +50,9 @@ describe("getProducts endpoint", () => {
     expect(endpoint.method).toBe("GET");
   });
 
-  test("has correct path for common app user id", () => {
-    expect(endpoint.url()).toBe(
-      "http://localhost:8000/rcbilling/v1/subscribers/someAppUserId/products?id=monthly&id=annual",
+  test("has correct urlPath for common app user id", () => {
+    expect(endpoint.urlPath()).toBe(
+      "/rcbilling/v1/subscribers/someAppUserId/products?id=monthly&id=annual",
     );
   });
 
@@ -63,9 +61,9 @@ describe("getProducts endpoint", () => {
       new GetProductsEndpoint("some+User/id#That$Requires&Encoding", [
         "product+id/That$requires!Encoding",
         "productIdWithoutEncoding",
-      ]).url(),
+      ]).urlPath(),
     ).toBe(
-      "http://localhost:8000/rcbilling/v1/subscribers/some%2BUser%2Fid%23That%24Requires%26Encoding/products?id=product%2Bid%2FThat%24requires!Encoding&id=productIdWithoutEncoding",
+      "/rcbilling/v1/subscribers/some%2BUser%2Fid%23That%24Requires%26Encoding/products?id=product%2Bid%2FThat%24requires!Encoding&id=productIdWithoutEncoding",
     );
   });
 });
@@ -77,18 +75,16 @@ describe("getCustomerInfo endpoint", () => {
     expect(endpoint.method).toBe("GET");
   });
 
-  test("has correct path for common app user id", () => {
-    expect(endpoint.url()).toBe(
-      "http://localhost:8000/v1/subscribers/someAppUserId",
-    );
+  test("has correct urlPath for common app user id", () => {
+    expect(endpoint.urlPath()).toBe("/v1/subscribers/someAppUserId");
   });
 
   test("correctly encodes app user id", () => {
     expect(
-      new GetCustomerInfoEndpoint("some+User/id#That$Requires&Encoding").url(),
-    ).toBe(
-      "http://localhost:8000/v1/subscribers/some%2BUser%2Fid%23That%24Requires%26Encoding",
-    );
+      new GetCustomerInfoEndpoint(
+        "some+User/id#That$Requires&Encoding",
+      ).urlPath(),
+    ).toBe("/v1/subscribers/some%2BUser%2Fid%23That%24Requires%26Encoding");
   });
 });
 
@@ -99,8 +95,8 @@ describe("getBrandingInfo endpoint", () => {
     expect(endpoint.method).toBe("GET");
   });
 
-  test("has correct path", () => {
-    expect(endpoint.url()).toBe("http://localhost:8000/rcbilling/v1/branding");
+  test("has correct urlPath", () => {
+    expect(endpoint.urlPath()).toBe("/rcbilling/v1/branding");
   });
 });
 
@@ -111,9 +107,9 @@ describe("getCheckoutStatus endpoint", () => {
     expect(endpoint.method).toBe("GET");
   });
 
-  test("has correct path", () => {
-    expect(endpoint.url()).toBe(
-      "http://localhost:8000/rcbilling/v1/checkout/someOperationSessionId",
+  test("has correct urlPath", () => {
+    expect(endpoint.urlPath()).toBe(
+      "/rcbilling/v1/checkout/someOperationSessionId",
     );
   });
 });


### PR DESCRIPTION
## Motivation / Description
This adds a new property that can be set as part of the `httpConfig` during the `configure` method. This will be used as the base url for all backend requests performed by the SDK.

## Changes introduced

## Linear ticket (if any)

## Additional comments
