### PR TITLE
Change endpoint to use the new `/purchase`

### DIFF
--- a/examples/rcbilling-demo/src/tests/main.test.ts
+++ b/examples/rcbilling-demo/src/tests/main.test.ts
@@ -98,7 +98,7 @@ test.describe("Main", () => {
     const cardButton = singleCard.getByRole("button");
     await cardButton.click();
 
-    await page.route("*/**/subscribe", async (route) => {
+    await page.route("*/**/purchase", async (route) => {
       await route.fulfill({
         body: '{ "code": 7110, "message": "Test error message"}',
         status: 400,

--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -4,7 +4,7 @@ import {
   type PurchasesErrorExtra,
 } from "../entities/errors";
 import { type Backend } from "../networking/backend";
-import { type SubscribeResponse } from "../networking/responses/subscribe-response";
+import { type PurchaseResponse } from "../networking/responses/purchase-response";
 import {
   CheckoutSessionStatus,
   type CheckoutStatusError,
@@ -117,9 +117,9 @@ export class PurchaseOperationHelper {
     purchaseOption: PurchaseOption,
     email: string,
     presentedOfferingContext: PresentedOfferingContext,
-  ): Promise<SubscribeResponse> {
+  ): Promise<PurchaseResponse> {
     try {
-      const subscribeResponse = await this.backend.postSubscribe(
+      const subscribeResponse = await this.backend.postPurchase(
         appUserId,
         productId,
         email,

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -6,10 +6,10 @@ import {
   GetCustomerInfoEndpoint,
   GetOfferingsEndpoint,
   GetProductsEndpoint,
-  SubscribeEndpoint,
+  PurchaseEndpoint,
 } from "./endpoints";
 import { type SubscriberResponse } from "./responses/subscriber-response";
-import { type SubscribeResponse } from "./responses/subscribe-response";
+import { type PurchaseResponse } from "./responses/purchase-response";
 import { type ProductsResponse } from "./responses/products-response";
 import { type BrandingInfoResponse } from "./responses/branding-response";
 import { type CheckoutStatusResponse } from "./responses/checkout-status-response";
@@ -72,14 +72,14 @@ export class Backend {
     );
   }
 
-  async postSubscribe(
+  async postPurchase(
     appUserId: string,
     productId: string,
     email: string,
     presentedOfferingContext: PresentedOfferingContext,
     purchaseOption: PurchaseOption,
-  ): Promise<SubscribeResponse> {
-    type SubscribeRequestBody = {
+  ): Promise<PurchaseResponse> {
+    type PurchaseRequestBody = {
       app_user_id: string;
       product_id: string;
       email: string;
@@ -93,7 +93,7 @@ export class Backend {
       };
     };
 
-    const requestBody: SubscribeRequestBody = {
+    const requestBody: PurchaseRequestBody = {
       app_user_id: appUserId,
       product_id: productId,
       email: email,
@@ -118,8 +118,8 @@ export class Backend {
         presentedOfferingContext.placementIdentifier;
     }
 
-    return await performRequest<SubscribeRequestBody, SubscribeResponse>(
-      new SubscribeEndpoint(),
+    return await performRequest<PurchaseRequestBody, PurchaseResponse>(
+      new PurchaseEndpoint(),
       {
         apiKey: this.API_KEY,
         body: requestBody,

--- a/src/networking/endpoints.ts
+++ b/src/networking/endpoints.ts
@@ -25,12 +25,12 @@ export class GetOfferingsEndpoint implements Endpoint {
   }
 }
 
-export class SubscribeEndpoint implements Endpoint {
+export class PurchaseEndpoint implements Endpoint {
   method: HttpMethodType = "POST";
-  name: string = "subscribe";
+  name: string = "purchase";
 
   urlPath(): string {
-    return `${RC_BILLING_PATH}/subscribe`;
+    return `${RC_BILLING_PATH}/purchase`;
   }
 }
 
@@ -97,7 +97,7 @@ export class GetCheckoutStatusEndpoint implements Endpoint {
 
 export type SupportedEndpoint =
   | GetOfferingsEndpoint
-  | SubscribeEndpoint
+  | PurchaseEndpoint
   | GetProductsEndpoint
   | GetCustomerInfoEndpoint
   | GetBrandingInfoEndpoint

--- a/src/networking/responses/purchase-response.ts
+++ b/src/networking/responses/purchase-response.ts
@@ -1,4 +1,4 @@
-export interface SubscribeResponse {
+export interface PurchaseResponse {
   operation_session_id: string;
   next_action: string;
   data: {

--- a/src/tests/helpers/purchase-operation-helper.test.ts
+++ b/src/tests/helpers/purchase-operation-helper.test.ts
@@ -22,7 +22,7 @@ describe("PurchaseOperationHelper", () => {
   let purchaseOperationHelper: PurchaseOperationHelper;
 
   const operationSessionId = "test-operation-session-id";
-  const successSubscribeBody: PurchaseResponse = {
+  const successPurchaseBody: PurchaseResponse = {
     operation_session_id: operationSessionId,
     next_action: "collect_payment_info",
     data: {
@@ -127,7 +127,7 @@ describe("PurchaseOperationHelper", () => {
 
   test("pollCurrentPurchaseForCompletion fails if poll request fails", async () => {
     setPurchaseResponse(
-      HttpResponse.json(successSubscribeBody, {
+      HttpResponse.json(successPurchaseBody, {
         status: StatusCodes.OK,
       }),
     );
@@ -158,7 +158,7 @@ describe("PurchaseOperationHelper", () => {
 
   test("pollCurrentPurchaseForCompletion success if poll returns success", async () => {
     setPurchaseResponse(
-      HttpResponse.json(successSubscribeBody, {
+      HttpResponse.json(successPurchaseBody, {
         status: StatusCodes.OK,
       }),
     );
@@ -221,7 +221,7 @@ describe("PurchaseOperationHelper", () => {
 
   test("pollCurrentPurchaseForCompletion error if poll returns error", async () => {
     setPurchaseResponse(
-      HttpResponse.json(successSubscribeBody, {
+      HttpResponse.json(successPurchaseBody, {
         status: StatusCodes.OK,
       }),
     );

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -14,7 +14,7 @@ import {
   PurchasesError,
 } from "../../entities/errors";
 import { expectPromiseToError } from "../test-helpers";
-import { type SubscribeResponse } from "../../networking/responses/subscribe-response";
+import { type PurchaseResponse } from "../../networking/responses/purchase-response";
 
 let server: SetupServer;
 let backend: Backend;
@@ -341,26 +341,26 @@ describe("getProducts request", () => {
   });
 });
 
-describe("subscribe request", () => {
-  function setSubscribeResponse(httpResponse: HttpResponse) {
+describe("purchase request", () => {
+  function setPurchaseResponse(httpResponse: HttpResponse) {
     server.use(
-      http.post("http://localhost:8000/rcbilling/v1/subscribe", () => {
+      http.post("http://localhost:8000/rcbilling/v1/purchase", () => {
         return httpResponse;
       }),
     );
   }
 
-  test("can post subscribe successfully", async () => {
-    const subscribeResponse: SubscribeResponse = {
+  test("can post purchase successfully", async () => {
+    const purchaseResponse: PurchaseResponse = {
       operation_session_id: "test-operation-session-id",
       next_action: "collect_payment_info",
       data: {
         client_secret: "seti_123",
       },
     };
-    setSubscribeResponse(HttpResponse.json(subscribeResponse, { status: 200 }));
+    setPurchaseResponse(HttpResponse.json(purchaseResponse, { status: 200 }));
     expect(
-      await backend.postSubscribe(
+      await backend.postPurchase(
         "someAppUserId",
         "monthly",
         "testemail@revenuecat.com",
@@ -371,15 +371,15 @@ describe("subscribe request", () => {
         },
         { id: "base_option", priceId: "test_price_id" },
       ),
-    ).toEqual(subscribeResponse);
+    ).toEqual(purchaseResponse);
   });
 
   test("throws an error if the backend returns a server error", async () => {
-    setSubscribeResponse(
+    setPurchaseResponse(
       HttpResponse.json(null, { status: StatusCodes.INTERNAL_SERVER_ERROR }),
     );
     await expectPromiseToError(
-      backend.postSubscribe(
+      backend.postPurchase(
         "someAppUserId",
         "monthly",
         "testemail@revenuecat.com",
@@ -393,13 +393,13 @@ describe("subscribe request", () => {
       new PurchasesError(
         ErrorCode.UnknownBackendError,
         "Unknown backend error.",
-        "Request: subscribe. Status code: 500. Body: null.",
+        "Request: purchase. Status code: 500. Body: null.",
       ),
     );
   });
 
   test("throws a known error if the backend returns a request error with correct body", async () => {
-    setSubscribeResponse(
+    setPurchaseResponse(
       HttpResponse.json(
         {
           code: BackendErrorCode.BackendInvalidAPIKey,
@@ -409,7 +409,7 @@ describe("subscribe request", () => {
       ),
     );
     await expectPromiseToError(
-      backend.postSubscribe(
+      backend.postPurchase(
         "someAppUserId",
         "monthly",
         "testemail@revenuecat.com",
@@ -429,7 +429,7 @@ describe("subscribe request", () => {
   });
 
   test("throws a PurchaseInvalidError if the backend returns with a offer not found error", async () => {
-    setSubscribeResponse(
+    setPurchaseResponse(
       HttpResponse.json(
         {
           code: BackendErrorCode.BackendOfferNotFound,
@@ -439,7 +439,7 @@ describe("subscribe request", () => {
       ),
     );
     await expectPromiseToError(
-      backend.postSubscribe(
+      backend.postPurchase(
         "someAppUserId",
         "monthly",
         "testemail@revenuecat.com",
@@ -459,9 +459,9 @@ describe("subscribe request", () => {
   });
 
   test("throws network error if cannot reach server", async () => {
-    setSubscribeResponse(HttpResponse.error());
+    setPurchaseResponse(HttpResponse.error());
     await expectPromiseToError(
-      backend.postSubscribe(
+      backend.postPurchase(
         "someAppUserId",
         "monthly",
         "testemail@revenuecat.com",

--- a/src/tests/networking/endpoints.test.ts
+++ b/src/tests/networking/endpoints.test.ts
@@ -5,7 +5,7 @@ import {
   GetCustomerInfoEndpoint,
   GetOfferingsEndpoint,
   GetProductsEndpoint,
-  SubscribeEndpoint,
+  PurchaseEndpoint,
 } from "../../networking/endpoints";
 
 describe("getOfferings endpoint", () => {
@@ -28,15 +28,15 @@ describe("getOfferings endpoint", () => {
   });
 });
 
-describe("subscribe endpoint", () => {
-  const endpoint = new SubscribeEndpoint();
+describe("purchase endpoint", () => {
+  const endpoint = new PurchaseEndpoint();
 
   test("uses correct method", () => {
     expect(endpoint.method).toBe("POST");
   });
 
   test("has correct urlPath", () => {
-    expect(endpoint.urlPath()).toBe("/rcbilling/v1/subscribe");
+    expect(endpoint.urlPath()).toBe("/rcbilling/v1/purchase");
   });
 });
 

--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -9,7 +9,7 @@
   import StateNeedsAuthInfo from "./states/state-needs-auth-info.svelte";
   import ConditionalFullScreen from "./conditional-full-screen.svelte";
   import Shell from "./shell.svelte";
-  import { type SubscribeResponse } from "../networking/responses/subscribe-response";
+  import { type PurchaseResponse } from "../networking/responses/purchase-response";
   import { type BrandingInfoResponse } from "../networking/responses/branding-response";
   import {
     PurchaseFlowError,
@@ -39,7 +39,7 @@
     .join("; ");
 
   let productDetails: Product | null = null;
-  let paymentInfoCollectionMetadata: SubscribeResponse | null = null;
+  let paymentInfoCollectionMetadata: PurchaseResponse | null = null;
   let lastError: PurchaseFlowError | null = null;
   const productId = rcPackage.rcBillingProduct.identifier ?? null;
   const defaultPurchaseOption =

--- a/src/ui/states/state-needs-payment-info.svelte
+++ b/src/ui/states/state-needs-payment-info.svelte
@@ -8,7 +8,7 @@
   import ModalFooter from "../modal-footer.svelte";
   import StateLoading from "./state-loading.svelte";
   import RowLayout from "../layout/row-layout.svelte";
-  import { type SubscribeResponse } from "../../networking/responses/subscribe-response";
+  import { type PurchaseResponse } from "../../networking/responses/purchase-response";
   import {
     PurchaseFlowError,
     PurchaseFlowErrorCode,
@@ -22,7 +22,7 @@
   export let onClose: any;
   export let onContinue: any;
   export let onError: any;
-  export let paymentInfoCollectionMetadata: SubscribeResponse;
+  export let paymentInfoCollectionMetadata: PurchaseResponse;
   export let processing = false;
   export let productDetails: Product;
   export let purchaseOptionToUse: PurchaseOption;


### PR DESCRIPTION
## Motivation / Description
We are changing the endpoint name to be more precise now that we will support non subscriptions.

## Changes introduced

## Linear ticket (if any)

## Additional comments
