### PR TITLE
Stabilize Chromatic rendering

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -9,7 +9,7 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
-    chromatic: { delay: 1_000 }, // Time for Stripe to render
+    chromatic: { delay: 5_000 }, // Time for Stripe to render
   },
 };
 

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -9,6 +9,7 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
+    chromatic: { delay: 1_000 }, // Time for Stripe to render
   },
 };
 


### PR DESCRIPTION
## Motivation / Description

Chromatic sometimes shows diffs that should not be there. The hypothesis is this is due to Stripe not given enough time to render all the components. This branch tries to reproduce and fix it by giving a global delay before taking snapshots of the stories prior to sending them to chromatic.

## Changes introduced

- 1st build: None (to reproduce).
- 2nd build: Add 1s delay (to fix).
- 3rd build: Add 5s delay (to fix).

## Results

Caveats:
- It is difficult to say if the current latest baseline is "stable". So there may be changes if it is not showing in the Chromatic build of this PR.
- The `1_000` ms and `5_000` ms are arbitrary durations. So changes in Chromatic could appear because it is not enough time to stabilize.

- [**0s build**](https://www.chromatic.com/build?appId=6751ce4c50d424102499e900&number=117) diffs on `Italian` and `Spanish`.
- [**1s build**](https://www.chromatic.com/build?appId=6751ce4c50d424102499e900&number=118) diffs on `itUnderscoreIT`.
- [**5s build**](https://www.chromatic.com/build?appId=6751ce4c50d424102499e900&number=119) diffs on `Italian` and `itUnderscoreIT`

## Conclusion

I am not sure the Chromatic changes in this build are explained by rendering time. The main diffs I see are that `Data di scadenza` and `Codice di sicurezza` are rendered in different rows on this build. On the other hand, the baseline build renders them in a single row. But the diffs have not even been consistent across the 2nd and 3rd build. Unsure if this is worth merging.

Perhaps there is a mix of issues. Baseline build not stable and changes on stripe's end.