### PR TITLE
[WEB-2248] wpl-product-selection-prices-should-not-show-us

### DIFF
--- a/src/helpers/price-labels.ts
+++ b/src/helpers/price-labels.ts
@@ -11,14 +11,22 @@ export const formatPrice = (
   priceInMicros: number,
   currency: string,
   locale?: string,
+  additionalFormattingOptions: {
+    maximumFractionDigits?: number;
+  } = {},
 ): string => {
   const price = microsToDollars(priceInMicros);
+
   const formatter = new Intl.NumberFormat(locale, {
     style: "currency",
     currency,
+    currencyDisplay: "symbol",
+    ...additionalFormattingOptions,
   });
 
-  return formatter.format(price);
+  const formattedPrice = formatter.format(price);
+
+  return formattedPrice.replace("US$", "$");
 };
 
 export const getTranslatedPeriodFrequency = (

--- a/src/tests/helpers/price-labels.test.ts
+++ b/src/tests/helpers/price-labels.test.ts
@@ -38,8 +38,11 @@ describe("formatPrice", () => {
     expect(formatPrice(9990000, "USD", "en-US")).toEqual("$9.99");
     expect(formatPrice(10000000, "USD", "en-US")).toEqual("$10.00");
     expect(formatPrice(990000, "USD", "en-US")).toEqual("$0.99");
+    expect(formatPrice(9900000, "USD", "es-MX")).toEqual("USD 9.90");
+    expect(formatPrice(9900000, "MXN", "es-MX")).toEqual("$9.90");
     expect(formatPrice(9990000, "EUR", "en-US")).toEqual("€9.99");
-    expect(formatPrice(9990000, "USD", "es-ES")).toEqual("9,99 US$");
+    expect(formatPrice(9990000, "USD", "es-ES")).toEqual("9,99 $");
+    expect(formatPrice(9990000, "USD", "en-GB")).toEqual("$9.99");
     expect(formatPrice(9990000, "CNY", "en-US")).toEqual("CN¥9.99");
     expect(formatPrice(9990000, "CNY", "zh-CN")).toEqual("¥9.99");
   });

--- a/src/ui/localization/translator.ts
+++ b/src/ui/localization/translator.ts
@@ -88,7 +88,10 @@ export class Translator {
   public formatPrice(priceInMicros: number, currency: string): string {
     const price = priceInMicros / 1000000;
 
-    const additionalFormattingOptions: { maximumFractionDigits?: number } = {};
+    const additionalFormattingOptions: {
+      maximumFractionDigits?: number;
+      currencyDisplay?: "narrowSymbol";
+    } = { currencyDisplay: "narrowSymbol" };
     if (price === 0) {
       additionalFormattingOptions.maximumFractionDigits = 0;
     }

--- a/src/ui/localization/translator.ts
+++ b/src/ui/localization/translator.ts
@@ -4,6 +4,7 @@ import { englishLocale } from "./constants";
 
 import type { LocalizationKeys } from "./supportedLanguages";
 import { supportedLanguages } from "./supportedLanguages";
+import { formatPrice } from "../../helpers/price-labels";
 
 export type EmptyString = "";
 
@@ -86,22 +87,21 @@ export class Translator {
   }
 
   public formatPrice(priceInMicros: number, currency: string): string {
-    const price = priceInMicros / 1000000;
-
     const additionalFormattingOptions: {
       maximumFractionDigits?: number;
       currencyDisplay?: "narrowSymbol";
     } = { currencyDisplay: "narrowSymbol" };
-    if (price === 0) {
+    if (priceInMicros === 0) {
       additionalFormattingOptions.maximumFractionDigits = 0;
     }
 
     try {
-      return new Intl.NumberFormat(this.locale, {
-        style: "currency",
+      return formatPrice(
+        priceInMicros,
         currency,
-        ...additionalFormattingOptions,
-      }).format(price);
+        this.locale,
+        additionalFormattingOptions,
+      );
     } catch {
       Logger.errorLog(
         `Failed to create a price formatter for locale: ${this.locale}`,
@@ -109,22 +109,24 @@ export class Translator {
     }
 
     try {
-      return new Intl.NumberFormat(this.fallbackLocale, {
-        style: "currency",
+      return formatPrice(
+        priceInMicros,
         currency,
-        ...additionalFormattingOptions,
-      }).format(price);
+        this.fallbackLocale,
+        additionalFormattingOptions,
+      );
     } catch {
       Logger.errorLog(
         `Failed to create a price formatter for locale: ${this.fallbackLocale}`,
       );
     }
 
-    return new Intl.NumberFormat(englishLocale, {
-      style: "currency",
+    return formatPrice(
+      priceInMicros,
       currency,
-      ...additionalFormattingOptions,
-    }).format(price);
+      englishLocale,
+      additionalFormattingOptions,
+    );
   }
 
   get locale(): string {


### PR DESCRIPTION
We can't use `currencyDisplay: narrowSymbol` as that introduces too much ambiguity in the cases of the Canadian dollar, Mexican dollar, yuan vs yen.. etc

We also do some DRY
