### PR TITLE
Remove checkout_session_id

### DIFF
--- a/examples/webbilling-demo/src/tests/main.test.ts
+++ b/examples/webbilling-demo/src/tests/main.test.ts
@@ -372,7 +372,6 @@ test.describe("Main", () => {
 
           const properties = event?.properties;
           expect(typeof properties.trace_id).toBe("string");
-          expect(properties.checkout_session_id).toBeNull();
 
           return true;
         } catch (error) {

--- a/src/behavioural-events/event.ts
+++ b/src/behavioural-events/event.ts
@@ -4,7 +4,6 @@ import { v4 as uuidv4 } from "uuid";
 export type EventData = {
   eventName: string;
   traceId: string;
-  checkoutSessionId: string | null;
   appUserId: string;
   properties: EventProperties;
   context: EventContext;
@@ -68,7 +67,6 @@ export class Event {
       properties: {
         ...this.data.properties,
         traceId: this.data.traceId,
-        checkoutSessionId: this.data.checkoutSessionId,
       },
     }) as EventPayload;
   }

--- a/src/behavioural-events/events-tracker.ts
+++ b/src/behavioural-events/events-tracker.ts
@@ -27,9 +27,7 @@ export interface EventsTrackerProps {
 
 export interface IEventsTracker {
   getTraceId(): string;
-  getCheckoutSessionId(): string | null;
   updateUser(appUserId: string): Promise<void>;
-  generateCheckoutSessionId(): void;
   trackSDKEvent(props: SDKEvent): void;
   trackExternalEvent(props: TrackEventProps): void;
   dispose(): void;
@@ -42,7 +40,6 @@ export default class EventsTracker implements IEventsTracker {
   private readonly flushManager: FlushManager;
   private readonly traceId: string = uuid();
   private appUserId: string;
-  private checkoutSessionId: string | null = null;
 
   constructor(props: EventsTrackerProps) {
     this.apiKey = props.apiKey;
@@ -60,16 +57,8 @@ export default class EventsTracker implements IEventsTracker {
     this.appUserId = appUserId;
   }
 
-  public generateCheckoutSessionId() {
-    this.checkoutSessionId = uuid();
-  }
-
   public getTraceId() {
     return this.traceId;
-  }
-
-  public getCheckoutSessionId() {
-    return this.checkoutSessionId;
   }
 
   public trackSDKEvent(props: SDKEvent): void {
@@ -85,7 +74,6 @@ export default class EventsTracker implements IEventsTracker {
       const event = new Event({
         eventName: props.eventName,
         traceId: this.traceId,
-        checkoutSessionId: this.checkoutSessionId,
         appUserId: this.appUserId,
         context: buildEventContext(props.source),
         properties: props.properties || {},

--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -140,7 +140,6 @@ export class PurchaseOperationHelper {
   ): Promise<PurchaseResponse> {
     try {
       const traceId = this.eventsTracker.getTraceId();
-      const checkoutSessionId = this.eventsTracker.getCheckoutSessionId();
 
       const subscribeResponse = await this.backend.postPurchase(
         appUserId,
@@ -150,7 +149,6 @@ export class PurchaseOperationHelper {
         purchaseOption,
         metadata,
         traceId,
-        checkoutSessionId ?? "",
       );
       this.operationSessionId = subscribeResponse.operation_session_id;
       return subscribeResponse;

--- a/src/main.ts
+++ b/src/main.ts
@@ -567,8 +567,6 @@ export class Purchases {
     const purchaseOptionToUse =
       purchaseOption ?? rcPackage.webBillingProduct.defaultPurchaseOption;
 
-    this.eventsTracker.generateCheckoutSessionId();
-
     const event = createCheckoutSessionStartEvent({
       appearance: this._brandingInfo?.appearance,
       rcPackage,

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -81,7 +81,6 @@ export class Backend {
     purchaseOption: PurchaseOption,
     metadata: PurchaseMetadata | undefined = undefined,
     traceId: string,
-    checkoutSessionId: string,
   ): Promise<PurchaseResponse> {
     type PurchaseRequestBody = {
       app_user_id: string;
@@ -98,7 +97,6 @@ export class Backend {
       supports_direct_payment: boolean;
       metadata?: PurchaseMetadata;
       trace_id: string;
-      checkout_session_id: string;
     };
 
     const requestBody: PurchaseRequestBody = {
@@ -110,7 +108,6 @@ export class Backend {
         presentedOfferingContext.offeringIdentifier,
       supports_direct_payment: true,
       trace_id: traceId,
-      checkout_session_id: checkoutSessionId,
     };
 
     if (metadata) {

--- a/src/stories/fixtures.ts
+++ b/src/stories/fixtures.ts
@@ -126,7 +126,6 @@ export const defaultContext = {
     trackExternalEvent: () => {},
     trackSDKEvent: () => {},
     updateUser: () => Promise.resolve(),
-    generateCheckoutSessionId: () => {},
     dispose: () => {},
   },
 };

--- a/src/tests/behavioral-events/events-tracker.test.ts
+++ b/src/tests/behavioral-events/events-tracker.test.ts
@@ -74,7 +74,6 @@ describe("EventsTracker", (test) => {
             },
             properties: {
               trace_id: "c1365463-ce59-4b83-b61b-ef0d883e9047",
-              checkout_session_id: null,
               a: "b",
               b: 1,
               c: false,
@@ -110,10 +109,9 @@ describe("EventsTracker", (test) => {
     );
   });
 
-  test<EventsTrackerFixtures>("passes the checkout session id to the event", async ({
+  test<EventsTrackerFixtures>("passes the checkout trace id to the event", async ({
     eventsTracker,
   }) => {
-    eventsTracker.generateCheckoutSessionId();
     eventsTracker.trackExternalEvent({
       eventName: "external",
       source: "sdk",
@@ -126,7 +124,7 @@ describe("EventsTracker", (test) => {
           events: expect.arrayContaining([
             expect.objectContaining({
               properties: expect.objectContaining({
-                checkout_session_id: expect.any(String),
+                trace_id: expect.any(String),
               }),
             }),
           ]),

--- a/src/tests/helpers/purchase-operation-helper.test.ts
+++ b/src/tests/helpers/purchase-operation-helper.test.ts
@@ -37,9 +37,7 @@ describe("PurchaseOperationHelper", () => {
     backend = new Backend("test_api_key");
     const eventsTrackerMock: IEventsTracker = {
       getTraceId: () => "test-trace-id",
-      getCheckoutSessionId: () => "test-checkout-session-id",
       updateUser: () => Promise.resolve(),
-      generateCheckoutSessionId: () => {},
       trackSDKEvent: () => {},
       trackExternalEvent: () => {},
       dispose: () => {},
@@ -73,16 +71,12 @@ describe("PurchaseOperationHelper", () => {
     );
   }
 
-  test("startPurchase forwards the trace_id and checkout_session_id to the backend", async () => {
+  test("startPurchase forwards the trace_id to the backend", async () => {
     server.use(
       http.post("http://localhost:8000/rcbilling/v1/purchase", async (req) => {
         const json = (await req.request.json()) as Record<string, unknown>;
 
-        if (
-          json &&
-          json["trace_id"] === "test-trace-id" &&
-          json["checkout_session_id"] === "test-checkout-session-id"
-        ) {
+        if (json && json["trace_id"] === "test-trace-id") {
           return HttpResponse.json(successPurchaseBody, { status: 200 });
         }
 

--- a/src/tests/mocks/events-tracker-mock-provider.ts
+++ b/src/tests/mocks/events-tracker-mock-provider.ts
@@ -4,7 +4,6 @@ import { vi } from "vitest";
 export function createEventsTrackerMock() {
   return {
     updateUser: vi.fn(),
-    generateCheckoutSessionId: vi.fn(),
     trackSDKEvent: vi.fn(),
     trackExternalEvent: vi.fn(),
     dispose: vi.fn(),

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -378,7 +378,6 @@ describe("purchase request", () => {
       { id: "base_option", priceId: "test_price_id" },
       { utm_campaign: "test-campaign" },
       "test-trace-id",
-      "test-checkout-session-id",
     );
 
     expect(purchaseMethodAPIMock).toHaveBeenCalledTimes(1);
@@ -396,7 +395,6 @@ describe("purchase request", () => {
       supports_direct_payment: true,
       metadata: { utm_campaign: "test-campaign" },
       trace_id: "test-trace-id",
-      checkout_session_id: "test-checkout-session-id",
     });
 
     expect(result).toEqual(purchaseResponse);
@@ -419,7 +417,6 @@ describe("purchase request", () => {
         { id: "base_option", priceId: "test_price_id" },
         { utm_campaign: "test-campaign" },
         "test-trace-id",
-        "test-checkout-session-id",
       ),
       new PurchasesError(
         ErrorCode.UnknownBackendError,
@@ -452,7 +449,6 @@ describe("purchase request", () => {
         { id: "base_option", priceId: "test_price_id" },
         { utm_campaign: "test-campaign" },
         "test-trace-id",
-        "test-checkout-session-id",
       ),
       new PurchasesError(
         ErrorCode.InvalidCredentialsError,
@@ -485,7 +481,6 @@ describe("purchase request", () => {
         { id: "base_option", priceId: "test_price_id" },
         { utm_campaign: "test-campaign" },
         "test-trace-id",
-        "test-checkout-session-id",
       ),
       new PurchasesError(
         ErrorCode.PurchaseInvalidError,
@@ -510,7 +505,6 @@ describe("purchase request", () => {
         { id: "base_option", priceId: "test_price_id" },
         { utm_campaign: "test-campaign" },
         "test-trace-id",
-        "test-checkout-session-id",
       ),
       new PurchasesError(
         ErrorCode.NetworkError,

--- a/src/tests/purchase.events.test.ts
+++ b/src/tests/purchase.events.test.ts
@@ -47,7 +47,6 @@ describe("Purchases.configure()", () => {
             app_user_id: "someAppUserId",
             context: {},
             properties: {
-              checkout_session_id: null,
               trace_id: "c1365463-ce59-4b83-b61b-ef0d883e9047",
             },
           },
@@ -80,7 +79,6 @@ describe("Purchases.configure()", () => {
             context: {},
             properties: {
               trace_id: "c1365463-ce59-4b83-b61b-ef0d883e9047",
-              checkout_session_id: "c1365463-ce59-4b83-b61b-ef0d883e9047",
               customer_email_provided_by_developer: false,
               customization_color_buttons_primary: null,
               customization_color_accent: null,
@@ -133,7 +131,6 @@ describe("Purchases.configure()", () => {
             context: {},
             properties: {
               trace_id: "c1365463-ce59-4b83-b61b-ef0d883e9047",
-              checkout_session_id: "c1365463-ce59-4b83-b61b-ef0d883e9047",
               outcome: "finished",
               with_redemption_info: false,
             },
@@ -178,7 +175,6 @@ describe("Purchases.configure()", () => {
             context: {},
             properties: {
               trace_id: "c1365463-ce59-4b83-b61b-ef0d883e9047",
-              checkout_session_id: "c1365463-ce59-4b83-b61b-ef0d883e9047",
               outcome: "closed",
             },
           },
@@ -224,7 +220,6 @@ describe("Purchases.configure()", () => {
             context: {},
             properties: {
               trace_id: "c1365463-ce59-4b83-b61b-ef0d883e9047",
-              checkout_session_id: "c1365463-ce59-4b83-b61b-ef0d883e9047",
               outcome: "errored",
               error_code: "0",
               error_message: "Unexpected error",


### PR DESCRIPTION
## Motivation / Description

There is little value and some confusion added recording `checkout_session_id`. Given that every time a purchase flow is started an event is recorded `checkout_session_start` and another one when a purchase flow is ended `checkout_session_end` one can already derive the information given by `checkout_session_id` from the order of events.

## Changes introduced

- Completely remove `checkout_session_id`.