### PR TITLE
Update UI to support consumables and non consumables

### DIFF
--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -253,7 +253,7 @@
             />
           {/if}
           {#if state === "success"}
-            <StateSuccess {brandingInfo} onContinue={handleContinue} />
+            <StateSuccess {productDetails} {brandingInfo} onContinue={handleContinue} />
           {/if}
         </Shell>
       </div>

--- a/src/ui/states/state-present-offer.svelte
+++ b/src/ui/states/state-present-offer.svelte
@@ -1,43 +1,58 @@
 <script lang="ts">
     import ModalSection from "../modal-section.svelte";
     import { getRenewsLabel, getTrialsLabel } from "../../helpers/price-labels";
-    import type { Product, PurchaseOption, SubscriptionOption } from "../../entities/offerings";
+    import {
+        type NonSubscriptionOption,
+        type Product,
+        ProductType,
+        type PurchaseOption,
+        type SubscriptionOption,
+    } from "../../entities/offerings";
 
     export let productDetails: Product;
     export let purchaseOption: PurchaseOption;
 
+    const isSubscription = productDetails.productType === ProductType.Subscription;
     const subscriptionOption: SubscriptionOption | null | undefined =
       purchaseOption as SubscriptionOption;
-    const trial = subscriptionOption?.trial;
-    const basePrice = subscriptionOption?.base?.price;
+    const nonSubscriptionOption: NonSubscriptionOption | null | undefined =
+      purchaseOption as NonSubscriptionOption;
+    const subscriptionTrial = subscriptionOption?.trial;
+
+    const subscriptionBasePrice = subscriptionOption?.base?.price;
+    const nonSubscriptionBasePrice = nonSubscriptionOption?.basePrice;
 </script>
 
 <ModalSection>
     <div class="rcb-pricing-info">
-        <span>{productDetails.displayName}</span>
+        <span>{productDetails.title}</span>
 
-        <span class="rcb-product-price">
-            {#if trial?.periodDuration}
-                {getTrialsLabel(trial.periodDuration)} free trial
-            {/if}
-            {#if !trial?.periodDuration && basePrice }
-                {basePrice.formattedPrice}
-            {/if}
-
-        </span>
-        {#if (trial && basePrice)}
-            <span class="rcb-product-price-after-trial">
-                {trial && basePrice && `${
-                    basePrice.formattedPrice} after end of trial`}
+        {#if isSubscription}
+            <span class="rcb-product-price">
+                {#if subscriptionTrial?.periodDuration}
+                    {getTrialsLabel(subscriptionTrial.periodDuration)} free trial
+                {/if}
+                {#if !subscriptionTrial?.periodDuration && subscriptionBasePrice }
+                    {subscriptionBasePrice.formattedPrice}
+                {/if}
             </span>
-        {/if}
-        <ul class="rcb-product-details">
-            {#if productDetails.normalPeriodDuration}
-                <li>Renews {getRenewsLabel(productDetails.normalPeriodDuration)}</li>
+            {#if (subscriptionTrial && subscriptionBasePrice)}
+                <span class="rcb-product-price-after-trial">
+                    {subscriptionTrial && subscriptionBasePrice && `${
+                      subscriptionBasePrice.formattedPrice} after end of trial`}
+                </span>
             {/if}
-            <li>Continues until canceled</li>
-            <li>Cancel anytime</li>
-        </ul>
+            <ul class="rcb-product-details">
+                {#if productDetails.normalPeriodDuration}
+                    <li>Renews {getRenewsLabel(productDetails.normalPeriodDuration)}</li>
+                {/if}
+                <li>Continues until canceled</li>
+                <li>Cancel anytime</li>
+            </ul>
+        {/if}
+        {#if !isSubscription}
+            <span class="rcb-product-price">{nonSubscriptionBasePrice?.formattedPrice}</span>
+        {/if}
     </div>
 </ModalSection>
 

--- a/src/ui/states/state-success.svelte
+++ b/src/ui/states/state-success.svelte
@@ -2,9 +2,13 @@
   import IconSuccess from "../assets/icon-success.svelte";
   import { type BrandingInfoResponse } from "../../networking/responses/branding-response";
   import MessageLayout from "../layout/message-layout.svelte";
+  import { type Product, ProductType } from "../../entities/offerings";
 
+  export let productDetails: Product | null = null;
   export let brandingInfo: BrandingInfoResponse | null = null;
   export let onContinue: () => void;
+
+  const isSubscription = productDetails?.productType === ProductType.Subscription;
 </script>
 
 <MessageLayout
@@ -14,5 +18,7 @@
   {onContinue}
 >
   <IconSuccess slot="icon" />
-  Your plan is now active.
+  {#if isSubscription}
+    Your plan is now active.
+  {/if}
 </MessageLayout>


### PR DESCRIPTION
## Motivation / Description
Most changes to support OTP are done in #191.
 
This adapts the purchase flow UI to better support consumables and non consumables. Changes are on the side bar with the product detail and the purchase success screen
| Product detail | Purchase success |
| --- | --- |
| <img width="1172" alt="image" src="https://github.com/user-attachments/assets/704d09ee-1bbb-4b30-a7ae-28ae76d807b8"> | <img width="665" alt="image" src="https://github.com/user-attachments/assets/176cf096-1ae4-4d50-87a6-94f2191f78d5"> |


## Changes introduced

## Linear ticket (if any)

## Additional comments
