### PR TITLE
[WEB-1912] Add customerEmailProvided property to CheckoutSessionStart event

### DIFF
--- a/src/behavioural-events/event-helpers.ts
+++ b/src/behavioural-events/event-helpers.ts
@@ -35,6 +35,7 @@ export function createCheckoutSessionStartEvent(
   appearance: BrandingAppearance | undefined,
   rcPackage: Package,
   purchaseOptionToUse: PurchaseOption,
+  customerEmail: string | undefined,
 ): CheckoutSessionStartEvent {
   return {
     eventName: TrackedEventName.CheckoutSessionStart,
@@ -58,6 +59,7 @@ export function createCheckoutSessionStartEvent(
       selectedProduct: rcPackage.rcBillingProduct.identifier,
       selectedPackage: rcPackage.identifier,
       selectedPurchaseOption: purchaseOptionToUse.id,
+      customerEmailProvidedByDeveloper: Boolean(customerEmail),
     },
   };
 }

--- a/src/behavioural-events/tracked-events.ts
+++ b/src/behavioural-events/tracked-events.ts
@@ -52,6 +52,7 @@ export interface CheckoutSessionStartEvent extends IEvent {
     selectedProduct: string;
     selectedPackage: string;
     selectedPurchaseOption: string;
+    customerEmailProvidedByDeveloper: boolean;
   };
 }
 

--- a/src/tests/ui/purchases-ui.test.ts
+++ b/src/tests/ui/purchases-ui.test.ts
@@ -58,6 +58,7 @@ describe("PurchasesUI", () => {
     expect(eventsTrackerMock.trackEvent).toHaveBeenCalledWith({
       eventName: "checkout_session_start",
       properties: {
+        customerEmailProvidedByDeveloper: true,
         customizationOptions: null,
         productInterval: product.normalPeriodDuration,
         productPrice: product.currentPrice.amountMicros,

--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -105,6 +105,7 @@
       appearance,
       rcPackage,
       purchaseOptionToUse,
+      customerEmail,
     );
     eventsTracker.trackEvent(event);
 


### PR DESCRIPTION
## Motivation / Description

We are interested in tracking when the billing email entry screen is skipped. But the original trigger for this event is starting a purchase flow with an already provide email. So instead of tracking a new event, I am adding the corresponding property to the CheckoutSessionEvent event.

## Changes introduced

- Add `customerEmailProvided` property to `CheckoutSessionStart` event.