### PR TITLE
This adds an API to set PlatformInfo information to be used by hybrids integrating the JS SDK

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -3295,6 +3295,78 @@
         },
         {
           "kind": "Interface",
+          "canonicalReference": "@revenuecat/purchases-js!PlatformInfo:interface",
+          "docComment": "/**\n * PlatformInfo is an interface that represents the information about the platform. Used by RevenueCat Hybrid SDKs to provide information about the platform.\n *\n * @public @experimental\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare interface PlatformInfo "
+            }
+          ],
+          "fileUrlPath": "dist/Purchases.es.d.ts",
+          "releaseTag": "Public",
+          "name": "PlatformInfo",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PlatformInfo#flavor:member",
+              "docComment": "/**\n * The flavor of the SDK.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly flavor: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "flavor",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PlatformInfo#version:member",
+              "docComment": "/**\n * The version of the hybrid SDK.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly version: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "version",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
+          "extendsTokenRanges": []
+        },
+        {
+          "kind": "Interface",
           "canonicalReference": "@revenuecat/purchases-js!PresentedOfferingContext:interface",
           "docComment": "/**\n * Contains data about the context in which an offering was presented.\n *\n * @public\n */\n",
           "excerptTokens": [
@@ -5401,6 +5473,55 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "setLogLevel"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@revenuecat/purchases-js!Purchases.setPlatformInfo:member(1)",
+              "docComment": "/**\n * Meant to be used by RevenueCat hybrids SDKS only.\n *\n * @experimental\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "static setPlatformInfo(platformInfo: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PlatformInfo",
+                  "canonicalReference": "@revenuecat/purchases-js!PlatformInfo:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": true,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "platformInfo",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "setPlatformInfo"
             }
           ],
           "implementsTokenRanges": []

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -243,6 +243,12 @@ export enum PeriodUnit {
 }
 
 // @public
+export interface PlatformInfo {
+    readonly flavor: string;
+    readonly version: string;
+}
+
+// @public
 export interface PresentedOfferingContext {
     readonly offeringIdentifier: string;
     readonly placementIdentifier: string | null;
@@ -341,6 +347,7 @@ export class Purchases {
     // @deprecated
     purchasePackage(rcPackage: Package, customerEmail?: string, htmlTarget?: HTMLElement): Promise<PurchaseResult>;
     static setLogLevel(logLevel: LogLevel): void;
+    static setPlatformInfo(platformInfo: PlatformInfo): void;
 }
 
 // @public

--- a/src/entities/platform-info.ts
+++ b/src/entities/platform-info.ts
@@ -1,0 +1,16 @@
+/**
+ * PlatformInfo is an interface that represents the information about the platform.
+ * Used by RevenueCat Hybrid SDKs to provide information about the platform.
+ * @public
+ * @experimental
+ */
+export interface PlatformInfo {
+  /**
+   * The flavor of the SDK.
+   */
+  readonly flavor: string;
+  /**
+   * The version of the hybrid SDK.
+   */
+  readonly version: string;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,6 +64,7 @@ import { SDKEventName } from "./behavioural-events/sdk-events";
 import { autoParseUTMParams } from "./helpers/utm-params";
 import { defaultFlagsConfig, type FlagsConfig } from "./entities/flags-config";
 import { generateUUID } from "./helpers/uuid-helper";
+import type { PlatformInfo } from "./entities/platform-info";
 
 export { ProductType } from "./entities/offerings";
 export type {
@@ -104,6 +105,7 @@ export type { PurchaseParams } from "./entities/purchase-params";
 export type { RedemptionInfo } from "./entities/redemption-info";
 export type { PurchaseResult } from "./entities/purchase-result";
 export type { BrandingAppearance } from "./entities/branding";
+export type { PlatformInfo } from "./entities/platform-info";
 
 const ANONYMOUS_PREFIX = "$RCAnonymousID:";
 
@@ -139,6 +141,9 @@ export class Purchases {
   private readonly eventsTracker: IEventsTracker;
 
   /** @internal */
+  private static _platformInfo: PlatformInfo | undefined = undefined;
+
+  /** @internal */
   private static instance: Purchases | undefined = undefined;
 
   /**
@@ -149,6 +154,19 @@ export class Purchases {
    */
   static setLogLevel(logLevel: LogLevel) {
     Logger.setLogLevel(logLevel);
+  }
+
+  /**
+   * Meant to be used by RevenueCat hybrids SDKS only.
+   * @experimental
+   * */
+  static setPlatformInfo(platformInfo: PlatformInfo) {
+    Purchases._platformInfo = platformInfo;
+  }
+
+  /** @internal */
+  static getPlatformInfo(): PlatformInfo | undefined {
+    return Purchases._platformInfo;
   }
 
   /**

--- a/src/networking/http-client.ts
+++ b/src/networking/http-client.ts
@@ -9,6 +9,7 @@ import { RC_ENDPOINT, VERSION } from "../helpers/constants";
 import { StatusCodes } from "http-status-codes";
 import { isSandboxApiKey } from "../helpers/api-key-helper";
 import type { HttpConfig } from "../entities/http-config";
+import { Purchases } from "../main";
 
 interface HttpRequestConfig<RequestBody> {
   apiKey: string;
@@ -106,6 +107,8 @@ const CONTENT_TYPE_HEADER = "Content-Type";
 const ACCEPT_HEADER = "Accept";
 const PLATFORM_HEADER = "X-Platform";
 const VERSION_HEADER = "X-Version";
+const FLAVOR_HEADER = "X-Platform-Flavor";
+const FLAVOR_VERSION_HEADER = "X-Platform-Flavor-Version";
 const IS_SANDBOX_HEADER = "X-Is-Sandbox";
 
 export const SDK_HEADERS = new Set([
@@ -115,6 +118,8 @@ export const SDK_HEADERS = new Set([
   PLATFORM_HEADER,
   VERSION_HEADER,
   IS_SANDBOX_HEADER,
+  FLAVOR_HEADER,
+  FLAVOR_VERSION_HEADER,
 ]);
 
 export function getHeaders(
@@ -130,6 +135,14 @@ export function getHeaders(
     [VERSION_HEADER]: VERSION,
     [IS_SANDBOX_HEADER]: `${isSandboxApiKey(apiKey)}`,
   };
+  const platformInfo = Purchases.getPlatformInfo();
+  if (platformInfo) {
+    const platform_info_headers = {
+      [FLAVOR_HEADER]: platformInfo.flavor,
+      [FLAVOR_VERSION_HEADER]: platformInfo.version,
+    };
+    all_headers = { ...all_headers, ...platform_info_headers };
+  }
   if (headers) {
     all_headers = { ...all_headers, ...headers };
   }


### PR DESCRIPTION
## Motivation / Description
We have some extra headers to identify when an SDK is used through a hybrid SDK. This allows the hybrid SDK to provide this information so we can get accurate data.

## Changes introduced

## Linear ticket (if any)

## Additional comments
