### PR TITLE
ECO-1336-layout components

### DIFF
--- a/src/stories/state-present-offer.stories.svelte
+++ b/src/stories/state-present-offer.stories.svelte
@@ -3,32 +3,35 @@
   import StatePresentOffer from "../ui/states/state-present-offer.svelte";
   import Shell from "../ui/shell.svelte";
   import { mapStyleOverridesToStyleVariables } from "../helpers/process-style-overrides.ts";
+  import Layout from "../ui/layout/layout.svelte";
+  import Container from "../ui/layout/container.svelte";
+  import Aside from "../ui/layout/aside-block.svelte";
 
 
-  let subscriptionOption={
-    id:"option_id_1",
-    priceId:'price_1',
+  let subscriptionOption = {
+    id: "option_id_1",
+    priceId: "price_1",
     base: {
       periodDuration: "P1M",
       price: {
-        id:'price_1',
+        id: "price_1",
         amount: 999,
-        amountMicros:999,
+        amountMicros: 999,
         currency: "USD",
         formattedPrice: "9.99$",
       },
       cycleCount: 0,
     },
-  }
+  };
 
   let product = {
     identifier: "some_product_123",
     displayName: "Some Product 123",
-    title:"Some Product 123",
+    title: "Some Product 123",
     productType: "subscription",
     currentPrice: {
       amount: 999,
-      amountMicros:999,
+      amountMicros: 999,
       currency: "USD",
       formattedPrice: "9.99$",
     },
@@ -36,7 +39,7 @@
     presentedOfferingIdentifier: "some_offering_identifier",
     defaultSubscriptionOption: subscriptionOption,
     subscriptionOptions: {
-      option_id_1: subscriptionOption
+      option_id_1: subscriptionOption,
     },
   };
 </script>
@@ -45,15 +48,16 @@
 <Meta title="StoryContext" component={StatePresentOffer} />
 
 
-
 <Template let:args>
-    <div class="rcb-ui-container" style={mapStyleOverridesToStyleVariables(args?.brandingAppearance)}>
-      <div class="rcb-ui-aside">
-      <Shell dark>
-        <StatePresentOffer {...args} />
-      </Shell>
-      </div>
-    </div>
+  <Container style={mapStyleOverridesToStyleVariables(args?.brandingAppearance)}>
+    <Layout>
+      <Aside>
+        <Shell dark>
+          <StatePresentOffer {...args} />
+        </Shell>
+      </Aside>
+    </Layout>
+  </Container>
 </Template>
 
 

--- a/src/ui/layout/aside-block.svelte
+++ b/src/ui/layout/aside-block.svelte
@@ -1,0 +1,28 @@
+<script>
+  export let style = "";
+</script>
+
+<div class="rcb-ui-aside" style={style}>
+  <slot />
+</div>
+
+<style>
+    .rcb-ui-aside {
+        margin-right: 16px;
+        flex: 320px 1 0;
+        max-width: 480px;
+    }
+
+    @media screen and (max-width: 960px) {
+        .rcb-ui-aside {
+            margin-right: 0;
+            margin-bottom: 16px;
+            min-width: 100%;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            flex: none;
+            max-width: none;
+        }
+    }
+</style>

--- a/src/ui/layout/container.svelte
+++ b/src/ui/layout/container.svelte
@@ -1,0 +1,19 @@
+<script>
+  export let style = "";
+</script>
+
+<div class="rcb-ui-container" style={style}>
+  <slot />
+</div>
+
+
+<style>
+    .rcb-ui-container {
+        color-scheme: none;
+        font-size: 16px;
+        line-height: 1.5em;
+        font-weight: 400;
+        font-family: -apple-system, "system-ui", "Segoe UI", Roboto, Oxygen, Ubuntu,
+        Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+    }
+</style>

--- a/src/ui/layout/layout.svelte
+++ b/src/ui/layout/layout.svelte
@@ -1,0 +1,40 @@
+<script>
+  export let style = "";
+</script>
+
+
+<div class="rcb-ui-layout" style={style}>
+  <slot />
+</div>
+
+
+<style>
+    .rcb-ui-layout {
+        width: 100vw;
+        margin-right: auto;
+        display: flex;
+        justify-content: center;
+        align-items: flex-start;
+        position: relative;
+        padding: 0px 80px;
+        box-sizing: border-box;
+    }
+
+    @media screen and (max-width: 960px) {
+        .rcb-ui-layout {
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 100%;
+            min-width: 100%;
+        }
+    }
+
+    @media screen and (max-width: 960px) and (max-height: 960px) {
+        .rcb-ui-layout {
+            overflow-y: scroll;
+            justify-content: flex-start;
+            padding: 16px 0;
+        }
+    }
+</style>

--- a/src/ui/layout/main-block.svelte
+++ b/src/ui/layout/main-block.svelte
@@ -1,0 +1,23 @@
+<script>
+  export let style = "";
+</script>
+
+<div class="rcb-ui-main" style={style}>
+  <slot />
+</div>
+
+<style>
+    .rcb-ui-main {
+        flex: 480px 1 0;
+        max-width: 640px;
+    }
+
+    @media screen and (max-width: 960px) {
+
+        .rcb-ui-main {
+            flex: none;
+            max-width: none;
+            min-width: 100%;
+        }
+    }
+</style>

