### PR TITLE
Fix PeriodUnit enum not being exported correctly

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -98,7 +98,8 @@ export {
   UninitializedPurchasesError,
 } from "./entities/errors";
 export type { PurchasesErrorExtra } from "./entities/errors";
-export type { Period, PeriodUnit } from "./helpers/duration-helper";
+export { PeriodUnit } from "./helpers/duration-helper";
+export type { Period } from "./helpers/duration-helper";
 export type { HttpConfig } from "./entities/http-config";
 export type { FlagsConfig } from "./entities/flags-config";
 export { LogLevel } from "./entities/log-level";


### PR DESCRIPTION
## Motivation / Description
We were not exporting the `PeriodUnit` enum correctly, which can cause issues in consumers if trying to use that type directly. For enums, we need to export the enum itself as well, not just the type.

## Changes introduced

## Linear ticket (if any)

## Additional comments
