### PR TITLE
Remove redundant event fields

### DIFF
--- a/examples/rcbilling-demo/src/tests/main.test.ts
+++ b/examples/rcbilling-demo/src/tests/main.test.ts
@@ -297,9 +297,7 @@ test.describe("Main", () => {
           event?.context?.utm?.campaign === null &&
           event?.context?.utm?.content === null &&
           event?.context?.utm?.term === null &&
-          event?.context?.page?.path !== undefined &&
           event?.context?.page?.referrer === "" &&
-          event?.context?.page?.search === "" &&
           event?.context?.page?.url !== undefined &&
           event?.context?.page?.title ===
             "Health Check – RevenueCat Billing Demo"

--- a/src/behavioural-events/event-context.ts
+++ b/src/behavioural-events/event-context.ts
@@ -21,9 +21,7 @@ interface EventContext {
     term: string | null;
   };
   page: {
-    path: string;
     referrer: string;
-    search: string;
     url: string;
     title: string;
   };
@@ -52,9 +50,7 @@ export function buildEventContext(): EventContext & EventProperties {
       term: urlParams.get("utm_term") ?? null,
     },
     page: {
-      path: window.location.pathname,
       referrer: document.referrer,
-      search: window.location.search,
       url: window.location.href,
       title: document.title,
     },

--- a/src/tests/behavioral-events/event-context.test.ts
+++ b/src/tests/behavioral-events/event-context.test.ts
@@ -73,9 +73,7 @@ describe("buildEventContext", () => {
         term: null,
       },
       page: {
-        path: "/home",
         referrer: "https://referrer.com",
-        search: "?utm_source=google&utm_medium=cpc&utm_campaign=spring_sale",
         url: "https://example.com/home?utm_source=google&utm_medium=cpc&utm_campaign=spring_sale",
         title: "Example Page",
       },


### PR DESCRIPTION
## Motivation / Description

Noticed these are redundant given it sends the full URL already. Later in the data pipeline it can be parsed from it if needed.