### PR TITLE
[WEB-1915] Track purchase successful events

### DIFF
--- a/src/behavioural-events/event-helpers.ts
+++ b/src/behavioural-events/event-helpers.ts
@@ -3,13 +3,13 @@ import type {
   CheckoutSessionClosedEvent,
   CheckoutSessionErroredEvent,
   PurchaseSuccessfulDismissEvent,
-} from "./tracked-events";
+} from "./sdk-events";
 import {
   TrackedEventName,
   type BillingEmailEntryErrorEvent,
   type CheckoutSessionStartEvent,
   type SDKInitializedEvent,
-} from "./tracked-events";
+} from "./sdk-events";
 import { VERSION } from "../helpers/constants";
 import type { BrandingAppearance } from "../networking/responses/branding-response";
 import type { Package } from "../entities/offerings";

--- a/src/behavioural-events/event-helpers.ts
+++ b/src/behavioural-events/event-helpers.ts
@@ -2,6 +2,7 @@ import type {
   CheckoutSessionFinishedEvent,
   CheckoutSessionClosedEvent,
   CheckoutSessionErroredEvent,
+  PurchaseSuccessfulDismissEvent,
 } from "./tracked-events";
 import {
   TrackedEventName,
@@ -101,6 +102,17 @@ export function createCheckoutSessionEndErroredEvent(
       outcome: "errored",
       errorCode: errorCode,
       errorMessage: errorMessage,
+    },
+  };
+}
+
+export function createPurchaseSuccessfulDismissEvent(
+  buttonPressed: "go_back_to_app" | "close",
+): PurchaseSuccessfulDismissEvent {
+  return {
+    eventName: TrackedEventName.PurchaseSuccessfulDismiss,
+    properties: {
+      buttonPressed: buttonPressed,
     },
   };
 }

--- a/src/behavioural-events/events-tracker.ts
+++ b/src/behavioural-events/events-tracker.ts
@@ -6,6 +6,7 @@ import { defaultHttpConfig, type HttpConfig } from "../entities/http-config";
 import { FlushManager } from "./flush-manager";
 import { Logger } from "../helpers/logger";
 import { type EventProperties, Event } from "./event";
+import type { SDKEvent } from "./sdk-events";
 
 const MIN_INTERVAL_RETRY = 2_000;
 const MAX_INTERVAL_RETRY = 60_000;
