### PR TITLE
fix: non subscription double description

### DIFF
--- a/src/stories/product-info-header.stories.svelte
+++ b/src/stories/product-info-header.stories.svelte
@@ -1,5 +1,5 @@
 <script module>
-  import { brandingLanguageViewportModes } from "../../.storybook/modes";
+  import { brandingModes } from "../../.storybook/modes";
   import { defineMeta, setTemplate } from "@storybook/addon-svelte-csf";
   import { withNavbarDecorator } from "./utils/decorators";
   import ProductInfoHeader from "../ui/components/product-info/header.svelte";
@@ -12,7 +12,7 @@
     decorators: [withNavbarDecorator],
     parameters: {
       chromatic: {
-        modes: brandingLanguageViewportModes,
+        modes: brandingModes,
       },
     },
   });

--- a/src/stories/product-info-pricing.stories.svelte
+++ b/src/stories/product-info-pricing.stories.svelte
@@ -1,5 +1,5 @@
 <script module>
-  import { brandingLanguageViewportModes } from "../../.storybook/modes";
+  import { brandingModes } from "../../.storybook/modes";
   import { defineMeta, setTemplate } from "@storybook/addon-svelte-csf";
   import { withNavbarDecorator } from "./utils/decorators";
   import ProductInfoPricing from "../ui/components/product-info/pricing.svelte";
@@ -18,7 +18,7 @@
     decorators: [withNavbarDecorator],
     parameters: {
       chromatic: {
-        modes: brandingLanguageViewportModes,
+        modes: brandingModes,
       },
     },
   });

--- a/src/stories/product-info-pricing.stories.svelte
+++ b/src/stories/product-info-pricing.stories.svelte
@@ -9,8 +9,6 @@
     subscriptionOptionWithTrial,
     nonSubscriptionOption,
     consumableProduct,
-    nonConsumableProduct,
-    colorfulBrandingAppearance,
   } from "./fixtures";
 
   const { Story } = defineMeta({
@@ -33,38 +31,23 @@
   />
 </Story>
 
-<Story name="Subscription With Trial">
+<Story name="Trial">
   <ProductInfoPricing
     productDetails={product}
     purchaseOption={subscriptionOptionWithTrial}
   />
 </Story>
 
-<Story name="Consumable">
+<Story name="Non Subscription">
   <ProductInfoPricing
     productDetails={consumableProduct}
     purchaseOption={nonSubscriptionOption}
   />
 </Story>
 
-<Story name="Consumable With Description">
+<Story name="Non Subscription With Description">
   <ProductInfoPricing
     productDetails={consumableProduct}
-    purchaseOption={nonSubscriptionOption}
-    showProductDescription={true}
-  />
-</Story>
-
-<Story name="Non Consumable">
-  <ProductInfoPricing
-    productDetails={nonConsumableProduct}
-    purchaseOption={nonSubscriptionOption}
-  />
-</Story>
-
-<Story name="Non Consumable With Description">
-  <ProductInfoPricing
-    productDetails={nonConsumableProduct}
     purchaseOption={nonSubscriptionOption}
     showProductDescription={true}
   />

--- a/src/stories/product-info-pricing.stories.svelte
+++ b/src/stories/product-info-pricing.stories.svelte
@@ -44,11 +44,3 @@
     purchaseOption={nonSubscriptionOption}
   />
 </Story>
-
-<Story name="Non Subscription With Description">
-  <ProductInfoPricing
-    productDetails={consumableProduct}
-    purchaseOption={nonSubscriptionOption}
-    showProductDescription={true}
-  />
-</Story>

--- a/src/stories/product-info.stories.svelte
+++ b/src/stories/product-info.stories.svelte
@@ -24,18 +24,10 @@
   });
 </script>
 
-<Story name="Subscription With Description">
+<Story name="Default">
   <ProductInfo
     productDetails={product}
     purchaseOption={subscriptionOption}
-    showProductDescription={true}
-  />
-</Story>
-
-<Story name="Non Subscription With Description">
-  <ProductInfo
-    productDetails={consumableProduct}
-    purchaseOption={nonSubscriptionOption}
     showProductDescription={true}
   />
 </Story>

