### PR TITLE
Add `amountMicros` to `Price` interface

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -2865,7 +2865,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@revenuecat/purchases-js!Price#amount:member",
-              "docComment": "/**\n * Price in full units of the currency.\n */\n",
+              "docComment": "/**\n * Price in cents of the currency.\n *\n * @deprecated\n *\n * - Use {@link Price.amountMicros} instead.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -2884,6 +2884,33 @@
               "isOptional": false,
               "releaseTag": "Public",
               "name": "amount",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!Price#amountMicros:member",
+              "docComment": "/**\n * Price in micro-units of the currency. For example, $9.99 is represented as 9990000.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly amountMicros: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "number"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "amountMicros",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -205,7 +205,9 @@ export interface PresentedOfferingContext {
 
 // @public
 export interface Price {
+    // @deprecated
     readonly amount: number;
+    readonly amountMicros: number;
     readonly currency: string;
     readonly formattedPrice: string;
 }

--- a/src/entities/offerings.ts
+++ b/src/entities/offerings.ts
@@ -3,10 +3,11 @@ import {
   type PackageResponse,
   type TargetingResponse,
 } from "../networking/responses/offerings-response";
-import {
-  type PricingPhaseResponse,
-  type ProductResponse,
-  type SubscriptionOptionResponse,
+import type {
+  PriceResponse,
+  PricingPhaseResponse,
+  ProductResponse,
+  SubscriptionOptionResponse,
 } from "../networking/responses/products-response";
 import { notEmpty } from "../helpers/type-helper";
 import { formatPrice } from "../helpers/price-labels";
@@ -62,9 +63,14 @@ export enum PackageType {
  */
 export interface Price {
   /**
-   * Price in full units of the currency.
+   * Price in cents of the currency.
+   * @deprecated - Use {@link Price.amountMicros} instead.
    */
   readonly amount: number;
+  /**
+   * Price in micro-units of the currency. For example, $9.99 is represented as 9990000.
+   */
+  readonly amountMicros: number;
   /**
    * Returns ISO 4217 currency code for price.
    * For example, if price is specified in British pounds sterling,
@@ -319,11 +325,12 @@ export interface Offerings {
   readonly current: Offering | null;
 }
 
-const toPrice = (priceData: { amount: number; currency: string }): Price => {
+const toPrice = (priceData: PriceResponse): Price => {
   return {
-    amount: priceData.amount,
+    amount: priceData.amount_micros / 10000,
+    amountMicros: priceData.amount_micros,
     currency: priceData.currency,
-    formattedPrice: formatPrice(priceData.amount, priceData.currency),
+    formattedPrice: formatPrice(priceData.amount_micros, priceData.currency),
   };
 };
 

--- a/src/helpers/price-labels.ts
+++ b/src/helpers/price-labels.ts
@@ -11,11 +11,11 @@ export const priceLabels: Record<string, string> = {
 };
 
 export const formatPrice = (
-  priceInCents: number,
+  priceInMicros: number,
   currency: string,
   locale?: string,
 ): string => {
-  const price = priceInCents / 100;
+  const price = priceInMicros / 1000000;
   const formatter = new Intl.NumberFormat(locale, {
     style: "currency",
     currency,

--- a/src/networking/responses/products-response.ts
+++ b/src/networking/responses/products-response.ts
@@ -1,5 +1,5 @@
 export interface PriceResponse {
-  amount: number;
+  amount_micros: number;
   currency: string;
 }
 

--- a/src/tests/helpers/price-labels.test.ts
+++ b/src/tests/helpers/price-labels.test.ts
@@ -19,12 +19,12 @@ describe("getRenewsLabel", () => {
 
 describe("formatPrice", () => {
   test("should return expected formatted price", () => {
-    expect(formatPrice(999, "USD", "en-US")).toEqual("$9.99");
-    expect(formatPrice(1000, "USD", "en-US")).toEqual("$10.00");
-    expect(formatPrice(99, "USD", "en-US")).toEqual("$0.99");
-    expect(formatPrice(999, "EUR", "en-US")).toEqual("€9.99");
-    expect(formatPrice(999, "USD", "es-ES")).toEqual("9,99 US$");
-    expect(formatPrice(999, "CNY", "en-US")).toEqual("CN¥9.99");
-    expect(formatPrice(999, "CNY", "zh-CN")).toEqual("¥9.99");
+    expect(formatPrice(9990000, "USD", "en-US")).toEqual("$9.99");
+    expect(formatPrice(10000000, "USD", "en-US")).toEqual("$10.00");
+    expect(formatPrice(990000, "USD", "en-US")).toEqual("$0.99");
+    expect(formatPrice(9990000, "EUR", "en-US")).toEqual("€9.99");
+    expect(formatPrice(9990000, "USD", "es-ES")).toEqual("9,99 US$");
+    expect(formatPrice(9990000, "CNY", "en-US")).toEqual("CN¥9.99");
+    expect(formatPrice(9990000, "CNY", "zh-CN")).toEqual("¥9.99");
   });
 });

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -177,6 +177,7 @@ describe("getOfferings", () => {
         },
         price: {
           amount: 500,
+          amountMicros: 5000000,
           currency: "USD",
           formattedPrice: "$5.00",
         },
@@ -199,6 +200,7 @@ describe("getOfferings", () => {
         currentPrice: {
           currency: "USD",
           amount: 500,
+          amountMicros: 5000000,
           formattedPrice: "$5.00",
         },
         displayName: "Monthly test 2",
@@ -258,6 +260,7 @@ describe("getOfferings", () => {
         },
         price: {
           amount: 500,
+          amountMicros: 5000000,
           currency: "USD",
           formattedPrice: "$5.00",
         },
@@ -279,6 +282,7 @@ describe("getOfferings", () => {
         currentPrice: {
           currency: "USD",
           amount: 500,
+          amountMicros: 5000000,
           formattedPrice: "$5.00",
         },
         displayName: "Monthly test 2",

--- a/src/tests/mocks/offering-mock-provider.ts
+++ b/src/tests/mocks/offering-mock-provider.ts
@@ -1,6 +1,7 @@
 import {
   type Package,
   PackageType,
+  type SubscriptionOption,
   type TargetingContext,
 } from "../../entities/offerings";
 import { PeriodUnit } from "../../helpers/duration-helper";
@@ -11,7 +12,7 @@ export function createMonthlyPackageMock(
     revision: 123,
   },
 ): Package {
-  const subscriptionOption = {
+  const subscriptionOption: SubscriptionOption = {
     id: "base_option",
     priceId: "test_price_id",
     base: {
@@ -23,6 +24,7 @@ export function createMonthlyPackageMock(
       },
       price: {
         amount: 300,
+        amountMicros: 3000000,
         currency: "USD",
         formattedPrice: "$3.00",
       },
@@ -36,6 +38,7 @@ export function createMonthlyPackageMock(
       currentPrice: {
         currency: "USD",
         amount: 300,
+        amountMicros: 3000000,
         formattedPrice: "$3.00",
       },
       displayName: "Monthly test",

--- a/src/tests/test-responses.ts
+++ b/src/tests/test-responses.ts
@@ -3,7 +3,7 @@ import type { OfferingsResponse } from "../networking/responses/offerings-respon
 
 const monthlyProductResponse = {
   current_price: {
-    amount: 300,
+    amount_micros: 3000000,
     currency: "USD",
   },
   identifier: "monthly",
@@ -20,7 +20,7 @@ const monthlyProductResponse = {
         period_duration: "P1M",
         cycle_count: 1,
         price: {
-          amount: 300,
+          amount_micros: 3000000,
           currency: "USD",
         },
       },
@@ -31,7 +31,7 @@ const monthlyProductResponse = {
 
 const monthly2ProductResponse = {
   current_price: {
-    amount: 500,
+    amount_micros: 5000000,
     currency: "USD",
   },
   identifier: "monthly_2",
@@ -48,7 +48,7 @@ const monthly2ProductResponse = {
         period_duration: "P1M",
         cycle_count: 1,
         price: {
-          amount: 500,
+          amount_micros: 5000000,
           currency: "USD",
         },
       },


### PR DESCRIPTION
## Motivation / Description

This adds a new `amountMicros` field to `Price`. It keeps the previous `amount` field but deprecates it.

Need to hold until the backend part of this is deployed.

## Changes introduced

## Linear ticket (if any)

## Additional comments