@@ -24,7 +25,8 @@ export interface EventsTrackerProps {
 export interface IEventsTracker {
   updateUser(appUserId: string): Promise<void>;
   generateCheckoutSessionId(): Promise<void>;
-  trackEvent(props: TrackEventProps): void;
+  trackSDKEvent(props: SDKEvent): void;
+  trackExternalEvent(props: TrackEventProps): void;
   dispose(): void;
 }
 
@@ -60,7 +62,15 @@ export default class EventsTracker implements IEventsTracker {
     this.checkoutSessionId = uuid();
   }
 
-  public trackEvent(props: TrackEventProps): void {
+  public trackSDKEvent(props: SDKEvent): void {
+    this.trackEvent(props);
+  }
+
+  public trackExternalEvent(props: TrackEventProps): void {
+    this.trackEvent(props);
+  }
+
+  private trackEvent(props: TrackEventProps) {
     try {
       Logger.debugLog(
         `Queueing event ${props.eventName} with properties ${JSON.stringify(props)}`,

--- a/src/behavioural-events/events-tracker.ts
+++ b/src/behavioural-events/events-tracker.ts
@@ -24,7 +24,7 @@ export interface EventsTrackerProps {
 
 export interface IEventsTracker {
   updateUser(appUserId: string): Promise<void>;
-  generateCheckoutSessionId(): Promise<void>;
+  generateCheckoutSessionId(): void;
   trackSDKEvent(props: SDKEvent): void;
   trackExternalEvent(props: TrackEventProps): void;
   dispose(): void;
@@ -58,7 +58,7 @@ export default class EventsTracker implements IEventsTracker {
     this.appUserId = appUserId;
   }
 
-  public async generateCheckoutSessionId() {
+  public generateCheckoutSessionId() {
     this.checkoutSessionId = uuid();
   }
 

--- a/src/behavioural-events/sdk-events.ts
+++ b/src/behavioural-events/sdk-events.ts
@@ -1,6 +1,6 @@
 import type { EventProperties } from "./event";
 
-export type TrackedEvent =
+export type SDKEvent =
   | SDKInitializedEvent
   | CheckoutSessionStartEvent
   | CheckoutSessionFinishedEvent
@@ -10,7 +10,9 @@ export type TrackedEvent =
   | BillingEmailEntryDismissEvent
   | BillingEmailEntrySubmitEvent
   | BillingEmailEntrySuccessEvent
-  | BillingEmailEntryErrorEvent;
+  | BillingEmailEntryErrorEvent
+  | PurchaseSuccessfulImpressionEvent
+  | PurchaseSuccessfulDismissEvent;
 
 export enum TrackedEventName {
   SDKInitialized = "sdk_initialized",

--- a/src/behavioural-events/tracked-events.ts
+++ b/src/behavioural-events/tracked-events.ts
@@ -21,6 +21,8 @@ export enum TrackedEventName {
   BillingEmailEntrySubmit = "billing_email_entry_submit",
   BillingEmailEntrySuccess = "billing_email_entry_success",
   BillingEmailEntryError = "billing_email_entry_error",
+  PurchaseSuccessfulImpression = "purchase_successful_impression",
+  PurchaseSuccessfulDismiss = "purchase_successful_dismiss",
 }
 
 interface IEvent {
@@ -105,5 +107,16 @@ export interface BillingEmailEntryErrorEvent extends IEvent {
   properties: {
     errorCode: number | null;
     errorMessage: string;
+  };
+}
+
+export interface PurchaseSuccessfulImpressionEvent extends IEvent {
+  eventName: TrackedEventName.PurchaseSuccessfulImpression;
+}
+
+export interface PurchaseSuccessfulDismissEvent extends IEvent {
+  eventName: TrackedEventName.PurchaseSuccessfulDismiss;
+  properties: {
+    buttonPressed: "go_back_to_app" | "close";
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -256,7 +256,7 @@ export class Purchases {
     this.backend = new Backend(this._API_KEY, httpConfig);
     this.purchaseOperationHelper = new PurchaseOperationHelper(this.backend);
     const sdkInitializedEvent = createSDKInitializedEvent();
-    this.eventsTracker.trackEvent(sdkInitializedEvent);
+    this.eventsTracker.trackSDKEvent(sdkInitializedEvent);
   }
 
   /**
@@ -562,7 +562,7 @@ export class Purchases {
       purchaseOptionToUse,
       customerEmail,
     );
-    this.eventsTracker.trackEvent(event);
+    this.eventsTracker.trackSDKEvent(event);
 
     return new Promise((resolve, reject) => {
       mount(RCPurchasesUI, {
@@ -574,7 +574,7 @@ export class Purchases {
           customerEmail,
           onFinished: async (redemptionInfo: RedemptionInfo | null) => {
             const event = createCheckoutSessionEndFinishedEvent(redemptionInfo);
-            this.eventsTracker.trackEvent(event);
+            this.eventsTracker.trackSDKEvent(event);
             Logger.debugLog("Purchase finished");
             certainHTMLTarget.innerHTML = "";
             // TODO: Add info about transaction in result.
@@ -586,7 +586,7 @@ export class Purchases {
           },
           onClose: () => {
             const event = createCheckoutSessionEndClosedEvent();
-            this.eventsTracker.trackEvent(event);
+            this.eventsTracker.trackSDKEvent(event);
             certainHTMLTarget.innerHTML = "";
             Logger.debugLog("Purchase cancelled by user");
             reject(new PurchasesError(ErrorCode.UserCancelledError));
@@ -596,7 +596,7 @@ export class Purchases {
               e.errorCode,
               e.message,
             );
-            this.eventsTracker.trackEvent(event);
+            this.eventsTracker.trackSDKEvent(event);
             certainHTMLTarget.innerHTML = "";
             reject(PurchasesError.getForPurchasesFlowError(e));
           },
@@ -716,6 +716,6 @@ export class Purchases {
    * @internal
    */
   public _trackEvent(props: TrackEventProps): void {
-    this.eventsTracker.trackEvent(props);
+    this.eventsTracker.trackExternalEvent(props);
   }
 }

--- a/src/stories/fixtures.ts
+++ b/src/stories/fixtures.ts
@@ -1,3 +1,4 @@
+import { eventsTrackerContextKey } from "../ui/constants";
 import {
   type Product,
   ProductType,
@@ -116,5 +117,15 @@ export const purchaseResponse = {
     client_secret: "test_client_secret",
     publishable_api_key: "test_publishable_api_key",
     stripe_account_id: "test_stripe_account_id",
+  },
+};
+
+export const defaultContext = {
+  [eventsTrackerContextKey]: {
+    trackExternalEvent: () => {},
+    trackSDKEvent: () => {},
+    updateUser: () => Promise.resolve(),
+    generateCheckoutSessionId: () => {},
+    dispose: () => {},
   },
 };

--- a/src/stories/purchase-flow.stories.svelte
+++ b/src/stories/purchase-flow.stories.svelte
@@ -23,6 +23,7 @@
     product,
     purchaseFlowError,
     subscriptionOption,
+    defaultContext,
   } from "./fixtures";
   import { Translator } from "../ui/localization/translator";
   import {
@@ -36,7 +37,7 @@
     brandingInfo: brandingInfo,
     lastError: purchaseFlowError,
     onContinue: () => {},
-    context: {},
+    context: defaultContext,
   };
 
   let customLabelsTranslator = new Translator(
@@ -289,7 +290,7 @@
   name="Italian"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: italianTranslator },
+    context: { ...defaultContext, [translatorContextKey]: italianTranslator },
     brandingInfo: brandingInfo,
   }}
 />
@@ -297,7 +298,7 @@
   name="itUnderscoreIT"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: it_ITTranslator },
+    context: { ...defaultContext, [translatorContextKey]: it_ITTranslator },
     brandingInfo: brandingInfo,
   }}
 />
@@ -305,7 +306,7 @@
   name="itDashIT"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: itDashITTranslator },
+    context: { ...defaultContext, [translatorContextKey]: itDashITTranslator },
     brandingInfo: brandingInfo,
   }}
 />
@@ -314,7 +315,7 @@
   name="Spanish"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: spanishTranslator },
+    context: { ...defaultContext, [translatorContextKey]: spanishTranslator },
     brandingInfo: brandingInfo,
   }}
 />