--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -20,6 +20,11 @@
   import IconCart from "./assets/icon-cart.svelte";
   import BrandingInfoUI from "./branding-info-ui.svelte";
   import SandboxBanner from "./sandbox-banner.svelte";
+  import Layout from "./ui/layout/layout.svelte";
+  import Container from "./ui/layout/container.svelte";
+  import Aside from "./ui/layout/aside-block.svelte";
+  import Main from "./ui/layout/main-block.svelte";
+
   import { mapStyleOverridesToStyleVariables } from "../helpers/process-style-overrides";
 
   export let asModal = true;
@@ -177,19 +182,19 @@
   const closeWithError = () => {
     onError(
       lastError ??
-        new PurchaseFlowError(
-          PurchaseFlowErrorCode.UnknownError,
-          "Unknown error without state set.",
-        ),
+      new PurchaseFlowError(
+        PurchaseFlowErrorCode.UnknownError,
+        "Unknown error without state set.",
+      ),
     );
   };
 </script>
 
-<div class="rcb-ui-container">
+<Container>
   <ConditionalFullScreen condition={asModal}>
-    <div class="rcb-ui-layout" style={colorVariables}>
+    <Layout style={colorVariables}>
       {#if statesWhereOfferDetailsAreShown.includes(state)}
-        <div class="rcb-ui-aside">
+        <Aside>
           <Shell dark>
             <ModalHeader slot="header">
               <BrandingInfoUI {brandingInfo} />
@@ -206,9 +211,9 @@
               />
             {/if}
           </Shell>
-        </div>
+        </Aside>
       {/if}
-      <div class="rcb-ui-main">
+      <Main>
         <Shell>
           {#if state === "present-offer" && productDetails && purchaseOptionToUse}
             <StatePresentOffer
@@ -258,76 +263,7 @@
             <StateSuccess {productDetails} {brandingInfo} onContinue={handleContinue} />
           {/if}
         </Shell>
-      </div>
-    </div>
+      </Main>
+    </Layout>
   </ConditionalFullScreen>
-</div>
-
-<style>
-  .rcb-ui-container {
-    color-scheme: none;
-    font-size: 16px;
-    line-height: 1.5em;
-    font-weight: 400;
-    font-family: -apple-system, "system-ui", "Segoe UI", Roboto, Oxygen, Ubuntu,
-      Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-  }
-
-  .rcb-ui-layout {
-    width: 100vw;
-    width: 100 dvw;
-    margin-right: auto;
-    display: flex;
-    justify-content: center;
-    align-items: flex-start;
-    position: relative;
-    padding: 0px 80px;
-    box-sizing: border-box;
-  }
-
-  .rcb-ui-aside {
-    margin-right: 16px;
-    flex: 320px 1 0;
-    max-width: 480px;
-  }
-
-  .rcb-ui-main {
-    flex: 480px 1 0;
-    max-width: 640px;
-  }
-
-  @media screen and (max-width: 960px) {
-    .rcb-ui-layout {
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      height: 100%;
-      min-width: 100%;
-    }
-
-    .rcb-ui-aside {
-      margin-right: 0;
-      margin-bottom: 16px;
-      min-width: 100%;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      flex: none;
-      max-width: none;
-    }
-
-    .rcb-ui-main {
-      flex: none;
-      max-width: none;
-      min-width: 100%;
-    }
-  }
-
-  @media screen and (max-width: 960px) and (max-height: 960px) {
-    .rcb-ui-layout {
-      overflow-y: scroll;
-      justify-content: flex-start;
-      padding: 16px 0px;
-    }
-  }
-</style>
+</Container>

--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -20,10 +20,10 @@
   import IconCart from "./assets/icon-cart.svelte";
   import BrandingInfoUI from "./branding-info-ui.svelte";
   import SandboxBanner from "./sandbox-banner.svelte";
-  import Layout from "./ui/layout/layout.svelte";
-  import Container from "./ui/layout/container.svelte";
-  import Aside from "./ui/layout/aside-block.svelte";
-  import Main from "./ui/layout/main-block.svelte";
+  import Layout from "./layout/layout.svelte";
+  import Container from "./layout/container.svelte";
+  import Aside from "./layout/aside-block.svelte";
+  import Main from "./layout/main-block.svelte";
 
   import { mapStyleOverridesToStyleVariables } from "../helpers/process-style-overrides";
 


### PR DESCRIPTION
## Motivation / Description
The style for the layout components was defined at rcb-ui level.

This made it harder to write stories reusing the style (apart from copy pasting it).

This PR refactors the existing code to create some layout components that match the ones used in the rcb-ui entrypoint component. It also moves the style in the specific components.

## Changes introduced
* Created the aside-block, main-block, layout and container components
* Used those components in rcb-ui and cleaned up the style from there
* Used those components in the state-present-offer.stories.svelte so that now I can see the result of the customisation changes (there was no style before)