### PR TITLE
Storybook with locale in toolbar

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -7,6 +7,7 @@ const config: StorybookConfig = {
     "@storybook/addon-essentials",
     "@storybook/addon-interactions",
     "@storybook/addon-controls",
+    "@storybook/sveltekit",
     {
       name: "@storybook/addon-svelte-csf",
       options: {

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -51,6 +51,53 @@ const preview: Preview = {
       };
     },
   ],
+  globalTypes: {
+    locale: {
+      description: "Pick an example locale",
+      toolbar: {
+        title: "Locale",
+        icon: "globe",
+        dynamicTitle: true,
+        items: [
+          {
+            value: "en",
+            title: "English",
+          },
+          {
+            value: "fr",
+            title: "French",
+          },
+          {
+            value: "de",
+            title: "German",
+          },
+          {
+            value: "es",
+            title: "Spanish",
+          },
+          {
+            value: "it",
+            title: "Italian",
+          },
+          {
+            value: "ja",
+            title: "Japanese",
+          },
+          {
+            value: "ca",
+            title: "Catalan",
+          },
+          {
+            value: "ar",
+            title: "Arabic",
+          },
+        ],
+      },
+    },
+  },
+  initialGlobals: {
+    locale: "en",
+  },
 };
 
 export default preview;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from "@storybook/svelte";
+import GlobalDecorator from "../src/stories/utils/global-decorator.svelte";
 
 const preview: Preview = {
   parameters: {
@@ -36,6 +37,20 @@ const preview: Preview = {
       },
     },
   },
+  decorators: [
+    (Story, context) => {
+      return {
+        Component: GlobalDecorator,
+        props: {
+          globals: context.globals,
+          children: () => ({
+            Component: Story,
+            props: context.args,
+          }),
+        },
+      };
+    },
+  ],
 };
 
 export default preview;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1886,9 +1886,9 @@
       }
     },
     "node_modules/@storybook/addon-backgrounds": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-8.5.0.tgz",
-      "integrity": "sha512-lzyFLs7niNsqlhH5kdUrp7htLiMIcjY50VLWe0PaeJ6T6GZ7X9qhQzROAUV6cGqzyd8A6y/LzIUntDPMVEm/6g==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-8.6.4.tgz",
+      "integrity": "sha512-lRYGumlYdd1RptQJvOTRMx/q2pDmg2MO5GX4la7VfI8KrUyeuC1ZOSRDEcXeTuAZWJztqmtymg6bB7cAAoxCFA==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
@@ -1900,13 +1900,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.0"
+        "storybook": "^8.6.4"
       }
     },
     "node_modules/@storybook/addon-controls": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-8.5.0.tgz",
-      "integrity": "sha512-1fivx77A/ahObrPl0L66o9i9MUNfqXxsrpekne5gjMNXw9XJFIRNUe/ddL4CMmwu7SgVbj2QV+q5E5mlnZNTJw==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-8.6.4.tgz",
+      "integrity": "sha512-oMMP9Bj0RMfYmaitjFt6oBSjKH4titUqP+wE6PrZ3v+Om56f4buqfNKXRf80As2OrsZn0pjj95muWzVVHqIhyQ==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
@@ -1918,21 +1918,21 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.0"
+        "storybook": "^8.6.4"
       }
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-8.5.0.tgz",
-      "integrity": "sha512-REwLSr1VgOVNJZwP3y3mldhOjBHlM5fqTvq/tC8NaYpAzx9O4rZdoUSZxW3tYtoNoYrHpB8kzRTeZl8WSdKllw==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-8.6.4.tgz",
+      "integrity": "sha512-+kbcjvEAH0Xs+k+raAwfC0WmJilWhxBYnLLeazP3m5AkVI3sIjbzuuZ78NR0DCdRkw9BpuuXMHv5o4tIvLIUlw==",
       "dev": true,
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/blocks": "8.5.0",
-        "@storybook/csf-plugin": "8.5.0",
-        "@storybook/react-dom-shim": "8.5.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "@storybook/blocks": "8.6.4",
+        "@storybook/csf-plugin": "8.6.4",
+        "@storybook/react-dom-shim": "8.6.4",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -1940,24 +1940,40 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.0"
+        "storybook": "^8.6.4"
+      }
+    },
+    "node_modules/@storybook/addon-docs/node_modules/@storybook/csf-plugin": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.6.4.tgz",
+      "integrity": "sha512-7UpEp4PFTy1iKjZiRaYMG7zvnpLIRPyD0+lUJUlLYG4UIemV3onvnIi1Je1tSZ4hfTup+ulom7JLztVSHZGRMg==",
+      "dev": true,
+      "dependencies": {
+        "unplugin": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.4"
       }
     },
     "node_modules/@storybook/addon-essentials": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-8.5.0.tgz",
-      "integrity": "sha512-RrHRdaw2j3ugZiYQ6OHt3Ff08ID4hwAvipqULEsbEnEw3VlXOaW/MT5e2M7kW3MHskQ3iJ6XAD1Y1rNm432Pzw==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-8.6.4.tgz",
+      "integrity": "sha512-3pF0ZDl5EICqe0eOupPQq6PxeupwkLsfTWANuuJUYTJur82kvJd3Chb7P9vqw0A0QBx6106mL6PIyjrFJJMhLg==",
       "dev": true,
       "dependencies": {
-        "@storybook/addon-actions": "8.5.0",
-        "@storybook/addon-backgrounds": "8.5.0",
-        "@storybook/addon-controls": "8.5.0",
-        "@storybook/addon-docs": "8.5.0",
-        "@storybook/addon-highlight": "8.5.0",
-        "@storybook/addon-measure": "8.5.0",
-        "@storybook/addon-outline": "8.5.0",
-        "@storybook/addon-toolbars": "8.5.0",
-        "@storybook/addon-viewport": "8.5.0",
+        "@storybook/addon-actions": "8.6.4",
+        "@storybook/addon-backgrounds": "8.6.4",
+        "@storybook/addon-controls": "8.6.4",
+        "@storybook/addon-docs": "8.6.4",
+        "@storybook/addon-highlight": "8.6.4",
+        "@storybook/addon-measure": "8.6.4",
+        "@storybook/addon-outline": "8.6.4",
+        "@storybook/addon-toolbars": "8.6.4",
+        "@storybook/addon-viewport": "8.6.4",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -1965,29 +1981,52 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.0"
+        "storybook": "^8.6.4"
       }
     },
-    "node_modules/@storybook/addon-essentials/node_modules/@storybook/addon-viewport": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-8.5.0.tgz",
-      "integrity": "sha512-MlhVELImk9YzjEgGR2ciLC8d5tUSGcO7my4kWIClN0VyTRcvG4ZfwrsEC+jN3/l52nrgjLmKrDX5UAGZm6w5mQ==",
+    "node_modules/@storybook/addon-essentials/node_modules/@storybook/addon-actions": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-8.6.4.tgz",
+      "integrity": "sha512-mCcyfkeb19fJX0dpQqqZCnWBwjVn0/27xcpR0mbm/KW2wTByU6bKFFujgrHsX3ONl97IcIaUnmwwUwBr1ebZXw==",
       "dev": true,
       "dependencies": {
-        "memoizerific": "^1.11.3"
+        "@storybook/global": "^5.0.0",
+        "@types/uuid": "^9.0.1",
+        "dequal": "^2.0.2",
+        "polished": "^4.2.2",
+        "uuid": "^9.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.0"
+        "storybook": "^8.6.4"
+      }
+    },
+    "node_modules/@storybook/addon-essentials/node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true
+    },
+    "node_modules/@storybook/addon-essentials/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@storybook/addon-highlight": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-8.5.0.tgz",
-      "integrity": "sha512-/JxYzMK5aJSYs0K/0eAEFyER2dMoxqwM891MdnkNwLFdyrM58lzHee00F9oEX6zeQoRUNQPRepq0ui2PvbTMGw==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-8.6.4.tgz",
+      "integrity": "sha512-jFREXnSE/7VuBR8kbluN+DBVkMXEV7MGuCe8Ytb1/D2Q0ohgJe395dfVgEgSMXErOwsn//NV/NgJp6JNXH2DrA==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0"
@@ -1997,7 +2036,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.0"
+        "storybook": "^8.6.4"
       }
     },
     "node_modules/@storybook/addon-interactions": {
@@ -2054,9 +2093,9 @@
       }
     },
     "node_modules/@storybook/addon-measure": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-8.5.0.tgz",
