### PR TITLE
Change modal border radius to 16px

### DIFF
--- a/src/ui/modal.svelte
+++ b/src/ui/modal.svelte
@@ -15,7 +15,7 @@
 
   .rcb-modal-main {
     box-sizing: border-box;
-    border-radius: 8px;
+    border-radius: 16px;
     background-color: var(--rc-color-white);
     color: var(--rc-color-grey-text-dark);
     min-height: 460px;


### PR DESCRIPTION
## Motivation / Description
The border radius of modals was not consistent with the designs (8px instead of 16px); this changes that

## Changes introduced

## Linear ticket (if any)
https://revenuecat.slack.com/archives/C05TUASTSG4/p1721591753803999

## Additional comments
