### PR TITLE
fix: Improve payment method validation by displaying Stripe errors in the form when possible

### DIFF
--- a/src/entities/errors.ts
+++ b/src/entities/errors.ts
@@ -175,8 +175,6 @@ export class ErrorCodeUtils {
         return ErrorCode.NetworkError;
       case PurchaseFlowErrorCode.MissingEmailError:
         return ErrorCode.PurchaseInvalidError;
-      case PurchaseFlowErrorCode.StripeError:
-        return ErrorCode.StoreProblemError;
       case PurchaseFlowErrorCode.UnknownError:
         return ErrorCode.UnknownError;
       case PurchaseFlowErrorCode.AlreadyPurchasedError:

--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -28,7 +28,6 @@ export enum PurchaseFlowErrorCode {
   ErrorChargingPayment = 1,
   UnknownError = 2,
   NetworkError = 3,
-  StripeError = 4,
   MissingEmailError = 5,
   AlreadyPurchasedError = 6,
 }
@@ -52,7 +51,6 @@ export class PurchaseFlowError extends Error {
       case PurchaseFlowErrorCode.ErrorSettingUpPurchase:
       case PurchaseFlowErrorCode.ErrorChargingPayment:
       case PurchaseFlowErrorCode.AlreadyPurchasedError:
-      case PurchaseFlowErrorCode.StripeError:
       case PurchaseFlowErrorCode.UnknownError:
         return false;
     }
@@ -77,9 +75,6 @@ export class PurchaseFlowError extends Error {
         return "Payment failed.";
       case PurchaseFlowErrorCode.NetworkError:
         return "Network error. Please check your internet connection.";
-      case PurchaseFlowErrorCode.StripeError:
-        // For stripe errors, we can display the stripe-provided error message.
-        return this.message;
       case PurchaseFlowErrorCode.MissingEmailError:
         return "Email is required to complete the purchase.";
       case PurchaseFlowErrorCode.AlreadyPurchasedError:

--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -28,8 +28,8 @@ export enum PurchaseFlowErrorCode {
   ErrorChargingPayment = 1,
   UnknownError = 2,
   NetworkError = 3,
-  MissingEmailError = 5,
-  AlreadyPurchasedError = 6,
+  MissingEmailError = 4,
+  AlreadyPurchasedError = 5,
 }
 
 export class PurchaseFlowError extends Error {

--- a/src/ui/button.svelte
+++ b/src/ui/button.svelte
@@ -45,6 +45,7 @@
   button:disabled {
     color: var(--rc-color-grey-text-light);
     background-color: var(--rc-color-grey-ui-dark);
+    outline: none;
   }
 
   button.intent-primary:disabled {

--- a/src/ui/layout/message-layout.svelte
+++ b/src/ui/layout/message-layout.svelte
@@ -8,19 +8,23 @@
 
   export let brandingInfo: BrandingInfoResponse | null = null;
   export let onContinue: () => void;
-  export let title: string;
+  export let title: string | null = null;
   export let type: string;
   export let closeButtonTitle: string = "Go back to app";
 </script>
 
 <RowLayout gutter="32px">
-  <BrandAndCloseHeader {brandingInfo} onClose={onContinue} />
+  {#if title}
+    <BrandAndCloseHeader {brandingInfo} onClose={onContinue} />
+  {/if}
   <ModalSection>
-    <div class="rcb-modal-message" data-type={type}>
+    <div class="rcb-modal-message" data-type={type} data-has-title={!!title}>
       <RowLayout gutter="48px">
         <slot name="icon" />
         <RowLayout gutter="16px">
-          <span class="title">{title}</span>
+          {#if title}
+            <span class="title">{title}</span>
+          {/if}
           <span class="subtitle">
             <slot />
           </span>
@@ -44,6 +48,10 @@
     text-align: center;
     margin-bottom: 16px;
     margin-top: 16px;
+  }
+
+  .rcb-modal-message[data-has-title="false"] {
+    margin-top: 80px;
   }
 
   .title {

--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -253,7 +253,6 @@
             {paymentInfoCollectionMetadata}
             onContinue={handleContinue}
             onClose={handleClose}
-            onError={handleError}
             processing={state === "polling-purchase-status"}
             {productDetails}
             {purchaseOptionToUse}

--- a/src/ui/states/state-error.svelte
+++ b/src/ui/states/state-error.svelte
@@ -72,9 +72,6 @@
           LocalizationKeys.StateErrorErrorMessageNetworkError,
           { errorCode: publicErrorCode },
         );
-      case PurchaseFlowErrorCode.StripeError:
-        // For stripe errors, we can display the stripe-provided error message.
-        return lastError.message;
       case PurchaseFlowErrorCode.MissingEmailError:
         return translator.translate(
           LocalizationKeys.StateErrorErrorMessageMissingEmailError,


### PR DESCRIPTION
## Motivation / Description

We’ve improved the handling of validation errors by processing them internally and properly rendering the error messages directly to the customer. This enhancement ensures that errors are displayed within the purchase flow, preventing customers from being redirected out of the flow due to unhandled validation issues.

## Changes introduced

ed43e80 - chore: Remove `PurchaseFlowErrorCode.StripeError` type
b269eaf - feat: Handle payment method info error internally
b38727a - chore: Make `title` and optional property in `message-layout`
7d56303 - fix: Remove outline on disable buttons

## Screenshots

| Before | After | 
|----------|----------|
| ![image](https://github.com/user-attachments/assets/0f009459-366b-47bd-b9b5-8ffe7593d3f2) _Pressing `Try Again` exits to the paywall view_ | ![image](https://github.com/user-attachments/assets/1669a406-36af-4dd4-bb52-6750aa14b1b7) |

| Before | After | 
|----------|----------|
| ![image](https://github.com/user-attachments/assets/8d4df28b-4590-419a-8a45-cb4d1ea5218e) _Pressing `Try Again` exits to the paywall view_ | ![image](https://github.com/user-attachments/assets/42399767-4ee7-4853-a990-e824f701de0f) _Pressing `Try Again` returns to the `Secure Checkout`_ |