@@ -323,7 +324,7 @@
   name="esUnderscoreES"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: es_ESTranslator },
+    context: { ...defaultContext, [translatorContextKey]: es_ESTranslator },
     brandingInfo: brandingInfo,
   }}
 />
@@ -332,7 +333,7 @@
   name="esDashES"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: esDashESTranslator },
+    context: { ...defaultContext, [translatorContextKey]: esDashESTranslator },
     brandingInfo: brandingInfo,
   }}
 />
@@ -341,7 +342,10 @@
   name="CustomLabels"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: customLabelsTranslator },
+    context: {
+      ...defaultContext,
+      [translatorContextKey]: customLabelsTranslator,
+    },
     brandingInfo: brandingInfo,
   }}
 />
@@ -350,7 +354,10 @@
   name="CustomLabelsIT"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: italianCustomLabelsTranslator },
+    context: {
+      ...defaultContext,
+      [translatorContextKey]: italianCustomLabelsTranslator,
+    },
     brandingInfo: brandingInfo,
   }}
 />
@@ -359,7 +366,10 @@
   name="CustomLabelsES"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: spanishCustomLabelsTranslator },
+    context: {
+      ...defaultContext,
+      [translatorContextKey]: spanishCustomLabelsTranslator,
+    },
     brandingInfo: brandingInfo,
   }}
 />

--- a/src/stories/state-needs-auth-info.stories.svelte
+++ b/src/stories/state-needs-auth-info.stories.svelte
@@ -9,6 +9,7 @@
   import {
     brandingInfo,
     colorfulBrandingAppearance,
+    defaultContext,
     product,
     subscriptionOption,
   } from "./fixtures";
@@ -23,6 +24,7 @@
     productDetails: product,
     purchaseOption: subscriptionOption,
     brandingInfo: brandingInfo,
+    context: defaultContext,
   };
 
   let customLabelsTranslator = new Translator(
@@ -111,7 +113,7 @@
   name="Italian"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: italianTranslator },
+    context: { ...defaultContext, [translatorContextKey]: italianTranslator },
   }}
 />
 
@@ -119,7 +121,7 @@
   name="Spanish"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: spanishTranslator },
+    context: { ...defaultContext, [translatorContextKey]: spanishTranslator },
   }}
 />
 
@@ -127,7 +129,10 @@
   name="CustomLabels"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: customLabelsTranslator },
+    context: {
+      ...defaultContext,
+      [translatorContextKey]: customLabelsTranslator,
+    },
   }}
 />
 
@@ -135,8 +140,10 @@
   name="CustomLabelsIT"
   args={{
     ...defaultArgs,
-
-    context: { [translatorContextKey]: italianCustomLabelsTranslator },
+    context: {
+      ...defaultContext,
+      [translatorContextKey]: italianCustomLabelsTranslator,
+    },
   }}
 />
 
@@ -144,6 +151,9 @@
   name="CustomLabelsES"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: spanishCustomLabelsTranslator },
+    context: {
+      ...defaultContext,
+      [translatorContextKey]: spanishCustomLabelsTranslator,
+    },
   }}
 />

--- a/src/stories/state-needs-payment-info.stories.svelte
+++ b/src/stories/state-needs-payment-info.stories.svelte
@@ -12,6 +12,7 @@
     colorfulBrandingAppearance,
     product,
     subscriptionOption,
+    defaultContext,
   } from "./fixtures";
   import {
     englishLocale,
@@ -25,6 +26,7 @@
   let defaultArgs = {
     productDetails: product,
     purchaseOption: subscriptionOption,
+    context: defaultContext,
   };
 
   let customLabelsTranslator = new Translator(
@@ -127,7 +129,7 @@
   name="Italian"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: italianTranslator },
+    context: { ...defaultContext, [translatorContextKey]: italianTranslator },
   }}
 />
 
