### PR TITLE
Small fix to make Pills the default shape in the customization

### DIFF
--- a/src/ui/theme/shapes.ts
+++ b/src/ui/theme/shapes.ts
@@ -22,4 +22,4 @@ export const PillsShape: Shape = {
   "modal-border-radius": "16px",
 };
 
-export const DefaultShape = RoundedShape;
+export const DefaultShape = PillsShape;


### PR DESCRIPTION
## Motivation / Description
When implementing the customization I erroneously picked the default shape as rounded and not pills.
This PR fixes it.


## All 3 apps aligned now 
(customer portal, WPL, sdk)
![Screenshot 2024-10-25 at 12 13 37](https://github.com/user-attachments/assets/974d6813-dbfe-4be5-972b-b7398f593232)
