### PR TITLE
Change purchase API to avoid breaking change

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -3945,12 +3945,12 @@
         },
         {
           "kind": "Interface",
-          "canonicalReference": "@revenuecat/purchases-js!~PurchaseResult:interface",
-          "docComment": "",
+          "canonicalReference": "@revenuecat/purchases-js!PurchaseResult:interface",
+          "docComment": "/**\n * Represents the result of a purchase operation.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "declare interface PurchaseResult "
+              "text": "export declare interface PurchaseResult "
             }
           ],
           "fileUrlPath": "dist/Purchases.es.d.ts",
@@ -3960,8 +3960,8 @@
           "members": [
             {
               "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!~PurchaseResult#customerInfo:member",
-              "docComment": "",
+              "canonicalReference": "@revenuecat/purchases-js!PurchaseResult#customerInfo:member",
+              "docComment": "/**\n * The customer information after the purchase.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -3988,8 +3988,8 @@
             },
             {
               "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!~PurchaseResult#redemptionInfo:member",
-              "docComment": "",
+              "canonicalReference": "@revenuecat/purchases-js!PurchaseResult#redemptionInfo:member",
+              "docComment": "/**\n * The redemption information after the purchase if available.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -4638,16 +4638,16 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<{\n             purchaseResult: "
+                  "text": "<"
                 },
                 {
                   "kind": "Reference",
                   "text": "PurchaseResult",
-                  "canonicalReference": "@revenuecat/purchases-js!~PurchaseResult:interface"
+                  "canonicalReference": "@revenuecat/purchases-js!PurchaseResult:interface"
                 },
                 {
                   "kind": "Content",
-                  "text": ";\n         }>"
+                  "text": ">"
                 },
                 {
                   "kind": "Content",
@@ -4718,16 +4718,16 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<{\n            purchaseResult: "
+                  "text": "<"
                 },
                 {
                   "kind": "Reference",
                   "text": "PurchaseResult",
-                  "canonicalReference": "@revenuecat/purchases-js!~PurchaseResult:interface"
+                  "canonicalReference": "@revenuecat/purchases-js!PurchaseResult:interface"
                 },
                 {
                   "kind": "Content",
-                  "text": ";\n        }>"
+                  "text": ">"
                 },
                 {
                   "kind": "Content",

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -274,11 +274,9 @@ export interface PurchaseParams {
     rcPackage: Package;
 }
 
-// @public (undocumented)
-interface PurchaseResult {
-    // (undocumented)
+// @public
+export interface PurchaseResult {
     readonly customerInfo: CustomerInfo;
-    // (undocumented)
     readonly redemptionInfo: RedemptionInfo | null;
 }
 
@@ -297,13 +295,9 @@ export class Purchases {
     // (undocumented)
     isSandbox(): boolean;
     preload(): Promise<void>;
-    purchase(params: PurchaseParams): Promise<{
-        purchaseResult: PurchaseResult;
-    }>;
+    purchase(params: PurchaseParams): Promise<PurchaseResult>;
     // @deprecated
-    purchasePackage(rcPackage: Package, customerEmail?: string, htmlTarget?: HTMLElement): Promise<{
-        purchaseResult: PurchaseResult;
-    }>;
+    purchasePackage(rcPackage: Package, customerEmail?: string, htmlTarget?: HTMLElement): Promise<PurchaseResult>;
     static setLogLevel(logLevel: LogLevel): void;
 }
 
@@ -351,10 +345,6 @@ export interface TargetingContext {
 export class UninitializedPurchasesError extends Error {
     constructor();
 }
-
-// Warnings were encountered during analysis:
-//
-// dist/Purchases.es.d.ts:722:13 - (ae-forgotten-export) The symbol "PurchaseResult" needs to be exported by the entry point Purchases.es.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/examples/rcbilling-demo/src/pages/paywall/index.tsx
+++ b/examples/rcbilling-demo/src/pages/paywall/index.tsx
@@ -111,24 +111,19 @@ const PaywallPage: React.FC = () => {
 
     // How do we complete the purchase?
     try {
-      const { purchaseResult } = await purchases.purchase({
+      const { customerInfo, redemptionInfo } = await purchases.purchase({
         rcPackage: pkg,
         purchaseOption: option,
       });
 
+      console.log(`CustomerInfo after purchase: ${customerInfo}`);
       console.log(
-        `CustomerInfo after purchase: ${purchaseResult.customerInfo}`,
-      );
-      console.log(
-        `RedemptionInfo after purchase: ${JSON.stringify(purchaseResult.redemptionInfo)}`,
+        `RedemptionInfo after purchase: ${JSON.stringify(redemptionInfo)}`,
       );
 
       let queryParamRedemptionInfoUrl = "";
-      if (
-        purchaseResult.redemptionInfo &&
-        purchaseResult.redemptionInfo.redeemUrl
-      ) {
-        queryParamRedemptionInfoUrl = `?redeem_url=${purchaseResult.redemptionInfo.redeemUrl}`;
+      if (redemptionInfo && redemptionInfo.redeemUrl) {
+        queryParamRedemptionInfoUrl = `?redeem_url=${redemptionInfo.redeemUrl}`;
       }
 
       navigate(

--- a/src/entities/purchase-result.ts
+++ b/src/entities/purchase-result.ts
@@ -1,7 +1,17 @@
-import { CustomerInfo } from "./customer-info";
-import { RedemptionInfo } from "./redemption-info";
+import type { CustomerInfo } from "./customer-info";
+import type { RedemptionInfo } from "./redemption-info";
 
+/**
+ * Represents the result of a purchase operation.
+ * @public
+ */
 export interface PurchaseResult {
+  /**
+   * The customer information after the purchase.
+   */
   readonly customerInfo: CustomerInfo;
+  /**
+   * The redemption information after the purchase if available.
+   */
   readonly redemptionInfo: RedemptionInfo | null;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,8 +45,8 @@ import {
   findOfferingByPlacementId,
   toOfferings,
 } from "./helpers/offerings-parser";
-import { RedemptionInfo } from "./entities/redemption-info";
-import { PurchaseResult } from "./entities/purchase-result";
+import { type RedemptionInfo } from "./entities/redemption-info";
+import { type PurchaseResult } from "./entities/purchase-result";
 
 export { ProductType } from "./entities/offerings";
 export type {
@@ -83,6 +83,7 @@ export type { GetOfferingsParams } from "./entities/get-offerings-params";
 export { OfferingKeyword } from "./entities/get-offerings-params";
 export type { PurchaseParams } from "./entities/purchase-params";
 export type { RedemptionInfo } from "./entities/redemption-info";
+export type { PurchaseResult } from "./entities/purchase-result";
 
 /**
  * Entry point for Purchases SDK. It should be instantiated as soon as your
@@ -330,9 +331,7 @@ export class Purchases {
     rcPackage: Package,
     customerEmail?: string,
     htmlTarget?: HTMLElement,
-  ): Promise<{
-    purchaseResult: PurchaseResult;
-  }> {
+  ): Promise<PurchaseResult> {
     return this.purchase({
       rcPackage,
       customerEmail,
@@ -350,9 +349,7 @@ export class Purchases {
    * @throws {@link PurchasesError} if there is an error while performing the purchase. If the {@link PurchasesError.errorCode} is {@link ErrorCode.UserCancelledError}, the user cancelled the purchase.
    */
   @requiresLoadedResources
-  public purchase(params: PurchaseParams): Promise<{
-    purchaseResult: PurchaseResult;
-  }> {
+  public purchase(params: PurchaseParams): Promise<PurchaseResult> {
     const { rcPackage, purchaseOption, htmlTarget, customerEmail } = params;
     let resolvedHTMLTarget =
       htmlTarget ?? document.getElementById("rcb-ui-root");
@@ -391,11 +388,11 @@ export class Purchases {
             Logger.debugLog("Purchase finished");
             certainHTMLTarget.innerHTML = "";
             // TODO: Add info about transaction in result.
-            let purchaseResult: PurchaseResult = {
+            const purchaseResult: PurchaseResult = {
               customerInfo: await this._getCustomerInfoForUserId(appUserId),
               redemptionInfo: redemptionInfo,
             };
-            resolve({ purchaseResult: purchaseResult });
+            resolve(purchaseResult);
           },
           onClose: () => {
             certainHTMLTarget.innerHTML = "";


### PR DESCRIPTION
## Motivation / Description
We changed the API in a breaking way to add some new data in #220. However, we could avoid the breaking change by making the purchase method keep returning the same object but just with an additional field.

## Changes introduced

## Linear ticket (if any)

## Additional comments
