### PR TITLE
[WEB-2001] Add context to events

### DIFF
--- a/examples/rcbilling-demo/src/tests/main.test.ts
+++ b/examples/rcbilling-demo/src/tests/main.test.ts
@@ -285,7 +285,25 @@ test.describe("Main", () => {
           event?.app_user_id === userId &&
           event?.properties?.checkout_session_id === null &&
           event?.properties?.trace_id !== undefined &&
-          event?.properties?.sdk_version !== undefined
+          event?.properties?.sdk_version !== undefined &&
+          event?.context?.library?.name === "purchases-js" &&
+          event?.context?.library?.version === "0.15.1" &&
+          event?.context?.locale !== undefined &&
+          event?.context?.user_agent !== undefined &&
+          event?.context?.time_zone !== undefined &&
+          event?.context?.screen_size?.width !== undefined &&
+          event?.context?.screen_size?.height !== undefined &&
+          event?.context?.utm?.source === null &&
+          event?.context?.utm?.medium === null &&
+          event?.context?.utm?.campaign === null &&
+          event?.context?.utm?.content === null &&
+          event?.context?.utm?.term === null &&
+          event?.context?.page?.path !== undefined &&
+          event?.context?.page?.referrer === "" &&
+          event?.context?.page?.search === "" &&
+          event?.context?.page?.url !== undefined &&
+          event?.context?.page?.title ===
+            "Health Check – RevenueCat Billing Demo"
         );
       }),
       { timeout: 3_000 },

--- a/src/behavioural-events/event-context.ts
+++ b/src/behavioural-events/event-context.ts
@@ -1,0 +1,33 @@
+import { VERSION } from "../helpers/constants";
+
+export function buildEventContext() {
+  const urlParams = new URLSearchParams(window.location.search);
+
+  return {
+    library: {
+      name: "purchases-js",
+      version: VERSION,
+    },
+    locale: navigator.language,
+    user_agent: navigator.userAgent,
+    time_zone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    screen_size: {
+      width: screen.width,
+      height: screen.height,
+    },
+    utm: {
+      source: urlParams.get("utm_source") ?? null,
+      medium: urlParams.get("utm_medium") ?? null,
+      campaign: urlParams.get("utm_campaign") ?? null,
+      content: urlParams.get("utm_content") ?? null,
+      term: urlParams.get("utm_term") ?? null,
+    },
+    page: {
+      path: window.location.pathname,
+      referrer: document.referrer,
+      search: window.location.search,
+      url: window.location.href,
+      title: document.title,
+    },
+  };
+}

--- a/src/behavioural-events/event.ts
+++ b/src/behavioural-events/event.ts
@@ -1,5 +1,6 @@
 import { camelToUnderscore } from "../helpers/camel-to-underscore";
 import { v4 as uuidv4 } from "uuid";
