### PR TITLE
WEB-2065: Adding automatically utm params to metadata

### DIFF
--- a/src/helpers/utm-params.ts
+++ b/src/helpers/utm-params.ts
@@ -1,0 +1,21 @@
+export const autoParseUTMParams = () => {
+  const params = new URLSearchParams(window.location.search);
+
+  const possible_params = [
+    "utm_source",
+    "utm_medium",
+    "utm_campaign",
+    "utm_term",
+    "utm_content",
+  ];
+  const utmParams: { [key: string]: string } = {};
+
+  possible_params.forEach((param) => {
+    const paramValue = params.get(param);
+    if (paramValue !== null) {
+      utmParams[param] = paramValue;
+    }
+  });
+
+  return utmParams;
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,7 @@ import { PaywallDefaultContainerZIndex } from "./ui/theme/constants";
 import { parseOfferingIntoVariables } from "./helpers/paywall-variables-helpers";
 import { Translator } from "./ui/localization/translator";
 import { englishLocale } from "./ui/localization/constants";
+import { autoParseUTMParams } from "./helpers/utm-params";
 
 export { ProductType } from "./entities/offerings";
 export type {
@@ -524,6 +525,9 @@ export class Purchases {
 
     const localeToBeUsed = selectedLocale || defaultLocale;
 
+    const utmParamsMetadata = autoParseUTMParams();
+    const metadata = { ...utmParamsMetadata, ...(params.metadata || {}) };
+
     return new Promise((resolve, reject) => {
       mount(RCPurchasesUI, {
         target: certainHTMLTarget,
@@ -556,7 +560,7 @@ export class Purchases {
           purchaseOperationHelper: this.purchaseOperationHelper,
           asModal,
           selectedLocale: localeToBeUsed,
-          metadata: params.metadata,
+          metadata: metadata,
           defaultLocale,
         },
       });

--- a/src/tests/helpers/utm-params.test.ts
+++ b/src/tests/helpers/utm-params.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "vitest";
+import { spyOn } from "@vitest/spy";
+import { autoParseUTMParams } from "../../helpers/utm-params";
+
+describe("autoParseUTMParams", () => {
+  test("should return an empty object if no utm param is set", () => {
+    spyOn(URLSearchParams.prototype, "get").mockImplementation(() => null);
+    const utmParams = autoParseUTMParams();
+    expect(utmParams).toEqual({});
+  });
+
+  test("should return all utm params if set", () => {
+    const mockUTMParams: { [key: string]: string } = {
+      utm_source: "source",
+      utm_medium: "medium",
+      utm_campaign: "campaign",
+      utm_term: "term",
+      utm_content: "content",
+    };
+
+    spyOn(URLSearchParams.prototype, "get").mockImplementation(
+      (key: string) => {
+        if (mockUTMParams[key] === undefined) {
+          return null;
+        }
+        return mockUTMParams[key];
+      },
+    );
+
+    const utmParams = autoParseUTMParams();
+    expect(utmParams).toEqual(mockUTMParams);
+  });
+
+  test("should return only the utm params that are set set", () => {
+    const mockUTMParams: { [key: string]: string | null } = {
+      utm_source: "source",
+      utm_campaign: null,
+      utm_term: "term",
+      utm_content: "content",
+    };
+
+    spyOn(URLSearchParams.prototype, "get").mockImplementation(
+      (key: string) => {
+        if (mockUTMParams[key] === undefined) {
+          return null;
+        }
+        return mockUTMParams[key];
+      },
+    );
+
+    const utmParams = autoParseUTMParams();
+    expect(utmParams).toEqual({
+      utm_source: "source",
+      utm_term: "term",
+      utm_content: "content",
+    });
+  });
+});


### PR DESCRIPTION
## Motivation / Description
We want to track UTM parameters automatically in the WPL.
However this might be useful also for the sdk itself.


## Changes introduced
* Added a autoParseUTMParams function
* Added tests
* Using the autoParseUTMParams function before executing the purchase.

## Additional comments
This is an implicit behaviour, we could avoid doing this and passing them only explicitly through the metadata (web-1998) but maybe is a good dev experience if they get picked automatically without the need of updating the code but just downloading the latest version of the sdk.