### PR TITLE
Validate app user id on change

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -700,6 +700,7 @@ export class Purchases {
    * @param newAppUserId - The user id to change to.
    */
   public async changeUser(newAppUserId: string): Promise<CustomerInfo> {
+    validateAppUserId(newAppUserId);
     this._appUserId = newAppUserId;
     this.eventsTracker.updateUser(newAppUserId);
     // TODO: Cancel all pending requests if any.

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -105,11 +105,16 @@ describe("Purchases.isEntitledTo", () => {
 });
 
 describe("Purchases.changeUser", () => {
-  test("can change user", () => {
+  test("throws error if given invalid user id", async () => {
+    const purchases = configurePurchases();
+    await expect(purchases.changeUser("")).rejects.toThrow(PurchasesError);
+  });
+
+  test("can change user", async () => {
     const newAppUserId = "newAppUserId";
     const purchases = configurePurchases();
     expect(purchases.getAppUserId()).toEqual(testUserId);
-    purchases.changeUser(newAppUserId);
+    await purchases.changeUser(newAppUserId);
     expect(purchases.getAppUserId()).toEqual(newAppUserId);
   });
 });


### PR DESCRIPTION
## Motivation / Description

While looking into [this reported issue](https://revenuecat.zendesk.com/agent/tickets/54693). I noticed the validation of `appUserId` is not happening when in the `changeUser` function. This is technically a breaking change but given it could be a source of bugs maybe it should be integrated anyways?

@tonidero wdyt?
