### PR TITLE
Fix handling unrecognized error codes in purchase operation

### DIFF
--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -251,6 +251,30 @@ export class PurchaseOperationHelper {
           ),
         );
         return;
+      case CheckoutStatusErrorCodes.SetupIntentCompletionFailed:
+        reject(
+          new PurchaseFlowError(
+            PurchaseFlowErrorCode.ErrorSettingUpPurchase,
+            "Setup intent completion failed",
+          ),
+        );
+        return;
+      case CheckoutStatusErrorCodes.AlreadyPurchased:
+        reject(
+          new PurchaseFlowError(
+            PurchaseFlowErrorCode.AlreadyPurchasedError,
+            "Purchased was already completed",
+          ),
+        );
+        return;
+      default:
+        reject(
+          new PurchaseFlowError(
+            PurchaseFlowErrorCode.UnknownError,
+            "Unknown error code received",
+          ),
+        );
+        return;
     }
   }
 }

--- a/src/networking/responses/checkout-status-response.ts
+++ b/src/networking/responses/checkout-status-response.ts
@@ -9,10 +9,12 @@ export enum CheckoutStatusErrorCodes {
   SetupIntentCreationFailed = 1,
   PaymentMethodCreationFailed = 2,
   PaymentChargeFailed = 3,
+  SetupIntentCompletionFailed = 4,
+  AlreadyPurchased = 5,
 }
 
 export interface CheckoutStatusError {
-  readonly code: CheckoutStatusErrorCodes;
+  readonly code: CheckoutStatusErrorCodes | number;
   readonly message: string;
 }
 

--- a/src/tests/helpers/purchase-operation-helper.test.ts
+++ b/src/tests/helpers/purchase-operation-helper.test.ts
@@ -258,6 +258,46 @@ describe("PurchaseOperationHelper", () => {
       ),
     );
   });
+
+  test("pollCurrentPurchaseForCompletion error if poll returns unknown error code", async () => {
+    setPurchaseResponse(
+      HttpResponse.json(successPurchaseBody, {
+        status: StatusCodes.OK,
+      }),
+    );
+    const getCheckoutStatusResponse: CheckoutStatusResponse = {
+      operation: {
+        status: CheckoutSessionStatus.Failed,
+        isExpired: false,
+        error: {
+          code: 12345,
+          message: "test-error-message",
+        },
+      },
+    };
+    setGetCheckoutStatusResponse(
+      HttpResponse.json(getCheckoutStatusResponse, { status: StatusCodes.OK }),
+    );
+
+    await purchaseOperationHelper.startPurchase(
+      "test-app-user-id",
+      "test-product-id",
+      { id: "test-option-id", priceId: "test-price-id" },
+      "test-email",
+      {
+        offeringIdentifier: "test-offering-id",
+        targetingContext: null,
+        placementIdentifier: null,
+      },
+    );
+    await expectPromiseToPurchaseFlowError(
+      purchaseOperationHelper.pollCurrentPurchaseForCompletion(),
+      new PurchaseFlowError(
+        PurchaseFlowErrorCode.UnknownError,
+        "Unknown error code received",
+      ),
+    );
+  });
 });
 
 function verifyExpectedError(e: unknown, expectedError: PurchaseFlowError) {


### PR DESCRIPTION
## Motivation / Description
We were not handling unrecognized error codes in the polling operation session endpoint correctly... It was basically getting stuck without returning a response to the developer. This fixes that so we handle unknown error codes by returning an unknown error.

## Changes introduced

## Linear ticket (if any)

## Additional comments
