### PR TITLE
Add additional error details and display

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -4427,6 +4427,19 @@
                 },
                 {
                   "kind": "Content",
+                  "text": ", \n             extra?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PurchasesErrorExtra",
+                  "canonicalReference": "@revenuecat/purchases-js!PurchasesErrorExtra:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | undefined"
+                },
+                {
+                  "kind": "Content",
                   "text": ");"
                 }
               ],
@@ -4455,6 +4468,14 @@
                   "parameterTypeTokenRange": {
                     "startIndex": 5,
                     "endIndex": 6
+                  },
+                  "isOptional": true
+                },
+                {
+                  "parameterName": "extra",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 7,
+                    "endIndex": 9
                   },
                   "isOptional": true
                 }
@@ -4486,6 +4507,41 @@
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "@revenuecat/purchases-js!PurchasesError#extra:member",
+              "docComment": "/**\n * Contains extra information that is available in certain types of errors.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly extra?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PurchasesErrorExtra",
+                  "canonicalReference": "@revenuecat/purchases-js!PurchasesErrorExtra:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | undefined"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "extra",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
               },
               "isStatic": false,
               "isProtected": false,
@@ -4557,6 +4613,78 @@
             "endIndex": 2
           },
           "implementsTokenRanges": []
+        },
+        {
+          "kind": "Interface",
+          "canonicalReference": "@revenuecat/purchases-js!PurchasesErrorExtra:interface",
+          "docComment": "/**\n * Extra information that is available in certain types of errors.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare interface PurchasesErrorExtra "
+            }
+          ],
+          "fileUrlPath": "dist/Purchases.es.d.ts",
+          "releaseTag": "Public",
+          "name": "PurchasesErrorExtra",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PurchasesErrorExtra#backendErrorCode:member",
+              "docComment": "/**\n * If this is a RevenueCat backend error, the error code from the servers.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly backendErrorCode?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "number"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "backendErrorCode",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PurchasesErrorExtra#statusCode:member",
+              "docComment": "/**\n * If this is a request error, the HTTP status code of the response.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly statusCode?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "number"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "statusCode",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
+          "extendsTokenRanges": []
         },
         {
           "kind": "TypeAlias",

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -282,11 +282,19 @@ export class PurchasesError extends Error {
     constructor(
     errorCode: ErrorCode,
     message?: string,
-    underlyingErrorMessage?: string | null | undefined);
+    underlyingErrorMessage?: string | null | undefined,
+    extra?: PurchasesErrorExtra | undefined);
     readonly errorCode: ErrorCode;
+    readonly extra?: PurchasesErrorExtra | undefined;
     // (undocumented)
     toString: () => string;
     readonly underlyingErrorMessage?: string | null | undefined;
+}
+
+// @public
+export interface PurchasesErrorExtra {
+    readonly backendErrorCode?: number;
+    readonly statusCode?: number;
 }
 
 // @public

--- a/examples/rcbilling-demo/src/tests/main.test.ts
+++ b/examples/rcbilling-demo/src/tests/main.test.ts
@@ -59,10 +59,10 @@ test.describe("Main", () => {
     const cardButton = singleCard.getByRole("button");
     await cardButton.click();
 
-    await page.route('*/**/subscribe', async route => {
+    await page.route("*/**/subscribe", async (route) => {
       await route.fulfill({
-        body: "{ \"code\": 7110, \"message\": \"Test error message\"}",
-        status: 400
+        body: '{ "code": 7110, "message": "Test error message"}',
+        status: 400,
       });
     });
 
@@ -72,7 +72,9 @@ test.describe("Main", () => {
     const errorTitleText = page.getByText("Something went wrong");
     await expect(errorTitleText).toBeVisible();
 
-    const errorMessageText = page.getByText("Purchase not started due to an error. Error code: 7110");
+    const errorMessageText = page.getByText(
+      "Purchase not started due to an error. Error code: 7110",
+    );
     await expect(errorMessageText).toBeVisible();
   });
 });

--- a/examples/rcbilling-demo/src/tests/main.test.ts
+++ b/examples/rcbilling-demo/src/tests/main.test.ts
@@ -43,6 +43,38 @@ test.describe("Main", () => {
     const successText = page.getByText("Purchase successful");
     await expect(successText).toBeVisible();
   });
+
+  test("Displays error when unknown backend error", async ({
+    browser,
+    browserName,
+  }) => {
+    const userId = `${getUserId(browserName)}_already_purchased`;
+    const page = await setupTest(browser, userId);
+
+    // Gets all elements that match the selector
+    const packageCards = await getAllElementsByLocator(page, CARD_SELECTOR);
+    const singleCard = packageCards[1];
+
+    // Perform purchase
+    const cardButton = singleCard.getByRole("button");
+    await cardButton.click();
+
+    await page.route('*/**/subscribe', async route => {
+      await route.fulfill({
+        body: "{ \"code\": 7110, \"message\": \"Test error message\"}",
+        status: 400
+      });
+    });
+
+    await enterEmailAndContinue(page, userId);
+
+    // Confirm error page has shown.
+    const errorTitleText = page.getByText("Something went wrong");
+    await expect(errorTitleText).toBeVisible();
+
+    const errorMessageText = page.getByText("Purchase not started due to an error. Error code: 7110");
+    await expect(errorMessageText).toBeVisible();
+  });
 });
 
 const getUserId = (browserName: string) =>

