### PR TITLE
[WEB-2056] Use a different domain for event tracking

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,3 @@
 VITE_RC_ENDPOINT=http://localhost:8000
+VITE_RC_ANALYTICS_ENDPOINT=https://localhost:8000
 VITE_ASSETS_ENDPOINT=https://da08ctfrofx1b.cloudfront.net

--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,3 @@
 VITE_RC_ENDPOINT=https://api.revenuecat.com
+VITE_RC_ANALYTICS_ENDPOINT=https://api.mimircat.com
 VITE_ASSETS_ENDPOINT=https://da08ctfrofx1b.cloudfront.net

--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,3 @@
 VITE_RC_ENDPOINT=https://api.revenuecat.com
-VITE_RC_ANALYTICS_ENDPOINT=https://api.mimircat.com
+VITE_RC_ANALYTICS_ENDPOINT=https://e.revenue.cat
 VITE_ASSETS_ENDPOINT=https://da08ctfrofx1b.cloudfront.net

--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,3 @@
 VITE_RC_ENDPOINT=http://localhost:8000
+VITE_RC_ANALYTICS_ENDPOINT=http://localhost:8000
 VITE_ASSETS_ENDPOINT=https://da08ctfrofx1b.cloudfront.net

--- a/examples/rcbilling-demo/src/tests/main.test.ts
+++ b/examples/rcbilling-demo/src/tests/main.test.ts
@@ -301,7 +301,7 @@ function successfulEventTrackingResponseMatcher(
 ) {
   return async (response: Response) => {
     if (
-      response.url() !== "https://api.revenuecat.com/v1/events" ||
+      response.url() !== "https://e.revenue.cat/v1/events" ||
       response.status() !== 200
     ) {
       return false;

--- a/src/behavioural-events/events-tracker.ts
+++ b/src/behavioural-events/events-tracker.ts
@@ -1,8 +1,7 @@
 import { v4 as uuid } from "uuid";
-import { RC_ENDPOINT } from "../helpers/constants";
+import { RC_ANALYTICS_ENDPOINT } from "../helpers/constants";
 import { HttpMethods } from "msw";
 import { getHeaders } from "../networking/http-client";
-import { defaultHttpConfig, type HttpConfig } from "../entities/http-config";
 import { FlushManager } from "./flush-manager";
 import { Logger } from "../helpers/logger";
 import { type EventProperties, Event } from "./event";
@@ -19,7 +18,6 @@ export interface TrackEventProps {
 export interface EventsTrackerProps {
   apiKey: string;
   appUserId: string;
-  httpConfig?: HttpConfig;
 }
 
 export interface IEventsTracker {
@@ -42,10 +40,8 @@ export default class EventsTracker implements IEventsTracker {
   constructor(props: EventsTrackerProps) {
     Logger.debugLog(`Events tracker created for traceId ${this.traceId}`);
 
-    const httpConfig = props.httpConfig || defaultHttpConfig;
-
     this.apiKey = props.apiKey;
-    this.eventsUrl = `${httpConfig.proxyURL || RC_ENDPOINT}/v1/events`;
+    this.eventsUrl = `${RC_ANALYTICS_ENDPOINT}/v1/events`;
     this.appUserId = props.appUserId;
     this.flushManager = new FlushManager(
       MIN_INTERVAL_RETRY,

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -1,2 +1,4 @@
 export const VERSION = "0.15.1";
 export const RC_ENDPOINT = import.meta.env.VITE_RC_ENDPOINT as string;
+export const RC_ANALYTICS_ENDPOINT = import.meta.env
+  .VITE_RC_ANALYTICS_ENDPOINT as string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -250,7 +250,6 @@ export class Purchases {
     }
     this.eventsTracker = new EventsTracker({
       apiKey: this._API_KEY,
-      httpConfig: httpConfig,
       appUserId: this._appUserId,
     });
     this.backend = new Backend(this._API_KEY, httpConfig);


### PR DESCRIPTION
## Motivation / Description

This is a safeguard in case at some point we were to run into domain blocking issues. It happened once in the past and it became problematic for some users.