-      "integrity": "sha512-e8pJy2sICyj0Ff0W1PFc6HPE6PqcjnnHtfuDaO3M9uSKJLYkpTWJ8i1VSP178f8seq44r5/PdQCHqs5q5l3zgw==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-8.6.4.tgz",
+      "integrity": "sha512-IpVL1rTy1tO8sy140eU3GdVB1QJ6J62+V6GSstcmqTLxDJQk5jFfg7hVbPEAZZ2sPFmeyceP9AMoBBo0EB355A==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
@@ -2067,13 +2106,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.0"
+        "storybook": "^8.6.4"
       }
     },
     "node_modules/@storybook/addon-outline": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-outline/-/addon-outline-8.5.0.tgz",
-      "integrity": "sha512-r12sk1b38Ph6NroWAOTfjbJ/V+gDobm7tKQQlbSDf6fgX7cqyPHmKjfNDCOCQpXouZm/Jm+41zd758PW+Yt4ng==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-outline/-/addon-outline-8.6.4.tgz",
+      "integrity": "sha512-28nAslKTy0zWMdxAZcipMDYrEp1TkXVooAsqMGY5AMXMiORi1ObjhmjTLhVt1dXp+aDg0X+M3B6PqoingmHhqQ==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
@@ -2084,7 +2123,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.0"
+        "storybook": "^8.6.4"
       }
     },
     "node_modules/@storybook/addon-svelte-csf": {
@@ -2111,22 +2150,22 @@
       }
     },
     "node_modules/@storybook/addon-toolbars": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-8.5.0.tgz",
-      "integrity": "sha512-q3yYYO2WX8K2DYNM++FzixGDjzYaeREincgsl2WXYXrcuGb5hkOoOgRiAQL8Nz9NQ1Eo+B/yZxrhG/5VoVhUUQ==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-8.6.4.tgz",
+      "integrity": "sha512-PU2lvgwCKDn93zpp5MEog103UUmSSugcxDf18xaoa9D15Qtr+YuQHd2hXbxA7+dnYL9lA7MLYsstfxE91ieM4Q==",
       "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.0"
+        "storybook": "^8.6.4"
       }
     },
     "node_modules/@storybook/addon-viewport": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-8.5.2.tgz",
-      "integrity": "sha512-W+7nrMQmxHcUNGsXjmb/fak1mD0a5vf4y1hBhSM7/131t8KBsvEu4ral8LTUhc4ZzuU1eIUM0Qth7SjqHqm5bA==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-8.6.4.tgz",
+      "integrity": "sha512-O5Ij+SRVg6grY6JOL5lOpsFyopZxuZEl2GHfh2SUf9hfowNS0QAgFpJupqXkwZzRSrlf9uKrLkjB6ulLgN2gOQ==",
       "dev": true,
       "dependencies": {
         "memoizerific": "^1.11.3"
@@ -2136,16 +2175,15 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.2"
+        "storybook": "^8.6.4"
       }
     },
     "node_modules/@storybook/blocks": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-8.5.0.tgz",
-      "integrity": "sha512-2sTOgjH/JFOgWnpqkKjpKVvKAgUaC9ZBjH1gnCoA5dne/SDafYaCAYfv6yZn7g2Xm1sTxWCAmMIUkYSALeWr+w==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-8.6.4.tgz",
+      "integrity": "sha512-+oPXwT3KzJzsdkQuGEzBqOKTIFlb6qmlCWWbDwAnP0SEqYHoTVRTAIa44icFP0EZeIe+ypFVAm1E7kWTLmw1hQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/csf": "0.1.12",
         "@storybook/icons": "^1.2.12",
         "ts-dedent": "^2.0.0"
       },
@@ -2154,9 +2192,9 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^8.5.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^8.6.4"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -2165,15 +2203,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@storybook/blocks/node_modules/@storybook/csf": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.12.tgz",
-      "integrity": "sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^2.19.0"
       }
     },
     "node_modules/@storybook/builder-vite": {
@@ -2209,15 +2238,15 @@
       }
     },
     "node_modules/@storybook/core": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.5.2.tgz",
-      "integrity": "sha512-rCOpXZo2XbdKVnZiv8oC9FId/gLkStpKGGL7hhdg/RyjcyUyTfhsvaf7LXKZH2A0n/UpwFxhF3idRfhgc1XiSg==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.6.4.tgz",
+      "integrity": "sha512-glDbjEBi3wokw1T+KQtl93irHO9N0LCwgylWfWVXYDdQjUJ7pGRQGnw73gPX7Ds9tg3myXFC83GjmY94UYSMbA==",
       "dev": true,
       "dependencies": {
-        "@storybook/csf": "0.1.12",
+        "@storybook/theming": "8.6.4",
         "better-opn": "^3.0.2",
         "browser-assert": "^1.2.1",
-        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0",
         "esbuild-register": "^3.5.0",
         "jsdoc-type-pratt-parser": "^4.0.0",
         "process": "^0.11.10",
@@ -2239,19 +2268,23 @@
         }
       }
     },
-    "node_modules/@storybook/core/node_modules/@storybook/csf": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.12.tgz",
-      "integrity": "sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==",
+    "node_modules/@storybook/core/node_modules/@storybook/theming": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.4.tgz",
+      "integrity": "sha512-g9Ns4uenC9oAWETaJ/tEKEIPMdS+CqjNWZz5Wbw1bLNhXwADZgKrVqawzZi64+bYYtQ+i8VCTjPoFa6s2eHiDQ==",
       "dev": true,
-      "dependencies": {
-        "type-fest": "^2.19.0"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
       }
     },
     "node_modules/@storybook/core/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -2364,9 +2397,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.5.0.tgz",
