### PR TITLE
fix: prevent RangeError in formatPrice across browsers

### DIFF
--- a/src/helpers/price-labels.ts
+++ b/src/helpers/price-labels.ts
@@ -17,12 +17,16 @@ export const formatPrice = (
 ): string => {
   const price = microsToDollars(priceInMicros);
 
-  const formatter = new Intl.NumberFormat(locale, {
+  const formatterOptions: Intl.NumberFormatOptions = {
     style: "currency",
     currency,
     currencyDisplay: "symbol",
     ...additionalFormattingOptions,
-  });
+    // Some browsers require minimumFractionDigits to be set if maximumFractionDigits is set.
+    minimumFractionDigits: additionalFormattingOptions.maximumFractionDigits,
+  };
+
+  const formatter = new Intl.NumberFormat(locale, formatterOptions);
 
   const formattedPrice = formatter.format(price);
 


### PR DESCRIPTION
## Motivation / Description

Improved number formatting options handling to ensure valid values are passed to
Intl.NumberFormat, preventing RangeError exceptions in various browser environments (e.g. Vivo Browser).

## Changes introduced

## Linear ticket (if any)

## Additional comments
