### PR TITLE
Return operation session id on successful purchase

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -3846,7 +3846,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "@revenuecat/purchases-js!PurchaseMetadata:type",
-          "docComment": "/**\n * Metadata that can be passed to the backend when making a purchase. They will propagate to the payment gateway (i.e. Stripe) and to the RevenueCat.\n *\n * @public\n */\n",
+          "docComment": "/**\n * Metadata that can be passed to the backend when making a purchase. They will propagate to the payment gateway (i.e. Stripe) and to RevenueCat.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -4199,6 +4199,33 @@
               "isOptional": false,
               "releaseTag": "Public",
               "name": "customerInfo",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PurchaseResult#operationSessionId:member",
+              "docComment": "/**\n * The operation session id of the purchase.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly operationSessionId: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "operationSessionId",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -294,6 +294,7 @@ export interface PurchaseParams {
 // @public
 export interface PurchaseResult {
     readonly customerInfo: CustomerInfo;
+    readonly operationSessionId: string;
     readonly redemptionInfo: RedemptionInfo | null;
 }
 

--- a/src/entities/purchase-result.ts
+++ b/src/entities/purchase-result.ts
@@ -14,4 +14,9 @@ export interface PurchaseResult {
    * The redemption information after the purchase if available.
    */
   readonly redemptionInfo: RedemptionInfo | null;
+
+  /**
+   * The operation session id of the purchase.
+   */
+  readonly operationSessionId: string;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -590,7 +590,10 @@ export class Purchases {
           rcPackage,
           purchaseOption: purchaseOptionToUse,
           customerEmail,
-          onFinished: async (redemptionInfo: RedemptionInfo | null) => {
+          onFinished: async (
+            operationSessionId: string,
+            redemptionInfo: RedemptionInfo | null,
+          ) => {
             const event = createCheckoutSessionEndFinishedEvent({
               redemptionInfo,
             });
@@ -601,6 +604,7 @@ export class Purchases {
             const purchaseResult: PurchaseResult = {
               customerInfo: await this._getCustomerInfoForUserId(appUserId),
               redemptionInfo: redemptionInfo,
+              operationSessionId: operationSessionId,
             };
             resolve(purchaseResult);
           },

--- a/src/tests/helpers/purchase-operation-helper.test.ts
+++ b/src/tests/helpers/purchase-operation-helper.test.ts
@@ -230,7 +230,7 @@ describe("PurchaseOperationHelper", () => {
     await purchaseOperationHelper.pollCurrentPurchaseForCompletion();
   });
 
-  test("pollCurrentPurchaseForCompletion success with redemption info if poll returns success", async () => {
+  test("pollCurrentPurchaseForCompletion success with redemption info and operation session id if poll returns success", async () => {
     setPurchaseResponse(
       HttpResponse.json(successPurchaseBody, {
         status: StatusCodes.OK,
@@ -266,6 +266,7 @@ describe("PurchaseOperationHelper", () => {
     expect(pollResult.redemptionInfo?.redeemUrl).toEqual(
       "test-url://redeem_my_rcb?token=1234",
     );
+    expect(pollResult.operationSessionId).toEqual(operationSessionId);
   });
 
   // TODO: Fix test that fails due to using same response multiple times

--- a/src/tests/purchase.events.test.ts
+++ b/src/tests/purchase.events.test.ts
@@ -106,7 +106,7 @@ describe("Purchases.configure()", () => {
 
   test("tracks the CheckoutSessionEnded event upon finishing a purchase", async () => {
     vi.mocked(mount).mockImplementation((_component, options) => {
-      options.props?.onFinished(null);
+      options.props?.onFinished("test-operation-session-id", null);
       return vi.fn();
     });
 

--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -46,7 +46,10 @@
   export let purchaseOption: PurchaseOption;
   export let metadata: PurchaseMetadata | undefined;
   export let brandingInfo: BrandingInfoResponse | null;
-  export let onFinished: (redemptionInfo: RedemptionInfo | null) => void;
+  export let onFinished: (
+    operationSessionId: string,
+    redemptionInfo: RedemptionInfo | null,
+  ) => void;
   export let onError: (error: PurchaseFlowError) => void;
   export let onClose: () => void;
   export let purchases: Purchases;
@@ -73,6 +76,7 @@
     | "error" = "present-offer";
 
   let redemptionInfo: RedemptionInfo | null = null;
+  let operationSessionId: string | null = null;
 
   const statesWhereOfferDetailsAreShown = [
     "present-offer",
@@ -176,6 +180,7 @@
         .then((pollResult) => {
           state = "success";
           redemptionInfo = pollResult.redemptionInfo;
+          operationSessionId = pollResult.operationSessionId;
         })
         .catch((error: PurchaseFlowError) => {
           handleError(error);
@@ -184,7 +189,7 @@
     }
 
     if (state === "success" || state === "error") {
-      onFinished(redemptionInfo);
+      onFinished(operationSessionId!, redemptionInfo);
       return;
     }
 


### PR DESCRIPTION
## Motivation / Description

In order to redirect the user to the success page via the backend, we need to expose the `operationSessionId` for WPL. This ID identifies the purchase made so it sounds reasonable to me to expose it in the SDK so the developer has some reference to hold on if they want to keep it.

## Changes introduced

- Return `operationSessionId` on `PurchaseResult`.
