### PR TITLE
Fix for the select options background color on windows

### DIFF
--- a/src/stories/purchase-flow.stories.svelte
+++ b/src/stories/purchase-flow.stories.svelte
@@ -74,6 +74,30 @@
     "es",
     englishLocale,
   );
+
+  const labyrinthosBranding = {
+    color_accent: "#B89662",
+    color_buttons_primary: "#B89662",
+    color_error: "#f04141",
+    color_form_bg: "#FFFFFF",
+    color_page_bg: "#0A2722",
+    color_product_info_bg: "#465551",
+    font: "default",
+    shapes: "pill",
+    show_product_description: true,
+  };
+
+  const iptvWebBranding = {
+    color_accent: "#FF3B30",
+    color_buttons_primary: "#ff3b30",
+    color_error: "#F2545B",
+    color_form_bg: "#1f1f1f",
+    color_page_bg: "#141414",
+    color_product_info_bg: "#1f1f1f",
+    font: "default",
+    shapes: "pill",
+    show_product_description: false,
+  };
 </script>
 
 <Meta title="PurchaseFlow" />
@@ -212,6 +236,28 @@
       appearance: {
         shapes: "rectangle",
       },
+    },
+  }}
+/>
+
+<Story
+  name="Labyrinthos"
+  args={{
+    ...defaultArgs,
+    brandingInfo: {
+      ...brandingInfo,
+      appearance: labyrinthosBranding,
+    },
+  }}
+/>
+
+<Story
+  name="IPTV Web"
+  args={{
+    ...defaultArgs,
+    brandingInfo: {
+      ...brandingInfo,
+      appearance: iptvWebBranding,
     },
   }}
 />

--- a/src/ui/states/state-needs-payment-info.svelte
+++ b/src/ui/states/state-needs-payment-info.svelte
@@ -199,7 +199,7 @@
           ".Input": {
             boxShadow: "none",
             border: `2px solid ${customColors["grey-ui-dark"]}`,
-            backgroundColor: "transparent",
+            backgroundColor: customColors["background"],
             color: customColors["grey-text-dark"],
           },
           ".Input:focus": {

--- a/src/ui/states/state-needs-payment-info.svelte
+++ b/src/ui/states/state-needs-payment-info.svelte
@@ -199,7 +199,7 @@
           ".Input": {
             boxShadow: "none",
             border: `2px solid ${customColors["grey-ui-dark"]}`,
-            backgroundColor: customColors["background"],
+            backgroundColor: customColors["input-background"],
             color: customColors["grey-text-dark"],
           },
           ".Input:focus": {

--- a/src/ui/theme/colors.ts
+++ b/src/ui/theme/colors.ts
@@ -32,7 +32,7 @@ export const DEFAULT_FORM_COLORS: Colors = {
   "grey-text-light": "rgba(0,0,0,0.5)",
   "grey-ui-dark": "rgba(0,0,0,0.125)",
   "grey-ui-light": "rgba(0,0,0,0.005)",
-  "input-background": "transparent",
+  "input-background": "white",
   background: "white",
 };
 
@@ -48,7 +48,7 @@ export const DEFAULT_INFO_COLORS: Colors = {
   "grey-text-light": "rgba(255,255,255,0.5)",
   "grey-ui-dark": "rgba(255,255,255,0.125)",
   "grey-ui-light": "rgba(255,255,255,0.005)",
-  "input-background": "transparent",
+  "input-background": "#000000",
   background: "#000000",
 };
 
@@ -68,10 +68,12 @@ export const ColorsToBrandingAppearanceMapping: Record<
 
 export const FormColorsToBrandingAppearanceMapping = {
   ...ColorsToBrandingAppearanceMapping,
+  "input-background": "color_form_bg",
   background: "color_form_bg",
 };
 
 export const InfoColorsToBrandingAppearanceMapping = {
   ...ColorsToBrandingAppearanceMapping,
+  "input-background": "color_product_info_bg",
   background: "color_product_info_bg",
 };


### PR DESCRIPTION
## Motivation / Description
The background was not applied to the input css but we were using transparent. This PR fixes it.

This was reported by a customer here:
https://community.revenuecat.com/sdks-51/websdk-checkout-form-styling-5604

## Changes introduced
Passed the background color to the input class in Stripe.