### PR TITLE
Refactor `PurchasesUIInner`

### DIFF
--- a/src/stories/pages/purchase.stories.svelte
+++ b/src/stories/pages/purchase.stories.svelte
@@ -108,6 +108,6 @@
     defaultPurchaseOption: subscriptionOptionWithTrial,
   }}
 />
-<Story name="Loading" args={{ currentView: "loading" }} />
+<Story name="Loading" args={{ currentView: "loading-payment-page" }} />
 <Story name="Payment complete" args={{ currentView: "success" }} />
 <Story name="Payment failed" args={{ currentView: "error" }} />

--- a/src/stories/pages/purchase.stories.svelte
+++ b/src/stories/pages/purchase.stories.svelte
@@ -16,7 +16,6 @@
     subscriptionOptionWithTrial,
     checkoutStartResponse,
   } from "../fixtures";
-  import { toProductInfoStyleVar } from "../../ui/theme/utils";
   import { PurchaseOperationHelper } from "../../helpers/purchase-operation-helper";
 
   const defaultArgs = {
@@ -59,14 +58,12 @@
   context: StoryContext<typeof Story>,
 )}
   {@const brandingInfo = brandingInfos[context.globals.brandingName]}
-  {@const colorVariables = toProductInfoStyleVar(brandingInfo.appearance)}
   <PurchasesInner
     isSandbox={args.isSandbox}
     currentView={args.currentView}
     productDetails={args.productDetails}
     purchaseOptionToUse={args.purchaseOptionToUse}
     {brandingInfo}
-    {colorVariables}
     handleContinue={() => {}}
     closeWithError={() => {}}
     lastError={null}