--- a/examples/rcbilling-demo/src/util/PurchasesLoader.ts
+++ b/examples/rcbilling-demo/src/util/PurchasesLoader.ts
@@ -30,7 +30,7 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
     if (!Purchases.isConfigured()) {
       Purchases.configure(apiKey, appUserId);
     } else {
-      Purchases.getSharedInstance().changeUser(appUserId);
+      await Purchases.getSharedInstance().changeUser(appUserId);
     }
     const purchases = Purchases.getSharedInstance();
 

--- a/src/entities/errors.ts
+++ b/src/entities/errors.ts
@@ -215,6 +215,20 @@ export enum BackendErrorCode {
 }
 
 /**
+ * Extra information that is available in certain types of errors.
+ */
+export interface PurchasesErrorExtra {
+  /**
+   * If this is a request error, the HTTP status code of the response.
+   */
+  readonly statusCode?: number;
+  /**
+   * If this is a RevenueCat backend error, the error code from the servers.
+   */
+  readonly backendErrorCode?: number;
+}
+
+/**
  * Error class for Purchases SDK. You should handle these errors and react
  * accordingly in your app.
  * @public
@@ -231,6 +245,7 @@ export class PurchasesError extends Error {
       errorCode,
       ErrorCodeUtils.getPublicMessage(errorCode),
       backendErrorMessage,
+      { backendErrorCode: backendErrorCode },
     );
   }
 
@@ -262,6 +277,10 @@ export class PurchasesError extends Error {
      * can be useful for debugging and logging.
      */
     public readonly underlyingErrorMessage?: string | null,
+    /**
+     * Contains extra information that is available in certain types of errors.
+     */
+    public readonly extra?: PurchasesErrorExtra,
   ) {
     super(message);
   }

--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -1,4 +1,8 @@
-import { ErrorCode, PurchasesError } from "../entities/errors";
+import {
+  ErrorCode,
+  PurchasesError,
+  type PurchasesErrorExtra,
+} from "../entities/errors";
 import { type Backend } from "../networking/backend";
 import { type SubscribeResponse } from "../networking/responses/subscribe-response";
 import {
@@ -28,6 +32,8 @@ export class PurchaseFlowError extends Error {
     public readonly errorCode: PurchaseFlowErrorCode,
     message?: string,
     public readonly underlyingErrorMessage?: string | null,
+    public readonly purchasesErrorCode?: ErrorCode,
+    public readonly extra?: PurchasesErrorExtra,
   ) {
     super(message);
   }
@@ -43,6 +49,29 @@ export class PurchaseFlowError extends Error {
       case PurchaseFlowErrorCode.StripeError:
       case PurchaseFlowErrorCode.UnknownError:
         return false;
+    }
+  }
+
+  getPublicErrorMessage(): string {
+    const errorCode =
+      this.extra?.backendErrorCode ?? this.purchasesErrorCode ?? this.errorCode;
+    switch (this.errorCode) {
+      // TODO: Localize these messages
+      case PurchaseFlowErrorCode.UnknownError:
+        return `An unknown error occurred. Error code: ${errorCode}`;
+      case PurchaseFlowErrorCode.ErrorSettingUpPurchase:
+        return `Purchase not started due to an error. Error code: ${errorCode}`;
+      case PurchaseFlowErrorCode.ErrorChargingPayment:
+        return "Payment failed.";
+      case PurchaseFlowErrorCode.NetworkError:
+        return "Network error. Please check your internet connection.";
+      case PurchaseFlowErrorCode.StripeError:
+        // For stripe errors, we can display the stripe-provided error message.
+        return this.message;
+      case PurchaseFlowErrorCode.MissingEmailError:
+        return "Email is required to complete the purchase.";
+      case PurchaseFlowErrorCode.AlreadySubscribedError:
+        return "You are already subscribed to this product.";
     }
   }
 