--- a/src/stories/product-info.stories.svelte
+++ b/src/stories/product-info.stories.svelte
@@ -1,0 +1,41 @@
+<script module>
+  import { brandingLanguageViewportModes } from "../../.storybook/modes";
+  import { defineMeta, setTemplate } from "@storybook/addon-svelte-csf";
+  import { withNavbarDecorator } from "./utils/decorators";
+  import ProductInfo from "../ui/components/product-info.svelte";
+  import {
+    product,
+    subscriptionOption,
+    subscriptionOptionWithTrial,
+    nonSubscriptionOption,
+    consumableProduct,
+  } from "./fixtures";
+
+  const { Story } = defineMeta({
+    component: ProductInfo,
+    title: "Components/ProductInfo",
+    // @ts-expect-error ignore typing of decorator
+    decorators: [withNavbarDecorator],
+    parameters: {
+      chromatic: {
+        modes: brandingLanguageViewportModes,
+      },
+    },
+  });
+</script>
+
+<Story name="Subscription With Description">
+  <ProductInfo
+    productDetails={product}
+    purchaseOption={subscriptionOption}
+    showProductDescription={true}
+  />
+</Story>
+
+<Story name="Non Subscription With Description">
+  <ProductInfo
+    productDetails={consumableProduct}
+    purchaseOption={nonSubscriptionOption}
+    showProductDescription={true}
+  />
+</Story>

--- a/src/stories/product-info.stories.svelte
+++ b/src/stories/product-info.stories.svelte
@@ -1,5 +1,5 @@
 <script module>
-  import { brandingLanguageViewportModes } from "../../.storybook/modes";
+  import { brandingModes } from "../../.storybook/modes";
   import { defineMeta, setTemplate } from "@storybook/addon-svelte-csf";
   import { withNavbarDecorator } from "./utils/decorators";
   import ProductInfo from "../ui/components/product-info.svelte";
@@ -18,7 +18,7 @@
     decorators: [withNavbarDecorator],
     parameters: {
       chromatic: {
-        modes: brandingLanguageViewportModes,
+        modes: brandingModes,
       },
     },
   });

--- a/src/ui/components/product-info.svelte
+++ b/src/ui/components/product-info.svelte
@@ -9,7 +9,7 @@
 
   export let productDetails: Product;
   export let purchaseOption: PurchaseOption;
-  export let showProductDescription: boolean = false;
+  export let showProductDescription: boolean;
 
   const isSubscription =
     productDetails.productType === ProductType.Subscription;
@@ -18,12 +18,7 @@
 <section>
   <div class="rcb-pricing-info" class:has-expanded-details={isSubscription}>
     <ProductInfoHeader {productDetails} {showProductDescription} />
-
-    <ProductInfoPricing
-      {productDetails}
-      {purchaseOption}
-      {showProductDescription}
-    />
+    <ProductInfoPricing {productDetails} {purchaseOption} />
   </div>
 </section>
 

--- a/src/ui/components/product-info.svelte
+++ b/src/ui/components/product-info.svelte
@@ -4,14 +4,12 @@
     type PurchaseOption,
     ProductType,
   } from "../../entities/offerings";
-  import type { BrandingAppearance } from "../../entities/branding";
   import ProductInfoHeader from "./product-info/header.svelte";
   import ProductInfoPricing from "./product-info/pricing.svelte";
 
   export let productDetails: Product;
   export let purchaseOption: PurchaseOption;
-  export let brandingAppearance: BrandingAppearance | null | undefined =
-    undefined;
+  export let showProductDescription: boolean = false;
 
   const isSubscription =
     productDetails.productType === ProductType.Subscription;
@@ -19,15 +17,12 @@
 
 <section>
   <div class="rcb-pricing-info" class:has-expanded-details={isSubscription}>
-    <ProductInfoHeader
-      {productDetails}
-      showProductDescription={brandingAppearance?.show_product_description}
-    />
+    <ProductInfoHeader {productDetails} {showProductDescription} />
 
     <ProductInfoPricing
       {productDetails}
       {purchaseOption}
-      showProductDescription={brandingAppearance?.show_product_description}
+      {showProductDescription}
     />
   </div>
 </section>