@@ -135,7 +137,7 @@
   name="Spanish"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: spanishTranslator },
+    context: { ...defaultContext, [translatorContextKey]: spanishTranslator },
   }}
 />
 
@@ -143,7 +145,10 @@
   name="CustomLabels"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: customLabelsTranslator },
+    context: {
+      ...defaultContext,
+      [translatorContextKey]: customLabelsTranslator,
+    },
   }}
 />
 
@@ -151,8 +156,10 @@
   name="CustomLabelsIT"
   args={{
     ...defaultArgs,
-
-    context: { [translatorContextKey]: italianCustomLabelsTranslator },
+    context: {
+      ...defaultContext,
+      [translatorContextKey]: italianCustomLabelsTranslator,
+    },
   }}
 />
 
@@ -160,7 +167,9 @@
   name="CustomLabelsES"
   args={{
     ...defaultArgs,
-
-    context: { [translatorContextKey]: spanishCustomLabelsTranslator },
+    context: {
+      ...defaultContext,
+      [translatorContextKey]: spanishCustomLabelsTranslator,
+    },
   }}
 />

--- a/src/stories/state-present-offer.stories.svelte
+++ b/src/stories/state-present-offer.stories.svelte
@@ -12,6 +12,7 @@
     product,
     subscriptionOption,
     subscriptionOptionWithTrial,
+    defaultContext,
   } from "./fixtures";
   import IconCart from "../ui/icons/icon-cart.svelte";
   import ModalHeader from "../ui/modal-header.svelte";
@@ -28,7 +29,7 @@
     purchaseOption: subscriptionOption,
     brandingInfo: brandingInfo,
     sandbox: false,
-    context: {},
+    context: defaultContext,
   };
 
   let customLabelsTranslator = new Translator(
@@ -188,7 +189,7 @@
   name="Italian"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: italianTranslator },
+    context: { ...defaultContext, [translatorContextKey]: italianTranslator },
     purchaseOption: subscriptionOptionWithTrial,
   }}
 />
@@ -197,7 +198,7 @@
   name="Spanish"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: spanishTranslator },
+    context: { ...defaultContext, [translatorContextKey]: spanishTranslator },
   }}
 />
 
@@ -205,7 +206,10 @@
   name="CustomLabels"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: customLabelsTranslator },
+    context: {
+      ...defaultContext,
+      [translatorContextKey]: customLabelsTranslator,
+    },
     productDetails: { ...product, description: null },
   }}
 />
@@ -214,8 +218,10 @@
   name="CustomLabelsIT"
   args={{
     ...defaultArgs,
-
-    context: { [translatorContextKey]: italianCustomLabelsTranslator },
+    context: {
+      ...defaultContext,
+      [translatorContextKey]: italianCustomLabelsTranslator,
+    },
     productDetails: { ...product, description: null },
   }}
 />
@@ -224,8 +230,10 @@
   name="CustomLabelsES"
   args={{
     ...defaultArgs,
-
-    context: { [translatorContextKey]: spanishCustomLabelsTranslator },
+    context: {
+      ...defaultContext,
+      [translatorContextKey]: spanishCustomLabelsTranslator,
+    },
     productDetails: { ...product, description: null },
   }}
 />
@@ -249,7 +257,7 @@
       ...subscriptionOption,
       base: { ...subscriptionOption.base, price: priceJPY },
     },
-    context: { [translatorContextKey]: spanishTranslator },
+    context: { ...defaultContext, [translatorContextKey]: spanishTranslator },
   }}
 />
 
@@ -272,7 +280,7 @@
       ...subscriptionOption,
       base: { ...subscriptionOption.base, price: priceEUR },
     },
-    context: { [translatorContextKey]: spanishTranslator },
+    context: { ...defaultContext, [translatorContextKey]: spanishTranslator },
   }}
 />
 

--- a/src/stories/state-success.stories.svelte
+++ b/src/stories/state-success.stories.svelte
@@ -10,6 +10,7 @@
     colorfulBrandingAppearance,
     product,
     subscriptionOption,
+    defaultContext,
   } from "./fixtures";
   import { Translator } from "../ui/localization/translator";
   import {
@@ -22,6 +23,7 @@
     productDetails: product,
     purchaseOption: subscriptionOption,
     brandingInfo: brandingInfo,
+    context: defaultContext,
   };
 
   let customLabelsTranslator = new Translator(
@@ -107,7 +109,7 @@
   name="Italian"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: italianTranslator },
+    context: { ...defaultContext, [translatorContextKey]: italianTranslator },
   }}
 />
 
@@ -115,7 +117,7 @@
   name="Spanish"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: spanishTranslator },
+    context: { ...defaultContext, [translatorContextKey]: spanishTranslator },
   }}
 />
 