+import { buildEventContext } from "./event-context";
 
 export type EventData = {
   eventName: string;
@@ -46,6 +47,7 @@ export class Event {
       type: this.EVENT_TYPE,
       event_name: this.data.eventName,
       app_user_id: this.data.appUserId,
+      context: buildEventContext(),
       properties: {
         ...(camelToUnderscore(this.data.properties) as EventProperties),
         trace_id: this.data.traceId,

--- a/src/tests/behavioral-events/event-context.test.ts
+++ b/src/tests/behavioral-events/event-context.test.ts
@@ -1,0 +1,84 @@
+import { buildEventContext } from "../../behavioural-events/event-context";
+import { VERSION } from "../../helpers/constants";
+import { beforeAll, describe, expect, it } from "vitest";
+
+describe("buildEventContext", () => {
+  beforeAll(() => {
+    // Mocking global objects
+    Object.defineProperty(window, "location", {
+      value: {
+        search: "?utm_source=google&utm_medium=cpc&utm_campaign=spring_sale",
+        pathname: "/home",
+        href: "https://example.com/home?utm_source=google&utm_medium=cpc&utm_campaign=spring_sale",
+      },
+      writable: true,
+    });
+
+    Object.defineProperty(document, "referrer", {
+      value: "https://referrer.com",
+      writable: true,
+    });
+
+    Object.defineProperty(document, "title", {
+      value: "Example Page",
+      writable: true,
+    });
+
+    Object.defineProperty(navigator, "language", {
+      value: "en-US",
+      writable: true,
+    });
+
+    Object.defineProperty(navigator, "userAgent", {
+      value: "Mozilla/5.0",
+      writable: true,
+    });
+
+    Object.defineProperty(Intl.DateTimeFormat.prototype, "resolvedOptions", {
+      value: () => ({ timeZone: "America/New_York" }),
+      writable: true,
+    });
+
+    Object.defineProperty(screen, "width", {
+      value: 1920,
+      writable: true,
+    });
+
+    Object.defineProperty(screen, "height", {
+      value: 1080,
+      writable: true,
+    });
+  });
+
+  it("should build the correct event context", () => {
+    const context = buildEventContext();
+
+    expect(context).toEqual({
+      library: {
+        name: "purchases-js",
+        version: VERSION,
+      },
+      locale: "en-US",
+      user_agent: "Mozilla/5.0",
+      time_zone: "America/New_York",
+      screen_size: {
+        width: 1920,
+        height: 1080,
+      },
+      utm: {
+        source: "google",
+        medium: "cpc",
+        campaign: "spring_sale",
+        content: null,
+        term: null,
+      },
+      page: {
+        path: "/home",
+        referrer: "https://referrer.com",
+        search: "?utm_source=google&utm_medium=cpc&utm_campaign=spring_sale",
+        url: "https://example.com/home?utm_source=google&utm_medium=cpc&utm_campaign=spring_sale",
+        title: "Example Page",
+      },
+    });
+  });
+});

--- a/src/tests/behavioral-events/events-tracker.test.ts
+++ b/src/tests/behavioral-events/events-tracker.test.ts
@@ -10,6 +10,15 @@ interface EventsTrackerFixtures {
   eventsTracker: EventsTracker;
 }
 
+vi.mock("../../behavioural-events/event-context", () => ({
+  buildEventContext: vi.fn().mockReturnValue({
+    library: {
+      name: "purchases-js",
+      version: "1.0.0",
+    },
+  }),
+}));
+
 describe("EventsTracker", (test) => {
   const date = new Date(1988, 10, 18, 13, 37, 0);
   vi.mock("uuid", () => ({
@@ -59,6 +68,12 @@ describe("EventsTracker", (test) => {
             timestamp_ms: date.getTime(),
             event_name: "external",
             app_user_id: "someAppUserId",
+            context: {
+              library: {
+                name: "purchases-js",
+                version: "1.0.0",
+              },
+            },
             properties: {
               trace_id: "c1365463-ce59-4b83-b61b-ef0d883e9047",
               checkout_session_id: null,

--- a/src/tests/purchase.events.test.ts
+++ b/src/tests/purchase.events.test.ts
@@ -19,6 +19,9 @@ describe("Purchases.configure()", () => {
 
   beforeEach(async () => {
     vi.spyOn(Logger, "debugLog").mockImplementation(() => undefined);
+    vi.mock("../behavioural-events/event-context", () => ({
+      buildEventContext: vi.fn().mockReturnValue({}),
+    }));
     vi.useFakeTimers();
     vi.setSystemTime(date);
     configurePurchases();
@@ -42,6 +45,7 @@ describe("Purchases.configure()", () => {
             event_name: "sdk_initialized",
             timestamp_ms: date.getTime(),
             app_user_id: "someAppUserId",
+            context: {},
             properties: {
               checkout_session_id: null,
               sdk_version: "0.15.1",


### PR DESCRIPTION
## Motivation / Description

Adds browser context to every event tracked. Based most of it from Segment's track API.

Notice I decided to:
- Skipped `os` given it's parsed form `user_agent` so rather defer the calculation to the backend for now.
- Skipped `ip` there is no standard way to fetch it from the browser so might as well do it on the backend, plus it's going to be more consistent to the way we gather those anyways in other places.