### PR TITLE
Add convenience method to generate RC-like anonymous IDs

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -4214,12 +4214,12 @@
             },
             {
               "kind": "Method",
-              "canonicalReference": "@revenuecat/purchases-js!Purchases.generateRevenueCatAnonymousId:member(1)",
+              "canonicalReference": "@revenuecat/purchases-js!Purchases.generateRevenueCatAnonymousAppUserId:member(1)",
               "docComment": "/**\n * Generates an anonymous app user ID that follows RevenueCat's format. This can be used when you don't have a user identifier system in place. The generated ID will be in the format: $RCAnonymousID:<UUID without dashes>\n *\n * @returns A new anonymous app user ID string\n *\n * @public\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "static generateRevenueCatAnonymousId(): "
+                  "text": "static generateRevenueCatAnonymousAppUserId(): "
                 },
                 {
                   "kind": "Content",
@@ -4241,7 +4241,7 @@
               "parameters": [],
               "isOptional": false,
               "isAbstract": false,
-              "name": "generateRevenueCatAnonymousId"
+              "name": "generateRevenueCatAnonymousAppUserId"
             },
             {
               "kind": "Method",

--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -4214,6 +4214,37 @@
             },
             {
               "kind": "Method",
+              "canonicalReference": "@revenuecat/purchases-js!Purchases.generateRevenueCatAnonymousId:member(1)",
+              "docComment": "/**\n * Generates an anonymous app user ID that follows RevenueCat's format. This can be used when you don't have a user identifier system in place. The generated ID will be in the format: $RCAnonymousID:<UUID without dashes>\n *\n * @returns A new anonymous app user ID string\n *\n * @public\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "static generateRevenueCatAnonymousId(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": true,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "generateRevenueCatAnonymousId"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "@revenuecat/purchases-js!Purchases#getAppUserId:member(1)",
               "docComment": "/**\n * Gets the current app user id.\n */\n",
               "excerptTokens": [

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -285,7 +285,7 @@ export class Purchases {
     changeUser(newAppUserId: string): Promise<CustomerInfo>;
     close(): void;
     static configure(apiKey: string, appUserId: string, httpConfig?: HttpConfig): Purchases;
-    static generateRevenueCatAnonymousId(): string;
+    static generateRevenueCatAnonymousAppUserId(): string;
     getAppUserId(): string;
     getCurrentOfferingForPlacement(placementIdentifier: string, params?: GetOfferingsParams): Promise<Offering | null>;
     getCustomerInfo(): Promise<CustomerInfo>;

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -285,6 +285,7 @@ export class Purchases {
     changeUser(newAppUserId: string): Promise<CustomerInfo>;
     close(): void;
     static configure(apiKey: string, appUserId: string, httpConfig?: HttpConfig): Purchases;
+    static generateRevenueCatAnonymousId(): string;
     getAppUserId(): string;
     getCurrentOfferingForPlacement(placementIdentifier: string, params?: GetOfferingsParams): Promise<Offering | null>;
     getCustomerInfo(): Promise<CustomerInfo>;

--- a/examples/rcbilling-demo/src/pages/login/index.tsx
+++ b/examples/rcbilling-demo/src/pages/login/index.tsx
@@ -1,11 +1,7 @@
 import React from "react";
 import Button from "../../components/Button";
 import { useNavigate } from "react-router-dom";
-import { v4 as uuidv4 } from "uuid";
-
-const generateRandomUserID = () => {
-  return `$RCAnonymousID:${uuidv4().replace(/-/g, "")}`;
-};
+import { Purchases } from "@revenuecat/purchases-js";
 
 const LoginPage: React.FC = () => {
   const navigate = useNavigate();
@@ -32,7 +28,9 @@ const LoginPage: React.FC = () => {
         <Button
           caption="Skip"
           onClick={() => {
-            navigateToAppUserIDPaywall(generateRandomUserID());
+            navigateToAppUserIDPaywall(
+              Purchases.generateRevenueCatAnonymousId(),
+            );
           }}
         />
       </form>

--- a/examples/rcbilling-demo/src/pages/login/index.tsx
+++ b/examples/rcbilling-demo/src/pages/login/index.tsx
@@ -29,7 +29,7 @@ const LoginPage: React.FC = () => {
           caption="Skip"
           onClick={() => {
             navigateToAppUserIDPaywall(
-              Purchases.generateRevenueCatAnonymousId(),
+              Purchases.generateRevenueCatAnonymousAppUserId(),
             );
           }}
         />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@revenuecat/purchases-js",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@revenuecat/purchases-js",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "@stripe/stripe-js": "^4.9.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -492,4 +492,16 @@ export class Purchases {
 
     return toCustomerInfo(subscriberResponse);
   }
+
+  /**
+   * Generates an anonymous app user ID that follows RevenueCat's format.
+   * This can be used when you don't have a user identifier system in place.
+   * The generated ID will be in the format: $RCAnonymousID:<UUID without dashes>
+   * @returns A new anonymous app user ID string
+   * @public
+   */
+  public static generateRevenueCatAnonymousId(): string {
+    const uuid = crypto.randomUUID();
+    return `$RCAnonymousID:${uuid.replace(/-/g, "")}`;
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -497,10 +497,11 @@ export class Purchases {
    * Generates an anonymous app user ID that follows RevenueCat's format.
    * This can be used when you don't have a user identifier system in place.
    * The generated ID will be in the format: $RCAnonymousID:<UUID without dashes>
+   * Example: $RCAnonymousID:123e4567e89b12d3a456426614174000
    * @returns A new anonymous app user ID string
    * @public
    */
-  public static generateRevenueCatAnonymousId(): string {
+  public static generateRevenueCatAnonymousAppUserId(): string {
     const uuid = crypto.randomUUID();
     return `$RCAnonymousID:${uuid.replace(/-/g, "")}`;
   }

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -190,3 +190,21 @@ describe("Purchases.preload()", () => {
     await purchases.preload();
   });
 });
+
+describe("Purchases.generateRevenueCatAnonymousId()", () => {
+  test("generates ID with correct format", () => {
+    const anonymousId = Purchases.generateRevenueCatAnonymousId();
+    expect(anonymousId).toMatch(/^\$RCAnonymousID:[0-9a-f]{32}$/);
+  });
+
+  test("generates unique IDs", () => {
+    const id1 = Purchases.generateRevenueCatAnonymousId();
+    const id2 = Purchases.generateRevenueCatAnonymousId();
+    expect(id1).not.toEqual(id2);
+  });
+
+  test("generated ID passes appUserId validation", () => {
+    const anonymousId = Purchases.generateRevenueCatAnonymousId();
+    expect(() => Purchases.configure(testApiKey, anonymousId)).not.toThrow();
+  });
+});

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -191,20 +191,20 @@ describe("Purchases.preload()", () => {
   });
 });
 
-describe("Purchases.generateRevenueCatAnonymousId()", () => {
+describe("Purchases.generateRevenueCatAnonymousAppUserId()", () => {
   test("generates ID with correct format", () => {
-    const anonymousId = Purchases.generateRevenueCatAnonymousId();
+    const anonymousId = Purchases.generateRevenueCatAnonymousAppUserId();
     expect(anonymousId).toMatch(/^\$RCAnonymousID:[0-9a-f]{32}$/);
   });
 
   test("generates unique IDs", () => {
-    const id1 = Purchases.generateRevenueCatAnonymousId();
-    const id2 = Purchases.generateRevenueCatAnonymousId();
+    const id1 = Purchases.generateRevenueCatAnonymousAppUserId();
+    const id2 = Purchases.generateRevenueCatAnonymousAppUserId();
     expect(id1).not.toEqual(id2);
   });
 
   test("generated ID passes appUserId validation", () => {
-    const anonymousId = Purchases.generateRevenueCatAnonymousId();
+    const anonymousId = Purchases.generateRevenueCatAnonymousAppUserId();
     expect(() => Purchases.configure(testApiKey, anonymousId)).not.toThrow();
   });
 });


### PR DESCRIPTION
## Motivation / Description
Add a new convenience method to generate anonymous app user IDs that follows RevenueCat's convention. Example:
```
$RCAnonymousID:123e4567e89b12d3a456426614174000
``` 

## Changes introduced

## Linear ticket (if any)

## Additional comments
