### PR TITLE
Fix test failures in getNextRenewalDate

### DIFF
--- a/src/tests/helpers/duration-helper.test.ts
+++ b/src/tests/helpers/duration-helper.test.ts
@@ -52,64 +52,64 @@ describe("parseISODuration", () => {
 
 describe("getNextRenewalDate", () => {
   test("should return null if willRenew is false", () => {
-    const startDate = new Date("2025-02-24");
+    const startDate = new Date(2025, 1, 24);
     const period: Period = { unit: PeriodUnit.Month, number: 1 };
     expect(getNextRenewalDate(startDate, period, false)).toBeNull();
   });
 
   test("should correctly add years to the date", () => {
-    const startDate = new Date("2025-02-24");
+    const startDate = new Date(2025, 1, 24);
     const period: Period = { unit: PeriodUnit.Year, number: 2 };
     expect(getNextRenewalDate(startDate, period, true)).toEqual(
-      new Date("2027-02-24"),
+      new Date(2027, 1, 24),
     );
   });
 
   test("should correctly add months to the date", () => {
-    const startDate = new Date("2025-01-31");
+    const startDate = new Date(2025, 0, 31);
     const period: Period = { unit: PeriodUnit.Month, number: 1 };
     expect(getNextRenewalDate(startDate, period, true)).toEqual(
-      new Date("2025-02-28"),
+      new Date(2025, 1, 28),
     ); // Handle month-end cases
   });
 
   test("should correctly add weeks to the date", () => {
-    const startDate = new Date("2025-02-24");
+    const startDate = new Date(2025, 1, 24);
     const period: Period = { unit: PeriodUnit.Week, number: 2 };
     expect(getNextRenewalDate(startDate, period, true)).toEqual(
-      new Date("2025-03-10"),
+      new Date(2025, 2, 10),
     );
   });
 
   test("should correctly add days to the date", () => {
-    const startDate = new Date("2025-02-24");
+    const startDate = new Date(2025, 1, 24);
     const period: Period = { unit: PeriodUnit.Day, number: 10 };
     expect(getNextRenewalDate(startDate, period, true)).toEqual(
-      new Date("2025-03-06"),
+      new Date(2025, 2, 6),
     );
   });
 
   test("should handle leap years correctly", () => {
-    const startDate = new Date("2024-02-29"); // Leap year date
+    const startDate = new Date(2024, 1, 29); // Leap year date
     const period: Period = { unit: PeriodUnit.Year, number: 1 };
     expect(getNextRenewalDate(startDate, period, true)).toEqual(
-      new Date("2025-02-28"),
+      new Date(2025, 1, 28),
     );
   });
 
   test("should handle repeated leap years correctly", () => {
-    const startDate = new Date("2024-02-29"); // Leap year date
+    const startDate = new Date(2024, 1, 29); // Leap year date
     const period: Period = { unit: PeriodUnit.Year, number: 4 };
     expect(getNextRenewalDate(startDate, period, true)).toEqual(
-      new Date("2028-02-29"),
+      new Date(2028, 1, 29),
     );
   });
 
   test("should handle edge cases for month increments", () => {
-    const startDate = new Date("2025-01-31");
+    const startDate = new Date(2025, 0, 31);
     const period: Period = { unit: PeriodUnit.Month, number: 1 };
     expect(getNextRenewalDate(startDate, period, true)).toEqual(
-      new Date("2025-02-28"),
+      new Date(2025, 1, 28),
     );
   });
 });


### PR DESCRIPTION
## Motivation / Description

The recently introduced tests of getNextRenewalDate fail after 15:00PST since there's is an UTC <> PST day leap