### PR TITLE
Quieter test logs

### DIFF
--- a/src/tests/test-responses.ts
+++ b/src/tests/test-responses.ts
@@ -258,8 +258,8 @@ export function getRequestHandlers(): RequestHandler[] {
     const body = offeringsResponsesPerUserId[userId]!;
     const url = `http://localhost:8000/v1/subscribers/${userId}/offerings`;
     requestHandlers.push(
-      http.get(url, () => {
-        APIGetRequest({ url: url });
+      http.get(url, ({ request }) => {
+        APIGetRequest({ url: request.url });
         return HttpResponse.json(body, { status: 200 });
       }),
     );
@@ -267,10 +267,10 @@ export function getRequestHandlers(): RequestHandler[] {
 
   Object.keys(productsResponsesPerUserId).forEach((userId: string) => {
     const body = productsResponsesPerUserId[userId]!;
-    const url = `http://localhost:8000/rcbilling/v1/subscribers/${userId}/products?id=monthly&id=monthly_2`;
+    const url = `http://localhost:8000/rcbilling/v1/subscribers/${userId}/products`;
     requestHandlers.push(
-      http.get(url, () => {
-        APIGetRequest({ url: url });
+      http.get(url, ({ request }) => {
+        APIGetRequest({ url: request.url });
         return HttpResponse.json(body, { status: 200 });
       }),
     );
@@ -280,8 +280,8 @@ export function getRequestHandlers(): RequestHandler[] {
     const body = customerInfoResponsePerUserId[userId]!;
     const url = `http://localhost:8000/v1/subscribers/${userId}`;
     requestHandlers.push(
-      http.get(url, () => {
-        APIGetRequest({ url: url });
+      http.get(url, ({ request }) => {
+        APIGetRequest({ url: request.url });
         return HttpResponse.json(body, { status: 200 });
       }),
     );
@@ -289,8 +289,8 @@ export function getRequestHandlers(): RequestHandler[] {
 
   const brandingUrl = "http://localhost:8000/rcbilling/v1/branding";
   requestHandlers.push(
-    http.get(brandingUrl, () => {
-      APIGetRequest({ url: brandingUrl });
+    http.get(brandingUrl, ({ request }) => {
+      APIGetRequest({ url: request.url });
       return HttpResponse.json(brandingInfoResponse, { status: 200 });
     }),
   );

--- a/src/ui/localization/translator.ts
+++ b/src/ui/localization/translator.ts
@@ -1,3 +1,4 @@
+import { Logger } from "../../helpers/logger";
 import type { PeriodUnit } from "../../helpers/duration-helper";
 import { englishLocale } from "./constants";
 
@@ -93,7 +94,7 @@ export class Translator {
         currency,
       }).format(price);
     } catch {
-      console.debug(
+      Logger.errorLog(
         `Failed to create a price formatter for locale: ${this.locale}`,
       );
     }
@@ -104,7 +105,7 @@ export class Translator {
         currency,
       }).format(price);
     } catch {
-      console.debug(
+      Logger.errorLog(
         `Failed to create a price formatter for locale: ${this.fallbackLocale}`,
       );
     }


### PR DESCRIPTION
## Motivation / Description

There were some noisy logs happening.

## Changes introduced

- Use `Logger.debugLog` instead of `console.debug`.
- Remove redundant query parameters in request handler matcher