### PR TITLE
Improve formatted price calculation

### DIFF
--- a/examples/rcbilling-demo/src/tests/main.test.ts
+++ b/examples/rcbilling-demo/src/tests/main.test.ts
@@ -14,7 +14,7 @@ test.describe("Main", () => {
     // Gets all elements that match the selector
     const packageCards = await getAllElementsByLocator(page, CARD_SELECTOR);
 
-    const EXPECTED_VALUES = [/30\.00/, /19\.99/, /15\.00/];
+    const EXPECTED_VALUES = [/30[,.]00/, /19[,.]99/, /15[,.]00/];
 
     await Promise.all(
       packageCards.map(

--- a/src/helpers/price-labels.ts
+++ b/src/helpers/price-labels.ts
@@ -10,9 +10,13 @@ export const priceLabels: Record<string, string> = {
   P1W: "weekly",
 };
 
-export const formatPrice = (priceInCents: number, currency: string): string => {
+export const formatPrice = (
+  priceInCents: number,
+  currency: string,
+  locale?: string,
+): string => {
   const price = priceInCents / 100;
-  const formatter = new Intl.NumberFormat("en-US", {
+  const formatter = new Intl.NumberFormat(locale, {
     style: "currency",
     currency,
   });

--- a/src/tests/helpers/price-labels.test.ts
+++ b/src/tests/helpers/price-labels.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { getRenewsLabel } from "../../helpers/price-labels";
+import { formatPrice, getRenewsLabel } from "../../helpers/price-labels";
 
 describe("getRenewsLabel", () => {
   test("should return correct text for single period durations", () => {
@@ -14,5 +14,15 @@ describe("getRenewsLabel", () => {
     expect(getRenewsLabel("P3M")).toEqual("every 3 months");
     expect(getRenewsLabel("P2W")).toEqual("every 2 weeks");
     expect(getRenewsLabel("P14D")).toEqual("every 14 days");
+  });
+});
+
+describe("formatPrice", () => {
+  test("should return expected formatted price", () => {
+    expect(formatPrice(999, "USD")).toEqual("$9.99");
+    expect(formatPrice(1000, "USD")).toEqual("$10.00");
+    expect(formatPrice(999, "EUR")).toEqual("€9.99");
+    expect(formatPrice(999, "EUR", "en-US")).toEqual("€9.99");
+    expect(formatPrice(999, "USD", "es-ES")).toEqual("9,99 US$");
   });
 });

--- a/src/tests/helpers/price-labels.test.ts
+++ b/src/tests/helpers/price-labels.test.ts
@@ -19,10 +19,12 @@ describe("getRenewsLabel", () => {
 
 describe("formatPrice", () => {
   test("should return expected formatted price", () => {
-    expect(formatPrice(999, "USD")).toEqual("$9.99");
-    expect(formatPrice(1000, "USD")).toEqual("$10.00");
-    expect(formatPrice(999, "EUR")).toEqual("€9.99");
+    expect(formatPrice(999, "USD", "en-US")).toEqual("$9.99");
+    expect(formatPrice(1000, "USD", "en-US")).toEqual("$10.00");
+    expect(formatPrice(99, "USD", "en-US")).toEqual("$0.99");
     expect(formatPrice(999, "EUR", "en-US")).toEqual("€9.99");
     expect(formatPrice(999, "USD", "es-ES")).toEqual("9,99 US$");
+    expect(formatPrice(999, "CNY", "en-US")).toEqual("CN¥9.99");
+    expect(formatPrice(999, "CNY", "zh-CN")).toEqual("¥9.99");
   });
 });

--- a/src/ui/states/state-present-offer.svelte
+++ b/src/ui/states/state-present-offer.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import ModalSection from "../modal-section.svelte";
-    import {formatPrice, getRenewsLabel} from "../../helpers/price-labels";
-    import {getTrialsLabel} from "../../helpers/price-labels.js";
+    import { getRenewsLabel, getTrialsLabel } from "../../helpers/price-labels";
     import type { Product, PurchaseOption, SubscriptionOption } from "../../entities/offerings";
 
     export let productDetails: Product;

--- a/src/ui/states/state-present-offer.svelte
+++ b/src/ui/states/state-present-offer.svelte
@@ -22,19 +22,14 @@
                 {getTrialsLabel(trial.periodDuration)} free trial
             {/if}
             {#if !trial?.periodDuration && basePrice }
-                {basePrice.currency || ''} {formatPrice(
-                    basePrice.amount,
-                    basePrice.currency,
-                )}
+                {basePrice.currency || ''} {basePrice.formattedPrice}
             {/if}
 
         </span>
         {#if (trial && basePrice)}
             <span class="rcb-product-price-after-trial">
-                {trial && basePrice && `${basePrice.currency} ${formatPrice(
-                  basePrice.amount,
-                  basePrice.currency,
-                )} after end of trial`}
+                {trial && basePrice && `${basePrice.currency} ${
+                    basePrice.formattedPrice} after end of trial`}
             </span>
         {/if}
         <ul class="rcb-product-details">


### PR DESCRIPTION
## Motivation / Description
Some changes to the formatted price calculation in preparatio for multi-currency
- Removes hardcoded `en-US` locale. Now we will leave `Intl` to get the locale
- Cleanup to use `formattedPrice` instead of calculating it again.

## Changes introduced

## Linear ticket (if any)

## Additional comments
