### PR TITLE
[Behavior change] Fail configuration if trying to add additional headers that are reserved for SDK

### DIFF
--- a/src/helpers/configuration-validators.ts
+++ b/src/helpers/configuration-validators.ts
@@ -1,4 +1,5 @@
 import { ErrorCode, PurchasesError } from "../entities/errors";
+import { SDK_HEADERS } from "../networking/http-client";
 
 export function validateApiKey(apiKey: string) {
   const api_key_regex = /^rcb_[a-zA-Z0-9_.-]+$/;
@@ -40,5 +41,20 @@ export function validateProxyUrl(proxyUrl?: string) {
       ErrorCode.ConfigurationError,
       "Invalid proxy URL. The proxy URL should not end with a trailing slash.",
     );
+  }
+}
+
+export function validateAdditionalHeaders(
+  additionalHeaders?: Record<string, string>,
+) {
+  if (additionalHeaders) {
+    for (const header in additionalHeaders) {
+      if (SDK_HEADERS.has(header)) {
+        throw new PurchasesError(
+          ErrorCode.ConfigurationError,
+          `Invalid additional headers. Some headers are reserved for internal use.`,
+        );
+      }
+    }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,7 @@ import {
 import { type LogLevel } from "./entities/log-level";
 import { Logger } from "./helpers/logger";
 import {
+  validateAdditionalHeaders,
   validateApiKey,
   validateAppUserId,
   validateProxyUrl,
@@ -140,6 +141,7 @@ export class Purchases {
     validateApiKey(apiKey);
     validateAppUserId(appUserId);
     validateProxyUrl(httpConfig.proxyURL);
+    validateAdditionalHeaders(httpConfig.additionalHeaders);
     Purchases.instance = new Purchases(apiKey, appUserId, httpConfig);
     return Purchases.getSharedInstance();
   }

--- a/src/networking/http-client.ts
+++ b/src/networking/http-client.ts
@@ -93,18 +93,34 @@ function getBody<RequestBody>(body?: RequestBody): string | null {
   }
 }
 
+const AUTHORIZATION_HEADER = "Authorization";
+const CONTENT_TYPE_HEADER = "Content-Type";
+const ACCEPT_HEADER = "Accept";
+const PLATFORM_HEADER = "X-Platform";
+const VERSION_HEADER = "X-Version";
+const IS_SANDBOX_HEADER = "X-Is-Sandbox";
+
+export const SDK_HEADERS = new Set([
+  AUTHORIZATION_HEADER,
+  CONTENT_TYPE_HEADER,
+  ACCEPT_HEADER,
+  PLATFORM_HEADER,
+  VERSION_HEADER,
+  IS_SANDBOX_HEADER,
+]);
+
 function getHeaders(
   apiKey: string,
   headers?: { [key: string]: string },
   additionalHeaders?: { [key: string]: string },
 ): { [key: string]: string } {
   let all_headers = {
-    Authorization: `Bearer ${apiKey}`,
-    "Content-Type": "application/json",
-    Accept: "application/json",
-    "X-Platform": "web",
-    "X-Version": VERSION,
-    "X-Is-Sandbox": `${isSandboxApiKey(apiKey)}`,
+    [AUTHORIZATION_HEADER]: `Bearer ${apiKey}`,
+    [CONTENT_TYPE_HEADER]: "application/json",
+    [ACCEPT_HEADER]: "application/json",
+    [PLATFORM_HEADER]: "web",
+    [VERSION_HEADER]: VERSION,
+    [IS_SANDBOX_HEADER]: `${isSandboxApiKey(apiKey)}`,
   };
   if (headers) {
     all_headers = { ...all_headers, ...headers };

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -52,6 +52,22 @@ describe("Purchases.configure()", () => {
     ).toThrowError(PurchasesError);
   });
 
+  test("throws error if given invalid proxy url", () => {
+    expect(() =>
+      Purchases.configure(testApiKey, testUserId, {
+        proxyURL: "https://test.revenuecat.com/",
+      }),
+    ).toThrowError(PurchasesError);
+  });
+
+  test("throws error if given reserved additional header", () => {
+    expect(() =>
+      Purchases.configure(testApiKey, testUserId, {
+        additionalHeaders: { "X-Version": "123" },
+      }),
+    ).toThrowError(PurchasesError);
+  });
+
   test("configures successfully", () => {
     const purchases = Purchases.configure(testApiKey, testUserId);
     expect(purchases).toBeDefined();


### PR DESCRIPTION
## Motivation / Description
This is a behavior change. If trying to set additional headers that are reserved for the SDK, the `Purchases.configure` call will fail.

## Changes introduced

## Linear ticket (if any)

## Additional comments
