### PR TITLE
[WEB-2120] loading success and error states layout tweaks only changes

### DIFF
--- a/src/ui/layout/message-layout.svelte
+++ b/src/ui/layout/message-layout.svelte
@@ -95,9 +95,12 @@
   }
 
   @container layout-query-container (width >= 768px) {
+    .message-layout {
+      min-height: 440px;
+    }
     .message-layout-content {
       justify-content: flex-start;
-      flex-grow: 0;
+      flex-grow: 1;
     }
 
     .message-layout-footer {

--- a/src/ui/sandbox-banner.svelte
+++ b/src/ui/sandbox-banner.svelte
@@ -28,6 +28,7 @@
   .rcb-ui-sandbox-banner {
     position: absolute;
     top: 0;
+    z-index: 1000002;
     left: 0;
     width: 100%;
     background-color: var(--rc-color-warning);

--- a/src/ui/states/state-needs-payment-info.svelte
+++ b/src/ui/states/state-needs-payment-info.svelte
@@ -364,6 +364,7 @@
     .checkout-container {
       gap: var(--rc-spacing-gapXLarge-desktop);
       margin-top: var(--rc-spacing-gapXLarge-desktop);
+      min-height: 482px;
     }
 
     .checkout-pay-container {


### PR DESCRIPTION
## Motivation / Description

This doesn't touch the email form alignment as that is part of a follow up PR. But aligns vertically the "Continue" buttons of the payment form with success and error states.

Also increments z-index of sandbox bar so fade in animation of header doesn't show on top