### PR TITLE
Demo App: Allow using anonymous IDs and generate deep links on demo app

### DIFF
--- a/examples/rcbilling-demo/package-lock.json
+++ b/examples/rcbilling-demo/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.18.0",
+        "uuid": "^10.0.0",
         "vitest": "^0.34.6"
       },
       "devDependencies": {
@@ -3814,6 +3815,19 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/examples/rcbilling-demo/package.json
+++ b/examples/rcbilling-demo/package.json
@@ -22,6 +22,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.18.0",
+    "uuid": "^10.0.0",
     "vitest": "^0.34.6"
   },
   "devDependencies": {

--- a/examples/rcbilling-demo/src/pages/login/index.tsx
+++ b/examples/rcbilling-demo/src/pages/login/index.tsx
@@ -1,9 +1,19 @@
 import React from "react";
 import Button from "../../components/Button";
 import { useNavigate } from "react-router-dom";
+import { v4 as uuidv4 } from "uuid";
+
+const generateRandomUserID = () => {
+  return `$RCAnonymousID:${uuidv4().replace(/-/g, "")}`;
+};
 
 const LoginPage: React.FC = () => {
   const navigate = useNavigate();
+  const navigateToAppUserIDPaywall = (appUserId?: string) => {
+    if (appUserId) {
+      navigate(`/paywall/${encodeURIComponent(appUserId)}`);
+    }
+  };
   return (
     <div className="login">
       <h1>Hello! What’s your user ID?</h1>
@@ -16,9 +26,13 @@ const LoginPage: React.FC = () => {
             const appUserId = (
               document.getElementById("app-user-id") as HTMLInputElement | null
             )?.value;
-            if (appUserId) {
-              navigate(`/paywall/${encodeURIComponent(appUserId)}`);
-            }
+            navigateToAppUserIDPaywall(appUserId);
+          }}
+        />
+        <Button
+          caption="Skip"
+          onClick={() => {
+            navigateToAppUserIDPaywall(generateRandomUserID());
           }}
         />
       </form>

--- a/examples/rcbilling-demo/src/pages/success/index.tsx
+++ b/examples/rcbilling-demo/src/pages/success/index.tsx
@@ -6,7 +6,7 @@ import LogoutButton from "../../components/LogoutButton";
 import { Purchases } from "@revenuecat/purchases-js";
 
 const isAnonymousUser = () => {
-  const anonymousIDRegex = /^RCAnonymousID:([a-f0-9]{32})$/;
+  const anonymousIDRegex = /^\$RCAnonymousID:([a-f0-9]{32})$/;
   return anonymousIDRegex.test(Purchases.getSharedInstance().getAppUserId());
 };
 

--- a/examples/rcbilling-demo/src/pages/success/index.tsx
+++ b/examples/rcbilling-demo/src/pages/success/index.tsx
@@ -3,6 +3,17 @@ import AppStoreButton from "../../components/AppStoreButton";
 import PlayStoreButton from "../../components/PlayStoreButton";
 import AppLogo from "../../components/AppLogo";
 import LogoutButton from "../../components/LogoutButton";
+import { Purchases } from "@revenuecat/purchases-js";
+
+const isAnonymousUser = () => {
+  const anonymousIDRegex = /^RCAnonymousID:([a-f0-9]{32})$/;
+  return anonymousIDRegex.test(Purchases.getSharedInstance().getAppUserId());
+};
+
+const generateDeepLink = () => {
+  const appUserId = Purchases.getSharedInstance().getAppUserId();
+  return `revenuecatbilling://redeem_rcb_purchase?redemption_token=${encodeURIComponent(appUserId)}`;
+};
 
 const SuccessPage: React.FC = () => {
   return (
@@ -18,6 +29,18 @@ const SuccessPage: React.FC = () => {
           <AppStoreButton />
           <PlayStoreButton />
         </div>
+        {isAnonymousUser() && (
+          <>
+            <h5 className="description">
+              You are currently using an anonymous user. To save your
+              subscription across devices, please download the app and tap on
+              this link from your device.
+            </h5>
+            <a href={generateDeepLink()}>
+              <button className="button">Redeem</button>
+            </a>
+          </>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
## Motivation / Description
This has 2 main changes:
- Adds an `Skip` button in the login button
- Adds a `Redeem` button in the success page with a deep link to the app including the anonymous user id.

| Skip button | Redeem button |
| ---- | ---- |
| <img width="391" alt="image" src="https://github.com/user-attachments/assets/1baa3fd8-2ae7-4e7c-92f2-c3faf84400d2"> | <img width="389" alt="image" src="https://github.com/user-attachments/assets/c2540788-1c2a-4442-a97f-02fcf24d3976"> |

## Changes introduced

## Linear ticket (if any)

## Additional comments
