### PR TITLE
Fix/purchase-flow-need-auth-info accessibility improvements

### DIFF
--- a/src/ui/button.svelte
+++ b/src/ui/button.svelte
@@ -3,14 +3,17 @@
   export let disabled = false;
   export let testId: string | undefined = undefined;
   export let type: "reset" | "submit" | "button" | null | undefined = undefined;
+  export let ariaBusy = false;
 </script>
 
 <button
+  tabindex={0}
   on:click
   class={`intent-${intent}`}
   {disabled}
   data-testid={testId}
   {type}
+  aria-busy={ariaBusy}
 >
   <slot />
 </button>

--- a/src/ui/close-button.svelte
+++ b/src/ui/close-button.svelte
@@ -4,7 +4,13 @@
   export let disabled = false;
 </script>
 
-<button on:click class="close-button" {disabled}>
+<button
+  tabindex={0}
+  on:click
+  class="close-button"
+  aria-label="Close"
+  {disabled}
+>
   <div>
     {@html Icon}
   </div>

--- a/src/ui/states/state-needs-auth-info.svelte
+++ b/src/ui/states/state-needs-auth-info.svelte
@@ -52,7 +52,7 @@
     <ModalSection>
       <div class="form-container">
         <div class="form-label">
-          <label for="email">
+          <label for="email" id="email-label">
             <Localized
               key={LocalizationKeys.StateNeedsAuthInfoEmailInputLabel}
             />
@@ -60,22 +60,29 @@
         </div>
         <div class="form-input {inputClass}">
           <input
+            id="email"
             name="email"
+            autocomplete="email"
+            spellcheck="false"
+            inputmode="email"
             placeholder={translator.translate(
               LocalizationKeys.StateNeedsAuthInfoEmailInputPlaceholder,
             )}
             autocapitalize="off"
+            aria-invalid={!!error}
+            aria-describedby={error ? "email-error" : undefined}
+            aria-labelledby="email-label"
             bind:value={email}
           />
         </div>
         {#if error}
-          <div class="form-error">{error}</div>
+          <div class="form-error" id="email-error" role="alert">{error}</div>
         {/if}
       </div>
     </ModalSection>
     <ModalFooter>
       <RowLayout>
-        <Button disabled={processing} type="submit">
+        <Button disabled={processing} type="submit" ariaBusy={processing}>
           {#if processing}
             <ProcessingAnimation />
           {:else}


### PR DESCRIPTION
## Motivation / Description

Hey, I was going through the codebase to familiarize myself with it and noted some accessibility stuff is missing from inputs and buttons so thought I'd commit a small fix for it. Feel free to just disregard this PR incase it's not relevant / other internal changes incoming 😊 

## Changes introduced

- Fixes email input to display the correct keyboard type (email) on virtual keyboards.
- Fixes close button focus with screen readers.
- Improves email input descriptions with screen readers.
- Explicitly sets tabIndex for safari browsers to make buttons tab focusable, [issue described here](https://stackoverflow.com/questions/1848390/safari-ignoring-tabindex)

## Linear ticket (if any)

## Additional comments