-      "integrity": "sha512-7P8xg4FiuFpM6kQOzZynno+0zyLVs8NgsmRK58t3JRZXbda1tzlxTXzvqx4hUevvbPJGjmrB0F3xTFH+8Otnvw==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.6.4.tgz",
+      "integrity": "sha512-kTGJ3aFdmfCFzYaDFGmZWfTXr9xhbUaf0tJ6+nEjc4tME6mFwMI+tTUT6U/J6mJhZuc2DjvIRA7bM0x77dIDqw==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -2375,7 +2408,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^8.5.0"
+        "storybook": "^8.6.4"
       }
     },
     "node_modules/@storybook/svelte": {
@@ -2813,9 +2846,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "19.0.7",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.7.tgz",
-      "integrity": "sha512-MoFsEJKkAtZCrC1r6CM8U22GzhG7u2Wir8ons/aCKH6MBdD1ibV24zOSSkdZVUKqN5i396zG5VKLYZ3yaUZdLA==",
+      "version": "19.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
+      "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -8736,9 +8769,9 @@
       }
     },
     "node_modules/recast": {
-      "version": "0.23.9",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.9.tgz",
-      "integrity": "sha512-Hx/BGIbwj+Des3+xy5uAtAbdCyqK9y9wbBcDFDYanLS9JnMqf7OeF87HQwUimE87OEc72mr6tkKUKMBBL+hF9Q==",
+      "version": "0.23.11",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
+      "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
       "dev": true,
       "dependencies": {
         "ast-types": "^0.16.1",
@@ -9447,12 +9480,12 @@
       "license": "MIT"
     },
     "node_modules/storybook": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.5.2.tgz",
-      "integrity": "sha512-pf84emQ7Pd5jBdT2gzlNs4kRaSI3pq0Lh8lSfV+YqIVXztXIHU+Lqyhek2Lhjb7btzA1tExrhJrgQUsIji7i7A==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.6.4.tgz",
+      "integrity": "sha512-XXh1Acvf1r3BQX0BDLQw6yhZ7yUGvYxIcKOBuMdetnX7iXtczipJTfw0uyFwk0ltkKEE9PpJvivYmARF3u64VQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/core": "8.5.2"
+        "@storybook/core": "8.6.4"
       },
       "bin": {
         "getstorybook": "bin/index.cjs",

--- a/src/networking/responses/branding-response.ts
+++ b/src/networking/responses/branding-response.ts
@@ -7,5 +7,4 @@ export type BrandingInfoResponse = {
   id: string;
   app_name: string | null;
   support_email?: string | null;
-  gateway_tax_collection_enabled: boolean;
 };

--- a/src/stories/fixtures.ts
+++ b/src/stories/fixtures.ts
@@ -122,7 +122,6 @@ export const brandingInfo: BrandingInfoResponse = {
   app_icon: "1005820_1715624566.png",
   app_icon_webp: "1005820_1715624566.webp",
   appearance: null,
-  gateway_tax_collection_enabled: true,
 };
 
 export const purchaseFlowError = new PurchaseFlowError(1);

--- a/src/stories/purchase-flow-custom-appearance-desktop-embedded.stories.svelte
+++ b/src/stories/purchase-flow-custom-appearance-desktop-embedded.stories.svelte
@@ -1,10 +1,7 @@
 <script module>
   import { defineMeta, setTemplate } from "@storybook/addon-svelte-csf";
-  import WithContext from "./utils/with-context.svelte";
   import { toProductInfoStyleVar } from "../ui/theme/utils";
   import RcbUiInner from "../ui/rcb-ui-inner.svelte";
-  import { translatorContextKey } from "../ui/localization/constants";
-  import { Translator } from "../ui/localization/translator";
   import {
     brandingInfo,
     colorfulBrandingAppearance,
@@ -58,21 +55,12 @@
         id="embedding-container"
         style="width: 500px; height: 600px; position: relative; overflow: hidden; background-color: lightgray;"
       >
-        <WithContext
-          context={{
-            ...args.context,
-            [translatorContextKey]: args.locale
-              ? new Translator({}, args.locale, args.locale)
-              : undefined,
-          }}
-        >
-          <RcbUiInner
-            {...args}
-            {colorVariables}
-            isInElement={true}
-            paymentInfoCollectionMetadata={paymentMetadata}
-          />
-        </WithContext>
+        <RcbUiInner
+          {...args}
+          {colorVariables}
+          isInElement={true}
+          paymentInfoCollectionMetadata={paymentMetadata}
+        />
       </div>
       <div style="padding: 20px;">
         <h1>Homer's Web page</h1>

--- a/src/stories/purchase-flow-custom-appearance-desktop-embedded.stories.svelte
+++ b/src/stories/purchase-flow-custom-appearance-desktop-embedded.stories.svelte
@@ -48,8 +48,6 @@
 </script>
 
 <script lang="ts">
-  import { eventsTrackerContextKey } from "../ui/constants";
-
   setTemplate(template);
 </script>
 
@@ -66,7 +64,6 @@
             [translatorContextKey]: args.locale
               ? new Translator({}, args.locale, args.locale)
               : undefined,
-            [eventsTrackerContextKey]: { trackSDKEvent: () => {} },
           }}
         >
           <RcbUiInner

--- a/src/stories/purchase-flow-custom-appearance-desktop.stories.svelte
+++ b/src/stories/purchase-flow-custom-appearance-desktop.stories.svelte
@@ -1,10 +1,7 @@
 <script module>
   import { defineMeta, setTemplate } from "@storybook/addon-svelte-csf";
-  import WithContext from "./utils/with-context.svelte";
   import { toProductInfoStyleVar } from "../ui/theme/utils";
   import RcbUiInner from "../ui/rcb-ui-inner.svelte";
-  import { translatorContextKey } from "../ui/localization/constants";
-  import { Translator } from "../ui/localization/translator";
   import {
     brandingInfo,
     colorfulBrandingAppearance,
@@ -51,20 +48,11 @@
 </script>
 
 {#snippet template(args: any)}
-  <WithContext
-    context={{
-      ...args.context,
-      [translatorContextKey]: args.locale
-        ? new Translator({}, args.locale, args.locale)
-        : undefined,
-    }}
-  >
-    <RcbUiInner
-      {...args}
-      {colorVariables}
-      paymentInfoCollectionMetadata={paymentMetadata}
-    />
-  </WithContext>
+  <RcbUiInner
+    {...args}
+    {colorVariables}
+    paymentInfoCollectionMetadata={paymentMetadata}
+  />
 {/snippet}
 
 <Story name="Email Input" args={{ currentView: "needs-auth-info" }} />

--- a/src/stories/purchase-flow-custom-appearance-desktop.stories.svelte
+++ b/src/stories/purchase-flow-custom-appearance-desktop.stories.svelte
@@ -47,8 +47,6 @@
 </script>
 
 <script lang="ts">
-  import { eventsTrackerContextKey } from "../ui/constants";
-
   setTemplate(template);
 </script>
 
@@ -59,7 +57,6 @@
       [translatorContextKey]: args.locale
         ? new Translator({}, args.locale, args.locale)
         : undefined,
-      [eventsTrackerContextKey]: { trackSDKEvent: () => {} },
     }}
   >
     <RcbUiInner

--- a/src/stories/purchase-flow-custom-appearance-mobile.stories.svelte
+++ b/src/stories/purchase-flow-custom-appearance-mobile.stories.svelte
@@ -48,8 +48,6 @@
 </script>
 
 <script lang="ts">
-  import { eventsTrackerContextKey } from "../ui/constants";
-
   setTemplate(template);
 </script>
 
@@ -60,7 +58,6 @@
       [translatorContextKey]: args.locale
         ? new Translator({}, args.locale, args.locale)
         : undefined,
-      [eventsTrackerContextKey]: { trackSDKEvent: () => {} },
     }}
   >
     <RcbUiInner

--- a/src/stories/purchase-flow-custom-appearance-mobile.stories.svelte
+++ b/src/stories/purchase-flow-custom-appearance-mobile.stories.svelte
@@ -1,9 +1,7 @@
 <script module>
   import { defineMeta, setTemplate } from "@storybook/addon-svelte-csf";
-  import WithContext from "./utils/with-context.svelte";
   import { toProductInfoStyleVar } from "../ui/theme/utils";
   import RcbUiInner from "../ui/rcb-ui-inner.svelte";
-  import { Translator } from "../ui/localization/translator";
 
   import {
     brandingInfo,
@@ -15,7 +13,6 @@
   } from "./fixtures";
   import { buildCheckoutStartResponse } from "./utils/purchase-response-builder";
   import { type CheckoutStartResponse } from "../networking/responses/checkout-start-response";
-  import { translatorContextKey } from "../ui/localization/constants";
 
   const defaultArgs = {
     context: {},
@@ -52,20 +49,11 @@
 </script>
 
 {#snippet template(args: any)}
-  <WithContext
-    context={{
-      ...args.context,
-      [translatorContextKey]: args.locale
-        ? new Translator({}, args.locale, args.locale)
-        : undefined,
-    }}
-  >
-    <RcbUiInner
-      {...args}
-      {colorVariables}
-      paymentInfoCollectionMetadata={paymentMetadata}
-    />
-  </WithContext>
+  <RcbUiInner
+    {...args}
+    {colorVariables}
+    paymentInfoCollectionMetadata={paymentMetadata}
+  />
 {/snippet}
 
 <Story

--- a/src/stories/purchase-flow-desktop-embedded.stories.svelte
+++ b/src/stories/purchase-flow-desktop-embedded.stories.svelte
@@ -1,10 +1,7 @@
 <script module>
   import { defineMeta, setTemplate } from "@storybook/addon-svelte-csf";
-  import WithContext from "./utils/with-context.svelte";
   import { toProductInfoStyleVar } from "../ui/theme/utils";
   import RcbUiInner from "../ui/rcb-ui-inner.svelte";
-  import { translatorContextKey } from "../ui/localization/constants";
-  import { Translator } from "../ui/localization/translator";
   import {
     brandingInfo,
     product,
@@ -57,21 +54,12 @@
         id="embedding-container"
         style="width: 500px; height: 600px; position: relative; overflow: hidden; background-color: lightgray;"
       >
-        <WithContext
-          context={{
-            ...args.context,
-            [translatorContextKey]: args.locale
-              ? new Translator({}, args.locale, args.locale)
-              : undefined,
-          }}
-        >
-          <RcbUiInner
-            {...args}
-            {colorVariables}
-            isInElement={true}
-            paymentInfoCollectionMetadata={paymentMetadata}
-          />
-        </WithContext>
+        <RcbUiInner
+          {...args}
+          {colorVariables}
+          isInElement={true}
+          paymentInfoCollectionMetadata={paymentMetadata}
+        />
       </div>
       <div style="padding: 20px;">
         <h1>Homer's Web page</h1>

--- a/src/stories/purchase-flow-desktop-embedded.stories.svelte
+++ b/src/stories/purchase-flow-desktop-embedded.stories.svelte
@@ -47,8 +47,6 @@
 </script>
 
 <script lang="ts">
-  import { eventsTrackerContextKey } from "../ui/constants";
-
   setTemplate(template);
 </script>
 
@@ -65,7 +63,6 @@
             [translatorContextKey]: args.locale
               ? new Translator({}, args.locale, args.locale)
               : undefined,
-            [eventsTrackerContextKey]: { trackSDKEvent: () => {} },
           }}
         >
           <RcbUiInner

--- a/src/stories/purchase-flow-desktop.stories.svelte
+++ b/src/stories/purchase-flow-desktop.stories.svelte
@@ -46,8 +46,6 @@
 </script>
 
 <script lang="ts">
-  import { eventsTrackerContextKey } from "../ui/constants";
-
   setTemplate(template);
 </script>
 
@@ -58,7 +56,6 @@
       [translatorContextKey]: args.locale
         ? new Translator({}, args.locale, args.locale)
         : undefined,
-      [eventsTrackerContextKey]: { trackSDKEvent: () => {} },
     }}
   >
     <RcbUiInner