--- a/src/ui/components/product-info/header.svelte
+++ b/src/ui/components/product-info/header.svelte
@@ -4,7 +4,7 @@
   import { ProductType, type Product } from "../../../entities/offerings";
 
   export let productDetails: Product;
-  export let showProductDescription: boolean = false;
+  export let showProductDescription: boolean;
 
   const isSubscription =
     productDetails.productType === ProductType.Subscription;

--- a/src/ui/components/product-info/pricing.svelte
+++ b/src/ui/components/product-info/pricing.svelte
@@ -1,240 +1,28 @@
 <script lang="ts">
-  import Localized from "../../localization/localized.svelte";
-  import { LocalizationKeys } from "../../localization/supportedLanguages";
   import {
-    type SubscriptionOption,
-    type NonSubscriptionOption,
     type Product,
     type PurchaseOption,
+    type NonSubscriptionOption,
+    type SubscriptionOption,
     ProductType,
   } from "../../../entities/offerings";
-  import { getTranslatedPeriodLength } from "../../../helpers/price-labels";
-  import type { Translator } from "../../localization/translator";
-  import { translatorContextKey } from "../../localization/constants";
-  import { type Writable } from "svelte/store";
-  import { getContext } from "svelte";
-  import { getNextRenewalDate } from "../../../helpers/duration-helper";
+  import NonSubscriptionPricing from "./pricing/non-subscription-pricing.svelte";
+  import SubscriptionPricing from "./pricing/subscription-pricing.svelte";
 
   export let productDetails: Product;
   export let purchaseOption: PurchaseOption;
   export let showProductDescription: boolean = false;
 
-  const subscriptionOption: SubscriptionOption | null | undefined =
-    purchaseOption as SubscriptionOption;
-  const nonSubscriptionOption: NonSubscriptionOption | null | undefined =
-    purchaseOption as NonSubscriptionOption;
-
   const isSubscription =
     productDetails.productType === ProductType.Subscription;