@@ -65,6 +94,8 @@ export class PurchaseFlowError extends Error {
       errorCode,
       e.message,
       e.underlyingErrorMessage,
+      e.errorCode,
+      e.extra,
     );
   }
 }

--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -58,9 +58,9 @@ export class PurchaseFlowError extends Error {
     switch (this.errorCode) {
       // TODO: Localize these messages
       case PurchaseFlowErrorCode.UnknownError:
-        return `An unknown error occurred. Error code: ${errorCode}`;
+        return `An unknown error occurred. Error code: ${errorCode}.`;
       case PurchaseFlowErrorCode.ErrorSettingUpPurchase:
-        return `Purchase not started due to an error. Error code: ${errorCode}`;
+        return `Purchase not started due to an error. Error code: ${errorCode}.`;
       case PurchaseFlowErrorCode.ErrorChargingPayment:
         return "Payment failed.";
       case PurchaseFlowErrorCode.NetworkError:

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,6 +68,7 @@ export {
   PurchasesError,
   UninitializedPurchasesError,
 } from "./entities/errors";
+export type { PurchasesErrorExtra } from "./entities/errors";
 export type { Period, PeriodUnit } from "./helpers/duration-helper";
 export type { HttpConfig } from "./entities/http-config";
 export { LogLevel } from "./entities/log-level";

--- a/src/networking/http-client.ts
+++ b/src/networking/http-client.ts
@@ -61,7 +61,12 @@ async function handleErrors(response: Response, endpoint: SupportedEndpoint) {
       const backendErrorCode: BackendErrorCode | null =
         ErrorCodeUtils.convertCodeToBackendErrorCode(backendErrorCodeNumber);
       if (backendErrorCode == null) {
-        throwUnknownError(endpoint, statusCode, errorBodyString);
+        throwUnknownError(
+          endpoint,
+          statusCode,
+          errorBodyString,
+          backendErrorCodeNumber,
+        );
       } else {
         throw PurchasesError.getForBackendError(
           backendErrorCode,
@@ -78,10 +83,13 @@ function throwUnknownError(
   endpoint: SupportedEndpoint,
   statusCode: number,
   errorBody: string | null,
+  backendErrorCode?: number,
 ) {
   throw new PurchasesError(
     ErrorCode.UnknownBackendError,
-    `Unknown backend error. Request: ${endpoint.name}. Status code: ${statusCode}. Body: ${errorBody}.`,
+    `Unknown backend error.`,
+    `Request: ${endpoint.name}. Status code: ${statusCode}. Body: ${errorBody}.`,
+    { backendErrorCode: backendErrorCode },
   );
 }
 

--- a/src/tests/helpers/purchase-operation-helper.test.ts
+++ b/src/tests/helpers/purchase-operation-helper.test.ts
@@ -74,7 +74,8 @@ describe("PurchaseOperationHelper", () => {
       ),
       new PurchaseFlowError(
         PurchaseFlowErrorCode.ErrorSettingUpPurchase,
-        "Unknown backend error. Request: subscribe. Status code: 500. Body: null.",
+        "Unknown backend error.",
+        "Request: subscribe. Status code: 500. Body: null.",
       ),
     );
   });
@@ -137,7 +138,8 @@ describe("PurchaseOperationHelper", () => {
       purchaseOperationHelper.pollCurrentPurchaseForCompletion(),
       new PurchaseFlowError(
         PurchaseFlowErrorCode.NetworkError,
-        "Unknown backend error. Request: getCheckoutStatus. Status code: 500. Body: null.",
+        "Unknown backend error.",
+        "Request: getCheckoutStatus. Status code: 500. Body: null.",
       ),
     );
   });

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -108,7 +108,8 @@ describe("getCustomerInfo request", () => {
       backend.getCustomerInfo("someAppUserId"),
       new PurchasesError(
         ErrorCode.UnknownBackendError,
-        "Unknown backend error. Request: getCustomerInfo. Status code: 500. Body: null.",
+        "Unknown backend error.",
+        "Request: getCustomerInfo. Status code: 500. Body: null.",
       ),
     );
   });
@@ -147,7 +148,8 @@ describe("getCustomerInfo request", () => {
       backend.getCustomerInfo("someAppUserId"),
       new PurchasesError(
         ErrorCode.UnknownBackendError,
-        'Unknown backend error. Request: getCustomerInfo. Status code: 400. Body: {"code":1234567890,"message":"Invalid error message"}.',
+        "Unknown backend error.",
+        'Request: getCustomerInfo. Status code: 400. Body: {"code":1234567890,"message":"Invalid error message"}.',
       ),
     );
   });
