### PR TITLE
Parse `price_id` and pass it back on subscribe

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -3127,6 +3127,34 @@
             },
             {
               "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!Product#defaultPurchaseOption:member",
+              "docComment": "/**\n * The default purchase option for this product.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly defaultPurchaseOption: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PurchaseOption",
+                  "canonicalReference": "@revenuecat/purchases-js!PurchaseOption:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "defaultPurchaseOption",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
               "canonicalReference": "@revenuecat/purchases-js!Product#defaultSubscriptionOption:member",
               "docComment": "/**\n * The default subscription option for this product. Null if no subscription options are available like in the case of consumables and non-consumables.\n */\n",
               "excerptTokens": [
@@ -3423,6 +3451,33 @@
               "isOptional": false,
               "releaseTag": "Public",
               "name": "id",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PurchaseOption#priceId:member",
+              "docComment": "/**\n * The public price id for this subscription option.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly priceId: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "priceId",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -221,6 +221,7 @@ export interface PricingPhase {
 // @public
 export interface Product {
     readonly currentPrice: Price;
+    readonly defaultPurchaseOption: PurchaseOption;
     readonly defaultSubscriptionOption: SubscriptionOption | null;
     readonly description: string | null;
     // @deprecated
@@ -239,6 +240,7 @@ export interface Product {
 // @public
 export interface PurchaseOption {
     readonly id: string;
+    readonly priceId: string;
 }
 
 // @public

--- a/src/entities/offerings.ts
+++ b/src/entities/offerings.ts
@@ -4,8 +4,8 @@ import {
   type TargetingResponse,
 } from "../networking/responses/offerings-response";
 import {
-  type ProductResponse,
   type PricingPhaseResponse,
+  type ProductResponse,
   type SubscriptionOptionResponse,
 } from "../networking/responses/products-response";
 import { notEmpty } from "../helpers/type-helper";
@@ -112,6 +112,10 @@ export interface PurchaseOption {
    * The unique id for a purchase option
    */
   readonly id: string;
+  /**
+   * The public price id for this subscription option.
+   */
+  readonly priceId: string;
 }
 
 /**
@@ -202,6 +206,10 @@ export interface Product {
    * The context from which this product was obtained.
    */
   readonly presentedOfferingContext: PresentedOfferingContext;
+  /**
+   * The default purchase option for this product.
+   */
+  readonly defaultPurchaseOption: PurchaseOption;
   /**
    * The default subscription option for this product. Null if no subscription
    * options are available like in the case of consumables and non-consumables.
@@ -338,6 +346,7 @@ const toSubscriptionOption = (
   }
   return {
     id: option.id,
+    priceId: option.price_id,
     base: toPricingPhase(option.base),
     trial: option.trial ? toPricingPhase(option.trial) : null,
   } as SubscriptionOption;
@@ -394,6 +403,7 @@ const toProduct = (
     normalPeriodDuration: defaultOption.base.periodDuration,
     presentedOfferingIdentifier: presentedOfferingContext.offeringIdentifier,
     presentedOfferingContext: presentedOfferingContext,
+    defaultPurchaseOption: defaultOption,
     defaultSubscriptionOption: defaultOption,
     subscriptionOptions: options,
   };

--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -67,7 +67,7 @@ export class PurchaseOperationHelper {
   async startPurchase(
     appUserId: string,
     productId: string,
-    purchaseOption: PurchaseOption | null | undefined,
+    purchaseOption: PurchaseOption,
     email: string,
     presentedOfferingContext: PresentedOfferingContext,
   ): Promise<SubscribeResponse> {
@@ -77,7 +77,7 @@ export class PurchaseOperationHelper {
         productId,
         email,
         presentedOfferingContext,
-        purchaseOption?.id,
+        purchaseOption,
       );
       this.operationSessionId = subscribeResponse.operation_session_id;
       return subscribeResponse;

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -14,7 +14,10 @@ import { type ProductsResponse } from "./responses/products-response";
 import { type BrandingInfoResponse } from "./responses/branding-response";
 import { type CheckoutStatusResponse } from "./responses/checkout-status-response";
 import { defaultHttpConfig, type HttpConfig } from "../entities/http-config";
-import { type PresentedOfferingContext } from "../entities/offerings";
+import type {
+  PresentedOfferingContext,
+  PurchaseOption,
+} from "../entities/offerings";
 
 export class Backend {
   private readonly API_KEY: string;
@@ -74,7 +77,7 @@ export class Backend {
     productId: string,
     email: string,
     presentedOfferingContext: PresentedOfferingContext,
-    purchaseOptionId?: string,
+    purchaseOption: PurchaseOption,
   ): Promise<SubscribeResponse> {
     type SubscribeRequestBody = {
       app_user_id: string;
@@ -82,6 +85,7 @@ export class Backend {
       email: string;
       presented_offering_identifier: string;
       offer_id?: string;
+      price_id: string;
       applied_targeting_rule?: {
         rule_id: string;
         revision: number;
@@ -92,12 +96,13 @@ export class Backend {
       app_user_id: appUserId,
       product_id: productId,
       email: email,
+      price_id: purchaseOption.priceId,
       presented_offering_identifier:
         presentedOfferingContext.offeringIdentifier,
     };
 
-    if (purchaseOptionId && purchaseOptionId !== "base_option") {
-      requestBody.offer_id = purchaseOptionId;
+    if (purchaseOption.id !== "base_option") {
+      requestBody.offer_id = purchaseOption.id;
     }
 
     if (presentedOfferingContext.targetingContext) {

--- a/src/networking/responses/products-response.ts
+++ b/src/networking/responses/products-response.ts
@@ -11,6 +11,7 @@ export interface PricingPhaseResponse {
 
 export interface PurchaseOptionResponse {
   id: string;
+  price_id: string;
 }
 
 export interface SubscriptionOptionResponse extends PurchaseOptionResponse {

--- a/src/tests/helpers/purchase-operation-helper.test.ts
+++ b/src/tests/helpers/purchase-operation-helper.test.ts
@@ -68,7 +68,7 @@ describe("PurchaseOperationHelper", () => {
       purchaseOperationHelper.startPurchase(
         "test-app-user-id",
         "test-product-id",
-        undefined,
+        { id: "test-option-id", priceId: "test-price-id" },
         "test-email",
         { offeringIdentifier: "test-offering-id", targetingContext: null },
       ),
@@ -94,7 +94,7 @@ describe("PurchaseOperationHelper", () => {
       purchaseOperationHelper.startPurchase(
         "test-app-user-id",
         "test-product-id",
-        undefined,
+        { id: "test-option-id", priceId: "test-price-id" },
         "test-email",
         { offeringIdentifier: "test-offering-id", targetingContext: null },
       ),
@@ -129,7 +129,7 @@ describe("PurchaseOperationHelper", () => {
     await purchaseOperationHelper.startPurchase(
       "test-app-user-id",
       "test-product-id",
-      undefined,
+      { id: "test-option-id", priceId: "test-price-id" },
       "test-email",
       { offeringIdentifier: "test-offering-id", targetingContext: null },
     );
@@ -162,7 +162,7 @@ describe("PurchaseOperationHelper", () => {
     await purchaseOperationHelper.startPurchase(
       "test-app-user-id",
       "test-product-id",
-      undefined,
+      { id: "test-option-id", priceId: "test-price-id" },
       "test-email",
       { offeringIdentifier: "test-offering-id", targetingContext: null },
     );
@@ -224,7 +224,7 @@ describe("PurchaseOperationHelper", () => {
     await purchaseOperationHelper.startPurchase(
       "test-app-user-id",
       "test-product-id",
-      undefined,
+      { id: "test-option-id", priceId: "test-price-id" },
       "test-email",
       { offeringIdentifier: "test-offering-id", targetingContext: null },
     );

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -167,6 +167,7 @@ describe("getOfferings", () => {
 
     const subscriptionOption = {
       id: "offer_12345",
+      priceId: "test_price_id",
       base: {
         cycleCount: 1,
         periodDuration: "P1M",
@@ -210,6 +211,7 @@ describe("getOfferings", () => {
           offeringIdentifier: "offering_2",
           targetingContext: null,
         },
+        defaultPurchaseOption: subscriptionOption,
         defaultSubscriptionOption: subscriptionOption,
         subscriptionOptions: {
           offer_12345: subscriptionOption,
@@ -244,6 +246,32 @@ describe("getOfferings", () => {
   test("can get offerings without current offering id", async () => {
     const purchases = configurePurchases("appUserIdWithoutCurrentOfferingId");
     const offerings = await purchases.getOfferings();
+    const subscriptionOption = {
+      id: "offer_12345",
+      priceId: "test_price_id",
+      base: {
+        cycleCount: 1,
+        periodDuration: "P1M",
+        period: {
+          number: 1,
+          unit: PeriodUnit.Month,
+        },
+        price: {
+          amount: 500,
+          currency: "USD",
+          formattedPrice: "$5.00",
+        },
+      },
+      trial: {
+        cycleCount: 1,
+        periodDuration: "P1W",
+        period: {
+          number: 1,
+          unit: PeriodUnit.Week,
+        },
+        price: null,
+      },
+    };
     const package2: Package = {
       identifier: "package_2",
       packageType: PackageType.Custom,
@@ -263,57 +291,10 @@ describe("getOfferings", () => {
           offeringIdentifier: "offering_2",
           targetingContext: null,
         },
-        defaultSubscriptionOption: {
-          id: "offer_12345",
-          base: {
-            cycleCount: 1,
-            periodDuration: "P1M",
-            period: {
-              number: 1,
-              unit: PeriodUnit.Month,
-            },
-            price: {
-              amount: 500,
-              currency: "USD",
-              formattedPrice: "$5.00",
-            },
-          },
-          trial: {
-            cycleCount: 1,
-            periodDuration: "P1W",
-            period: {
-              number: 1,
-              unit: PeriodUnit.Week,
-            },
-            price: null,
-          },
-        },
+        defaultPurchaseOption: subscriptionOption,
+        defaultSubscriptionOption: subscriptionOption,
         subscriptionOptions: {
-          offer_12345: {
-            id: "offer_12345",
-            base: {
-              cycleCount: 1,
-              periodDuration: "P1M",
-              period: {
-                number: 1,
-                unit: PeriodUnit.Month,
-              },
-              price: {
-                amount: 500,
-                currency: "USD",
-                formattedPrice: "$5.00",
-              },
-            },
-            trial: {
-              cycleCount: 1,
-              periodDuration: "P1W",
-              period: {
-                number: 1,
-                unit: PeriodUnit.Week,
-              },
-              price: null,
-            },
-          },
+          offer_12345: subscriptionOption,
         },
       },
     };

--- a/src/tests/mocks/offering-mock-provider.ts
+++ b/src/tests/mocks/offering-mock-provider.ts
@@ -11,6 +11,24 @@ export function createMonthlyPackageMock(
     revision: 123,
   },
 ): Package {
+  const subscriptionOption = {
+    id: "base_option",
+    priceId: "test_price_id",
+    base: {
+      cycleCount: 1,
+      periodDuration: "P1M",
+      period: {
+        number: 1,
+        unit: PeriodUnit.Month,
+      },
+      price: {
+        amount: 300,
+        currency: "USD",
+        formattedPrice: "$3.00",
+      },
+    },
+    trial: null,
+  };
   return {
     identifier: "$rc_monthly",
     packageType: PackageType.Monthly,
@@ -30,41 +48,10 @@ export function createMonthlyPackageMock(
         offeringIdentifier: "offering_1",
         targetingContext: targetingContext,
       },
-      defaultSubscriptionOption: {
-        id: "base_option",
-        base: {
-          cycleCount: 1,
-          periodDuration: "P1M",
-          period: {
-            number: 1,
-            unit: PeriodUnit.Month,
-          },
-          price: {
-            amount: 300,
-            currency: "USD",
-            formattedPrice: "$3.00",
-          },
-        },
-        trial: null,
-      },
+      defaultPurchaseOption: subscriptionOption,
+      defaultSubscriptionOption: subscriptionOption,
       subscriptionOptions: {
-        base_option: {
-          id: "base_option",
-          base: {
-            cycleCount: 1,
-            periodDuration: "P1M",
-            period: {
-              number: 1,
-              unit: PeriodUnit.Month,
-            },
-            price: {
-              amount: 300,
-              currency: "USD",
-              formattedPrice: "$3.00",
-            },
-          },
-          trial: null,
-        },
+        base_option: subscriptionOption,
       },
     },
   };

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -360,7 +360,7 @@ describe("subscribe request", () => {
         "monthly",
         "testemail@revenuecat.com",
         { offeringIdentifier: "offering_1", targetingContext: null },
-        undefined,
+        { id: "base_option", priceId: "test_price_id" },
       ),
     ).toEqual(subscribeResponse);
   });
@@ -375,7 +375,7 @@ describe("subscribe request", () => {
         "monthly",
         "testemail@revenuecat.com",
         { offeringIdentifier: "offering_1", targetingContext: null },
-        undefined,
+        { id: "base_option", priceId: "test_price_id" },
       ),
       new PurchasesError(
         ErrorCode.UnknownBackendError,
@@ -400,7 +400,7 @@ describe("subscribe request", () => {
         "monthly",
         "testemail@revenuecat.com",
         { offeringIdentifier: "offering_1", targetingContext: null },
-        undefined,
+        { id: "base_option", priceId: "test_price_id" },
       ),
       new PurchasesError(
         ErrorCode.InvalidCredentialsError,
@@ -426,7 +426,7 @@ describe("subscribe request", () => {
         "monthly",
         "testemail@revenuecat.com",
         { offeringIdentifier: "offering_1", targetingContext: null },
-        undefined,
+        { id: "base_option", priceId: "test_price_id" },
       ),
       new PurchasesError(
         ErrorCode.PurchaseInvalidError,
@@ -444,7 +444,7 @@ describe("subscribe request", () => {
         "monthly",
         "testemail@revenuecat.com",
         { offeringIdentifier: "offering_1", targetingContext: null },
-        undefined,
+        { id: "base_option", priceId: "test_price_id" },
       ),
       new PurchasesError(
         ErrorCode.NetworkError,

--- a/src/tests/test-responses.ts
+++ b/src/tests/test-responses.ts
@@ -15,6 +15,7 @@ const monthlyProductResponse = {
   subscription_options: {
     base_option: {
       id: "base_option",
+      price_id: "test_price_id",
       base: {
         period_duration: "P1M",
         cycle_count: 1,
@@ -42,6 +43,7 @@ const monthly2ProductResponse = {
   subscription_options: {
     offer_12345: {
       id: "offer_12345",
+      price_id: "test_price_id",
       base: {
         period_duration: "P1M",
         cycle_count: 1,

--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -43,8 +43,8 @@
     let brandingInfo: BrandingInfoResponse | null = null;
     let paymentInfoCollectionMetadata: SubscribeResponse | null = null;
     let lastError: PurchaseFlowError | null = null;
-    const productId = rcPackage?.rcBillingProduct?.identifier ?? null;
-    const defaultPurchaseOption = rcPackage?.rcBillingProduct?.defaultSubscriptionOption;
+    const productId = rcPackage.rcBillingProduct.identifier ?? null;
+    const defaultPurchaseOption = rcPackage.rcBillingProduct.defaultPurchaseOption;
     const purchaseOptionToUse = purchaseOption ? purchaseOption : defaultPurchaseOption;
 
     let state:

--- a/src/ui/states/state-present-offer.svelte
+++ b/src/ui/states/state-present-offer.svelte
@@ -21,13 +21,13 @@
                 {getTrialsLabel(trial.periodDuration)} free trial
             {/if}
             {#if !trial?.periodDuration && basePrice }
-                {basePrice.currency || ''} {basePrice.formattedPrice}
+                {basePrice.formattedPrice}
             {/if}
 
         </span>
         {#if (trial && basePrice)}
             <span class="rcb-product-price-after-trial">
-                {trial && basePrice && `${basePrice.currency} ${
+                {trial && basePrice && `${
                     basePrice.formattedPrice} after end of trial`}
             </span>
         {/if}


### PR DESCRIPTION
## Motivation / Description
This PR is based on #161. It has a few changes to allow performing purchases in different currencies.

- It adds a `defaultPurchaseOption` to the `StoreProduct`, this will be not null so it's also available for one-time products.
- Adds the `priceId` to the `PurchaseOption` interface.
- Parses the `price_id` from the `/products` response into the `PurchaseOption` interface.
- Passes the `price_id` to the `POST /subscribe` endpoint

## Changes introduced

## Linear ticket (if any)

## Additional comments