@@ -123,7 +125,10 @@
   name="CustomLabels"
   args={{
     ...defaultArgs,
-    context: { [translatorContextKey]: customLabelsTranslator },
+    context: {
+      ...defaultContext,
+      [translatorContextKey]: customLabelsTranslator,
+    },
   }}
 />
 
@@ -131,8 +136,10 @@
   name="CustomLabelsIT"
   args={{
     ...defaultArgs,
-
-    context: { [translatorContextKey]: italianCustomLabelsTranslator },
+    context: {
+      ...defaultContext,
+      [translatorContextKey]: italianCustomLabelsTranslator,
+    },
   }}
 />
 
@@ -140,7 +147,9 @@
   name="CustomLabelsES"
   args={{
     ...defaultArgs,
-
-    context: { [translatorContextKey]: spanishCustomLabelsTranslator },
+    context: {
+      ...defaultContext,
+      [translatorContextKey]: spanishCustomLabelsTranslator,
+    },
   }}
 />

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -221,7 +221,10 @@ describe("Purchases.generateRevenueCatAnonymousAppUserId()", () => {
 
   test("allows tracking events", () => {
     const purchases = configurePurchases();
-    const trackEventSpy = vi.spyOn(purchases["eventsTracker"], "trackEvent");
+    const trackEventSpy = vi.spyOn(
+      purchases["eventsTracker"],
+      "trackExternalEvent",
+    );
     purchases._trackEvent({
       eventName: "test_event",
       properties: {

--- a/src/tests/ui/purchases-ui.test.ts
+++ b/src/tests/ui/purchases-ui.test.ts
@@ -15,11 +15,13 @@ import {
   type PurchaseOperationHelper,
 } from "../../helpers/purchase-operation-helper";
 import type { PurchaseResponse } from "../../networking/responses/purchase-response";
+import { TrackedEventName } from "../../behavioural-events/sdk-events";
 
 const eventsTrackerMock: IEventsTracker = {
   updateUser: vi.fn(),
   generateCheckoutSessionId: vi.fn(),
-  trackEvent: vi.fn(),
+  trackSDKEvent: vi.fn(),
+  trackExternalEvent: vi.fn(),
   dispose: vi.fn(),
 } as unknown as IEventsTracker;
 
@@ -59,8 +61,8 @@ describe("PurchasesUI", () => {
   test("tracks the BillingEmailEntryImpression event when email has not been provided", async () => {
     render(PurchasesUI, { props: { ...basicProps, customerEmail: null } });
 
-    expect(eventsTrackerMock.trackEvent).toHaveBeenCalledWith({
-      eventName: "billing_email_entry_impression",
+    expect(eventsTrackerMock.trackSDKEvent).toHaveBeenCalledWith({
+      eventName: TrackedEventName.BillingEmailEntryImpression,
     });
   });
 
@@ -69,8 +71,8 @@ describe("PurchasesUI", () => {
       props: { ...basicProps, customerEmail: "test@test.com" },
     });
 
-    expect(eventsTrackerMock.trackEvent).not.toHaveBeenCalledWith({
-      eventName: "billing_email_entry_impression",
+    expect(eventsTrackerMock.trackSDKEvent).not.toHaveBeenCalledWith({
+      eventName: TrackedEventName.BillingEmailEntryImpression,
     });
   });
 
@@ -82,8 +84,8 @@ describe("PurchasesUI", () => {
     const continueButton = screen.getByText("Continue");
     await fireEvent.click(continueButton);
 
-    expect(eventsTrackerMock.trackEvent).toHaveBeenCalledWith({
-      eventName: "billing_email_entry_submit",
+    expect(eventsTrackerMock.trackSDKEvent).toHaveBeenCalledWith({
+      eventName: TrackedEventName.BillingEmailEntrySubmit,
     });
   });
 
@@ -95,8 +97,8 @@ describe("PurchasesUI", () => {
     const closeButton = screen.getByTestId("close-button");
     await fireEvent.click(closeButton);
 
-    expect(eventsTrackerMock.trackEvent).toHaveBeenCalledWith({
-      eventName: "billing_email_entry_dismiss",
+    expect(eventsTrackerMock.trackSDKEvent).toHaveBeenCalledWith({
+      eventName: TrackedEventName.BillingEmailEntryDismiss,
     });
     expect(basicProps.onClose).toHaveBeenCalled();
   });
@@ -111,8 +113,8 @@ describe("PurchasesUI", () => {
     const continueButton = screen.getByText("Continue");
     await fireEvent.click(continueButton);
 
-    expect(eventsTrackerMock.trackEvent).toHaveBeenCalledWith({
-      eventName: "billing_email_entry_error",
+    expect(eventsTrackerMock.trackSDKEvent).toHaveBeenCalledWith({
+      eventName: TrackedEventName.BillingEmailEntryError,
       properties: {
         errorCode: null,
         errorMessage:
@@ -143,8 +145,8 @@ describe("PurchasesUI", () => {
     const continueButton = screen.getByText("Continue");
     await fireEvent.click(continueButton);
 
-    expect(eventsTrackerMock.trackEvent).toHaveBeenCalledWith({
-      eventName: "billing_email_entry_error",
+    expect(eventsTrackerMock.trackSDKEvent).toHaveBeenCalledWith({
+      eventName: TrackedEventName.BillingEmailEntryError,
       properties: {
         errorCode: 4,
         errorMessage:
@@ -207,9 +209,9 @@ describe("PurchasesUI", () => {
     const continueButton = screen.getByText("Continue");
     await fireEvent.click(continueButton);
 
-    expect(eventsTrackerMock.trackEvent).toHaveBeenCalledWith(
+    expect(eventsTrackerMock.trackSDKEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        eventName: "billing_email_entry_error",
+        eventName: TrackedEventName.BillingEmailEntryError,
       }),
     );
   });
@@ -234,9 +236,9 @@ describe("PurchasesUI", () => {
     const continueButton = screen.getByText("Continue");
     await fireEvent.click(continueButton);
 
-    expect(eventsTrackerMock.trackEvent).not.toHaveBeenCalledWith(
+    expect(eventsTrackerMock.trackSDKEvent).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        eventName: "billing_email_entry_error",
+        eventName: TrackedEventName.BillingEmailEntryError,
       }),
     );
   });
@@ -261,8 +263,8 @@ describe("PurchasesUI", () => {
 
     await vi.advanceTimersToNextTimerAsync();
 
-    expect(eventsTrackerMock.trackEvent).toHaveBeenCalledWith({
-      eventName: "purchase_successful_impression",
+    expect(eventsTrackerMock.trackSDKEvent).toHaveBeenCalledWith({
+      eventName: TrackedEventName.PurchaseSuccessfulImpression,
     });
   });
 
@@ -285,8 +287,8 @@ describe("PurchasesUI", () => {
     const continueButton = screen.getByTestId("close-button");
     await fireEvent.click(continueButton);
 
-    expect(eventsTrackerMock.trackEvent).toHaveBeenCalledWith({
-      eventName: "purchase_successful_dismiss",
+    expect(eventsTrackerMock.trackSDKEvent).toHaveBeenCalledWith({
+      eventName: TrackedEventName.PurchaseSuccessfulDismiss,
       properties: {
         buttonPressed: "close",
       },
@@ -312,8 +314,8 @@ describe("PurchasesUI", () => {
     const continueButton = screen.getByText("Close");
     await fireEvent.click(continueButton);
 
-    expect(eventsTrackerMock.trackEvent).toHaveBeenCalledWith({
-      eventName: "purchase_successful_dismiss",
+    expect(eventsTrackerMock.trackSDKEvent).toHaveBeenCalledWith({
+      eventName: TrackedEventName.PurchaseSuccessfulDismiss,
       properties: {
         buttonPressed: "go_back_to_app",
       },

--- a/src/ui/layout/message-layout.svelte
+++ b/src/ui/layout/message-layout.svelte
@@ -8,6 +8,7 @@
 
   export let brandingInfo: BrandingInfoResponse | null = null;
   export let onContinue: () => void;
+  export let onClose: () => void;
   export let title: string | null = null;
   export let type: string;
   export let closeButtonTitle: string = "Go back to app";
@@ -15,7 +16,7 @@
 
 <RowLayout gutter="32px">
   {#if title}
-    <BrandAndCloseHeader {brandingInfo} onClose={onContinue} />
+    <BrandAndCloseHeader {brandingInfo} {onClose} />
   {/if}
   <ModalSection>
     <div class="rcb-modal-message" data-type={type} data-has-title={!!title}>

--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -99,10 +99,6 @@
         handleSubscribe();
       } else {
         state = "needs-auth-info";
-
-        eventsTracker.trackEvent({
-          eventName: TrackedEventName.BillingEmailEntryImpression,
-        });
       }
 
       return;

--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -37,7 +37,6 @@
   import { IEventsTracker } from "../behavioural-events/events-tracker";
   import { eventsTrackerContextKey } from "./constants";
   import { createBillingEmailEntryErrorEvent } from "../behavioural-events/event-helpers";
-  import { TrackedEventName } from "../behavioural-events/tracked-events";
 
   export let asModal = true;
   export let customerEmail: string | undefined;
@@ -194,7 +193,7 @@
         e.getErrorCode(),
         e.message,
       );
-      eventsTracker.trackEvent(event);
+      eventsTracker.trackSDKEvent(event);
     }
 
     if (state === "processing-auth-info" && e.isRecoverable()) {

--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -189,11 +189,13 @@
   };
 
   const handleError = (e: PurchaseFlowError) => {
-    const event = createBillingEmailEntryErrorEvent(
-      e.getErrorCode(),
-      e.message,
-    );
-    eventsTracker.trackEvent(event);
+    if (e.getErrorCode() === PurchaseFlowErrorCode.MissingEmailError) {
+      const event = createBillingEmailEntryErrorEvent(
+        e.getErrorCode(),
+        e.message,
+      );
+      eventsTracker.trackEvent(event);
+    }
 
     if (state === "processing-auth-info" && e.isRecoverable()) {
       lastError = e;

--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -164,9 +164,6 @@
       if (authInfo) {
         customerEmail = authInfo.email;
         state = "processing-auth-info";
-        eventsTracker.trackEvent({
-          eventName: TrackedEventName.BillingEmailEntrySubmit,
-        });
       }
 
       handleSubscribe();

--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -110,11 +110,6 @@
   });
 
   const handleClose = () => {
-    if (state === "needs-auth-info") {
-      eventsTracker.trackEvent({
-        eventName: TrackedEventName.BillingEmailEntryDismiss,
-      });
-    }
     onClose();
   };
 

--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -34,7 +34,7 @@
     englishLocale,
     translatorContextKey,
   } from "./localization/constants";
-  import { IEventsTracker } from "../behavioural-events/events-tracker";
+  import { type IEventsTracker } from "../behavioural-events/events-tracker";
   import { eventsTrackerContextKey } from "./constants";
   import { createBillingEmailEntryErrorEvent } from "../behavioural-events/event-helpers";
 

--- a/src/ui/states/state-error.svelte
+++ b/src/ui/states/state-error.svelte
@@ -97,6 +97,7 @@
   title={getTranslatedErrorTitle()}
   {brandingInfo}
   {onContinue}
+  onClose={onContinue}
   type="error"
   closeButtonTitle={translator.translate(
     LocalizationKeys.StateErrorButtonTryAgain,

--- a/src/ui/states/state-needs-auth-info.svelte
+++ b/src/ui/states/state-needs-auth-info.svelte
@@ -15,7 +15,7 @@
 
   import { LocalizationKeys } from "../localization/supportedLanguages";
   import { eventsTrackerContextKey } from "../constants";
-  import { IEventsTracker } from "../../behavioural-events/events-tracker";
+  import { type IEventsTracker } from "../../behavioural-events/events-tracker";
   import { createBillingEmailEntryErrorEvent } from "../../behavioural-events/event-helpers";
   import { TrackedEventName } from "../../behavioural-events/sdk-events";
 

--- a/src/ui/states/state-needs-auth-info.svelte
+++ b/src/ui/states/state-needs-auth-info.svelte
@@ -43,6 +43,9 @@
       const event = createBillingEmailEntryErrorEvent(null, errorMessage);
       eventsTracker.trackEvent(event);
     } else {
+      eventsTracker.trackEvent({
+        eventName: TrackedEventName.BillingEmailEntrySubmit,
+      });
       onContinue({ email });
     }
   };

--- a/src/ui/states/state-needs-auth-info.svelte
+++ b/src/ui/states/state-needs-auth-info.svelte
@@ -17,11 +17,19 @@
   import { eventsTrackerContextKey } from "../constants";
   import { IEventsTracker } from "../../behavioural-events/events-tracker";
   import { createBillingEmailEntryErrorEvent } from "../../behavioural-events/event-helpers";
+  import { TrackedEventName } from "../../behavioural-events/tracked-events";
 
   export let onContinue: any;
   export let onClose: () => void;
   export let processing: boolean;
   export let lastError: PurchaseFlowError | null;
+
+  function onCloseHandle() {
+    eventsTracker.trackEvent({
+      eventName: TrackedEventName.BillingEmailEntryDismiss,
+    });
+    onClose();
+  }
 
   const eventsTracker = getContext(eventsTrackerContextKey) as IEventsTracker;
 
@@ -48,7 +56,7 @@
     <span>
       <Localized key={LocalizationKeys.StateNeedsAuthInfoEmailStepTitle} />
     </span>
-    <CloseButton on:click={onClose} />
+    <CloseButton on:click={onCloseHandle} />
   </ModalHeader>
   <form on:submit|preventDefault={handleContinue}>
     <ModalSection>

--- a/src/ui/states/state-needs-auth-info.svelte
+++ b/src/ui/states/state-needs-auth-info.svelte
@@ -7,7 +7,7 @@
   import ProcessingAnimation from "../processing-animation.svelte";
   import { validateEmail } from "../../helpers/validators";
   import { PurchaseFlowError } from "../../helpers/purchase-operation-helper";
-  import { getContext } from "svelte";
+  import { getContext, onMount } from "svelte";
   import CloseButton from "../close-button.svelte";
   import Localized from "../localization/localized.svelte";
   import { translatorContextKey } from "../localization/constants";
@@ -49,6 +49,12 @@
       onContinue({ email });
     }
   };
+
+  onMount(() => {
+    eventsTracker.trackEvent({
+      eventName: TrackedEventName.BillingEmailEntryImpression,
+    });
+  });
 
   const translator: Translator =
     getContext(translatorContextKey) || Translator.fallback();

--- a/src/ui/states/state-needs-auth-info.svelte
+++ b/src/ui/states/state-needs-auth-info.svelte
@@ -17,7 +17,7 @@
   import { eventsTrackerContextKey } from "../constants";
   import { IEventsTracker } from "../../behavioural-events/events-tracker";
   import { createBillingEmailEntryErrorEvent } from "../../behavioural-events/event-helpers";
-  import { TrackedEventName } from "../../behavioural-events/tracked-events";
+  import { TrackedEventName } from "../../behavioural-events/sdk-events";
 
   export let onContinue: any;
   export let onClose: () => void;
@@ -25,7 +25,7 @@
   export let lastError: PurchaseFlowError | null;
 
   function onCloseHandle() {
-    eventsTracker.trackEvent({
+    eventsTracker.trackSDKEvent({
       eventName: TrackedEventName.BillingEmailEntryDismiss,
     });
     onClose();
@@ -41,9 +41,9 @@
     errorMessage ||= validateEmail(email) || "";
     if (errorMessage !== "") {
       const event = createBillingEmailEntryErrorEvent(null, errorMessage);
-      eventsTracker.trackEvent(event);
+      eventsTracker.trackSDKEvent(event);
     } else {
-      eventsTracker.trackEvent({
+      eventsTracker.trackSDKEvent({
         eventName: TrackedEventName.BillingEmailEntrySubmit,
       });
       onContinue({ email });
@@ -51,7 +51,7 @@
   };
 
   onMount(() => {
-    eventsTracker.trackEvent({
+    eventsTracker.trackSDKEvent({
       eventName: TrackedEventName.BillingEmailEntryImpression,
     });
   });

--- a/src/ui/states/state-needs-payment-info.svelte
+++ b/src/ui/states/state-needs-payment-info.svelte
@@ -270,6 +270,7 @@
                 LocalizationKeys.StateErrorButtonTryAgain,
               )}
               onContinue={handleErrorTryAgain}
+              onClose={handleErrorTryAgain}
               brandingInfo={null}
             >
               <IconError slot="icon" />

--- a/src/ui/states/state-success.svelte
+++ b/src/ui/states/state-success.svelte
@@ -9,7 +9,7 @@
   import Localized from "../localization/localized.svelte";
 
   import { LocalizationKeys } from "../localization/supportedLanguages";
-  import { TrackedEventName } from "../../behavioural-events/tracked-events";
+  import { TrackedEventName } from "../../behavioural-events/sdk-events";
   import { IEventsTracker } from "../../behavioural-events/events-tracker";
   import { eventsTrackerContextKey } from "../constants";
 
@@ -24,7 +24,7 @@
   const eventsTracker = getContext(eventsTrackerContextKey) as IEventsTracker;
 
   function handleContinue() {
-    eventsTracker.trackEvent({
+    eventsTracker.trackSDKEvent({
       eventName: TrackedEventName.PurchaseSuccessfulDismiss,
       properties: {
         buttonPressed: "go_back_to_app",
@@ -34,7 +34,7 @@
   }
 
   function handleClose() {
-    eventsTracker.trackEvent({
+    eventsTracker.trackSDKEvent({
       eventName: TrackedEventName.PurchaseSuccessfulDismiss,
       properties: {
         buttonPressed: "close",
@@ -44,7 +44,7 @@
   }
 
   onMount(() => {
-    eventsTracker.trackEvent({
+    eventsTracker.trackSDKEvent({
       eventName: TrackedEventName.PurchaseSuccessfulImpression,
     });
   });

--- a/src/ui/states/state-success.svelte
+++ b/src/ui/states/state-success.svelte
@@ -10,7 +10,7 @@
 
   import { LocalizationKeys } from "../localization/supportedLanguages";
   import { TrackedEventName } from "../../behavioural-events/sdk-events";
-  import { IEventsTracker } from "../../behavioural-events/events-tracker";
+  import { type IEventsTracker } from "../../behavioural-events/events-tracker";
   import { eventsTrackerContextKey } from "../constants";
 
   export let productDetails: Product | null = null;


### PR DESCRIPTION
## Motivation / Description

Adds tracking for the purchase successful events, including impression and dimiss.

## Changes introduced

- Moved tracking events from `rcb-ui` down whenever possible to:
    -  prevent giant main view to keep growing.
    - fire the events closest to the source.
- Split `EventsTracker.trackEvent(...)` into `EventsTracker.trackExternalEvent(...)` and `EventsTracker.trackSDKEvent(...)` to tighten API signatures.
- Add tracking for purchase success impression.
- Add tracking for purchase success dismiss (via main button or cross).