-  const subscriptionTrial = subscriptionOption?.trial;
-
-  const subscriptionBasePrice = subscriptionOption?.base?.price;
-  const nonSubscriptionBasePrice = nonSubscriptionOption?.basePrice;
-
-  const translator: Writable<Translator> = getContext(translatorContextKey);
-
-  let renewalDate = null;
-  const expectedPeriod =
-    subscriptionOption?.trial?.period || subscriptionOption?.base?.period;
-  if (expectedPeriod) {
-    renewalDate = getNextRenewalDate(
-      new Date(),
-      expectedPeriod,
-      isSubscription,
-    );
-  }
-
-  const formattedSubscriptionBasePrice =
-    subscriptionBasePrice &&
-    $translator.formatPrice(
-      subscriptionBasePrice.amountMicros,
-      subscriptionBasePrice.currency,
-    );
-
-  const formattedZeroPrice =
-    subscriptionBasePrice &&
-    $translator.formatPrice(0, subscriptionBasePrice.currency);
-
-  const formattedNonSubscriptionBasePrice =
-    nonSubscriptionBasePrice &&
-    $translator.formatPrice(
-      nonSubscriptionBasePrice.amountMicros,
-      nonSubscriptionBasePrice.currency,
-    );
 </script>
 
 {#if isSubscription}
-  <div class="rcb-product-price-container">
-    {#if subscriptionTrial?.periodDuration}
-      <div class="rcb-product-trial">
-        <Localized
-          key={LocalizationKeys.ProductInfoFreeTrialDuration}
-          variables={{
-            trialDuration: getTranslatedPeriodLength(
-              subscriptionTrial.periodDuration || "",
-              $translator,
-            ),
-          }}
-        />
-      </div>
-    {/if}
-    <div>
-      {#if subscriptionBasePrice}
-        <span class="rcb-product-price">
-          <Localized
-            key={LocalizationKeys.ProductInfoProductPrice}
-            variables={{
-              productPrice: formattedSubscriptionBasePrice,
-            }}
-          />
-        </span>
-      {/if}
-
-      {#if subscriptionOption?.base?.period}
-        <span class="rcb-product-price-frequency">
-          <span class="rcb-product-price-frequency-text">
-            {$translator.translatePeriodFrequency(
-              subscriptionOption.base.period.number,
-              subscriptionOption.base.period.unit,
-              { useMultipleWords: true },
-            )}</span
-          >
-        </span>
-      {/if}
-    </div>
-  </div>
-
-  <div class="rcb-product-details expanded">
-    <div class="rcb-product-details-padding">
-      {#if subscriptionTrial?.periodDuration}
-        <div class="rcb-product-trial-explanation">
-          <div class="rcb-after-trial-ends rcb-text-dark">
-            <Localized
-              key={LocalizationKeys.ProductInfoPriceAfterFreeTrial}
-              variables={{
-                renewalDate:
-                  renewalDate &&
-                  $translator.translateDate(renewalDate, {
-                    dateStyle: "medium",
-                  }),
-              }}
-            />
-          </div>
-          <div class="rcb-after-trial-ends rcb-text-dark">
-            {formattedSubscriptionBasePrice}
-          </div>
-        </div>
-        <div class="rcb-product-trial-explanation">
-          <div class="rcb-text-dark rcb-total-due-today">
-            <Localized key={LocalizationKeys.ProductInfoPriceTotalDueToday} />
-          </div>
-          <div class="rcb-text-dark rcb-total-due-today">
-            {formattedZeroPrice}
-          </div>
-        </div>
-      {/if}
-    </div>
-  </div>
+  <SubscriptionPricing purchaseOption={purchaseOption as SubscriptionOption} />
 {:else}
-  <span class="rcb-product-price">
-    <Localized
-      key={LocalizationKeys.ProductInfoProductPrice}
-      variables={{ productPrice: formattedNonSubscriptionBasePrice }}
-    />
-  </span>
-
-  {#if showProductDescription}
-    <span class="rcb-product-description">
-      <Localized
-        key={LocalizationKeys.ProductInfoProductDescription}
-        variables={{ productDescription: productDetails.description }}
-      />
-    </span>
-  {/if}
+  <NonSubscriptionPricing
+    {productDetails}
+    {showProductDescription}
+    purchaseOption={purchaseOption as NonSubscriptionOption}
+  />
 {/if}
-
-<style>
-  .rcb-product-price {
-    color: var(--rc-color-grey-text-dark);
-    font: var(--rc-text-titleMedium-mobile);
-  }
-
-  .rcb-product-trial {
-    color: var(--rc-color-grey-text-dark);
-    font: var(--rc-text-titleLarge-mobile);
-  }
-
-  .rcb-product-price-frequency {
-    color: var(--rc-color-grey-text-dark);
-    font: var(--rc-text-body1-mobile);
-  }
-
-  .rcb-product-price-frequency-text {
-    white-space: nowrap;
-  }
-
-  .rcb-product-description {
-    font: var(--rc-text-body1-mobile);
-    color: var(--rc-color-grey-text-dark);
-  }
-
-  .rcb-product-details {
-    color: var(--rc-color-grey-text-light);
-    margin: 0;
-    overflow: hidden;
-    transition: max-height 0.2s ease-in-out;
-  }
-
-  .rcb-product-details-padding {
-    display: flex;
-    flex-direction: column;
-    gap: var(--rc-spacing-gapSmall-mobile);
-  }
-
-  .rcb-product-trial-explanation {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  .rcb-text-dark {
-    color: var(--rc-color-grey-text-dark);
-    font-weight: 500;
-  }
-
-  @container layout-query-container (width >= 768px) {
-    .rcb-product-price {
-      font: var(--rc-text-titleMedium-desktop);
-    }
-
-    .rcb-product-price-frequency {
-      font: var(--rc-text-body1-desktop);
-    }
-
-    .rcb-product-description {
-      font: var(--rc-text-body1-desktop);
-    }
-
-    .rcb-product-details {
-      max-height: 500px;
-      gap: var(--rc-spacing-gapXLarge-desktop);
-    }
-
-    .rcb-product-details-padding {
-      gap: var(--rc-spacing-gapMedium-desktop);
-    }
-
-    .rcb-total-due-today {
-      font: var(--rc-text-titleMedium-desktop);
-    }
-
-    .rcb-after-trial-ends {
-      font: var(--rc-text-body1-desktop);
-    }
-
-    .rcb-product-trial {
-      font: var(--rc-text-titleLarge-desktop);
-    }
-  }
-</style>

--- a/src/ui/components/product-info/pricing.svelte
+++ b/src/ui/components/product-info/pricing.svelte
@@ -11,7 +11,6 @@
 
   export let productDetails: Product;
   export let purchaseOption: PurchaseOption;
-  export let showProductDescription: boolean = false;
 
   const isSubscription =
     productDetails.productType === ProductType.Subscription;
@@ -21,8 +20,6 @@
   <SubscriptionPricing purchaseOption={purchaseOption as SubscriptionOption} />
 {:else}
   <NonSubscriptionPricing
-    {productDetails}
-    {showProductDescription}
     purchaseOption={purchaseOption as NonSubscriptionOption}
   />
 {/if}

--- a/src/ui/components/product-info/pricing/non-subscription-pricing.svelte
+++ b/src/ui/components/product-info/pricing/non-subscription-pricing.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import Localized from "../../../localization/localized.svelte";
+  import { LocalizationKeys } from "../../../localization/supportedLanguages";
+  import {
+    type NonSubscriptionOption,
+    type Product,
+  } from "../../../../entities/offerings";
+  import type { Translator } from "../../../localization/translator";
+  import { translatorContextKey } from "../../../localization/constants";
+  import { type Writable } from "svelte/store";
+  import { getContext } from "svelte";
+
+  export let productDetails: Product;
+  export let purchaseOption: NonSubscriptionOption;
+  export let showProductDescription: boolean = false;
+
+  const basePrice = purchaseOption?.basePrice;
+  const translator: Writable<Translator> = getContext(translatorContextKey);
+
+  const formattedNonSubscriptionBasePrice =
+    basePrice &&
+    $translator.formatPrice(basePrice.amountMicros, basePrice.currency);
+</script>
+
+<span class="rcb-product-price">
+  <Localized
+    key={LocalizationKeys.ProductInfoProductPrice}
+    variables={{ productPrice: formattedNonSubscriptionBasePrice }}
+  />
+</span>
+
+{#if showProductDescription}
+  <span class="rcb-product-description">
+    <Localized
+      key={LocalizationKeys.ProductInfoProductDescription}
+      variables={{ productDescription: productDetails.description }}
+    />
+  </span>
+{/if}
+
+<style>
+  .rcb-product-price {
+    color: var(--rc-color-grey-text-dark);
+    font: var(--rc-text-titleMedium-mobile);
+  }
+
+  .rcb-product-description {
+    font: var(--rc-text-body1-mobile);
+    color: var(--rc-color-grey-text-dark);
+  }
+
+  @container layout-query-container (width >= 768px) {
+    .rcb-product-price {
+      font: var(--rc-text-titleMedium-desktop);
+    }
+
+    .rcb-product-description {
+      font: var(--rc-text-body1-desktop);
+    }
+  }
+</style>

--- a/src/ui/components/product-info/pricing/non-subscription-pricing.svelte
+++ b/src/ui/components/product-info/pricing/non-subscription-pricing.svelte
@@ -1,18 +1,13 @@
 <script lang="ts">
   import Localized from "../../../localization/localized.svelte";
   import { LocalizationKeys } from "../../../localization/supportedLanguages";
-  import {
-    type NonSubscriptionOption,
-    type Product,
-  } from "../../../../entities/offerings";
+  import { type NonSubscriptionOption } from "../../../../entities/offerings";
   import type { Translator } from "../../../localization/translator";
   import { translatorContextKey } from "../../../localization/constants";
   import { type Writable } from "svelte/store";
   import { getContext } from "svelte";
 
-  export let productDetails: Product;
   export let purchaseOption: NonSubscriptionOption;
-  export let showProductDescription: boolean = false;
 
   const basePrice = purchaseOption?.basePrice;
   const translator: Writable<Translator> = getContext(translatorContextKey);
@@ -29,33 +24,15 @@
   />
 </span>
 
-{#if showProductDescription}
-  <span class="rcb-product-description">
-    <Localized
-      key={LocalizationKeys.ProductInfoProductDescription}
-      variables={{ productDescription: productDetails.description }}
-    />
-  </span>
-{/if}
-
 <style>
   .rcb-product-price {
     color: var(--rc-color-grey-text-dark);
     font: var(--rc-text-titleMedium-mobile);
   }
 
-  .rcb-product-description {
-    font: var(--rc-text-body1-mobile);
-    color: var(--rc-color-grey-text-dark);
-  }
-
   @container layout-query-container (width >= 768px) {
     .rcb-product-price {
       font: var(--rc-text-titleMedium-desktop);
-    }
-
-    .rcb-product-description {
-      font: var(--rc-text-body1-desktop);
     }
   }
 </style>

--- a/src/ui/components/product-info/pricing/subscription-pricing.svelte
+++ b/src/ui/components/product-info/pricing/subscription-pricing.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+  import Localized from "../../../localization/localized.svelte";
+  import { LocalizationKeys } from "../../../localization/supportedLanguages";
+  import type { Translator } from "../../../localization/translator";
+  import { type SubscriptionOption } from "../../../../entities/offerings";
+  import { getTranslatedPeriodLength } from "../../../../helpers/price-labels";
+  import { translatorContextKey } from "../../../localization/constants";
+  import { type Writable } from "svelte/store";
+  import { getContext } from "svelte";
+  import { getNextRenewalDate } from "../../../../helpers/duration-helper";
+
+  export let purchaseOption: SubscriptionOption;
+
+  const subscriptionBasePrice = purchaseOption?.base?.price;
+  const translator: Writable<Translator> = getContext(translatorContextKey);
+
+  let renewalDate = null;
+  const expectedPeriod =
+    purchaseOption?.trial?.period || purchaseOption?.base?.period;
+  if (expectedPeriod) {
+    renewalDate = getNextRenewalDate(new Date(), expectedPeriod, true);
+  }
+
+  const formattedSubscriptionBasePrice =
+    subscriptionBasePrice &&
+    $translator.formatPrice(
+      subscriptionBasePrice.amountMicros,
+      subscriptionBasePrice.currency,
+    );
+
+  const formattedZeroPrice =
+    subscriptionBasePrice &&
+    $translator.formatPrice(0, subscriptionBasePrice.currency);
+</script>
+
+<div class="rcb-product-price-container">
+  {#if purchaseOption?.trial?.periodDuration}
+    <div class="rcb-product-trial">
+      <Localized
+        key={LocalizationKeys.ProductInfoFreeTrialDuration}
+        variables={{
+          trialDuration: getTranslatedPeriodLength(
+            purchaseOption.trial.periodDuration || "",
+            $translator,
+          ),
+        }}
+      />
+    </div>
+  {/if}
+  <div>
+    {#if subscriptionBasePrice}
+      <span class="rcb-product-price">
+        <Localized
+          key={LocalizationKeys.ProductInfoProductPrice}
+          variables={{
+            productPrice: formattedSubscriptionBasePrice,
+          }}
+        />
+      </span>
+    {/if}
+
+    {#if purchaseOption?.base?.period}
+      <span class="rcb-product-price-frequency">
+        <span class="rcb-product-price-frequency-text">
+          {$translator.translatePeriodFrequency(
+            purchaseOption.base.period.number,
+            purchaseOption.base.period.unit,
+            { useMultipleWords: true },
+          )}</span
+        >
+      </span>
+    {/if}
+  </div>
+</div>
+
+<div class="rcb-product-details expanded">
+  <div class="rcb-product-details-padding">
+    {#if purchaseOption?.trial?.periodDuration}
+      <div class="rcb-product-trial-explanation">
+        <div class="rcb-after-trial-ends rcb-text-dark">
+          <Localized
+            key={LocalizationKeys.ProductInfoPriceAfterFreeTrial}
+            variables={{
+              renewalDate:
+                renewalDate &&
+                $translator.translateDate(renewalDate, {
+                  dateStyle: "medium",
+                }),
+            }}
+          />
+        </div>
+        <div class="rcb-after-trial-ends rcb-text-dark">
+          {formattedSubscriptionBasePrice}
+        </div>
+      </div>
+      <div class="rcb-product-trial-explanation">
+        <div class="rcb-text-dark rcb-total-due-today">
+          <Localized key={LocalizationKeys.ProductInfoPriceTotalDueToday} />
+        </div>
+        <div class="rcb-text-dark rcb-total-due-today">
+          {formattedZeroPrice}
+        </div>
+      </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .rcb-product-price {
+    color: var(--rc-color-grey-text-dark);
+    font: var(--rc-text-titleMedium-mobile);
+  }
+
+  .rcb-product-trial {
+    color: var(--rc-color-grey-text-dark);
+    font: var(--rc-text-titleLarge-mobile);
+  }
+
+  .rcb-product-price-frequency {
+    color: var(--rc-color-grey-text-dark);
+    font: var(--rc-text-body1-mobile);
+  }
+
+  .rcb-product-price-frequency-text {
+    white-space: nowrap;
+  }
+
+  .rcb-product-details {
+    color: var(--rc-color-grey-text-light);
+    margin: 0;
+    overflow: hidden;
+    transition: max-height 0.2s ease-in-out;
+  }
+
+  .rcb-product-details-padding {
+    display: flex;
+    flex-direction: column;
+    gap: var(--rc-spacing-gapSmall-mobile);
+  }
+
+  .rcb-product-trial-explanation {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .rcb-text-dark {
+    color: var(--rc-color-grey-text-dark);
+    font-weight: 500;
+  }
+
+  @container layout-query-container (width >= 768px) {
+    .rcb-product-price {
+      font: var(--rc-text-titleMedium-desktop);
+    }
+
+    .rcb-product-price-frequency {
+      font: var(--rc-text-body1-desktop);
+    }
+
+    .rcb-product-details {
+      max-height: 500px;
+      gap: var(--rc-spacing-gapXLarge-desktop);
+    }
+
+    .rcb-product-details-padding {
+      gap: var(--rc-spacing-gapMedium-desktop);
+    }
+
+    .rcb-total-due-today {
+      font: var(--rc-text-titleMedium-desktop);
+    }
+
+    .rcb-after-trial-ends {
+      font: var(--rc-text-body1-desktop);
+    }
+
+    .rcb-product-trial {
+      font: var(--rc-text-titleLarge-desktop);
+    }
+  }
+</style>

--- a/src/ui/purchases-ui-inner.svelte
+++ b/src/ui/purchases-ui-inner.svelte
@@ -71,8 +71,9 @@
           {#if productDetails && purchaseOptionToUse}
             <ProductInfo
               {productDetails}
-              brandingAppearance={brandingInfo?.appearance}
               purchaseOption={purchaseOptionToUse}
+              showProductDescription={brandingInfo?.appearance
+                ?.show_product_description}
             />
           {/if}
         {/snippet}
@@ -83,8 +84,9 @@
         {#if currentView === "present-offer" && productDetails && purchaseOptionToUse}
           <ProductInfo
             {productDetails}
-            brandingAppearance={brandingInfo?.appearance}
             purchaseOption={purchaseOptionToUse}
+            showProductDescription={brandingInfo?.appearance
+              ?.show_product_description}
           />
         {/if}
         {#if currentView === "present-offer" && !productDetails}

--- a/src/ui/purchases-ui-inner.svelte
+++ b/src/ui/purchases-ui-inner.svelte
@@ -73,7 +73,7 @@
               {productDetails}
               purchaseOption={purchaseOptionToUse}
               showProductDescription={brandingInfo?.appearance
-                ?.show_product_description}
+                ?.show_product_description ?? false}
             />
           {/if}
         {/snippet}
@@ -86,7 +86,7 @@
             {productDetails}
             purchaseOption={purchaseOptionToUse}
             showProductDescription={brandingInfo?.appearance
-              ?.show_product_description}
+              ?.show_product_description ?? false}
           />
         {/if}
         {#if currentView === "present-offer" && !productDetails}


### PR DESCRIPTION
## Motivation / Description

After extracting some more components I noticed that there is a scenario where a duplicate description is displayed for non subscription products that have the `show_product_description` active. I think it may have been a regression from https://github.com/RevenueCat/purchases-js/pull/377 , where the description was moved to the title for "Subscription" but the "Non Subscription" kept it.

## Screenshot

This is the reproduced screenshot of the story. This story has been removed given the option to pass description has been removed from the pricing extracted component:
<img width="563" alt="Screenshot 2025-03-14 at 14 42 03" src="https://github.com/user-attachments/assets/8dd051b6-106e-433a-aa54-2efe8ae9891a" />
