### PR TITLE
fix: Do not show error message if Google Pay or Apple Pay window is closed

### DIFF
--- a/src/ui/states/state-needs-payment-info.svelte
+++ b/src/ui/states/state-needs-payment-info.svelte
@@ -67,8 +67,13 @@
     });
 
     if (result.error) {
-      // payment failed, notify user
       processing = false;
+
+      if (!result.error.setup_intent?.last_setup_error) {
+        return;
+      }
+
+      // payment failed, notify user
       onError(
         new PurchaseFlowError(
           PurchaseFlowErrorCode.StripeError,


### PR DESCRIPTION
## Motivation / Description

## Changes introduced

## Linear ticket (if any)

## Additional comments