@@ -160,7 +162,8 @@ describe("getCustomerInfo request", () => {
       backend.getCustomerInfo("someAppUserId"),
       new PurchasesError(
         ErrorCode.UnknownBackendError,
-        "Unknown backend error. Request: getCustomerInfo. Status code: 400. Body: null.",
+        "Unknown backend error.",
+        "Request: getCustomerInfo. Status code: 400. Body: null.",
       ),
     );
   });
@@ -209,7 +212,8 @@ describe("getOfferings request", () => {
       backend.getOfferings("someAppUserId"),
       new PurchasesError(
         ErrorCode.UnknownBackendError,
-        "Unknown backend error. Request: getOfferings. Status code: 500. Body: null.",
+        "Unknown backend error.",
+        "Request: getOfferings. Status code: 500. Body: null.",
       ),
     );
   });
@@ -298,7 +302,8 @@ describe("getProducts request", () => {
       backend.getProducts("someAppUserId", ["monthly", "monthly_2"]),
       new PurchasesError(
         ErrorCode.UnknownBackendError,
-        "Unknown backend error. Request: getProducts. Status code: 500. Body: null.",
+        "Unknown backend error.",
+        "Request: getProducts. Status code: 500. Body: null.",
       ),
     );
   });
@@ -379,7 +384,8 @@ describe("subscribe request", () => {
       ),
       new PurchasesError(
         ErrorCode.UnknownBackendError,
-        "Unknown backend error. Request: subscribe. Status code: 500. Body: null.",
+        "Unknown backend error.",
+        "Request: subscribe. Status code: 500. Body: null.",
       ),
     );
   });

--- a/src/ui/states/state-error.svelte
+++ b/src/ui/states/state-error.svelte
@@ -20,28 +20,6 @@
     );
   });
 
-  function getErrorMessage(): string {
-    switch (lastError.errorCode) {
-      // TODO: Localize these messages
-      case PurchaseFlowErrorCode.UnknownError:
-        return "An unknown error occurred.";
-      case PurchaseFlowErrorCode.ErrorSettingUpPurchase:
-        return "Purchase not started due to an error.";
-      case PurchaseFlowErrorCode.ErrorChargingPayment:
-        return "Payment failed.";
-      case PurchaseFlowErrorCode.NetworkError:
-        return "Network error. Please check your internet connection.";
-      case PurchaseFlowErrorCode.StripeError:
-        // For stripe errors, we can display the stripe-provided error message.
-        return lastError.message;
-      case PurchaseFlowErrorCode.MissingEmailError:
-        return "Email is required to complete the purchase.";
-      case PurchaseFlowErrorCode.AlreadySubscribedError:
-        return "You are already subscribed to this product."
-    }
-    return lastError.message;
-  }
-
   function getErrorTitle(): string {
     switch (lastError.errorCode) {
       case PurchaseFlowErrorCode.AlreadySubscribedError:
@@ -59,7 +37,7 @@
   type="error"
 >
   <IconError slot="icon" />
-  {getErrorMessage()}
+  {lastError.getPublicErrorMessage()}
   {#if supportEmail}
     If this error persists, please contact <a href="mailto:{supportEmail}"
       >{supportEmail}</a

--- a/src/ui/states/state-error.svelte
+++ b/src/ui/states/state-error.svelte
@@ -39,7 +39,7 @@
   <IconError slot="icon" />
   {lastError.getPublicErrorMessage()}
   {#if supportEmail}
-    If this error persists, please contact <a href="mailto:{supportEmail}"
+    <br>If this error persists, please contact <a href="mailto:{supportEmail}"
       >{supportEmail}</a
     >.
   {/if}


### PR DESCRIPTION
## Motivation / Description
This adds a new field to the public `PurchasesError` type, `extra` that will contain some extra information about certain types of errors. This is used now to pass the backend error code through the purchases flow and display it in the error screen.

<img width="787" alt="image" src="https://github.com/user-attachments/assets/5eddccae-323b-48b8-95e8-d65207ac3569">


## Changes introduced

## Linear ticket (if any)

## Additional comments
