### PR TITLE
[WEB-2082] Append `trace_Id` and `checkout_session_id` to returned redeemUrl

### DIFF
--- a/src/behavioural-events/events-tracker.ts
+++ b/src/behavioural-events/events-tracker.ts
@@ -26,6 +26,7 @@ export interface EventsTrackerProps {
 }
 
 export interface IEventsTracker {
+  addTrackingQueryParameters(stringUrl: string): string;
   updateUser(appUserId: string): Promise<void>;
   generateCheckoutSessionId(): void;
   trackSDKEvent(props: SDKEvent): void;
@@ -62,6 +63,18 @@ export default class EventsTracker implements IEventsTracker {
 
   public generateCheckoutSessionId() {
     this.checkoutSessionId = uuid();
+  }
+
+  public addTrackingQueryParameters(stringUrl: string) {
+    const url = new URL(stringUrl);
+
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      url.searchParams.set("trace_id", this.traceId);
+      if (this.checkoutSessionId) {
+        url.searchParams.set("checkout_session_id", this.checkoutSessionId);
+      }
+    }
+    return url.toString();
   }
 
   public trackSDKEvent(props: SDKEvent): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -576,6 +576,14 @@ export class Purchases {
             const event = createCheckoutSessionEndFinishedEvent({
               redemptionInfo,
             });
+            const redeemUrl = redemptionInfo?.redeemUrl;
+            if (redeemUrl) {
+              redemptionInfo = {
+                ...redemptionInfo,
+                redeemUrl:
+                  this.eventsTracker.addTrackingQueryParameters(redeemUrl),
+              };
+            }
             this.eventsTracker.trackSDKEvent(event);
             Logger.debugLog("Purchase finished");
             certainHTMLTarget.innerHTML = "";

--- a/src/tests/purchase.test.ts
+++ b/src/tests/purchase.test.ts
@@ -1,8 +1,22 @@
-import { describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { configurePurchases } from "./base.purchases_test";
 import { APIGetRequest, type GetRequest } from "./test-responses";
+import { mount } from "svelte";
+import { Purchases } from "../main";
+
+vi.mock("svelte", () => ({
+  mount: vi.fn(),
+}));
+
+vi.mock("uuid", () => ({
+  v4: () => "c1365463-ce59-4b83-b61b-ef0d883e9047",
+}));
 
 describe("purchase", () => {
+  beforeEach(() => {
+    configurePurchases();
+  });
+
   test("purchase loads branding if not preloaded", async () => {
     const purchases = configurePurchases();
     const expectedRequest: GetRequest = {
@@ -21,6 +35,89 @@ describe("purchase", () => {
       new Promise((resolve) => setTimeout(resolve, 100)),
     ]);
     expect(APIGetRequest).toHaveBeenCalledWith(expectedRequest);
+  });
+
+  test("appends checkout session id to http urls", async () => {
+    vi.mocked(mount).mockImplementation((_component, options) => {
+      options.props?.onFinished({
+        redeemUrl: "https://example.com",
+      });
+      return vi.fn();
+    });
+
+    const purchases = Purchases.getSharedInstance();
+    const offerings = await purchases.getOfferings();
+    const packageToBuy = offerings.current?.availablePackages[0];
+
+    const result = await purchases.purchase({
+      rcPackage: packageToBuy!,
+    });
+
+    expect(result.redemptionInfo?.redeemUrl).not.toBeNull();
+
+    const redeemUrl = new URL(result.redemptionInfo!.redeemUrl!);
+
+    expect(redeemUrl.searchParams.get("trace_id")).toBe(
+      "c1365463-ce59-4b83-b61b-ef0d883e9047",
+    );
+    expect(redeemUrl.searchParams.get("checkout_session_id")).toBe(
+      "c1365463-ce59-4b83-b61b-ef0d883e9047",
+    );
+  });
+
+  test("appends checkout session id to https urls", async () => {
+    vi.mocked(mount).mockImplementation((_component, options) => {
+      options.props?.onFinished({
+        redeemUrl: "https://example.com",
+      });
+      return vi.fn();
+    });
+
+    const purchases = Purchases.getSharedInstance();
+    const offerings = await purchases.getOfferings();
+    const packageToBuy = offerings.current?.availablePackages[0];
+
+    const result = await purchases.purchase({
+      rcPackage: packageToBuy!,
+    });
+
+    expect(result.redemptionInfo?.redeemUrl).not.toBeNull();
+
+    const redeemUrl = new URL(result.redemptionInfo!.redeemUrl!);
+
+    expect(redeemUrl.searchParams.get("trace_id")).toBe(
+      "c1365463-ce59-4b83-b61b-ef0d883e9047",
+    );
+    expect(redeemUrl.searchParams.get("checkout_session_id")).toBe(
+      "c1365463-ce59-4b83-b61b-ef0d883e9047",
+    );
+  });
+
+  test("does NOT append params to other protocols", async () => {
+    vi.mocked(mount).mockImplementation((_component, options) => {
+      options.props?.onFinished({
+        redeemUrl: "rc-test://example.com/purchase/success",
+      });
+      return vi.fn();
+    });
+
+    const purchases = Purchases.getSharedInstance();
+    const offerings = await purchases.getOfferings();
+    const packageToBuy = offerings.current?.availablePackages[0];
+
+    const result = await purchases.purchase({
+      rcPackage: packageToBuy!,
+    });
+
+    expect(result.redemptionInfo?.redeemUrl).not.toBeNull();
+
+    const redeemUrl = new URL(result.redemptionInfo!.redeemUrl!);
+
+    expect(redeemUrl.toString()).toEqual(
+      "rc-test://example.com/purchase/success",
+    );
+    expect(redeemUrl.searchParams.get("trace_id")).toBeNull();
+    expect(redeemUrl.searchParams.get("checkout_session_id")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Motivation / Description

Given that we prefer to track the redemptions on the backend side, the `redeem_url` will now include `trace_id` and `checkout_session_id` when the url is a web one `http` or `https`. The future links will point to Khepri and redirect the user to the custom scheme.

They could also be append them to mobile links with custom schemes but given there is no expectation that they will make use of them I decided to skip them. @tonidero let me know if you prefer me to add them for those too.