### PR TITLE
Add support for getting a single offering

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -4221,6 +4221,85 @@
             },
             {
               "kind": "Method",
+              "canonicalReference": "@revenuecat/purchases-js!Purchases#getOffering:member(1)",
+              "docComment": "/**\n * Retrieves a specific offering by its identifier.\n *\n * @param offeringIdentifier - The identifier of the offering to retrieve.\n *\n * @param params - The parameters object to customise the offerings fetch. Check {@link GetOfferingsParams}\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getOffering(offeringIdentifier: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", params?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "GetOfferingsParams",
+                  "canonicalReference": "@revenuecat/purchases-js!GetOfferingsParams:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Offering",
+                  "canonicalReference": "@revenuecat/purchases-js!Offering:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | null>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 5,
+                "endIndex": 9
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "offeringIdentifier",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "params",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 3,
+                    "endIndex": 4
+                  },
+                  "isOptional": true
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "getOffering"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "@revenuecat/purchases-js!Purchases#getOfferings:member(1)",
               "docComment": "/**\n * Fetch the configured offerings for this user. You can configure these in the RevenueCat dashboard.\n */\n",
               "excerptTokens": [

--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -1524,7 +1524,7 @@
         {
           "kind": "Interface",
           "canonicalReference": "@revenuecat/purchases-js!GetOfferingsParams:interface",
-          "docComment": "/**\n * Parameters for the {@link Purchases.getOfferings} method.\n *\n * @public\n */\n",
+          "docComment": "",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -1561,6 +1561,38 @@
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!GetOfferingsParams#offeringIdentifier:member",
+              "docComment": "/**\n * The identifier of the offering to fetch. Can be a string identifier or one of the predefined keywords.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly offeringIdentifier?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string | "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "OfferingKeyword",
+                  "canonicalReference": "@revenuecat/purchases-js!OfferingKeyword:enum"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "offeringIdentifier",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
               }
             }
           ],