--- a/src/stories/purchase-flow-desktop.stories.svelte
+++ b/src/stories/purchase-flow-desktop.stories.svelte
@@ -1,10 +1,7 @@
 <script module>
   import { defineMeta, setTemplate } from "@storybook/addon-svelte-csf";
-  import WithContext from "./utils/with-context.svelte";
   import { toProductInfoStyleVar } from "../ui/theme/utils";
   import RcbUiInner from "../ui/rcb-ui-inner.svelte";
-  import { translatorContextKey } from "../ui/localization/constants";
-  import { Translator } from "../ui/localization/translator";
   import {
     brandingInfo,
     product,
@@ -50,20 +47,11 @@
 </script>
 
 {#snippet template(args: any)}
-  <WithContext
-    context={{
-      ...args.context,
-      [translatorContextKey]: args.locale
-        ? new Translator({}, args.locale, args.locale)
-        : undefined,
-    }}
-  >
-    <RcbUiInner
-      {...args}
-      {colorVariables}
-      paymentInfoCollectionMetadata={paymentMetadata}
-    />
-  </WithContext>
+  <RcbUiInner
+    {...args}
+    {colorVariables}
+    paymentInfoCollectionMetadata={paymentMetadata}
+  />
 {/snippet}
 
 <Story name="Email Input" args={{ currentView: "needs-auth-info" }} />

--- a/src/stories/purchase-flow-mobile.stories.svelte
+++ b/src/stories/purchase-flow-mobile.stories.svelte
@@ -28,7 +28,7 @@
   let { Story } = defineMeta({
     title: "Purchase flow (Mobile)",
     args: defaultArgs,
-    parameters: {},
+    parameters: { viewport: { defaultViewport: "mobile" } },
     loaders: [
       async () => {
         const paymentInfoCollectionMetadata: CheckoutStartResponse =
@@ -55,18 +55,10 @@
   />
 {/snippet}
 
-<Story
-  name="Email Input"
-  args={{ currentView: "needs-auth-info" }}
-  parameters={{ viewport: { defaultViewport: "mobile" } }}
-/>
+<Story name="Email Input" args={{ currentView: "needs-auth-info" }} />
 <Story
   name="Email Input (with Sandbox Banner)"
-  args={{
-    currentView: "needs-auth-info",
-    isSandbox: true,
-  }}
-  parameters={{ viewport: { defaultViewport: "mobile" } }}
+  args={{ currentView: "needs-auth-info", isSandbox: true }}
 />
 <Story
   name="Email Input (with Trial Product)"
@@ -79,7 +71,6 @@
     },
     purchaseOptionToUse: subscriptionOptionWithTrial,
   }}
-  parameters={{ viewport: { defaultViewport: "mobile" } }}
 />
 <Story
   name="Checkout (with Trial Product)"
@@ -96,26 +87,7 @@
     purchaseOptionToUse: subscriptionOptionWithTrial,
     defaultPurchaseOption: subscriptionOptionWithTrial,
   }}
-  parameters={{ viewport: { defaultViewport: "mobile" } }}
 />
-<Story
-  name="Loading"
-  args={{
-    currentView: "loading",
-  }}
-  parameters={{ viewport: { defaultViewport: "mobile" } }}
-/>
-<Story
-  name="Payment complete"
-  args={{
-    currentView: "success",
-  }}
-  parameters={{ viewport: { defaultViewport: "mobile" } }}
-/>
-<Story
-  name="Payment failed"
-  args={{
-    currentView: "error",
-  }}
-  parameters={{ viewport: { defaultViewport: "mobile" } }}
-/>
+<Story name="Loading" args={{ currentView: "loading" }} />
+<Story name="Payment complete" args={{ currentView: "success" }} />
+<Story name="Payment failed" args={{ currentView: "error" }} />

--- a/src/stories/purchase-flow-mobile.stories.svelte
+++ b/src/stories/purchase-flow-mobile.stories.svelte
@@ -1,9 +1,7 @@
 <script module>
   import { defineMeta, setTemplate } from "@storybook/addon-svelte-csf";
-  import WithContext from "./utils/with-context.svelte";
   import { toProductInfoStyleVar } from "../ui/theme/utils";
   import RcbUiInner from "../ui/rcb-ui-inner.svelte";
-  import { Translator } from "../ui/localization/translator";
 
   import {
     brandingInfo,
@@ -13,7 +11,6 @@
     subscriptionOptionWithTrial,
   } from "./fixtures";
   import { buildCheckoutStartResponse } from "./utils/purchase-response-builder";
-  import { translatorContextKey } from "../ui/localization/constants";
   import { type CheckoutStartResponse } from "../networking/responses/checkout-start-response";
 
   const defaultArgs = {
@@ -51,20 +48,11 @@
 </script>
 
 {#snippet template(args: any)}
-  <WithContext
-    context={{
-      ...args.context,
-      [translatorContextKey]: args.locale
-        ? new Translator({}, args.locale, args.locale)
-        : undefined,
-    }}
-  >
-    <RcbUiInner
-      {...args}
-      {colorVariables}
-      paymentInfoCollectionMetadata={paymentMetadata}
-    />
-  </WithContext>
+  <RcbUiInner
+    {...args}
+    {colorVariables}
+    paymentInfoCollectionMetadata={paymentMetadata}
+  />
 {/snippet}
 
 <Story

--- a/src/stories/purchase-flow-mobile.stories.svelte
+++ b/src/stories/purchase-flow-mobile.stories.svelte
@@ -47,8 +47,6 @@
 </script>
 
 <script lang="ts">
-  import { eventsTrackerContextKey } from "../ui/constants";
-
   setTemplate(template);
 </script>
 
@@ -59,7 +57,6 @@
       [translatorContextKey]: args.locale
         ? new Translator({}, args.locale, args.locale)
         : undefined,
-      [eventsTrackerContextKey]: { trackSDKEvent: () => {} },
     }}
   >
     <RcbUiInner

--- a/src/stories/purchase-flow-rtl.stories.svelte
+++ b/src/stories/purchase-flow-rtl.stories.svelte
@@ -1,10 +1,7 @@
 <script module>
   import { defineMeta, setTemplate } from "@storybook/addon-svelte-csf";
-  import WithContext from "./utils/with-context.svelte";
   import { toProductInfoStyleVar } from "../ui/theme/utils";
   import RcbUiInner from "../ui/rcb-ui-inner.svelte";
-  import { Translator } from "../ui/localization/translator";
-
   import {
     brandingInfo,
     product,
@@ -13,7 +10,6 @@
     subscriptionOptionWithTrial,
   } from "./fixtures";
   import { buildCheckoutStartResponse } from "./utils/purchase-response-builder";
-  import { translatorContextKey } from "../ui/localization/constants";
   import { type CheckoutStartResponse } from "../networking/responses/checkout-start-response";
 
   const defaultArgs = {
@@ -51,25 +47,17 @@
 </script>
 
 {#snippet template(args: any)}
-  <WithContext
-    context={{
-      ...args.context,
-      [translatorContextKey]: args.locale
-        ? new Translator({}, args.locale, args.locale)
-        : undefined,
-    }}
-  >
-    <RcbUiInner
-      {...args}
-      {colorVariables}
-      paymentInfoCollectionMetadata={paymentMetadata}
-    />
-  </WithContext>
+  <RcbUiInner
+    {...args}
+    {colorVariables}
+    paymentInfoCollectionMetadata={paymentMetadata}
+  />
 {/snippet}
 
 <Story
   name="Email Input (Arabic)"
-  args={{ currentView: "needs-auth-info", locale: "ar" }}
+  args={{ currentView: "needs-auth-info" }}
+  globals={{ locale: "ar" }}
   parameters={{ viewport: { defaultViewport: "mobile" } }}
 />
 <Story
@@ -77,8 +65,8 @@
   args={{
     currentView: "needs-auth-info",
     isSandbox: true,
-    locale: "ar",
   }}
+  globals={{ locale: "ar" }}
   parameters={{ viewport: { defaultViewport: "mobile" } }}
 />
 <Story
@@ -86,13 +74,13 @@
   args={{
     currentView: "needs-auth-info",
     isSandbox: true,
-    locale: "ar",
     productDetails: {
       ...product,
       normalPeriodDuration: "P1Y",
     },
     purchaseOptionToUse: subscriptionOptionWithTrial,
   }}
+  globals={{ locale: "ar" }}
   parameters={{ viewport: { defaultViewport: "mobile" } }}
 />
 <Story
@@ -100,31 +88,31 @@
   args={{
     ...defaultArgs,
     currentView: "needs-payment-info",
-    locale: "ar",
   }}
+  globals={{ locale: "ar" }}
   parameters={{ viewport: { defaultViewport: "mobile" } }}
 />
 <Story
   name="Loading (Arabic)"
   args={{
     currentView: "loading",
-    locale: "ar",
   }}
+  globals={{ locale: "ar" }}
   parameters={{ viewport: { defaultViewport: "mobile" } }}
 />
 <Story
   name="Payment complete (Arabic)"
   args={{
     currentView: "success",
-    locale: "ar",
   }}
+  globals={{ locale: "ar" }}
   parameters={{ viewport: { defaultViewport: "mobile" } }}
 />
 <Story
   name="Payment failed (Arabic)"
   args={{
     currentView: "error",
-    locale: "ar",
   }}
+  globals={{ locale: "ar" }}
   parameters={{ viewport: { defaultViewport: "mobile" } }}
 />

--- a/src/stories/purchase-flow-rtl.stories.svelte
+++ b/src/stories/purchase-flow-rtl.stories.svelte
@@ -27,7 +27,8 @@
   let { Story } = defineMeta({
     title: "Purchase flow Right To Left (Mobile)",
     args: defaultArgs,
-    parameters: {},
+    parameters: { viewport: { defaultViewport: "mobile" } },
+    globals: { locale: "ar" },
     loaders: [
       async () => {
         const paymentInfoCollectionMetadata: CheckoutStartResponse =
@@ -54,20 +55,10 @@
   />
 {/snippet}
 
-<Story
-  name="Email Input (Arabic)"
-  args={{ currentView: "needs-auth-info" }}
-  globals={{ locale: "ar" }}
-  parameters={{ viewport: { defaultViewport: "mobile" } }}
-/>
+<Story name="Email Input (Arabic)" args={{ currentView: "needs-auth-info" }} />
 <Story
   name="Email Input (with Sandbox Banner) (Arabic)"
-  args={{
-    currentView: "needs-auth-info",
-    isSandbox: true,
-  }}
-  globals={{ locale: "ar" }}
-  parameters={{ viewport: { defaultViewport: "mobile" } }}
+  args={{ currentView: "needs-auth-info", isSandbox: true }}
 />
 <Story
   name="Email Input (with Trial Product) (Arabic)"
@@ -80,39 +71,8 @@
     },
     purchaseOptionToUse: subscriptionOptionWithTrial,
   }}
-  globals={{ locale: "ar" }}
-  parameters={{ viewport: { defaultViewport: "mobile" } }}
 />
-<Story
-  name="Checkout (Arabic)"
-  args={{
-    ...defaultArgs,
-    currentView: "needs-payment-info",
-  }}
-  globals={{ locale: "ar" }}
-  parameters={{ viewport: { defaultViewport: "mobile" } }}
-/>
-<Story
-  name="Loading (Arabic)"
-  args={{
-    currentView: "loading",
-  }}
-  globals={{ locale: "ar" }}
-  parameters={{ viewport: { defaultViewport: "mobile" } }}
-/>
-<Story
-  name="Payment complete (Arabic)"
-  args={{
-    currentView: "success",
-  }}
-  globals={{ locale: "ar" }}
-  parameters={{ viewport: { defaultViewport: "mobile" } }}
-/>
-<Story
-  name="Payment failed (Arabic)"
-  args={{
-    currentView: "error",
-  }}
-  globals={{ locale: "ar" }}
-  parameters={{ viewport: { defaultViewport: "mobile" } }}
-/>
+<Story name="Checkout (Arabic)" args={{ currentView: "needs-payment-info" }} />
+<Story name="Loading (Arabic)" args={{ currentView: "loading" }} />
+<Story name="Payment complete (Arabic)" args={{ currentView: "success" }} />
+<Story name="Payment failed (Arabic)" args={{ currentView: "error" }} />

--- a/src/stories/purchase-flow-rtl.stories.svelte
+++ b/src/stories/purchase-flow-rtl.stories.svelte
@@ -47,8 +47,6 @@
 </script>
 
 <script lang="ts">
-  import { eventsTrackerContextKey } from "../ui/constants";
-
   setTemplate(template);
 </script>
 
@@ -59,7 +57,6 @@
       [translatorContextKey]: args.locale
         ? new Translator({}, args.locale, args.locale)
         : undefined,
-      [eventsTrackerContextKey]: { trackSDKEvent: () => {} },
     }}
   >
     <RcbUiInner

--- a/src/stories/purchase-flow-tablet.stories.svelte
+++ b/src/stories/purchase-flow-tablet.stories.svelte
@@ -1,10 +1,7 @@
 <script module>
   import { defineMeta, setTemplate } from "@storybook/addon-svelte-csf";
-  import WithContext from "./utils/with-context.svelte";
   import { toProductInfoStyleVar } from "../ui/theme/utils";
   import RcbUiInner from "../ui/rcb-ui-inner.svelte";
-  import { Translator } from "../ui/localization/translator";
-
   import {
     brandingInfo,
     product,
@@ -13,7 +10,6 @@
     subscriptionOptionWithTrial,
   } from "./fixtures";
   import { buildCheckoutStartResponse } from "./utils/purchase-response-builder";
-  import { translatorContextKey } from "../ui/localization/constants";
   import { type CheckoutStartResponse } from "../networking/responses/checkout-start-response";
 
   const defaultArgs = {
@@ -51,20 +47,11 @@
 </script>
 
 {#snippet template(args: any)}
-  <WithContext
-    context={{
-      ...args.context,
-      [translatorContextKey]: args.locale
-        ? new Translator({}, args.locale, args.locale)
-        : undefined,
-    }}
-  >
-    <RcbUiInner
-      {...args}
-      {colorVariables}
-      paymentInfoCollectionMetadata={paymentMetadata}
-    />
-  </WithContext>
+  <RcbUiInner
+    {...args}
+    {colorVariables}
+    paymentInfoCollectionMetadata={paymentMetadata}
+  />
 {/snippet}
 
 <Story

--- a/src/stories/purchase-flow-tablet.stories.svelte
+++ b/src/stories/purchase-flow-tablet.stories.svelte
@@ -47,8 +47,6 @@
 </script>
 
 <script lang="ts">
-  import { eventsTrackerContextKey } from "../ui/constants";
-
   setTemplate(template);
 </script>
 
@@ -59,7 +57,6 @@
       [translatorContextKey]: args.locale
         ? new Translator({}, args.locale, args.locale)
         : undefined,
-      [eventsTrackerContextKey]: { trackSDKEvent: () => {} },
     }}
   >
     <RcbUiInner

--- a/src/stories/utils/global-decorator.svelte
+++ b/src/stories/utils/global-decorator.svelte
@@ -1,0 +1,19 @@
+<script module>
+  import { eventsTrackerContextKey } from "../../ui/constants";
+  import { setContext, type Snippet } from "svelte";
+</script>
+
+<script lang="ts">
+  interface Props {
+    children?: Snippet;
+    globals?: {
+      [key: string]: any;
+    };
+  }
+
+  let { children }: Props = $props();
+
+  setContext(eventsTrackerContextKey, { trackSDKEvent: () => {} });
+</script>
+
+{@render children?.()}

--- a/src/stories/utils/global-decorator.svelte
+++ b/src/stories/utils/global-decorator.svelte
@@ -1,19 +1,34 @@
 <script module>
+  import { Translator } from "../../ui/localization/translator";
+  import { translatorContextKey } from "../../ui/localization/constants";
   import { eventsTrackerContextKey } from "../../ui/constants";
   import { setContext, type Snippet } from "svelte";
+  import { writable, type Writable } from "svelte/store";
 </script>
 
 <script lang="ts">
   interface Props {
     children?: Snippet;
     globals?: {
+      locale?: string;
       [key: string]: any;
     };
   }
 
-  let { children }: Props = $props();
+  let { children, globals = {} }: Props = $props();
 
+  const initiaLocale = globals.locale || "en";
+  const translator = new Translator({}, initiaLocale, initiaLocale);
+  const translatorStore: Writable<Translator> = writable(translator);
+
+  setContext(translatorContextKey, translatorStore);
   setContext(eventsTrackerContextKey, { trackSDKEvent: () => {} });
+
+  $effect(() => {
+    const newLocale = globals.locale;
+    const newTranslator = new Translator({}, newLocale, newLocale);
+    translatorStore.set(newTranslator);
+  });
 </script>
 
 {@render children?.()}

--- a/src/tests/ui/states/state-needs-auth-info.test.ts
+++ b/src/tests/ui/states/state-needs-auth-info.test.ts
@@ -5,11 +5,17 @@ import StateNeedsAuthInfo from "../../../ui/states/state-needs-auth-info.svelte"
 import { SDKEventName } from "../../../behavioural-events/sdk-events";
 import { createEventsTrackerMock } from "../../mocks/events-tracker-mock-provider";
 import { eventsTrackerContextKey } from "../../../ui/constants";
+import { writable } from "svelte/store";
+import { Translator } from "../../../ui/localization/translator";
+import { translatorContextKey } from "../../../ui/localization/constants";
 
 const eventsTrackerMock = createEventsTrackerMock();
 
 const defaultContext = new Map(
-  Object.entries({ [eventsTrackerContextKey]: eventsTrackerMock }),
+  Object.entries({
+    [eventsTrackerContextKey]: eventsTrackerMock,
+    [translatorContextKey]: writable(new Translator()),
+  }),
 );
 
 const basicProps = {

--- a/src/tests/ui/states/state-needs-payment-info.test.ts
+++ b/src/tests/ui/states/state-needs-payment-info.test.ts
@@ -13,6 +13,9 @@ import { createEventsTrackerMock } from "../../mocks/events-tracker-mock-provide
 import { eventsTrackerContextKey } from "../../../ui/constants";
 import type { PurchaseOperationHelper } from "../../../helpers/purchase-operation-helper";
 import type { CheckoutStartResponse } from "../../../networking/responses/checkout-start-response";
+import { writable } from "svelte/store";
+import { Translator } from "../../../ui/localization/translator";
+import { translatorContextKey } from "../../../ui/localization/constants";
 
 const eventsTrackerMock = createEventsTrackerMock();
 const purchaseOperationHelperMock: PurchaseOperationHelper = {
@@ -32,7 +35,10 @@ const basicProps = {
 };
 
 const defaultContext = new Map(
-  Object.entries({ [eventsTrackerContextKey]: eventsTrackerMock }),
+  Object.entries({
+    [eventsTrackerContextKey]: eventsTrackerMock,
+    [translatorContextKey]: writable(new Translator()),
+  }),
 );
 
 describe("PurchasesUI", () => {

--- a/src/tests/ui/states/state-success.test.ts
+++ b/src/tests/ui/states/state-success.test.ts
@@ -6,6 +6,9 @@ import { brandingInfo, rcPackage } from "../../../stories/fixtures";
 import { SDKEventName } from "../../../behavioural-events/sdk-events";
 import { createEventsTrackerMock } from "../../mocks/events-tracker-mock-provider";
 import { eventsTrackerContextKey } from "../../../ui/constants";
+import { Translator } from "../../../ui/localization/translator";
+import { writable } from "svelte/store";
+import { translatorContextKey } from "../../../ui/localization/constants";
 
 const eventsTrackerMock = createEventsTrackerMock();
 
@@ -16,7 +19,10 @@ const basicProps = {
 };
 
 const defaultContext = new Map(
-  Object.entries({ [eventsTrackerContextKey]: eventsTrackerMock }),
+  Object.entries({
+    [eventsTrackerContextKey]: eventsTrackerMock,
+    [translatorContextKey]: writable(new Translator()),
+  }),
 );
 
 describe("PurchasesUI", () => {

--- a/src/ui/localization/localized.svelte
+++ b/src/ui/localization/localized.svelte
@@ -5,7 +5,7 @@
     Translator,
   } from "./translator";
   import { getContext } from "svelte";
-  import { englishLocale, translatorContextKey } from "./constants";
+  import { translatorContextKey } from "./constants";
 
   import { LocalizationKeys } from "./supportedLanguages";
   import { type Writable } from "svelte/store";
@@ -14,37 +14,15 @@
     key?: LocalizationKeys | EmptyString | undefined;
     variables?: TranslationVariables;
     children?: any;
-    selectedLocale?: string;
-    defaultLocale?: string;
   }
 
-  const {
-    key = "",
-    selectedLocale,
-    defaultLocale = englishLocale,
-    variables,
-    children,
-  }: LocalizedProps = $props();
-  // Create a new translator if the user passes a selectedLocale
-  const userDefinedTranslator: Translator = new Translator(
-    {},
-    selectedLocale || "",
-    defaultLocale,
-  );
-  // Use the contextual translator if it exists
-  const contextTranslator =
-    getContext<Writable<Translator>>(translatorContextKey);
-  // Use the userDefinedTranslator if the selectedLocale is defined, otherwise use the contextTranslator, if neither of them is defined
-  // use the fallback translator.
-  const translator: Translator = $derived(
-    selectedLocale
-      ? userDefinedTranslator
-      : $contextTranslator || Translator.fallback(),
-  );
+  const { key = "", variables, children }: LocalizedProps = $props();
+
+  const translator = getContext<Writable<Translator>>(translatorContextKey);
 
   const translatedLabel = $derived(
     key
-      ? translator.translate(
+      ? $translator.translate(
           (key as LocalizationKeys) || ("" as EmptyString),
           variables,
         )

--- a/src/ui/localization/localized.svelte
+++ b/src/ui/localization/localized.svelte
@@ -8,6 +8,7 @@
   import { englishLocale, translatorContextKey } from "./constants";
 
   import { LocalizationKeys } from "./supportedLanguages";
+  import { type Writable } from "svelte/store";
 
   interface LocalizedProps {
     key?: LocalizationKeys | EmptyString | undefined;
@@ -31,12 +32,15 @@
     defaultLocale,
   );
   // Use the contextual translator if it exists
-  const contextTranslator: Translator = getContext(translatorContextKey);
+  const contextTranslator =
+    getContext<Writable<Translator>>(translatorContextKey);
   // Use the userDefinedTranslator if the selectedLocale is defined, otherwise use the contextTranslator, if neither of them is defined
   // use the fallback translator.
-  const translator: Translator = selectedLocale
-    ? userDefinedTranslator
-    : contextTranslator || Translator.fallback();
+  const translator: Translator = $derived(
+    selectedLocale
+      ? userDefinedTranslator
+      : $contextTranslator || Translator.fallback(),
+  );
 
   const translatedLabel = $derived(
     key

--- a/src/ui/rcb-ui.svelte
+++ b/src/ui/rcb-ui.svelte
@@ -27,6 +27,7 @@
   import { eventsTrackerContextKey } from "./constants";
   import { createCheckoutFlowErrorEvent } from "../behavioural-events/sdk-event-helpers";
   import type { PurchaseMetadata } from "../entities/offerings";
+  import { writable } from "svelte/store";
 
   export let customerEmail: string | undefined;
   export let appUserId: string;
@@ -60,10 +61,13 @@
   let operationSessionId: string | null = null;
 
   // Setting the context for the Localized components
-  setContext(
-    translatorContextKey,
-    new Translator(customTranslations, selectedLocale, defaultLocale),
+  let translator: Translator = new Translator(
+    customTranslations,
+    selectedLocale,
+    defaultLocale,
   );
+  var translatorStore = writable(translator);
+  setContext(translatorContextKey, translatorStore);
 
   onMount(() => {
     if (!isInElement) {

--- a/src/ui/states/state-error.svelte
+++ b/src/ui/states/state-error.svelte
@@ -13,14 +13,23 @@
   import Localized from "../localization/localized.svelte";
 
   import { LocalizationKeys } from "../localization/supportedLanguages";
+  import { type Writable } from "svelte/store";
 
   export let lastError: PurchaseFlowError;
   export let supportEmail: string | null = null;
   export let productDetails: Product | null = null;
   export let onContinue: () => void;
 
-  const translator: Translator =
-    getContext(translatorContextKey) || Translator.fallback();
+  const contextTranslator: Writable<Translator> =
+    getContext(translatorContextKey);
+
+  let translator: Translator = Translator.fallback();
+
+  $: {
+    if ($contextTranslator) {
+      translator = $contextTranslator;
+    }
+  }
 
   onMount(() => {
     Logger.errorLog(

--- a/src/ui/states/state-error.svelte
+++ b/src/ui/states/state-error.svelte
@@ -20,16 +20,7 @@
   export let productDetails: Product | null = null;
   export let onContinue: () => void;
 
-  const contextTranslator: Writable<Translator> =
-    getContext(translatorContextKey);
-
-  let translator: Translator = Translator.fallback();
-
-  $: {
-    if ($contextTranslator) {
-      translator = $contextTranslator;
-    }
-  }
+  const translator: Writable<Translator> = getContext(translatorContextKey);
 
   onMount(() => {
     Logger.errorLog(
@@ -41,16 +32,16 @@
     switch (lastError.errorCode) {
       case PurchaseFlowErrorCode.AlreadyPurchasedError:
         if (productDetails?.productType === ProductType.Subscription) {
-          return translator.translate(
+          return $translator.translate(
             LocalizationKeys.StateErrorErrorTitleAlreadySubscribed,
           );
         } else {
-          return translator.translate(
+          return $translator.translate(
             LocalizationKeys.StateErrorErrorTitleAlreadyPurchased,
           );
         }
       default:
-        return translator.translate(
+        return $translator.translate(
           LocalizationKeys.StateErrorErrorTitleOtherErrors,
         );
     }
@@ -60,38 +51,38 @@
     const publicErrorCode = lastError.getErrorCode();
     switch (lastError.errorCode) {
       case PurchaseFlowErrorCode.UnknownError:
-        return translator.translate(
+        return $translator.translate(
           LocalizationKeys.StateErrorErrorMessageUnknownError,
           { errorCode: publicErrorCode },
         );
       case PurchaseFlowErrorCode.ErrorSettingUpPurchase:
-        return translator.translate(
+        return $translator.translate(
           LocalizationKeys.StateErrorErrorMessageErrorSettingUpPurchase,
           { errorCode: publicErrorCode },
         );
       case PurchaseFlowErrorCode.ErrorChargingPayment:
-        return translator.translate(
+        return $translator.translate(
           LocalizationKeys.StateErrorErrorMessageErrorChargingPayment,
           { errorCode: publicErrorCode },
         );
       case PurchaseFlowErrorCode.NetworkError:
-        return translator.translate(
+        return $translator.translate(
           LocalizationKeys.StateErrorErrorMessageNetworkError,
           { errorCode: publicErrorCode },
         );
       case PurchaseFlowErrorCode.MissingEmailError:
-        return translator.translate(
+        return $translator.translate(
           LocalizationKeys.StateErrorErrorMessageMissingEmailError,
           { errorCode: publicErrorCode },
         );
       case PurchaseFlowErrorCode.AlreadyPurchasedError:
         if (productDetails?.productType === ProductType.Subscription) {
-          return translator.translate(
+          return $translator.translate(
             LocalizationKeys.StateErrorErrorMessageAlreadySubscribed,
             { errorCode: publicErrorCode },
           );
         } else {
-          return translator.translate(
+          return $translator.translate(
             LocalizationKeys.StateErrorErrorMessageAlreadyPurchased,
             { errorCode: publicErrorCode },
           );
@@ -104,7 +95,7 @@
   title={getTranslatedErrorTitle()}
   {onContinue}
   type="error"
-  closeButtonTitle={translator.translate(
+  closeButtonTitle={$translator.translate(
     LocalizationKeys.StateErrorButtonTryAgain,
   )}
 >

--- a/src/ui/states/state-needs-auth-info.svelte
+++ b/src/ui/states/state-needs-auth-info.svelte
@@ -51,16 +51,7 @@
     });
   });
 
-  const contextTranslator: Writable<Translator> =
-    getContext(translatorContextKey);
-
-  let translator: Translator = Translator.fallback();
-
-  $: {
-    if ($contextTranslator) {
-      translator = $contextTranslator;
-    }
-  }
+  const translator: Writable<Translator> = getContext(translatorContextKey);
 </script>
 
 <div class="rcb-state-container">
@@ -77,7 +68,7 @@
             id="email"
             name="email"
             inputmode="email"
-            placeholder={translator.translate(
+            placeholder={$translator.translate(
               LocalizationKeys.StateNeedsAuthInfoEmailInputPlaceholder,
             )}
             autocapitalize="off"

--- a/src/ui/states/state-needs-auth-info.svelte
+++ b/src/ui/states/state-needs-auth-info.svelte
@@ -17,6 +17,7 @@
   import { type IEventsTracker } from "../../behavioural-events/events-tracker";
   import { createCheckoutBillingFormErrorEvent } from "../../behavioural-events/sdk-event-helpers";
   import { SDKEventName } from "../../behavioural-events/sdk-events";
+  import { type Writable } from "svelte/store";
 
   export let onContinue: (params: ContinueHandlerParams) => void;
   export let processing: boolean;
@@ -50,8 +51,16 @@
     });
   });
 
-  const translator: Translator =
-    getContext(translatorContextKey) || Translator.fallback();
+  const contextTranslator: Writable<Translator> =
+    getContext(translatorContextKey);
+
+  let translator: Translator = Translator.fallback();
+
+  $: {
+    if ($contextTranslator) {
+      translator = $contextTranslator;
+    }
+  }
 </script>
 
 <div class="rcb-state-container">

--- a/src/ui/states/state-needs-payment-info.svelte
+++ b/src/ui/states/state-needs-payment-info.svelte
@@ -41,6 +41,7 @@
   import StateLoading from "./state-loading.svelte";
   import { getNextRenewalDate } from "../../helpers/duration-helper";
   import { formatPrice } from "../../helpers/price-labels";
+  import { type Writable } from "svelte/store";
 
   export let onContinue: (params?: ContinueHandlerParams) => void;
   export let paymentInfoCollectionMetadata: CheckoutStartResponse;
@@ -97,9 +98,17 @@
     }, 150);
   }
 
-  const translator: Translator =
-    getContext(translatorContextKey) || Translator.fallback();
-  const stripeElementLocale = (translator.locale ||
+  const contextTranslator =
+    getContext<Writable<Translator>>(translatorContextKey);
+
+  let translator: Translator = Translator.fallback();
+
+  $: {
+    if ($contextTranslator) {
+      translator = $contextTranslator;
+    }
+  }
+  $: stripeElementLocale = (translator.locale ||
     translator.fallbackLocale) as StripeElementLocale;
 
   /**
@@ -131,7 +140,7 @@
     return initialLocale;
   };
 
-  const localeToUse = getLocaleToUse(stripeElementLocale);
+  $: localeToUse = getLocaleToUse(stripeElementLocale);
 
   $: {
     // @ts-ignore

--- a/src/ui/states/state-needs-payment-info.svelte
+++ b/src/ui/states/state-needs-payment-info.svelte
@@ -98,18 +98,10 @@
     }, 150);
   }
 
-  const contextTranslator =
-    getContext<Writable<Translator>>(translatorContextKey);
+  const translator = getContext<Writable<Translator>>(translatorContextKey);
 
-  let translator: Translator = Translator.fallback();
-
-  $: {
-    if ($contextTranslator) {
-      translator = $contextTranslator;
-    }
-  }
-  $: stripeElementLocale = (translator.locale ||
-    translator.fallbackLocale) as StripeElementLocale;
+  $: stripeElementLocale = ($translator.locale ||
+    $translator.fallbackLocale) as StripeElementLocale;
 
   /**
    * This function converts some particular locales to the ones that stripe supports.
@@ -346,7 +338,7 @@
 
         <div class="rc-checkout-secure-container">
           <SecureCheckoutRc
-            termsInfo={translator.translate(
+            termsInfo={$translator.translate(
               LocalizationKeys.StateNeedsPaymentInfoTermsInfo,
               {
                 appName: brandingInfo?.app_name,
@@ -356,7 +348,7 @@
             subscriptionOption?.trial?.period &&
             subscriptionOption?.base?.period &&
             subscriptionOption?.base?.period?.unit
-              ? translator.translate(
+              ? $translator.translate(
                   LocalizationKeys.StateNeedsPaymentInfoTrialInfo,
                   {
                     price: formatPrice(
@@ -364,12 +356,12 @@
                       subscriptionOption?.base?.price.currency,
                       localeToUse,
                     ),
-                    perFrequency: translator.translatePeriodFrequency(
+                    perFrequency: $translator.translatePeriodFrequency(
                       subscriptionOption?.base?.period?.number || 1,
                       subscriptionOption?.base?.period?.unit,
                       { useMultipleWords: true },
                     ),
-                    renewalDate: translator.translateDate(
+                    renewalDate: $translator.translateDate(
                       getNextRenewalDate(
                         new Date(),
                         subscriptionOption.trial.period ||
@@ -390,7 +382,7 @@
       <MessageLayout
         title={null}
         type="error"
-        closeButtonTitle={translator.translate(
+        closeButtonTitle={$translator.translate(
           LocalizationKeys.StateErrorButtonTryAgain,
         )}
         onContinue={handleErrorTryAgain}

--- a/src/ui/states/state-present-offer.svelte
+++ b/src/ui/states/state-present-offer.svelte
@@ -34,31 +34,22 @@
   const subscriptionBasePrice = subscriptionOption?.base?.price;
   const nonSubscriptionBasePrice = nonSubscriptionOption?.basePrice;
 
-  const contextTranslator: Writable<Translator> =
-    getContext(translatorContextKey);
-
-  let translator: Translator = Translator.fallback();
-
-  $: {
-    if ($contextTranslator) {
-      translator = $contextTranslator;
-    }
-  }
+  const translator: Writable<Translator> = getContext(translatorContextKey);
 
   const formattedSubscriptionBasePrice =
     subscriptionBasePrice &&
-    translator.formatPrice(
+    $translator.formatPrice(
       subscriptionBasePrice.amountMicros,
       subscriptionBasePrice.currency,
     );
 
   const formattedZeroPrice =
     subscriptionBasePrice &&
-    translator.formatPrice(0, subscriptionBasePrice.currency);
+    $translator.formatPrice(0, subscriptionBasePrice.currency);
 
   const formattedNonSubscriptionBasePrice =
     nonSubscriptionBasePrice &&
-    translator.formatPrice(
+    $translator.formatPrice(
       nonSubscriptionBasePrice.amountMicros,
       nonSubscriptionBasePrice.currency,
     );
@@ -115,7 +106,7 @@
               variables={{
                 trialDuration: getTranslatedPeriodLength(
                   subscriptionTrial.periodDuration || "",
-                  translator,
+                  $translator,
                 ),
               }}
             />
@@ -136,7 +127,7 @@
           {#if subscriptionOption?.base?.period}
             <span class="rcb-product-price-frequency">
               <span class="rcb-product-price-frequency-text">
-                {translator.translatePeriodFrequency(
+                {$translator.translatePeriodFrequency(
                   subscriptionOption.base.period.number,
                   subscriptionOption.base.period.unit,
                   { useMultipleWords: true },
@@ -167,7 +158,7 @@
                   variables={{
                     renewalDate:
                       renewalDate &&
-                      translator.translateDate(renewalDate, {
+                      $translator.translateDate(renewalDate, {
                         dateStyle: "medium",
                       }),
                   }}

--- a/src/ui/states/state-present-offer.svelte
+++ b/src/ui/states/state-present-offer.svelte
@@ -15,6 +15,7 @@
   import type { BrandingAppearance } from "../../entities/branding";
   import { getTranslatedPeriodLength } from "../../helpers/price-labels";
   import { getNextRenewalDate } from "../../helpers/duration-helper";
+  import { type Writable } from "svelte/store";
 
   export let productDetails: Product;
   export let purchaseOption: PurchaseOption;
@@ -33,8 +34,16 @@
   const subscriptionBasePrice = subscriptionOption?.base?.price;
   const nonSubscriptionBasePrice = nonSubscriptionOption?.basePrice;
 
-  const translator: Translator =
-    getContext(translatorContextKey) || Translator.fallback();
+  const contextTranslator: Writable<Translator> =
+    getContext(translatorContextKey);
+
+  let translator: Translator = Translator.fallback();
+
+  $: {
+    if ($contextTranslator) {
+      translator = $contextTranslator;
+    }
+  }
 
   const formattedSubscriptionBasePrice =
     subscriptionBasePrice &&

--- a/src/ui/states/state-success.svelte
+++ b/src/ui/states/state-success.svelte
@@ -12,14 +12,22 @@
   import { type IEventsTracker } from "../../behavioural-events/events-tracker";
   import { eventsTrackerContextKey } from "../constants";
   import { type ContinueHandlerParams } from "../ui-types";
-
+  import { type Writable } from "svelte/store";
   export let productDetails: Product | null = null;
   export let onContinue: (params?: ContinueHandlerParams) => void;
 
   const isSubscription =
     productDetails?.productType === ProductType.Subscription;
-  const translator: Translator =
-    getContext(translatorContextKey) || Translator.fallback();
+  const contextTranslator: Writable<Translator> =
+    getContext(translatorContextKey);
+
+  let translator: Translator = Translator.fallback();
+
+  $: {
+    if ($contextTranslator) {
+      translator = $contextTranslator;
+    }
+  }
 
   const eventsTracker = getContext(eventsTrackerContextKey) as IEventsTracker;
 

--- a/src/ui/states/state-success.svelte
+++ b/src/ui/states/state-success.svelte
@@ -18,17 +18,7 @@
 
   const isSubscription =
     productDetails?.productType === ProductType.Subscription;
-  const contextTranslator: Writable<Translator> =
-    getContext(translatorContextKey);
-
-  let translator: Translator = Translator.fallback();
-
-  $: {
-    if ($contextTranslator) {
-      translator = $contextTranslator;
-    }
-  }
-
+  const translator: Writable<Translator> = getContext(translatorContextKey);
   const eventsTracker = getContext(eventsTrackerContextKey) as IEventsTracker;
 
   function handleContinue() {
@@ -50,9 +40,9 @@
 
 <MessageLayout
   type="success"
-  title={translator.translate(LocalizationKeys.StateSuccessPurchaseSuccessful)}
+  title={$translator.translate(LocalizationKeys.StateSuccessPurchaseSuccessful)}
   onContinue={handleContinue}
-  closeButtonTitle={translator.translate(
+  closeButtonTitle={$translator.translate(
     LocalizationKeys.StateSuccessButtonClose,
   )}
 >


### PR DESCRIPTION
## Motivation / Description

This is the first of a series of PRs to improve the experience with Storybook.

The first part involves adding global toolbar controls for:
- Locale (current PR)
- Branding

Next will be streamlining all the different purchase flow stories into a single one together with the use of Chromatic modes to apply the right combinations of global configurations of viewport, locale and branding. 

## Changes introduced

- Simplified the translator fallback. It is now set once upon initialization of the main component.
- Components are now reactive to changes in the translator by using a Svelte store in the translator context.
- Froze the config of locale for stories that describe a specific locale.
- Upgrade storybook addons.
- Add a global decorator for stories to set the global context.

## Screenshots

<img width="865" alt="Screenshot 2025-03-11 at 17 46 43" src="https://github.com/user-attachments/assets/f2187e86-9d35-4f9d-baa7-90c3760499f9" />
