### PR TITLE
Load branding before displaying UI

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -1524,7 +1524,7 @@
         {
           "kind": "Interface",
           "canonicalReference": "@revenuecat/purchases-js!GetOfferingsParams:interface",
-          "docComment": "/**\n * Parameters for the {@link Purchases.getOfferings}` method.\n *\n * @public\n */\n",
+          "docComment": "/**\n * Parameters for the {@link Purchases.getOfferings} method.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",

--- a/examples/rcbilling-demo/package-lock.json
+++ b/examples/rcbilling-demo/package-lock.json
@@ -34,7 +34,7 @@
     },
     "../..": {
       "name": "@revenuecat/purchases-js",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@stripe/stripe-js": "^2.2.0",

--- a/src/entities/get-offerings-params.ts
+++ b/src/entities/get-offerings-params.ts
@@ -1,5 +1,5 @@
 /**
- * Parameters for the {@link Purchases.getOfferings}` method.
+ * Parameters for the {@link Purchases.getOfferings} method.
  * @public
  */
 export interface GetOfferingsParams {

--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -16,7 +16,6 @@
     PurchaseFlowErrorCode,
     PurchaseOperationHelper,
   } from "../helpers/purchase-operation-helper";
-  import { Backend } from "../networking/backend";
   import ModalHeader from "./modal-header.svelte";
   import IconCart from "./assets/icon-cart.svelte";
   import BrandingInfoUI from "./branding-info-ui.svelte";
@@ -28,11 +27,11 @@
   export let appUserId: string;
   export let rcPackage: Package;
   export let purchaseOption: PurchaseOption | null | undefined;
+  export let brandingInfo: BrandingInfoResponse | null;
   export let onFinished: () => void;
   export let onError: (error: PurchaseFlowError) => void;
   export let onClose: () => void;
   export let purchases: Purchases;
-  export let backend: Backend;
   export let purchaseOperationHelper: PurchaseOperationHelper;
 
   const colorVariables = Object.entries(Colors)
@@ -40,7 +39,6 @@
     .join("; ");
 
   let productDetails: Product | null = null;
-  let brandingInfo: BrandingInfoResponse | null = null;
   let paymentInfoCollectionMetadata: SubscribeResponse | null = null;
   let lastError: PurchaseFlowError | null = null;
   const productId = rcPackage.rcBillingProduct.identifier ?? null;
@@ -71,7 +69,6 @@
 
   onMount(async () => {
     productDetails = rcPackage.rcBillingProduct;
-    brandingInfo = await backend.getBrandingInfo();
 
     if (state === "present-offer") {
       if (customerEmail) {


### PR DESCRIPTION
## Motivation / Description
There is a small jump when loading the billing flow UI, this is because it has to download the branding info after already displaying some info. This loads the branding during SDK configuration. In case it's not downloaded by the time we present the purchase flow, we will try to download it again.

### Before

https://github.com/user-attachments/assets/54bea295-8e9d-46af-82a4-a50f0364ce87

### After

https://github.com/user-attachments/assets/e7ca33cd-a3ec-4400-afd5-06c15d2837ad



## Changes introduced

## Linear ticket (if any)

## Additional comments
