### PR TITLE
Removing the lateral padding based on screen width only

### DIFF
--- a/src/ui/layout/layout.svelte
+++ b/src/ui/layout/layout.svelte
@@ -27,6 +27,7 @@
             justify-content: center;
             height: 100%;
             min-width: 100%;
+            padding: 16px 0;
         }
     }
 
@@ -34,7 +35,6 @@
         .rcb-ui-layout {
             overflow-y: scroll;
             justify-content: flex-start;
-            padding: 16px 0;
         }
     }
 </style>


### PR DESCRIPTION
## Motivation / Description
Moved the padding removal to the media query that considers only the screen width


### Before
<img width="495" alt="Screenshot 2024-11-19 at 16 19 19" src="https://github.com/user-attachments/assets/9d314932-2e87-49a2-8624-dec0ea50329d">


### After
<img width="495" alt="Screenshot 2024-11-19 at 16 19 26" src="https://github.com/user-attachments/assets/7b7592b9-c75b-4483-a0fe-f3fafe329615">