--- a/src/ui/layout/template.svelte
+++ b/src/ui/layout/template.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import Container from "./container.svelte";
+  import Layout from "./layout.svelte";
+  import NavBar from "./navbar.svelte";
+  import SandboxBanner from "../molecules/sandbox-banner.svelte";
+  import Main from "./main-block.svelte";
+  import { type BrandingInfoResponse } from "../../networking/responses/branding-response";
+  import BrandingInfoUI from "../molecules/branding-info.svelte";
+  import { type Snippet } from "svelte";
+
+  export interface Props {
+    brandingInfo: BrandingInfoResponse | null;
+    isInElement: boolean;
+    colorVariables: string;
+    isSandbox: boolean;
+    onClose: (() => void) | undefined;
+    navbarContent: Snippet<[]>;
+    mainContent: Snippet<[]>;
+  }
+
+  const {
+    brandingInfo,
+    isInElement,
+    colorVariables,
+    isSandbox,
+    onClose,
+    navbarContent,
+    mainContent,
+  }: Props = $props();
+</script>
+
+<Container brandingAppearance={brandingInfo?.appearance} {isInElement}>
+  {#if isSandbox}
+    <SandboxBanner style={colorVariables} {isInElement} />
+  {/if}
+  <Layout style={colorVariables}>
+    <NavBar
+      brandingAppearance={brandingInfo?.appearance}
+      {onClose}
+      showCloseButton={!isInElement}
+    >
+      {#snippet headerContent()}
+        <BrandingInfoUI {brandingInfo} />
+      {/snippet}
+
+      {#snippet bodyContent()}
+        {@render navbarContent?.()}
+      {/snippet}
+    </NavBar>
+    <Main brandingAppearance={brandingInfo?.appearance}>
+      {#snippet body()}
+        {@render mainContent?.()}
+      {/snippet}
+    </Main>
+  </Layout>
+</Container>

--- a/src/ui/layout/template.svelte
+++ b/src/ui/layout/template.svelte
@@ -7,11 +7,11 @@
   import { type BrandingInfoResponse } from "../../networking/responses/branding-response";
   import BrandingInfoUI from "../molecules/branding-info.svelte";
   import { type Snippet } from "svelte";
+  import { toProductInfoStyleVar } from "../theme/utils";
 
   export interface Props {
     brandingInfo: BrandingInfoResponse | null;
     isInElement: boolean;
-    colorVariables: string;
     isSandbox: boolean;
     onClose: (() => void) | undefined;
     navbarContent: Snippet<[]>;
@@ -21,12 +21,15 @@
   const {
     brandingInfo,
     isInElement,
-    colorVariables,
     isSandbox,
     onClose,
     navbarContent,
     mainContent,
   }: Props = $props();
+
+  const colorVariables = $derived(
+    toProductInfoStyleVar(brandingInfo?.appearance) ?? "",
+  );
 </script>
 
 <Container brandingAppearance={brandingInfo?.appearance} {isInElement}>

--- a/src/ui/molecules/loading.svelte
+++ b/src/ui/molecules/loading.svelte
@@ -1,0 +1,26 @@
+<script>
+  import Spinner from "../atoms/spinner.svelte";
+
+  let style = "";
+</script>
+
+<div class="rcb-modal-loader">
+  <Spinner />
+</div>
+
+<style>
+  .rcb-modal-loader {
+    width: 100%;
+    flex-grow: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  @container layout-query-container (width >= 768px) {
+    .rcb-modal-loader {
+      align-items: flex-start;
+      margin-top: calc(var(--rc-spacing-gapXXLarge-desktop) * 6);
+    }
+  }
+</style>

--- a/src/ui/purchases-ui-inner.svelte
+++ b/src/ui/purchases-ui-inner.svelte
@@ -10,7 +10,6 @@
   import ProductInfo from "./organisms/product-info.svelte";
   import {
     PurchaseFlowError,
-    PurchaseFlowErrorCode,
     PurchaseOperationHelper,
   } from "../helpers/purchase-operation-helper";
   import { type CheckoutStartResponse } from "../networking/responses/checkout-start-response";
@@ -63,13 +62,9 @@
     {/if}
     {#if currentView === "error"}
       <StateError
-        lastError={lastError ??
-          new PurchaseFlowError(
-            PurchaseFlowErrorCode.UnknownError,
-            "Unknown error without state set.",
-          )}
-        supportEmail={brandingInfo?.support_email}
+        {lastError}
         {productDetails}
+        supportEmail={brandingInfo?.support_email ?? null}
         onContinue={closeWithError}
       />
     {/if}

--- a/src/ui/purchases-ui-inner.svelte
+++ b/src/ui/purchases-ui-inner.svelte
@@ -36,7 +36,6 @@
   export let isInElement: boolean = false;
 
   const viewsWhereOfferDetailsAreShown: CurrentView[] = [
-    "present-offer",
     "needs-auth-info",
     "processing-auth-info",
     "needs-payment-info",
@@ -76,17 +75,6 @@
     {/if}
     <Main brandingAppearance={brandingInfo?.appearance}>
       {#snippet body()}
-        {#if currentView === "present-offer" && productDetails && purchaseOptionToUse}
-          <ProductInfo
-            {productDetails}
-            purchaseOption={purchaseOptionToUse}
-            showProductDescription={brandingInfo?.appearance
-              ?.show_product_description ?? false}
-          />
-        {/if}
-        {#if currentView === "present-offer" && !productDetails}
-          <StateLoading />
-        {/if}
         {#if currentView === "needs-auth-info" || currentView === "processing-auth-info"}
           <StateNeedsAuthInfo
             onContinue={handleContinue}

--- a/src/ui/purchases-ui-inner.svelte
+++ b/src/ui/purchases-ui-inner.svelte
@@ -1,9 +1,4 @@
 <script lang="ts">
-  import Container from "./layout/container.svelte";
-  import Layout from "./layout/layout.svelte";
-  import NavBar from "./layout/navbar.svelte";
-  import SandboxBanner from "./molecules/sandbox-banner.svelte";
-  import Main from "./layout/main-block.svelte";
   import StateNeedsPaymentInfo from "./states/state-needs-payment-info.svelte";
   import StateNeedsAuthInfo from "./states/state-needs-auth-info.svelte";
   import StateLoading from "./states/state-loading.svelte";
@@ -13,13 +8,13 @@
   import { type BrandingInfoResponse } from "../networking/responses/branding-response";
   import type { Product, PurchaseOption } from "../main";
   import ProductInfo from "./organisms/product-info.svelte";
-  import BrandingInfoUI from "./molecules/branding-info.svelte";
   import {
     PurchaseFlowError,
     PurchaseFlowErrorCode,
     PurchaseOperationHelper,
   } from "../helpers/purchase-operation-helper";
   import { type CheckoutStartResponse } from "../networking/responses/checkout-start-response";
+  import Template from "./layout/template.svelte";
 
   export let currentView: CurrentView;
   export let brandingInfo: BrandingInfoResponse | null;
@@ -36,68 +31,51 @@
   export let isInElement: boolean = false;
 </script>
 
-<Container brandingAppearance={brandingInfo?.appearance} {isInElement}>
-  {#if isSandbox}
-    <SandboxBanner style={colorVariables} {isInElement} />
-  {/if}
-  <Layout style={colorVariables}>
-    <NavBar
-      brandingAppearance={brandingInfo?.appearance}
-      {onClose}
-      showCloseButton={!isInElement}
-    >
-      {#snippet headerContent()}
-        <BrandingInfoUI {brandingInfo} />
-      {/snippet}
-
-      {#snippet bodyContent()}
-        <ProductInfo
-          {productDetails}
-          purchaseOption={purchaseOptionToUse}
-          showProductDescription={brandingInfo?.appearance
-            ?.show_product_description ?? false}
-        />
-      {/snippet}
-    </NavBar>
-    <Main brandingAppearance={brandingInfo?.appearance}>
-      {#snippet body()}
-        {#if currentView === "needs-auth-info" || currentView === "processing-auth-info"}
-          <StateNeedsAuthInfo
-            onContinue={handleContinue}
-            processing={currentView === "processing-auth-info"}
-            {lastError}
-          />
-        {/if}
-        {#if paymentInfoCollectionMetadata && (currentView === "needs-payment-info" || currentView === "polling-purchase-status")}
-          <StateNeedsPaymentInfo
-            {paymentInfoCollectionMetadata}
-            onContinue={handleContinue}
-            processing={currentView === "polling-purchase-status"}
-            {productDetails}
-            purchaseOption={purchaseOptionToUse}
-            {brandingInfo}
-            {purchaseOperationHelper}
-          />
-        {/if}
-        {#if currentView === "loading-payment-page"}
-          <StateLoading />
-        {/if}
-        {#if currentView === "error"}
-          <StateError
-            lastError={lastError ??
-              new PurchaseFlowError(
-                PurchaseFlowErrorCode.UnknownError,
-                "Unknown error without state set.",
-              )}
-            supportEmail={brandingInfo?.support_email}
-            {productDetails}
-            onContinue={closeWithError}
-          />
-        {/if}
-        {#if currentView === "success"}
-          <StateSuccess {productDetails} onContinue={handleContinue} />
-        {/if}
-      {/snippet}
-    </Main>
-  </Layout>
-</Container>
+<Template {brandingInfo} {isInElement} {colorVariables} {isSandbox} {onClose}>
+  {#snippet navbarContent()}
+    <ProductInfo
+      {productDetails}
+      purchaseOption={purchaseOptionToUse}
+      showProductDescription={brandingInfo?.appearance
+        ?.show_product_description ?? false}
+    />
+  {/snippet}
+  {#snippet mainContent()}
+    {#if currentView === "needs-auth-info" || currentView === "processing-auth-info"}
+      <StateNeedsAuthInfo
+        onContinue={handleContinue}
+        processing={currentView === "processing-auth-info"}
+        {lastError}
+      />
+    {/if}
+    {#if paymentInfoCollectionMetadata && (currentView === "needs-payment-info" || currentView === "polling-purchase-status")}
+      <StateNeedsPaymentInfo
+        {paymentInfoCollectionMetadata}
+        onContinue={handleContinue}
+        processing={currentView === "polling-purchase-status"}
+        {productDetails}
+        purchaseOption={purchaseOptionToUse}
+        {brandingInfo}
+        {purchaseOperationHelper}
+      />
+    {/if}
+    {#if currentView === "loading-payment-page"}
+      <StateLoading />
+    {/if}
+    {#if currentView === "error"}
+      <StateError
+        lastError={lastError ??
+          new PurchaseFlowError(
+            PurchaseFlowErrorCode.UnknownError,
+            "Unknown error without state set.",
+          )}
+        supportEmail={brandingInfo?.support_email}
+        {productDetails}
+        onContinue={closeWithError}
+      />
+    {/if}
+    {#if currentView === "success"}
+      <StateSuccess {productDetails} onContinue={handleContinue} />
+    {/if}
+  {/snippet}
+</Template>

--- a/src/ui/purchases-ui-inner.svelte
+++ b/src/ui/purchases-ui-inner.svelte
@@ -41,7 +41,7 @@
     "processing-auth-info",
     "needs-payment-info",
     "polling-purchase-status",
-    "loading",
+    "loading-payment-page",
     "success",
     "error",
   ];
@@ -105,7 +105,7 @@
             {purchaseOperationHelper}
           />
         {/if}
-        {#if currentView === "loading"}
+        {#if currentView === "loading-payment-page"}
           <StateLoading />
         {/if}
         {#if currentView === "error"}

--- a/src/ui/purchases-ui-inner.svelte
+++ b/src/ui/purchases-ui-inner.svelte
@@ -23,7 +23,7 @@
 
   export let currentView: CurrentView;
   export let brandingInfo: BrandingInfoResponse | null;
-  export let productDetails: Product | null;
+  export let productDetails: Product;
   export let purchaseOptionToUse: PurchaseOption;
   export let colorVariables: string = "";
   export let isSandbox: boolean = false;
@@ -51,14 +51,12 @@
       {/snippet}
 
       {#snippet bodyContent()}
-        {#if productDetails && purchaseOptionToUse}
-          <ProductInfo
-            {productDetails}
-            purchaseOption={purchaseOptionToUse}
-            showProductDescription={brandingInfo?.appearance
-              ?.show_product_description ?? false}
-          />
-        {/if}
+        <ProductInfo
+          {productDetails}
+          purchaseOption={purchaseOptionToUse}
+          showProductDescription={brandingInfo?.appearance
+            ?.show_product_description ?? false}
+        />
       {/snippet}
     </NavBar>
     <Main brandingAppearance={brandingInfo?.appearance}>
@@ -70,7 +68,7 @@
             {lastError}
           />
         {/if}
-        {#if paymentInfoCollectionMetadata && (currentView === "needs-payment-info" || currentView === "polling-purchase-status") && productDetails && purchaseOptionToUse}
+        {#if paymentInfoCollectionMetadata && (currentView === "needs-payment-info" || currentView === "polling-purchase-status")}
           <StateNeedsPaymentInfo
             {paymentInfoCollectionMetadata}
             onContinue={handleContinue}

--- a/src/ui/purchases-ui-inner.svelte
+++ b/src/ui/purchases-ui-inner.svelte
@@ -34,16 +34,6 @@
   export let paymentInfoCollectionMetadata: CheckoutStartResponse | null;
   export let purchaseOperationHelper: PurchaseOperationHelper;
   export let isInElement: boolean = false;
-
-  const viewsWhereOfferDetailsAreShown: CurrentView[] = [
-    "needs-auth-info",
-    "processing-auth-info",
-    "needs-payment-info",
-    "polling-purchase-status",
-    "loading-payment-page",
-    "success",
-    "error",
-  ];
 </script>
 
 <Container brandingAppearance={brandingInfo?.appearance} {isInElement}>
@@ -51,28 +41,26 @@
     <SandboxBanner style={colorVariables} {isInElement} />
   {/if}
   <Layout style={colorVariables}>
-    {#if viewsWhereOfferDetailsAreShown.includes(currentView)}
-      <NavBar
-        brandingAppearance={brandingInfo?.appearance}
-        {onClose}
-        showCloseButton={!isInElement}
-      >
-        {#snippet headerContent()}
-          <BrandingInfoUI {brandingInfo} />
-        {/snippet}
+    <NavBar
+      brandingAppearance={brandingInfo?.appearance}
+      {onClose}
+      showCloseButton={!isInElement}
+    >
+      {#snippet headerContent()}
+        <BrandingInfoUI {brandingInfo} />
+      {/snippet}
 
-        {#snippet bodyContent()}
-          {#if productDetails && purchaseOptionToUse}
-            <ProductInfo
-              {productDetails}
-              purchaseOption={purchaseOptionToUse}
-              showProductDescription={brandingInfo?.appearance
-                ?.show_product_description ?? false}
-            />
-          {/if}
-        {/snippet}
-      </NavBar>
-    {/if}
+      {#snippet bodyContent()}
+        {#if productDetails && purchaseOptionToUse}
+          <ProductInfo
+            {productDetails}
+            purchaseOption={purchaseOptionToUse}
+            showProductDescription={brandingInfo?.appearance
+              ?.show_product_description ?? false}
+          />
+        {/if}
+      {/snippet}
+    </NavBar>
     <Main brandingAppearance={brandingInfo?.appearance}>
       {#snippet body()}
         {#if currentView === "needs-auth-info" || currentView === "processing-auth-info"}

--- a/src/ui/purchases-ui-inner.svelte
+++ b/src/ui/purchases-ui-inner.svelte
@@ -20,7 +20,6 @@
   export let brandingInfo: BrandingInfoResponse | null;
   export let productDetails: Product;
   export let purchaseOptionToUse: PurchaseOption;
-  export let colorVariables: string = "";
   export let isSandbox: boolean = false;
   export let handleContinue: (params?: ContinueHandlerParams) => void;
   export let closeWithError: () => void;
@@ -31,7 +30,7 @@
   export let isInElement: boolean = false;
 </script>
 
-<Template {brandingInfo} {isInElement} {colorVariables} {isSandbox} {onClose}>
+<Template {brandingInfo} {isInElement} {isSandbox} {onClose}>
   {#snippet navbarContent()}
     <ProductInfo
       {productDetails}

--- a/src/ui/purchases-ui.svelte
+++ b/src/ui/purchases-ui.svelte
@@ -51,7 +51,7 @@
   export let isInElement: boolean = false;
 
   let colorVariables = "";
-  let productDetails: Product | null = null;
+  let productDetails: Product = rcPackage.webBillingProduct;
   let paymentInfoCollectionMetadata: CheckoutStartResponse | null = null;
   let lastError: PurchaseFlowError | null = null;
   const productId = rcPackage.webBillingProduct.identifier ?? null;
@@ -88,8 +88,6 @@
   setContext(eventsTrackerContextKey, eventsTracker);
 
   onMount(async () => {
-    productDetails = rcPackage.webBillingProduct;
-
     colorVariables = toProductInfoStyleVar(brandingInfo?.appearance);
 
     if (currentView === "initializing") {

--- a/src/ui/purchases-ui.svelte
+++ b/src/ui/purchases-ui.svelte
@@ -54,7 +54,7 @@
   let lastError: PurchaseFlowError | null = null;
   const productId = rcPackage.webBillingProduct.identifier ?? null;
 
-  let currentView: CurrentView | "initializing" = "initializing";
+  let currentView: CurrentView | null = null;
   let redemptionInfo: RedemptionInfo | null = null;
   let operationSessionId: string | null = null;
 
@@ -86,18 +86,6 @@
   setContext(eventsTrackerContextKey, eventsTracker);
 
   onMount(async () => {
-    if (currentView === "initializing") {
-      if (customerEmail) {
-        handleCheckoutStart();
-      } else {
-        currentView = "needs-auth-info";
-      }
-
-      return;
-    }
-  });
-
-  const handleCheckoutStart = () => {
     if (productId === null) {
       handleError(
         new PurchaseFlowError(
@@ -106,10 +94,17 @@
         ),
       );
       return;
-    } else if (currentView === "initializing") {
-      currentView = "loading-payment-page";
     }
 
+    if (!customerEmail) {
+      currentView = "needs-auth-info";
+    } else {
+      currentView = "loading-payment-page";
+      handleCheckoutStart();
+    }
+  });
+
+  const handleCheckoutStart = () => {
     if (!customerEmail) {
       handleError(
         new PurchaseFlowError(PurchaseFlowErrorCode.MissingEmailError),

--- a/src/ui/purchases-ui.svelte
+++ b/src/ui/purchases-ui.svelte
@@ -56,7 +56,7 @@
   let lastError: PurchaseFlowError | null = null;
   const productId = rcPackage.webBillingProduct.identifier ?? null;
 
-  let currentView: CurrentView = "present-offer";
+  let currentView: CurrentView | "initializing" = "initializing";
   let redemptionInfo: RedemptionInfo | null = null;
   let operationSessionId: string | null = null;
 
@@ -92,7 +92,7 @@
 
     colorVariables = toProductInfoStyleVar(brandingInfo?.appearance);
 
-    if (currentView === "present-offer") {
+    if (currentView === "initializing") {
       if (customerEmail) {
         handleCheckoutStart();
       } else {
@@ -112,7 +112,7 @@
         ),
       );
       return;
-    } else if (currentView === "present-offer") {
+    } else if (currentView === "initializing") {
       currentView = "loading-payment-page";
     }
 
@@ -209,7 +209,7 @@
 
 <PurchasesUiInner
   isSandbox={purchases.isSandbox()}
-  {currentView}
+  currentView={currentView as CurrentView}
   {brandingInfo}
   {productDetails}
   purchaseOptionToUse={purchaseOption}

--- a/src/ui/purchases-ui.svelte
+++ b/src/ui/purchases-ui.svelte
@@ -113,7 +113,7 @@
       );
       return;
     } else if (currentView === "present-offer") {
-      currentView = "loading";
+      currentView = "loading-payment-page";
     }
 
     if (!customerEmail) {

--- a/src/ui/purchases-ui.svelte
+++ b/src/ui/purchases-ui.svelte
@@ -9,7 +9,6 @@
     PurchaseOperationHelper,
   } from "../helpers/purchase-operation-helper";
 
-  import { toProductInfoStyleVar } from "./theme/utils";
   import { type RedemptionInfo } from "../entities/redemption-info";
   import {
     type CustomTranslations,
@@ -50,7 +49,6 @@
   export let customTranslations: CustomTranslations = {};
   export let isInElement: boolean = false;
 
-  let colorVariables = "";
   let productDetails: Product = rcPackage.webBillingProduct;
   let paymentInfoCollectionMetadata: CheckoutStartResponse | null = null;
   let lastError: PurchaseFlowError | null = null;
@@ -88,8 +86,6 @@
   setContext(eventsTrackerContextKey, eventsTracker);
 
   onMount(async () => {
-    colorVariables = toProductInfoStyleVar(brandingInfo?.appearance);
-
     if (currentView === "initializing") {
       if (customerEmail) {
         handleCheckoutStart();
@@ -216,7 +212,6 @@
   {paymentInfoCollectionMetadata}
   {purchaseOperationHelper}
   {closeWithError}
-  {colorVariables}
   {isInElement}
   {onClose}
 />

--- a/src/ui/states/state-error.svelte
+++ b/src/ui/states/state-error.svelte
@@ -15,21 +15,34 @@
   import { LocalizationKeys } from "../localization/supportedLanguages";
   import { type Writable } from "svelte/store";
 
-  export let lastError: PurchaseFlowError;
-  export let supportEmail: string | null = null;
-  export let productDetails: Product;
-  export let onContinue: () => void;
+  interface Props {
+    lastError: PurchaseFlowError | null;
+    supportEmail: string | null;
+    productDetails: Product;
+    onContinue: () => void;
+  }
+
+  const { lastError, supportEmail, productDetails, onContinue }: Props =
+    $props();
+
+  const error: PurchaseFlowError = $derived(
+    lastError ??
+      new PurchaseFlowError(
+        PurchaseFlowErrorCode.UnknownError,
+        "Unknown error without state set.",
+      ),
+  );
 
   const translator: Writable<Translator> = getContext(translatorContextKey);
 
   onMount(() => {
     Logger.errorLog(
-      `Displayed error: ${PurchaseFlowErrorCode[lastError.errorCode]}. Message: ${lastError.message ?? "None"}. Underlying error: ${lastError.underlyingErrorMessage ?? "None"}`,
+      `Displayed error: ${PurchaseFlowErrorCode[error.errorCode]}. Message: ${error.message ?? "None"}. Underlying error: ${error.underlyingErrorMessage ?? "None"}`,
     );
   });
 
   function getTranslatedErrorTitle(): string {
-    switch (lastError.errorCode) {
+    switch (error.errorCode) {
       case PurchaseFlowErrorCode.AlreadyPurchasedError:
         if (productDetails.productType === ProductType.Subscription) {
           return $translator.translate(
@@ -48,8 +61,8 @@
   }
 
   function getTranslatedErrorMessage(): string | undefined {
-    const publicErrorCode = lastError.getErrorCode();
-    switch (lastError.errorCode) {
+    const publicErrorCode = error.getErrorCode();
+    switch (error.errorCode) {
       case PurchaseFlowErrorCode.UnknownError:
         return $translator.translate(
           LocalizationKeys.StateErrorErrorMessageUnknownError,

--- a/src/ui/states/state-error.svelte
+++ b/src/ui/states/state-error.svelte
@@ -17,7 +17,7 @@
 
   export let lastError: PurchaseFlowError;
   export let supportEmail: string | null = null;
-  export let productDetails: Product | null = null;
+  export let productDetails: Product;
   export let onContinue: () => void;
 
   const translator: Writable<Translator> = getContext(translatorContextKey);
@@ -31,7 +31,7 @@
   function getTranslatedErrorTitle(): string {
     switch (lastError.errorCode) {
       case PurchaseFlowErrorCode.AlreadyPurchasedError:
-        if (productDetails?.productType === ProductType.Subscription) {
+        if (productDetails.productType === ProductType.Subscription) {
           return $translator.translate(
             LocalizationKeys.StateErrorErrorTitleAlreadySubscribed,
           );
@@ -76,7 +76,7 @@
           { errorCode: publicErrorCode },
         );
       case PurchaseFlowErrorCode.AlreadyPurchasedError:
-        if (productDetails?.productType === ProductType.Subscription) {
+        if (productDetails.productType === ProductType.Subscription) {
           return $translator.translate(
             LocalizationKeys.StateErrorErrorMessageAlreadySubscribed,
             { errorCode: publicErrorCode },

--- a/src/ui/states/state-loading.svelte
+++ b/src/ui/states/state-loading.svelte
@@ -1,26 +1,5 @@
 <script>
-  import Spinner from "../atoms/spinner.svelte";
-
-  let style = "";
+  import Loading from "../molecules/loading.svelte";
 </script>
 
-<div class="rcb-modal-loader">
-  <Spinner />
-</div>
-
-<style>
-  .rcb-modal-loader {
-    width: 100%;
-    flex-grow: 1;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
-
-  @container layout-query-container (width >= 768px) {
-    .rcb-modal-loader {
-      align-items: flex-start;
-      margin-top: calc(var(--rc-spacing-gapXXLarge-desktop) * 6);
-    }
-  }
-</style>
+<Loading />

--- a/src/ui/states/state-needs-payment-info.svelte
+++ b/src/ui/states/state-needs-payment-info.svelte
@@ -27,7 +27,7 @@
     createCheckoutPaymentGatewayErrorEvent,
   } from "../../behavioural-events/sdk-event-helpers";
   import { SDKEventName } from "../../behavioural-events/sdk-events";
-  import StateLoading from "./state-loading.svelte";
+  import Loading from "../molecules/loading.svelte";
   import { getNextRenewalDate } from "../../helpers/duration-helper";
   import { formatPrice } from "../../helpers/price-labels";
   import { type Writable } from "svelte/store";
@@ -149,7 +149,7 @@
 
 <div class="rc-checkout-container">
   {#if isStripeLoading || processing}
-    <StateLoading />
+    <Loading />
   {/if}
   <!-- <TextSeparator text="Pay by card" /> -->
   <form

--- a/src/ui/states/state-success.svelte
+++ b/src/ui/states/state-success.svelte
@@ -13,11 +13,11 @@
   import { eventsTrackerContextKey } from "../constants";
   import { type ContinueHandlerParams } from "../ui-types";
   import { type Writable } from "svelte/store";
-  export let productDetails: Product | null = null;
+  export let productDetails: Product;
   export let onContinue: (params?: ContinueHandlerParams) => void;
 
   const isSubscription =
-    productDetails?.productType === ProductType.Subscription;
+    productDetails.productType === ProductType.Subscription;
   const translator: Writable<Translator> = getContext(translatorContextKey);
   const eventsTracker = getContext(eventsTrackerContextKey) as IEventsTracker;
 

--- a/src/ui/ui-types.ts
+++ b/src/ui/ui-types.ts
@@ -1,7 +1,6 @@
 import type { PurchaseFlowError } from "../helpers/purchase-operation-helper";
 
 export type CurrentView =
-  | "present-offer"
   | "needs-auth-info"
   | "processing-auth-info"
   | "needs-payment-info"

--- a/src/ui/ui-types.ts
+++ b/src/ui/ui-types.ts
@@ -6,7 +6,7 @@ export type CurrentView =
   | "processing-auth-info"
   | "needs-payment-info"
   | "polling-purchase-status"
-  | "loading"
+  | "loading-payment-page"
   | "success"
   | "error";
 


### PR DESCRIPTION
## Motivation / Description

Structural and naming improvements prior to adding tax calculation logic on top of `RCPurchasesUIInner`.

## Changes introduced

- Removed `present-offer` as a `CurrentView`. It is not a real page but a temporary value prior to deciding which page should be shown. Made it explicit by adding `initializing` as an extra option for `currentView` variable in `PurchasesUI` (outside of the `CurrentView` type used by `PurchasesUIInner`).
- Removed nullability of `productDetails` and `purchaseOption`. Is is not possible and it does not make sense to handle a purchase without a product or purchase option. This was propagating in a few places and strangely handled without reason and causing some confusion.
- Extracted a `Template` component responsible for composing the different layout items common to all pages.
- Moved the responsibility of calculating `colorVariables` to the `Template` component.
- Moved the responsibility of the fallback unknown error value from `PurchasesInnerUI` to the `StateError` page.
- Extracted `Loading` molecule component to be reused by both `StateLoading` and `StateNeedsPaymentInfo` to better separate different tier components.