@@ -2236,6 +2268,44 @@
             }
           ],
           "extendsTokenRanges": []
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "@revenuecat/purchases-js!OfferingKeyword:enum",
+          "docComment": "/**\n * Parameters for the {@link Purchases.getOfferings} method.\n *\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare enum OfferingKeyword "
+            }
+          ],
+          "fileUrlPath": "dist/Purchases.es.d.ts",
+          "releaseTag": "Public",
+          "name": "OfferingKeyword",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "@revenuecat/purchases-js!OfferingKeyword.Current:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Current = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"current\""
+                }
+              ],
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "name": "Current"
+            }
+          ]
         },
         {
           "kind": "Interface",
@@ -4218,85 +4288,6 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "getCustomerInfo"
-            },
-            {
-              "kind": "Method",
-              "canonicalReference": "@revenuecat/purchases-js!Purchases#getOffering:member(1)",
-              "docComment": "/**\n * Retrieves a specific offering by its identifier.\n *\n * @param offeringIdentifier - The identifier of the offering to retrieve.\n *\n * @param params - The parameters object to customise the offerings fetch. Check {@link GetOfferingsParams}\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "getOffering(offeringIdentifier: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "string"
-                },
-                {
-                  "kind": "Content",
-                  "text": ", params?: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "GetOfferingsParams",
-                  "canonicalReference": "@revenuecat/purchases-js!GetOfferingsParams:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": "): "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "Promise",
-                  "canonicalReference": "!Promise:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": "<"
-                },
-                {
-                  "kind": "Reference",
-                  "text": "Offering",
-                  "canonicalReference": "@revenuecat/purchases-js!Offering:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": " | null>"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isStatic": false,
-              "returnTypeTokenRange": {
-                "startIndex": 5,
-                "endIndex": 9
-              },
-              "releaseTag": "Public",
-              "isProtected": false,
-              "overloadIndex": 1,
-              "parameters": [
-                {
-                  "parameterName": "offeringIdentifier",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 1,
-                    "endIndex": 2
-                  },
-                  "isOptional": false
-                },
-                {
-                  "parameterName": "params",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 3,
-                    "endIndex": 4
-                  },
-                  "isOptional": true
-                }
-              ],
-              "isOptional": false,
-              "isAbstract": false,
-              "name": "getOffering"
             },
             {
               "kind": "Method",

--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -1524,7 +1524,7 @@
         {
           "kind": "Interface",
           "canonicalReference": "@revenuecat/purchases-js!GetOfferingsParams:interface",
-          "docComment": "",
+          "docComment": "/**\n * Parameters for the {@link Purchases.getOfferings} method.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2272,7 +2272,7 @@
         {
           "kind": "Enum",
           "canonicalReference": "@revenuecat/purchases-js!OfferingKeyword:enum",
-          "docComment": "/**\n * Parameters for the {@link Purchases.getOfferings} method.\n *\n * @public\n */\n",
+          "docComment": "/**\n * Keywords for identifying specific offerings in the {@link Purchases.getOfferings} method.\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",

--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -2287,7 +2287,7 @@
             {
               "kind": "EnumMember",
               "canonicalReference": "@revenuecat/purchases-js!OfferingKeyword.Current:member",
-              "docComment": "",
+              "docComment": "/**\n * The current offering.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -107,7 +107,7 @@ export enum ErrorCode {
     UserCancelledError = 1
 }
 
-// @public (undocumented)
+// @public
 export interface GetOfferingsParams {
     readonly currency?: string;
     readonly offeringIdentifier?: string | OfferingKeyword;

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -276,6 +276,7 @@ export class Purchases {
     getAppUserId(): string;
     getCurrentOfferingForPlacement(placementIdentifier: string, params?: GetOfferingsParams): Promise<Offering | null>;
     getCustomerInfo(): Promise<CustomerInfo>;
+    getOffering(offeringIdentifier: string, params?: GetOfferingsParams): Promise<Offering | null>;
     getOfferings(params?: GetOfferingsParams): Promise<Offerings>;
     static getSharedInstance(): Purchases;
     static isConfigured(): boolean;

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -107,9 +107,10 @@ export enum ErrorCode {
     UserCancelledError = 1
 }
 
-// @public
+// @public (undocumented)
 export interface GetOfferingsParams {
     readonly currency?: string;
+    readonly offeringIdentifier?: string | OfferingKeyword;
 }
 
 // @public
@@ -151,6 +152,12 @@ export interface Offering {
     readonly threeMonth: Package | null;
     readonly twoMonth: Package | null;
     readonly weekly: Package | null;
+}
+
+// @public
+export enum OfferingKeyword {
+    // (undocumented)
+    Current = "current"
 }
 
 // @public
@@ -276,7 +283,6 @@ export class Purchases {
     getAppUserId(): string;
     getCurrentOfferingForPlacement(placementIdentifier: string, params?: GetOfferingsParams): Promise<Offering | null>;
     getCustomerInfo(): Promise<CustomerInfo>;
-    getOffering(offeringIdentifier: string, params?: GetOfferingsParams): Promise<Offering | null>;
     getOfferings(params?: GetOfferingsParams): Promise<Offerings>;
     static getSharedInstance(): Purchases;
     static isConfigured(): boolean;

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -156,7 +156,6 @@ export interface Offering {
 
 // @public
 export enum OfferingKeyword {
-    // (undocumented)
     Current = "current"
 }
 

--- a/examples/rcbilling-demo/src/pages/paywall/index.tsx
+++ b/examples/rcbilling-demo/src/pages/paywall/index.tsx
@@ -93,7 +93,7 @@ const PaywallPage: React.FC = () => {
   const { purchases, offering } = usePurchasesLoaderData();
 
   if (!offering) {
-    console.error("No current offering found");
+    console.error("No offering found");
     return <>No offering found!</>;
   }
   const packages: Package[] = offering?.availablePackages || [];

--- a/examples/rcbilling-demo/src/pages/paywall/index.tsx
+++ b/examples/rcbilling-demo/src/pages/paywall/index.tsx
@@ -1,6 +1,6 @@
 import { Offering, Package, PurchasesError } from "@revenuecat/purchases-js";
 import React from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { usePurchasesLoaderData } from "../../util/PurchasesLoader";
 import Button from "../../components/Button";
 import LogoutButton from "../../components/LogoutButton";
@@ -90,20 +90,13 @@ export const PackageCard: React.FC<IPackageCardProps> = ({
 
 const PaywallPage: React.FC = () => {
   const navigate = useNavigate();
-  const { purchases, offerings } = usePurchasesLoaderData();
-  const [searchParams] = useSearchParams();
+  const { purchases, offering } = usePurchasesLoaderData();
 
-  const offeringId = searchParams.get("offering_id");
-
-  const selectedOffering = offeringId
-    ? offerings.all[offeringId] || null
-    : offerings.current;
-
-  if (!selectedOffering) {
+  if (!offering) {
     console.error("No current offering found");
     return <>No offering found!</>;
   }
-  const packages: Package[] = selectedOffering?.availablePackages || [];
+  const packages: Package[] = offering?.availablePackages || [];
   if (packages.length == 0) {
     console.error("No packages found in current offering.");
   }
@@ -148,7 +141,7 @@ const PaywallPage: React.FC = () => {
               <PackageCard
                 key={pkg.identifier}
                 pkg={pkg}
-                offering={selectedOffering}
+                offering={offering}
                 onClick={() => onPackageCardClicked(pkg)}
               />
             ) : null,

--- a/examples/rcbilling-demo/src/pages/paywall/index.tsx
+++ b/examples/rcbilling-demo/src/pages/paywall/index.tsx
@@ -1,6 +1,6 @@
 import { Offering, Package, PurchasesError } from "@revenuecat/purchases-js";
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { usePurchasesLoaderData } from "../../util/PurchasesLoader";
 import Button from "../../components/Button";
 import LogoutButton from "../../components/LogoutButton";
@@ -91,13 +91,19 @@ export const PackageCard: React.FC<IPackageCardProps> = ({
 const PaywallPage: React.FC = () => {
   const navigate = useNavigate();
   const { purchases, offerings } = usePurchasesLoaderData();
+  const [searchParams] = useSearchParams();
 
-  const currentOffering = offerings.current;
-  if (!currentOffering) {
+  const offeringId = searchParams.get("offering_id");
+
+  const selectedOffering = offeringId
+    ? offerings.all[offeringId] || null
+    : offerings.current;
+
+  if (!selectedOffering) {
     console.error("No current offering found");
     return <>No offering found!</>;
   }
-  const packages: Package[] = currentOffering?.availablePackages || [];
+  const packages: Package[] = selectedOffering?.availablePackages || [];
   if (packages.length == 0) {
     console.error("No packages found in current offering.");
   }
@@ -142,7 +148,7 @@ const PaywallPage: React.FC = () => {
               <PackageCard
                 key={pkg.identifier}
                 pkg={pkg}
-                offering={currentOffering}
+                offering={selectedOffering}
                 onClick={() => onPackageCardClicked(pkg)}
               />
             ) : null,

--- a/examples/rcbilling-demo/src/tests/main.test.ts
+++ b/examples/rcbilling-demo/src/tests/main.test.ts
@@ -35,13 +35,20 @@ test.describe("Main", () => {
     browserName,
   }) => {
     const userId = getUserId(browserName);
-    const offeringId = "e2e_test_specific_offering"; // The offering ID you expect to filter by
+    const offeringId = "default_download";
     const page = await setupTest(browser, userId, offeringId);
 
     const packageCards = await getAllElementsByLocator(page, CARD_SELECTOR);
 
-    expect(packageCards.length).toBe(1);
-    await expect(packageCards[0]).toHaveText(/9[,.]99/); // Example expected value for offering_1
+    const EXPECTED_VALUES = [/30[,.]00/, /15[,.]00/, /19[,.]99/];
+
+    expect(packageCards.length).toBe(3);
+    await Promise.all(
+      packageCards.map(
+        async (card, index) =>
+          await expect(card).toHaveText(EXPECTED_VALUES[index]),
+      ),
+    );
   });
 
   test("Can purchase a subscription Product", async ({

--- a/examples/rcbilling-demo/src/tests/main.test.ts
+++ b/examples/rcbilling-demo/src/tests/main.test.ts
@@ -30,26 +30,18 @@ test.describe("Main", () => {
       ),
     );
   });
-
-  test("Displays specific offering when offering_id is provided", async ({
+  test("Get offerings can filter by offering ID", async ({
     browser,
     browserName,
   }) => {
-    const userId = `${getUserId(browserName)}_specific_offering`;
-    const offeringId = "e2e_test_specific_offering";
-
+    const userId = getUserId(browserName);
+    const offeringId = "e2e_test_specific_offering"; // The offering ID you expect to filter by
     const page = await setupTest(browser, userId, offeringId);
 
     const packageCards = await getAllElementsByLocator(page, CARD_SELECTOR);
 
-    const EXPECTED_VALUES = [/9[,.]99/];
-
-    await Promise.all(
-      packageCards.map(
-        async (card, index) =>
-          await expect(card).toHaveText(EXPECTED_VALUES[index]),
-      ),
-    );
+    expect(packageCards.length).toBe(1);
+    await expect(packageCards[0]).toHaveText(/9[,.]99/); // Example expected value for offering_1
   });
 
   test("Can purchase a subscription Product", async ({
@@ -162,6 +154,7 @@ async function setupTest(
 ) {
   const page = await browser.newPage();
   await navigateToUrl(page, userId, offeringId);
+
   return page;
 }
 
@@ -216,10 +209,9 @@ async function navigateToUrl(
     (import.meta.env?.VITE_RC_BILLING_DEMO_URL as string | undefined) ??
     _LOCAL_URL;
 
-  const url = offeringId
-    ? `${baseUrl}paywall/${encodeURIComponent(userId)}?offering_id=${offeringId}`
-    : `${baseUrl}paywall/${encodeURIComponent(userId)}`;
-
+  const url = `${baseUrl}paywall/${encodeURIComponent(userId)}${
+    offeringId ? `?offeringId=${offeringId}` : ""
+  }`;
   await page.goto(url);
 }
 

--- a/examples/rcbilling-demo/src/tests/main.test.ts
+++ b/examples/rcbilling-demo/src/tests/main.test.ts
@@ -31,6 +31,27 @@ test.describe("Main", () => {
     );
   });
 
+  test("Displays specific offering when offering_id is provided", async ({
+    browser,
+    browserName,
+  }) => {
+    const userId = `${getUserId(browserName)}_specific_offering`;
+    const offeringId = "e2e_test_specific_offering";
+
+    const page = await setupTest(browser, userId, offeringId);
+
+    const packageCards = await getAllElementsByLocator(page, CARD_SELECTOR);
+
+    const EXPECTED_VALUES = [/9[,.]99/];
+
+    await Promise.all(
+      packageCards.map(
+        async (card, index) =>
+          await expect(card).toHaveText(EXPECTED_VALUES[index]),
+      ),
+    );
+  });
+
   test("Can purchase a subscription Product", async ({
     browser,
     browserName,
@@ -134,9 +155,13 @@ async function performPurchase(page: Page, card: Locator, userId: string) {
 const getUserId = (browserName: string) =>
   `rc_billing_demo_test_${Date.now()}_${browserName}`;
 
-async function setupTest(browser: Browser, userId: string) {
+async function setupTest(
+  browser: Browser,
+  userId: string,
+  offeringId?: string,
+) {
   const page = await browser.newPage();
-  await navigateToUrl(page, userId);
+  await navigateToUrl(page, userId, offeringId);
   return page;
 }
 
@@ -182,11 +207,20 @@ async function enterCreditCardDetailsAndContinue(page: Page): Promise<void> {
   await page.getByTestId("PayButton").click();
 }
 
-async function navigateToUrl(page: Page, userId: string): Promise<void> {
+async function navigateToUrl(
+  page: Page,
+  userId: string,
+  offeringId?: string,
+): Promise<void> {
   const baseUrl =
     (import.meta.env?.VITE_RC_BILLING_DEMO_URL as string | undefined) ??
     _LOCAL_URL;
-  await page.goto(`${baseUrl}paywall/${encodeURIComponent(userId)}`);
+
+  const url = offeringId
+    ? `${baseUrl}paywall/${encodeURIComponent(userId)}?offering_id=${offeringId}`
+    : `${baseUrl}paywall/${encodeURIComponent(userId)}`;
+
+  await page.goto(url);
 }
 
 async function typeTextInPageSelector(page: Page, text: string): Promise<void> {

--- a/examples/rcbilling-demo/src/util/PurchasesLoader.ts
+++ b/examples/rcbilling-demo/src/util/PurchasesLoader.ts
@@ -1,7 +1,7 @@
 import {
   CustomerInfo,
   LogLevel,
-  Offerings,
+  Offering,
   Purchases,
 } from "@revenuecat/purchases-js";
 import { LoaderFunction, redirect, useLoaderData } from "react-router-dom";
@@ -11,7 +11,7 @@ const apiKey = import.meta.env.VITE_RC_API_KEY as string;
 type IPurchasesLoaderData = {
   purchases: Purchases;
   customerInfo: CustomerInfo;
-  offerings: Offerings;
+  offering: Offering;
 };
 
 const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
@@ -21,6 +21,7 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
   const appUserId = params["app_user_id"];
   const searchParams = new URL(request.url).searchParams;
   const currency = searchParams.get("currency");
+  const offeringId = searchParams.get("offeringId");
 
   if (!appUserId) {
     throw redirect("/");
@@ -35,12 +36,20 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
     const purchases = Purchases.getSharedInstance();
     const [customerInfo, offerings] = await Promise.all([
       purchases.getCustomerInfo(),
-      purchases.getOfferings({ currency: currency || undefined }),
+      purchases.getOfferings({
+        currency: currency || undefined,
+        offeringIdentifier: offeringId || undefined,
+      }),
     ]);
+
+    const offering = offeringId
+      ? offerings.all[offeringId] || null // Return the specified offering
+      : offerings.current || null; // Default to the current offering
+
     return {
       purchases,
       customerInfo,
-      offerings,
+      offering,
     };
   } catch {
     throw redirect("/");

--- a/src/entities/get-offerings-params.ts
+++ b/src/entities/get-offerings-params.ts
@@ -3,6 +3,9 @@
  * @public
  */
 export enum OfferingKeyword {
+  /**
+   * The current offering.
+   */
   Current = "current",
 }
 

--- a/src/entities/get-offerings-params.ts
+++ b/src/entities/get-offerings-params.ts
@@ -2,10 +2,20 @@
  * Parameters for the {@link Purchases.getOfferings} method.
  * @public
  */
+export enum OfferingKeyword {
+  Current = "current",
+}
+
 export interface GetOfferingsParams {
   /**
    * The currency code in ISO 4217 to fetch the offerings for.
    * If not specified, the default currency will be used.
    */
   readonly currency?: string;
+
+  /**
+   * The identifier of the offering to fetch.
+   * Can be a string identifier or one of the predefined keywords.
+   */
+  readonly offeringIdentifier?: string | OfferingKeyword;
 }

--- a/src/entities/get-offerings-params.ts
+++ b/src/entities/get-offerings-params.ts
@@ -1,6 +1,5 @@
 /**
- * Parameters for the {@link Purchases.getOfferings} method.
- * @public
+ * Keywords for identifying specific offerings in the {@link Purchases.getOfferings} method.
  */
 export enum OfferingKeyword {
   /**
@@ -9,6 +8,10 @@ export enum OfferingKeyword {
   Current = "current",
 }
 
+/**
+ * Parameters for the {@link Purchases.getOfferings} method.
+ * @public
+ */
 export interface GetOfferingsParams {
   /**
    * The currency code in ISO 4217 to fetch the offerings for.

--- a/src/entities/offerings.ts
+++ b/src/entities/offerings.ts
@@ -362,11 +362,13 @@ export interface Offering {
  */
 export interface Offerings {
   /**
-   * Dictionary of all {@link Offering} objects keyed by their identifier.
+   * Dictionary containing all {@link Offering} objects, keyed by their identifier.
    */
   readonly all: { [offeringId: string]: Offering };
   /**
    * Current offering configured in the RevenueCat dashboard.
+   * It can be `null` if no current offering is configured or if a specific offering
+   * was requested that is not the current one.
    */
   readonly current: Offering | null;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,10 +78,8 @@ export type { PurchasesErrorExtra } from "./entities/errors";
 export type { Period, PeriodUnit } from "./helpers/duration-helper";
 export type { HttpConfig } from "./entities/http-config";
 export { LogLevel } from "./entities/log-level";
-export type {
-  GetOfferingsParams,
-  OfferingKeyword,
-} from "./entities/get-offerings-params";
+export type { GetOfferingsParams } from "./entities/get-offerings-params";
+export { OfferingKeyword } from "./entities/get-offerings-params";
 export type { PurchaseParams } from "./entities/purchase-params";
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -237,18 +237,16 @@ export class Purchases {
     const appUserId = this._appUserId;
     const offeringsResponse = await this.backend.getOfferings(appUserId);
 
-    if (params?.offeringIdentifier) {
-      const offeringIdToFilter =
-        params.offeringIdentifier === OfferingKeyword.Current
-          ? offeringsResponse.current_offering_id
-          : params.offeringIdentifier;
+    const offeringIdFilter =
+      params?.offeringIdentifier === OfferingKeyword.Current
+        ? offeringsResponse.current_offering_id
+        : params?.offeringIdentifier;
 
-      if (offeringIdToFilter) {
-        offeringsResponse.offerings = offeringsResponse.offerings.filter(
-          (offering: OfferingResponse) =>
-            offering.identifier === offeringIdToFilter,
-        );
-      }
+    if (offeringIdFilter) {
+      offeringsResponse.offerings = offeringsResponse.offerings.filter(
+        (offering: OfferingResponse) =>
+          offering.identifier === offeringIdFilter,
+      );
     }
 
     return await this.getAllOfferings(offeringsResponse, appUserId, params);

--- a/src/main.ts
+++ b/src/main.ts
@@ -229,6 +229,7 @@ export class Purchases {
   /**
    * Fetch the configured offerings for this user. You can configure these
    * in the RevenueCat dashboard.
+   * @param params - The parameters object to customise the offerings fetch. Check {@link GetOfferingsParams}
    */
   public async getOfferings(params?: GetOfferingsParams): Promise<Offerings> {
     validateCurrency(params?.currency);

--- a/src/main.ts
+++ b/src/main.ts
@@ -262,6 +262,26 @@ export class Purchases {
     );
   }
 
+  /**
+   * Retrieves a specific offering by its identifier.
+   * @param offeringIdentifier - The identifier of the offering to retrieve.
+   * @param params - The parameters object to customise the offerings fetch. Check {@link GetOfferingsParams}
+   */
+  public async getOffering(
+    offeringIdentifier: string,
+    params?: GetOfferingsParams,
+  ): Promise<Offering | null> {
+    const appUserId = this._appUserId;
+    const offeringsResponse = await this.backend.getOfferings(appUserId);
+
+    const offerings = await this.getAllOfferings(
+      offeringsResponse,
+      appUserId,
+      params,
+    );
+    return offerings.all[offeringIdentifier] ?? null;
+  }
+
   private async getAllOfferings(
     offeringsResponse: OfferingsResponse,
     appUserId: string,
@@ -435,8 +455,8 @@ export class Purchases {
     });
     if (missingProductIds.length > 0) {
       Logger.debugLog(
-        `Could not find product data for product ids: 
-        ${missingProductIds.join()}. 
+        `Could not find product data for product ids:
+        ${missingProductIds.join()}.
         Please check that your product configuration is correct.`,
       );
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,7 +78,10 @@ export type { PurchasesErrorExtra } from "./entities/errors";
 export type { Period, PeriodUnit } from "./helpers/duration-helper";
 export type { HttpConfig } from "./entities/http-config";
 export { LogLevel } from "./entities/log-level";
-export type { GetOfferingsParams } from "./entities/get-offerings-params";
+export type {
+  GetOfferingsParams,
+  OfferingKeyword,
+} from "./entities/get-offerings-params";
 export type { PurchaseParams } from "./entities/purchase-params";
 
 /**

--- a/src/tests/purchase.offerings.test.ts
+++ b/src/tests/purchase.offerings.test.ts
@@ -313,3 +313,18 @@ describe("getOfferings placements", () => {
     ).toEqual("test_placement_id");
   });
 });
+
+describe("getOffering", () => {
+  test("gets null offering if offering id is missing", async () => {
+    const purchases = configurePurchases();
+    const offering = await purchases.getOffering("missing_offering_id");
+    expect(offering).toBeNull();
+  });
+
+  test("gets correct offering if identifier id is valid", async () => {
+    const purchases = configurePurchases();
+    const offering = await purchases.getOffering("offering_2");
+    expect(offering).not.toBeNull();
+    expect(offering?.identifier).toEqual("offering_2");
+  });
+});


### PR DESCRIPTION
## Motivation / Description

This adds a new API under Purchases.getOffering that allows to obtain an offering by its identifier.


## Changes introduced

## Linear ticket (if any)

## Additional comments
