### PR TITLE
[WEB-2140] restore scroll after closing modal + fixing height

### DIFF
--- a/src/stories/purchase-flow-desktop-embedded.stories.svelte
+++ b/src/stories/purchase-flow-desktop-embedded.stories.svelte
@@ -69,6 +69,7 @@
       <RcbUiInner
         {...args}
         {colorVariables}
+        isInElement={true}
         paymentInfoCollectionMetadata={paymentMetadata}
       />
     </WithContext>

--- a/src/ui/layout/container.svelte
+++ b/src/ui/layout/container.svelte
@@ -8,10 +8,17 @@
   let spacingStyle = new Theme(brandingAppearance).spacingStyleVars;
   let style = [textStyle, spacingStyle].join("; ");
 
+  export let isInElement: boolean = false;
+
   export let children: Snippet;
 </script>
 
-<div class="rcb-ui-container" {style}>
+<div
+  class="rcb-ui-container"
+  class:fullscreen={!isInElement}
+  class:inside={isInElement}
+  {style}
+>
   {@render children?.()}
 </div>
 
@@ -20,12 +27,7 @@
     display: flex;
     z-index: 1000001;
     flex-direction: column;
-    position: absolute;
-    top: 0;
-    left: 0;
     inset: 0;
-    width: 100%;
-    min-height: 100%;
     color-scheme: none;
     font-size: 16px;
     line-height: 1.5em;
@@ -45,5 +47,19 @@
       arial,
       sans-serif;
     overflow: auto;
+  }
+
+  .rcb-ui-container.fullscreen {
+    position: fixed;
+    width: 100vw;
+    min-height: 100vh;
+  }
+
+  .rcb-ui-container.inside {
+    position: absolute;
+    width: 100%;
+    min-height: 100%;
+    top: 0;
+    left: 0;
   }
 </style>

--- a/src/ui/rcb-ui-inner.svelte
+++ b/src/ui/rcb-ui-inner.svelte
@@ -28,6 +28,7 @@
   export let purchaseOptionToUse: PurchaseOption;
   export let colorVariables: string = "";
   export let isSandbox: boolean = false;
+  export let isInElement: boolean = false;
 
   export let handleContinue: (params?: ContinueHandlerParams) => void;
   export let closeWithError: () => void;
@@ -47,7 +48,7 @@
   ];
 </script>
 
-<Container brandingAppearance={brandingInfo?.appearance}>
+<Container brandingAppearance={brandingInfo?.appearance} {isInElement}>
   {#if isSandbox}
     <SandboxBanner style={colorVariables} />
   {/if}

--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -210,4 +210,5 @@
   {purchaseOperationHelper}
   {closeWithError}
   {colorVariables}
+  {isInElement}
 />


### PR DESCRIPTION
This PR:

- Fixes issue when closing modal. `onDestroy` is not being called so scroll is not returned to the app
- Fixes issue introduced by https://github.com/RevenueCat/purchases-js/pull/324/files#diff-890948e5715657ae559e6221fa767a9c6c771e193ddc37fc42add8c8ab491e6eL23 whereby the modal won't take the full screen when having scrolled down (since it's absolute 100%/100%). It fixes the issue by returning conditionally the previous styles, based on `isInElement`