### PR TITLE
[WEB-2082] Forward `trace_id` and `checkout_session_id` to start purchase

### DIFF
--- a/src/behavioural-events/events-tracker.ts
+++ b/src/behavioural-events/events-tracker.ts
@@ -26,6 +26,8 @@ export interface EventsTrackerProps {
 }
 
 export interface IEventsTracker {
+  getTraceId(): string;
+  getCheckoutSessionId(): string | null;
   updateUser(appUserId: string): Promise<void>;
   generateCheckoutSessionId(): void;
   trackSDKEvent(props: SDKEvent): void;
@@ -62,6 +64,14 @@ export default class EventsTracker implements IEventsTracker {
 
   public generateCheckoutSessionId() {
     this.checkoutSessionId = uuid();
+  }
+
+  public getTraceId() {
+    return this.traceId;
+  }
+
+  public getCheckoutSessionId() {
+    return this.checkoutSessionId;
   }
 
   public trackSDKEvent(props: SDKEvent): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -253,7 +253,10 @@ export class Purchases {
       appUserId: this._appUserId,
     });
     this.backend = new Backend(this._API_KEY, httpConfig);
-    this.purchaseOperationHelper = new PurchaseOperationHelper(this.backend);
+    this.purchaseOperationHelper = new PurchaseOperationHelper(
+      this.backend,
+      this.eventsTracker,
+    );
     this.eventsTracker.trackSDKEvent({
       eventName: SDKEventName.SDKInitialized,
     });

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -78,6 +78,8 @@ export class Backend {
     email: string,
     presentedOfferingContext: PresentedOfferingContext,
     purchaseOption: PurchaseOption,
+    traceId: string,
+    checkoutSessionId: string,
   ): Promise<PurchaseResponse> {
     type PurchaseRequestBody = {
       app_user_id: string;
@@ -92,6 +94,8 @@ export class Backend {
         revision: number;
       };
       supports_direct_payment: boolean;
+      trace_id: string;
+      checkout_session_id: string;
     };
 
     const requestBody: PurchaseRequestBody = {
@@ -102,6 +106,8 @@ export class Backend {
       presented_offering_identifier:
         presentedOfferingContext.offeringIdentifier,
       supports_direct_payment: true,
+      trace_id: traceId,
+      checkout_session_id: checkoutSessionId,
     };
 
     if (purchaseOption.id !== "base_option") {

--- a/src/tests/helpers/purchase-operation-helper.test.ts
+++ b/src/tests/helpers/purchase-operation-helper.test.ts
@@ -15,6 +15,7 @@ import {
   CheckoutStatusErrorCodes,
   type CheckoutStatusResponse,
 } from "../../networking/responses/checkout-status-response";
+import { type IEventsTracker } from "../../behavioural-events/events-tracker";
 
 describe("PurchaseOperationHelper", () => {
   let server: SetupServer;
@@ -34,7 +35,19 @@ describe("PurchaseOperationHelper", () => {
     server = setupServer();
     server.listen();
     backend = new Backend("test_api_key");
-    purchaseOperationHelper = new PurchaseOperationHelper(backend);
+    const eventsTrackerMock: IEventsTracker = {
+      getTraceId: () => "test-trace-id",
+      getCheckoutSessionId: () => "test-checkout-session-id",
+      updateUser: () => Promise.resolve(),
+      generateCheckoutSessionId: () => {},
+      trackSDKEvent: () => {},
+      trackExternalEvent: () => {},
+      dispose: () => {},
+    };
+    purchaseOperationHelper = new PurchaseOperationHelper(
+      backend,
+      eventsTrackerMock,
+    );
   });
 
   afterEach(() => {
@@ -59,6 +72,36 @@ describe("PurchaseOperationHelper", () => {
       ),
     );
   }
+
+  test("startPurchase forwards the trace_id and checkout_session_id to the backend", async () => {
+    server.use(
+      http.post("http://localhost:8000/rcbilling/v1/purchase", async (req) => {
+        const json = (await req.request.json()) as Record<string, unknown>;
+
+        if (
+          json &&
+          json["trace_id"] === "test-trace-id" &&
+          json["checkout_session_id"] === "test-checkout-session-id"
+        ) {
+          return HttpResponse.json(successPurchaseBody, { status: 200 });
+        }
+
+        return HttpResponse.json({ error: "Invalid request" }, { status: 500 });
+      }),
+    );
+    const result = await purchaseOperationHelper.startPurchase(
+      "test-app-user-id",
+      "test-product-id",
+      { id: "test-option-id", priceId: "test-price-id" },
+      "test-email",
+      {
+        offeringIdentifier: "test-offering-id",
+        targetingContext: null,
+        placementIdentifier: null,
+      },
+    );
+    expect(result).toEqual(successPurchaseBody);
+  });
 
   test("startPurchase fails if /purchase fails", async () => {
     setPurchaseResponse(

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -376,6 +376,8 @@ describe("purchase request", () => {
         placementIdentifier: null,
       },
       { id: "base_option", priceId: "test_price_id" },
+      "test-trace-id",
+      "test-checkout-session-id",
     );
 
     expect(purchaseMethodAPIMock).toHaveBeenCalledTimes(1);
@@ -391,6 +393,8 @@ describe("purchase request", () => {
       price_id: "test_price_id",
       presented_offering_identifier: "offering_1",
       supports_direct_payment: true,
+      trace_id: "test-trace-id",
+      checkout_session_id: "test-checkout-session-id",
     });
 
     expect(result).toEqual(purchaseResponse);
@@ -411,6 +415,8 @@ describe("purchase request", () => {
           placementIdentifier: null,
         },
         { id: "base_option", priceId: "test_price_id" },
+        "test-trace-id",
+        "test-checkout-session-id",
       ),
       new PurchasesError(
         ErrorCode.UnknownBackendError,
@@ -441,6 +447,8 @@ describe("purchase request", () => {
           placementIdentifier: null,
         },
         { id: "base_option", priceId: "test_price_id" },
+        "test-trace-id",
+        "test-checkout-session-id",
       ),
       new PurchasesError(
         ErrorCode.InvalidCredentialsError,
@@ -471,6 +479,8 @@ describe("purchase request", () => {
           placementIdentifier: null,
         },
         { id: "base_option", priceId: "test_price_id" },
+        "test-trace-id",
+        "test-checkout-session-id",
       ),
       new PurchasesError(
         ErrorCode.PurchaseInvalidError,
@@ -493,6 +503,8 @@ describe("purchase request", () => {
           placementIdentifier: null,
         },
         { id: "base_option", priceId: "test_price_id" },
+        "test-trace-id",
+        "test-checkout-session-id",
       ),
       new PurchasesError(
         ErrorCode.NetworkError,


### PR DESCRIPTION
## Motivation / Description

This will allow us to tie redemptions with events properly in the backend.