### PR TITLE
WEB-2336: Adjusted the gaps and moved the product description below the title

### DIFF
--- a/src/stories/purchase-flow-custom-appearance-mobile.stories.svelte
+++ b/src/stories/purchase-flow-custom-appearance-mobile.stories.svelte
@@ -98,6 +98,19 @@
   parameters={{ viewport: { defaultViewport: "mobile" } }}
 />
 <Story
+  name="Checkout (with Trial Product)"
+  args={{
+    currentView: "needs-payment-info",
+    isSandbox: true,
+    productDetails: {
+      ...product,
+      normalPeriodDuration: "P1Y",
+    },
+    purchaseOptionToUse: subscriptionOptionWithTrial,
+  }}
+  parameters={{ viewport: { defaultViewport: "mobile" } }}
+/>
+<Story
   name="Checkout"
   args={{
     ...defaultArgs,

--- a/src/ui/states/state-present-offer.svelte
+++ b/src/ui/states/state-present-offer.svelte
@@ -230,7 +230,7 @@
 
   .rcb-product-details {
     color: var(--rc-color-grey-text-light);
-    margin: 0px;
+    margin: 0;
     overflow: hidden;
     transition: max-height 0.2s ease-in-out;
   }
@@ -280,6 +280,10 @@
   @container layout-query-container (width >= 768px) {
     .only-mobile {
       display: none;
+    }
+
+    .rcb-product-details-padding {
+      gap: var(--rc-spacing-gapMedium-desktop);
     }
 
     .only-desktop {

--- a/src/ui/states/state-present-offer.svelte
+++ b/src/ui/states/state-present-offer.svelte
@@ -70,7 +70,7 @@
   <div class="rcb-pricing-info">
     <div class="rcb-pricing-info-header">
       {#if isSubscription}
-        <div class="rcb-subscribe-to">
+        <div class="rcb-subscribe-to only-desktop">
           <Localized
             key={LocalizationKeys.StatePresentOfferSubscribeTo}
             variables={{ productTitle: productDetails.title }}
@@ -84,7 +84,7 @@
         />
       </div>
       {#if brandingAppearance?.show_product_description && productDetails.description}
-        <span class="rcb-product-description only-desktop">
+        <span class="rcb-product-description">
           <Localized
             key={LocalizationKeys.StatePresentOfferProductDescription}
             variables={{
@@ -138,16 +138,6 @@
 
       <div class="rcb-product-details expanded">
         <div class="rcb-product-details-padding">
-          {#if brandingAppearance?.show_product_description && productDetails.description}
-            <span class="rcb-product-description only-mobile">
-              <Localized
-                key={LocalizationKeys.StatePresentOfferProductDescription}
-                variables={{
-                  productDescription: productDetails.description,
-                }}
-              />
-            </span>
-          {/if}
           {#if subscriptionTrial?.periodDuration}
             <div class="rcb-product-trial-explanation">
               <div class="rcb-after-trial-ends rcb-text-dark">
@@ -248,7 +238,7 @@
   .rcb-product-details-padding {
     display: flex;
     flex-direction: column;
-    gap: var(--rc-spacing-gapXLarge-mobile);
+    gap: var(--rc-spacing-gapSmall-mobile);
   }
 
   .rcb-product-trial-explanation {
@@ -271,13 +261,19 @@
     display: none;
   }
 
+  .rcb-pricing-info-header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--rc-spacing-gapSmall-desktop);
+  }
+
+  .rcb-pricing-info {
+    gap: var(--rc-spacing-gapXXLarge-mobile);
+  }
+
   @container layout-query-container (width < 768px) {
     .rcb-pricing-info {
       margin-top: var(--rc-spacing-gapXLarge-mobile);
-    }
-
-    .rcb-subscribe-to {
-      display: none;
     }
   }
 


### PR DESCRIPTION
## Before / After
Before
<img width="672" alt="Screenshot 2025-03-12 at 16 23 00" src="https://github.com/user-attachments/assets/4130cf3a-db0a-4418-8fa4-470524546340" />

After
<img width="672" alt="Screenshot 2025-03-12 at 16 23 18" src="https://github.com/user-attachments/assets/f96ce4dc-bb56-43f9-a89d-a357d83f1033" />


## Changes introduced
* Moved the product description right below the product name also on mobile
* Adjusted the gaps
