### PR TITLE
feat: Added Support for Direct Payment Flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,21 @@ npm install
 npm run build:dev
 ```
 
-To avoid publishing the package you can set it up as a local dependency.
-In your testing project install the library as.
+To avoid publishing the package you can use Yarn's link feature:
+
+1. In the purchases-js directory, register the package:
 
 ```bash
-npm i /path/to/purchases-js
+yarn link
 ```
+
+2. In your testing project, link to the registered package:
+
+```bash
+yarn link "@revenuecat/purchases-js"
+```
+
+> **Note:** Any changes you make to the library will be automatically reflected in your testing project after running `npm run build:dev` or `npm run build`.
 
 ## Running Storybook
 

--- a/examples/rcbilling-demo/src/tests/main.test.ts
+++ b/examples/rcbilling-demo/src/tests/main.test.ts
@@ -35,6 +35,7 @@ test.describe("Main", () => {
       ),
     );
   });
+
   test("Get offerings can filter by offering ID", async ({
     browser,
     browserName,

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -91,6 +91,7 @@ export class Backend {
         rule_id: string;
         revision: number;
       };
+      supports_direct_payment: boolean;
     };
 
     const requestBody: PurchaseRequestBody = {
@@ -100,6 +101,7 @@ export class Backend {
       price_id: purchaseOption.priceId,
       presented_offering_identifier:
         presentedOfferingContext.offeringIdentifier,
+      supports_direct_payment: true,
     };
 
     if (purchaseOption.id !== "base_option") {

--- a/src/stories/state-needs-payment-info.stories.svelte
+++ b/src/stories/state-needs-payment-info.stories.svelte
@@ -20,6 +20,7 @@
   import { Translator } from "../ui/localization/translator";
   import WithContext from "./utils/with-context.svelte";
   import { LocalizationKeys } from "../ui/localization/supportedLanguages";
+  import { SetupMode } from "./utils/purchase-response-builder";
 
   let defaultArgs = {
     productDetails: product,
@@ -62,7 +63,10 @@
       <ModalBackdrop>
         <Layout>
           <Main brandingAppearance={args.brandingInfo?.appearance}>
-            <StateNeedsPaymentInfoWithPurchaseResponse {args} />
+            <StateNeedsPaymentInfoWithPurchaseResponse
+              {args}
+              setupMode={SetupMode.PaidProduct}
+            />
           </Main>
         </Layout>
       </ModalBackdrop>

--- a/src/stories/utils/purchase-response-builder.ts
+++ b/src/stories/utils/purchase-response-builder.ts
@@ -82,7 +82,7 @@ const createPaymentIntent = async () => {
       "Content-Type": "application/x-www-form-urlencoded",
     },
     body: [
-      "amount=1000",
+      "amount=199",
       "currency=usd",
       "setup_future_usage=off_session",
       "payment_method_types[]=card",
@@ -106,6 +106,12 @@ export const buildPurchaseResponse = async (
   if (!restrictedSecretKey || !publishableApiKey || !accountId) {
     throw new Error(
       "Missing storybook setup environment variables. Check README.md for more information.",
+    );
+  }
+
+  if (!restrictedSecretKey.includes("test")) {
+    throw new Error(
+      "The secret key should be a test key. Check README.md for more information.",
     );
   }
 

--- a/src/stories/utils/purchase-response-builder.ts
+++ b/src/stories/utils/purchase-response-builder.ts
@@ -101,7 +101,7 @@ export enum SetupMode {
 }
 
 export const buildPurchaseResponse = async (
-  setupMode: SetupMode = SetupMode.TrialSubscription,
+  setupMode: SetupMode,
 ): Promise<PurchaseResponse> => {
   if (!restrictedSecretKey || !publishableApiKey || !accountId) {
     throw new Error(

--- a/src/stories/utils/state-needs-payment-info-with-purchase-response.svelte
+++ b/src/stories/utils/state-needs-payment-info-with-purchase-response.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
   import { type ComponentProps, onMount } from "svelte";
   import { type PurchaseResponse } from "../../networking/responses/purchase-response";
-  import { buildPurchaseResponse } from "./purchase-response-builder";
+  import {
+    buildPurchaseResponse,
+    SetupMode,
+  } from "./purchase-response-builder";
   import StateNeedsPaymentInfo from "../../ui/states/state-needs-payment-info.svelte";
 
   export let args: ComponentProps<StateNeedsPaymentInfo>;
+
+  export let setupMode: SetupMode = SetupMode.TrialSubscription;
 
   let paymentMetadata: PurchaseResponse | null = null;
   const overriddenArgs = {
@@ -12,14 +17,14 @@
     onContinue: async () => {
       alert("Payment info submitted successfully!\n The form will be reset");
       paymentMetadata = null;
-      paymentMetadata = await buildPurchaseResponse();
+      paymentMetadata = await buildPurchaseResponse(setupMode);
     },
   };
 
   let error: string | null = null;
   onMount(async () => {
     try {
-      paymentMetadata = await buildPurchaseResponse();
+      paymentMetadata = await buildPurchaseResponse(setupMode);
     } catch (err) {
       error = (err as Error).message;
     }


### PR DESCRIPTION
## Motivation / Description

Added Support for Direct Payment flow

## Changes introduced

- Added `supports_direct_payment` parameter in purchase request body
- README improvements
- Modified the storybook configuration to use a different purchase setup mode

## Linear ticket (if any)

[WEB-1806](https://linear.app/revenuecat/issue/WEB-1806/%5Brcb%5D%5Bsdk%5D-handle-paymentintent-secret-besides-setupintent)

## Additional comments

No breaking changes introduced
