### PR TITLE
[WEB-2013] Recalculate taxes during checkout (FF)

### DIFF
--- a/src/stories/fixtures.ts
+++ b/src/stories/fixtures.ts
@@ -260,7 +260,7 @@ export const priceBreakdownTaxDisabled: PriceBreakdown = {
   totalAmountInMicros: 9900000,
   totalExcludingTaxInMicros: 9900000,
   taxCollectionEnabled: false,
-  status: "calculated",
+  taxCalculationStatus: "calculated",
   taxAmountInMicros: 0,
   pendingReason: null,
   taxBreakdown: null,
@@ -272,7 +272,7 @@ export const priceBreakdownTaxInclusive: PriceBreakdown = {
   totalExcludingTaxInMicros: 8180000,
   taxAmountInMicros: 1718000,
   taxCollectionEnabled: true,
-  status: "calculated",
+  taxCalculationStatus: "calculated",
   taxBreakdown: [
     {
       tax_type: "VAT",
@@ -292,7 +292,7 @@ export const priceBreakdownTaxExclusive: PriceBreakdown = {
   totalExcludingTaxInMicros: 9900000,
   taxAmountInMicros: 693000,
   taxCollectionEnabled: true,
-  status: "calculated",
+  taxCalculationStatus: "calculated",
   taxBreakdown: [
     {
       tax_type: "tax_rate",
@@ -309,13 +309,13 @@ export const priceBreakdownTaxExclusive: PriceBreakdown = {
 export const priceBreakdownTaxLoading: PriceBreakdown = {
   ...priceBreakdownTaxExclusive,
   totalAmountInMicros: 9900000,
-  status: "loading",
+  taxCalculationStatus: "loading",
 };
 
 export const priceBreakdownTaxPending: PriceBreakdown = {
   ...priceBreakdownTaxExclusive,
   totalAmountInMicros: 9900000,
-  status: "pending",
+  taxCalculationStatus: "pending",
   pendingReason: null,
 };
 
@@ -325,7 +325,7 @@ export const priceBreakdownTaxExclusiveWithMultipleTaxItems: PriceBreakdown = {
   totalExcludingTaxInMicros: 9900000,
   taxAmountInMicros: 495000 + 987525,
   taxCollectionEnabled: true,
-  status: "calculated",
+  taxCalculationStatus: "calculated",
   taxBreakdown: [
     {
       tax_type: "GST",

--- a/src/stories/pages/purchase.stories.svelte
+++ b/src/stories/pages/purchase.stories.svelte
@@ -64,6 +64,7 @@
     priceBreakdown={priceBreakdownTaxDisabled}
     purchaseOperationHelper={null as unknown as PurchaseOperationHelper}
     isInElement={context.globals.viewport === "embedded"}
+    onTaxCustomerDetailsUpdated={() => {}}
   />
 {/snippet}
 

--- a/src/stripe/stripe-service.ts
+++ b/src/stripe/stripe-service.ts
@@ -8,7 +8,10 @@ import { loadStripe } from "@stripe/stripe-js";
 import type { BrandingInfoResponse } from "../networking/responses/branding-response";
 import { Theme } from "../ui/theme/theme";
 import { DEFAULT_TEXT_STYLES } from "../ui/theme/text";
-import type { GatewayParams } from "../networking/responses/stripe-elements";
+import type {
+  GatewayParams,
+  StripeElementsConfiguration,
+} from "../networking/responses/stripe-elements";
 export class StripeService {
   private static FORM_VALIDATED_CARD_ERROR_CODES = [
     "card_declined",
@@ -131,6 +134,19 @@ export class StripeService {
     });
 
     return { stripe, elements };
+  }
+
+  static async updateElementsConfiguration(
+    elements: StripeElements,
+    elementsConfiguration: StripeElementsConfiguration,
+  ) {
+    await elements.update({
+      mode: elementsConfiguration.mode,
+      paymentMethodTypes: elementsConfiguration.payment_method_types,
+      setupFutureUsage: elementsConfiguration.setup_future_usage,
+      amount: elementsConfiguration.amount,
+      currency: elementsConfiguration.currency,
+    });
   }
 
   static isStripeHandledCardError(error: StripeError) {

--- a/src/stripe/stripe-service.ts
+++ b/src/stripe/stripe-service.ts
@@ -55,11 +55,6 @@ export class StripeService {
     const elements = stripe.elements({
       loader: "always",
       locale: localeToUse,
-      mode: elementsConfiguration.mode,
-      paymentMethodTypes: elementsConfiguration.payment_method_types,
-      setupFutureUsage: elementsConfiguration.setup_future_usage,
-      amount: elementsConfiguration.amount,
-      currency: elementsConfiguration.currency,
       appearance: {
         theme: "stripe",
         labels: "floating",
@@ -132,6 +127,8 @@ export class StripeService {
         },
       },
     });
+
+    await this.updateElementsConfiguration(elements, elementsConfiguration);
 
     return { stripe, elements };
   }

--- a/src/tests/ui/pages/payment-entry-page.test.ts
+++ b/src/tests/ui/pages/payment-entry-page.test.ts
@@ -5,6 +5,7 @@ import {
   brandingInfo,
   rcPackage,
   checkoutStartResponse,
+  priceBreakdownTaxDisabled,
 } from "../../../stories/fixtures";
 import { SDKEventName } from "../../../behavioural-events/sdk-events";
 import { createEventsTrackerMock } from "../../mocks/events-tracker-mock-provider";
@@ -30,6 +31,7 @@ const purchaseOperationHelperMock: PurchaseOperationHelper = {
 
 const basicProps: ComponentProps<PaymentEntryPage> = {
   brandingInfo: brandingInfo,
+  priceBreakdown: priceBreakdownTaxDisabled,
   purchaseOption: rcPackage.webBillingProduct.defaultPurchaseOption,
   productDetails: rcPackage.webBillingProduct,
   processing: false,

--- a/src/ui/molecules/pricing-table.svelte
+++ b/src/ui/molecules/pricing-table.svelte
@@ -39,7 +39,7 @@
         </div>
       </div>
 
-      {#if priceBreakdown.status === "loading"}
+      {#if priceBreakdown.taxCalculationStatus === "loading"}
         <div class="rcb-pricing-table-row">
           <div class="rcb-pricing-table-header">
             {$translator.translate(LocalizationKeys.PricingTableTax)}
@@ -48,7 +48,7 @@
             <div class="rcb-pricing-table-value-loading">Loading</div>
           </div>
         </div>
-      {:else if priceBreakdown.status === "pending"}
+      {:else if priceBreakdown.taxCalculationStatus === "pending"}
         <div class="rcb-pricing-table-row">
           <div class="rcb-pricing-table-header">
             {$translator.translate(LocalizationKeys.PricingTableTax)}

--- a/src/ui/molecules/stripe-payment-elements.svelte
+++ b/src/ui/molecules/stripe-payment-elements.svelte
@@ -73,7 +73,6 @@
   $: if (elements) {
     (async () => {
       const elementsConfiguration = gatewayParams.elements_configuration;
-      console.debug("Updating gateway params", elementsConfiguration);
       if (!elementsConfiguration) return;
 
       await StripeService.updateElementsConfiguration(

--- a/src/ui/molecules/stripe-payment-elements.svelte
+++ b/src/ui/molecules/stripe-payment-elements.svelte
@@ -56,28 +56,15 @@
   export async function confirm(clientSecret: string) {
     if (!stripe || !elements) return;
 
-    const isSetupIntent = clientSecret.startsWith("seti_");
-    const baseOptions = {
+    const confirmError = await StripeService.confirmIntent(
+      stripe,
+      elements,
       clientSecret,
-      redirect: "if_required" as const,
-    };
+      lastConfirmationTokenId,
+    );
 
-    const confirmOptions = lastConfirmationTokenId
-      ? {
-          ...baseOptions,
-          confirmParams: { confirmation_token: lastConfirmationTokenId },
-        }
-      : {
-          ...baseOptions,
-          elements: elements,
-        };
-    const result =
-      await stripe[isSetupIntent ? "confirmSetup" : "confirmPayment"](
-        confirmOptions,
-      );
-
-    if (result.error) {
-      handleFormSubmissionError(result.error);
+    if (confirmError) {
+      handleFormSubmissionError(confirmError);
     } else {
       onConfirmationSuccess();
     }

--- a/src/ui/molecules/stripe-payment-elements.svelte
+++ b/src/ui/molecules/stripe-payment-elements.svelte
@@ -16,7 +16,10 @@
   import { translatorContextKey } from "../localization/constants";
   import { Translator } from "../localization/translator";
 
-  import { type GatewayParams } from "../../networking/responses/stripe-elements";
+  import {
+    type GatewayParams,
+    type StripeElementsConfiguration,
+  } from "../../networking/responses/stripe-elements";
   import { DEFAULT_FONT_FAMILY } from "../theme/text";
   import { StripeService } from "../../stripe/stripe-service";
   import { type Writable } from "svelte/store";
@@ -81,6 +84,17 @@
     } else {
       onConfirmationSuccess();
     }
+  }
+
+  export async function updateGatewayParams(
+    elementsConfiguration: StripeElementsConfiguration,
+  ) {
+    if (!stripe || !elements) return;
+
+    await StripeService.updateElementsConfiguration(
+      elements,
+      elementsConfiguration,
+    );
   }
 
   function handleFormSubmissionError(error: StripeError) {

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -33,6 +33,8 @@
   import PaymentButton from "../molecules/payment-button.svelte";
   import StripePaymentElements from "../molecules/stripe-payment-elements.svelte";
   import { type GatewayParams } from "../../networking/responses/stripe-elements";
+  import { type CheckoutCalculateTaxResponse } from "../../networking/responses/checkout-calculate-tax-response";
+  import { type StripeElementsConfiguration } from "../../networking/responses/stripe-elements";
 
   export let onContinue: (params?: ContinueHandlerParams) => void;
   export let gatewayParams: GatewayParams = {};
@@ -47,6 +49,9 @@
 
   let stripeSubmit: () => Promise<void>;
   let stripeConfirm: (clientSecret: string) => Promise<void>;
+  let updateStripeGatewayParams: (
+    elementsConfiguration: StripeElementsConfiguration,
+  ) => Promise<void>;
 
   let isPaymentInfoComplete = false;
   let isCalculatingTaxes = false;
@@ -99,6 +104,12 @@
       postalCode,
       taxCalculation,
     );
+
+    if (taxCalculation) {
+      updateStripeGatewayParams(
+        taxCalculation.gateway_params.elements_configuration,
+      );
+    }
     isCalculatingTaxes = false;
   }
 
@@ -180,6 +191,7 @@
         <StripePaymentElements
           bind:submit={stripeSubmit}
           bind:confirm={stripeConfirm}
+          bind:updateGatewayParams={updateStripeGatewayParams}
           bind:stripeLocale
           {gatewayParams}
           {brandingInfo}

--- a/src/ui/purchases-ui-inner.svelte
+++ b/src/ui/purchases-ui-inner.svelte
@@ -8,6 +8,7 @@
     type PriceBreakdown,
     type ContinueHandlerParams,
     type CurrentPage,
+    type TaxCustomerDetails,
   } from "./ui-types";
   import { type BrandingInfoResponse } from "../networking/responses/branding-response";
   import type { Product, PurchaseOption } from "../main";
@@ -32,6 +33,9 @@
   export let purchaseOperationHelper: PurchaseOperationHelper;
   export let isInElement: boolean = false;
   export let gatewayParams: GatewayParams;
+  export let onTaxCustomerDetailsUpdated: (
+    customerDetails: TaxCustomerDetails,
+  ) => void;
 </script>
 
 <Template {brandingInfo} {isInElement} {isSandbox} {onClose}>
@@ -64,6 +68,8 @@
         {brandingInfo}
         {purchaseOperationHelper}
         {gatewayParams}
+        {priceBreakdown}
+        {onTaxCustomerDetailsUpdated}
       />
     {/if}
 

--- a/src/ui/purchases-ui.svelte
+++ b/src/ui/purchases-ui.svelte
@@ -18,7 +18,11 @@
     englishLocale,
     translatorContextKey,
   } from "./localization/constants";
-  import { PriceBreakdown, type CurrentPage } from "./ui-types";
+  import {
+    type PriceBreakdown,
+    type TaxCustomerDetails,
+    type CurrentPage,
+  } from "./ui-types";
   import PurchasesUiInner from "./purchases-ui-inner.svelte";
   import { type ContinueHandlerParams } from "./ui-types";
   import { type IEventsTracker } from "../behavioural-events/events-tracker";
@@ -152,30 +156,7 @@
       })
       .then(async (result) => {
         if (priceBreakdown.taxCollectionEnabled) {
-          // TODO: Handle tax calculation errors including:
-          // - missing state
-          // - missing postal code
-          // - generic
-          // - unexpected error
-
-          const initialTaxCalculation =
-            await purchaseOperationHelper.checkoutCalculateTax();
-
-          priceBreakdown.status = "calculated";
-          priceBreakdown.totalAmountInMicros =
-            initialTaxCalculation.total_amount_in_micros;
-          priceBreakdown.taxAmountInMicros =
-            initialTaxCalculation.tax_amount_in_micros;
-          priceBreakdown.totalExcludingTaxInMicros =
-            initialTaxCalculation.total_excluding_tax_in_micros;
-          priceBreakdown.taxBreakdown =
-            initialTaxCalculation.pricing_phases.base.tax_breakdown;
-          priceBreakdown.pendingReason = null;
-
-          gatewayParams = {
-            ...gatewayParams,
-            ...initialTaxCalculation?.gateway_params,
-          };
+          await refreshTaxCalculation();
         }
         return result;
       })
@@ -223,6 +204,37 @@
     currentPage = "success";
   };
 
+  async function refreshTaxCalculation(
+    taxCustomerDetails: TaxCustomerDetails | undefined = undefined,
+  ) {
+    // TODO: Handle tax calculation errors including:
+    // - missing state
+    // - missing postal code
+    // - generic
+    // - unexpected error
+
+    priceBreakdown.taxCalculationStatus = "loading";
+
+    const taxCalculation = await purchaseOperationHelper.checkoutCalculateTax(
+      taxCustomerDetails?.countryCode,
+      taxCustomerDetails?.postalCode,
+    );
+
+    priceBreakdown.taxCalculationStatus = "calculated";
+    priceBreakdown.totalAmountInMicros = taxCalculation.total_amount_in_micros;
+    priceBreakdown.taxAmountInMicros = taxCalculation.tax_amount_in_micros;
+    priceBreakdown.totalExcludingTaxInMicros =
+      taxCalculation.total_excluding_tax_in_micros;
+    priceBreakdown.taxBreakdown =
+      taxCalculation.pricing_phases.base.tax_breakdown;
+    priceBreakdown.pendingReason = null;
+
+    gatewayParams.elements_configuration =
+      taxCalculation.gateway_params.elements_configuration;
+
+    console.debug("Tax calculation updated", taxCalculation);
+  }
+
   const handleError = (e: PurchaseFlowError) => {
     const event = createCheckoutFlowErrorEvent({
       errorCode: e.getErrorCode().toString(),
@@ -263,4 +275,5 @@
   {isInElement}
   {onClose}
   {priceBreakdown}
+  onTaxCustomerDetailsUpdated={refreshTaxCalculation}
 />

--- a/src/ui/purchases-ui.svelte
+++ b/src/ui/purchases-ui.svelte
@@ -231,8 +231,6 @@
 
     gatewayParams.elements_configuration =
       taxCalculation.gateway_params.elements_configuration;
-
-    console.debug("Tax calculation updated", taxCalculation);
   }
 
   const handleError = (e: PurchaseFlowError) => {

--- a/src/ui/purchases-ui.svelte
+++ b/src/ui/purchases-ui.svelte
@@ -64,7 +64,7 @@
     totalAmountInMicros: productDetails.currentPrice.amountMicros,
     totalExcludingTaxInMicros: productDetails.currentPrice.amountMicros,
     taxCollectionEnabled: false,
-    status: null,
+    taxCalculationStatus: null,
     pendingReason: null,
     taxAmountInMicros: null,
     taxBreakdown: null,
@@ -75,7 +75,7 @@
     brandingInfo?.gateway_tax_collection_enabled
   ) {
     priceBreakdown.taxCollectionEnabled = true;
-    priceBreakdown.status = "pending";
+    priceBreakdown.taxCalculationStatus = "pending";
   }
 
   // Setting the context for the Localized components
@@ -133,7 +133,7 @@
     }
 
     if (priceBreakdown.taxCollectionEnabled) {
-      priceBreakdown.status = "loading";
+      priceBreakdown.taxCalculationStatus = "loading";
     }
 
     purchaseOperationHelper

--- a/src/ui/ui-types.ts
+++ b/src/ui/ui-types.ts
@@ -26,7 +26,7 @@ export type PriceBreakdown = {
   totalAmountInMicros: number;
   taxCollectionEnabled: boolean;
   totalExcludingTaxInMicros: number;
-  status: TaxCalculationStatus | null;
+  taxCalculationStatus: TaxCalculationStatus | null;
   pendingReason: TaxCalculationPendingReason | null;
   taxAmountInMicros: number | null;
   taxBreakdown: TaxBreakdown[] | null;

--- a/src/ui/ui-types.ts
+++ b/src/ui/ui-types.ts
@@ -31,3 +31,8 @@ export type PriceBreakdown = {
   taxAmountInMicros: number | null;
   taxBreakdown: TaxBreakdown[] | null;
 };
+
+export type TaxCustomerDetails = {
+  countryCode: string | undefined;
+  postalCode: string | undefined;
+};


### PR DESCRIPTION
## Motivation / Description

This PR implements dynamic tax calculations based on customer location data collected from Stripe Payment Elements. The implementation allows for real-time tax updates as customers enter their billing information.

## Changes introduced

- Renamed `status` to `taxCalculationStatus` in the `PriceBreakdown` type to be more descriptive and avoid potential naming conflicts.
- Added tax customer details handling:
  - Created a new `TaxCustomerDetails` type to capture country code and postal code
  - Added `onTaxCustomerDetailsUpdated` callback to propagate customer location changes
- Enhanced Stripe integration:
  - Added `updateElementsConfiguration` method to update Stripe Elements configuration
  - Implemented `confirmIntent` method to handle both payment and setup intents
  - Added support for confirmation tokens to improve the payment flow
- Dynamic tax calculation:
  - Added real-time tax calculation when customer billing details change
  - Implemented loading states during tax calculation
  - Disabled payment button during tax calculation to prevent incorrect charges
- UI improvements:
  - Updated pricing table to reflect tax calculation status
  - Added proper handling of tax calculation states (`loading`, `pending`, `calculated`)

## Linear ticket

[WEB-2013](https://linear.app/revenuecat/issue/WEB-2014/%5Bwebsdk%5D-%5Bui%5D-re-calculate-taxes-every-time-the-billing-address-fields)

## Additional comments

Tax collection is still a work in progress and is currently behind a feature flag.
