### PR TITLE
ECO-1797: PR to fix price conversions in different languages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,5 @@
       "prettier --write --ignore-unknown",
       "eslint --fix --no-warn-ignored"
     ]
-  },
-  "packageManager": "pnpm@9.12.3+sha512.cce0f9de9c5a7c95bef944169cc5dfe8741abfb145078c0d508b868056848a87c81e626246cb60967cbd7fd29a6c062ef73ff840d96b3c86c40ac92cf4a813ee"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -105,5 +105,6 @@
       "prettier --write --ignore-unknown",
       "eslint --fix --no-warn-ignored"
     ]
-  }
+  },
+  "packageManager": "pnpm@9.12.3+sha512.cce0f9de9c5a7c95bef944169cc5dfe8741abfb145078c0d508b868056848a87c81e626246cb60967cbd7fd29a6c062ef73ff840d96b3c86c40ac92cf4a813ee"
 }

--- a/src/helpers/paywall-variables-helpers.ts
+++ b/src/helpers/paywall-variables-helpers.ts
@@ -132,10 +132,11 @@ function getTotalPriceAndPerMonth({
   full?: boolean;
   translator: Translator;
 }) {
-  if (!period || !period.number) return price.formattedPrice;
+  if (!period || !period.number)
+    return translator.formatPrice(price.amountMicros, price.currency);
 
   if (period.unit === PeriodUnit.Month && period.number == 1) {
-    return price.formattedPrice;
+    return translator.formatPrice(price.amountMicros, price.currency);
   }
 
   let pricePerMonth: string | undefined = "";
@@ -173,7 +174,10 @@ function getTotalPriceAndPerMonth({
   return translator.translate(
     LocalizationKeys.PaywallVariablesTotalPriceAndPerMonth,
     {
-      formattedPrice: price.formattedPrice,
+      formattedPrice: translator.formatPrice(
+        price.amountMicros,
+        price.currency,
+      ),
       period: translator.translatePeriod(period.number, period.unit, {
         noWhitespace: true,
         short: !full,
@@ -218,7 +222,10 @@ function parsePackageIntoVariables(
   translator: Translator,
 ) {
   const rcBillingProduct = pkg.rcBillingProduct;
-  const formattedPrice = rcBillingProduct.currentPrice.formattedPrice;
+  const formattedPrice = translator.formatPrice(
+    rcBillingProduct.currentPrice.amountMicros,
+    rcBillingProduct.currentPrice.currency,
+  );
   const product = getProductPerType(pkg);
   const productType = rcBillingProduct.productType;
 

--- a/src/stories/state-present-offer.stories.svelte
+++ b/src/stories/state-present-offer.stories.svelte
@@ -55,6 +55,34 @@
     "es",
     englishLocale,
   );
+
+  const priceJPY = {
+    currency: "JPY",
+    amount: 1000,
+    amountMicros: 1000000000,
+    formattedPrice: "¥1,000",
+  };
+
+  const priceEUR = {
+    currency: "EUR",
+    amount: 10,
+    amountMicros: 10000000,
+    formattedPrice: "€10.00",
+  };
+
+  const priceGBP = {
+    currency: "GBP",
+    amount: 10,
+    amountMicros: 10000000,
+    formattedPrice: "£10.00",
+  };
+
+  const priceCAD = {
+    currency: "CAD",
+    amount: 10,
+    amountMicros: 10000000,
+    formattedPrice: "CA$10.00",
+  };
 </script>
 
 <Meta title="StatePresentsOffer" component={StatePresentOffer} />
@@ -199,5 +227,73 @@
 
     context: { [translatorContextKey]: spanishCustomLabelsTranslator },
     productDetails: { ...product, description: null },
+  }}
+/>
+
+<Story
+  name="Price JPY"
+  args={{
+    ...defaultArgs,
+    purchaseOption: {
+      ...subscriptionOption,
+      base: { ...subscriptionOption.base, price: priceJPY },
+    },
+  }}
+/>
+
+<Story
+  name="Price JPY Spanish"
+  args={{
+    ...defaultArgs,
+    purchaseOption: {
+      ...subscriptionOption,
+      base: { ...subscriptionOption.base, price: priceJPY },
+    },
+    context: { [translatorContextKey]: spanishTranslator },
+  }}
+/>
+
+<Story
+  name="Price EUR"
+  args={{
+    ...defaultArgs,
+    purchaseOption: {
+      ...subscriptionOption,
+      base: { ...subscriptionOption.base, price: priceEUR },
+    },
+  }}
+/>
+
+<Story
+  name="Price EUR Spanish"
+  args={{
+    ...defaultArgs,
+    purchaseOption: {
+      ...subscriptionOption,
+      base: { ...subscriptionOption.base, price: priceEUR },
+    },
+    context: { [translatorContextKey]: spanishTranslator },
+  }}
+/>
+
+<Story
+  name="Price CAD"
+  args={{
+    ...defaultArgs,
+    purchaseOption: {
+      ...subscriptionOption,
+      base: { ...subscriptionOption.base, price: priceCAD },
+    },
+  }}
+/>
+
+<Story
+  name="Price GBP"
+  args={{
+    ...defaultArgs,
+    purchaseOption: {
+      ...subscriptionOption,
+      base: { ...subscriptionOption.base, price: priceGBP },
+    },
   }}
 />

--- a/src/tests/locale/locale.test.ts
+++ b/src/tests/locale/locale.test.ts
@@ -5,6 +5,9 @@ import {
   supportedLanguages,
 } from "../../ui/localization/supportedLanguages";
 import * as fs from "node:fs";
+import type { Price } from "../../entities/offerings";
+import { Translator } from "../../ui/localization/translator";
+import { type Period, PeriodUnit } from "../../helpers/duration-helper";
 
 const eqSet = (xs: Set<unknown>, ys: Set<unknown>) =>
   xs.size === ys.size && [...xs].every((x) => ys.has(x));
@@ -12,7 +15,6 @@ const eqSet = (xs: Set<unknown>, ys: Set<unknown>) =>
 describe("The Translator class", () => {
   test("should have the expected keys in all supported languages", () => {
     const expectedKeysSet = new Set(Object.values(LocalizationKeys));
-
     Object.entries(supportedLanguages).forEach(([lang, translations]) => {
       const otherLabelKeys = new Set(Object.keys(translations));
 
@@ -23,7 +25,81 @@ describe("The Translator class", () => {
     });
   });
 
-  test("all files present in /locales should be imported as a supportedLanguage", () => {
+  test("should not fail for any language/fallbackLanguage when formatting prices", () => {
+    const price: Price = {
+      amountMicros: 10000000,
+      currency: "USD",
+      formattedPrice: "$10.00",
+      amount: 10,
+    };
+
+    Object.entries(supportedLanguages).forEach(([lang]) => {
+      Object.entries(supportedLanguages).forEach(([fallbackLang]) => {
+        const translator = new Translator({}, lang, fallbackLang);
+        expect(
+          () => translator.formatPrice(price.amountMicros, price.currency),
+          `Formatting price failed for language ${lang}/${fallbackLang}`,
+        ).not.toThrow();
+      });
+    });
+  });
+
+  test("should not fail for any language/fallbackLanguage when translating labels", () => {
+    Object.entries(supportedLanguages).forEach(([lang]) => {
+      Object.entries(supportedLanguages).forEach(([fallbackLang]) => {
+        const translator = new Translator({}, lang, fallbackLang);
+        expect(
+          () =>
+            translator.translate(
+              LocalizationKeys.StateNeedsAuthInfoEmailStepTitle,
+            ),
+          `Translating failed for language ${lang}/${fallbackLang}`,
+        ).not.toThrow();
+      });
+    });
+  });
+
+  test("should not fail for wrong languages when translating labels", () => {
+    const translator = new Translator({}, "clearly_not_a_locale", "me_neither");
+    expect(
+      () =>
+        translator.translate(LocalizationKeys.StateNeedsAuthInfoEmailStepTitle),
+      `Translating failed for language`,
+    ).not.toThrow();
+  });
+
+  test("should not fail for any language/fallbackLanguage when translating periods", () => {
+    const period: Period = {
+      number: 10,
+      unit: PeriodUnit.Month,
+    };
+
+    Object.entries(supportedLanguages).forEach(([lang]) => {
+      Object.entries(supportedLanguages).forEach(([fallbackLang]) => {
+        const translator = new Translator({}, lang, fallbackLang);
+        expect(
+          () => translator.translatePeriod(period.number, period.unit),
+          `Translating failed for language ${lang}/${fallbackLang}`,
+        ).not.toThrow();
+      });
+    });
+  });
+
+  test("should not fail for wrong languages when translating periods", () => {
+    const period: Period = {
+      number: 10,
+      unit: PeriodUnit.Month,
+    };
+    const translator = new Translator({}, "clearly_not_a_locale", "me_neither");
+    expect(
+      () => translator.translatePeriod(period.number, period.unit),
+      `Translating failed for language`,
+    ).not.toThrow();
+  });
+});
+
+describe("The supportedLanguages", () => {
+  test("should include all the files present in /locales", () => {
     const files: string[] = [];
     fs.readdirSync("src/ui/localization/locale").forEach((file) => {
       if (file.endsWith(".json")) {

--- a/src/ui/localization/translator.ts
+++ b/src/ui/localization/translator.ts
@@ -86,12 +86,33 @@ export class Translator {
 
   public formatPrice(priceInMicros: number, currency: string): string {
     const price = priceInMicros / 1000000;
-    const formatter = new Intl.NumberFormat(this.locale, {
+
+    try {
+      return new Intl.NumberFormat(this.locale, {
+        style: "currency",
+        currency,
+      }).format(price);
+    } catch {
+      console.debug(
+        `Failed to create a price formatter for locale: ${this.locale}`,
+      );
+    }
+
+    try {
+      return new Intl.NumberFormat(this.fallbackLocale, {
+        style: "currency",
+        currency,
+      }).format(price);
+    } catch {
+      console.debug(
+        `Failed to create a price formatter for locale: ${this.locale}`,
+      );
+    }
+
+    return new Intl.NumberFormat(englishLocale, {
       style: "currency",
       currency,
-    });
-
-    return formatter.format(price);
+    }).format(price);
   }
 
   get locale(): string {

--- a/src/ui/localization/translator.ts
+++ b/src/ui/localization/translator.ts
@@ -105,7 +105,7 @@ export class Translator {
       }).format(price);
     } catch {
       console.debug(
-        `Failed to create a price formatter for locale: ${this.locale}`,
+        `Failed to create a price formatter for locale: ${this.fallbackLocale}`,
       );
     }
 

--- a/src/ui/states/state-present-offer.svelte
+++ b/src/ui/states/state-present-offer.svelte
@@ -36,6 +36,15 @@
 
   const translator: Translator =
     getContext(translatorContextKey) || Translator.fallback();
+
+  const formattedBasePrice =
+    subscriptionBasePrice &&
+    translator.formatPrice(
+      subscriptionBasePrice.amountMicros,
+      subscriptionBasePrice.currency,
+    );
+
+  const formattedPriceAfterTrial = subscriptionTrial && formattedBasePrice;
 </script>
 
 <ModalSection>
@@ -64,7 +73,7 @@
           <Localized
             key={LocalizationKeys.StatePresentOfferProductPrice}
             variables={{
-              productPrice: subscriptionBasePrice.formattedPrice,
+              productPrice: formattedBasePrice,
             }}
           />
         {/if}
@@ -74,10 +83,7 @@
           <Localized
             key={LocalizationKeys.StatePresentOfferPriceAfterFreeTrial}
             variables={{
-              productPrice:
-                subscriptionTrial &&
-                subscriptionBasePrice &&
-                subscriptionBasePrice.formattedPrice,
+              productPrice: formattedPriceAfterTrial,
             }}
           />
         </span>

--- a/src/ui/states/state-present-offer.svelte
+++ b/src/ui/states/state-present-offer.svelte
@@ -37,14 +37,22 @@
   const translator: Translator =
     getContext(translatorContextKey) || Translator.fallback();
 
-  const formattedBasePrice =
+  const formattedSubscriptionBasePrice =
     subscriptionBasePrice &&
     translator.formatPrice(
       subscriptionBasePrice.amountMicros,
       subscriptionBasePrice.currency,
     );
 
-  const formattedPriceAfterTrial = subscriptionTrial && formattedBasePrice;
+  const formattedSubscriptionPriceAfterTrial =
+    subscriptionTrial && formattedSubscriptionBasePrice;
+
+  const formattedNonSubscriptionBasePrice =
+    nonSubscriptionBasePrice &&
+    translator.formatPrice(
+      nonSubscriptionBasePrice.amountMicros,
+      nonSubscriptionBasePrice.currency,
+    );
 </script>
 
 <ModalSection>
@@ -73,7 +81,7 @@
           <Localized
             key={LocalizationKeys.StatePresentOfferProductPrice}
             variables={{
-              productPrice: formattedBasePrice,
+              productPrice: formattedSubscriptionBasePrice,
             }}
           />
         {/if}
@@ -83,7 +91,7 @@
           <Localized
             key={LocalizationKeys.StatePresentOfferPriceAfterFreeTrial}
             variables={{
-              productPrice: formattedPriceAfterTrial,
+              productPrice: formattedSubscriptionPriceAfterTrial,
             }}
           />
         </span>
@@ -126,7 +134,7 @@
       <span class="rcb-product-price">
         <Localized
           key={LocalizationKeys.StatePresentOfferProductPrice}
-          variables={{ productPrice: nonSubscriptionBasePrice?.formattedPrice }}
+          variables={{ productPrice: formattedNonSubscriptionBasePrice }}
         />
       </span>
 


### PR DESCRIPTION
## Motivation / Description
Some languages prefer the currency symbol before the number, others after.
This PR makes sure we do not use anymore the `formattedPrice` coming from the server since that string is not aware of the selected locale.

## How it looks like

Yen in english
<img width="1140" alt="Screenshot 2024-12-06 at 15 05 02" src="https://github.com/user-attachments/assets/0bd88ac6-7911-489f-aa2a-2686e8311a01">

Yen in spanish
<img width="1140" alt="Screenshot 2024-12-06 at 15 05 26" src="https://github.com/user-attachments/assets/79e30573-1452-477d-806a-e3f41bc5f2b9">
