### PR TITLE
[WEB-2398] Do not present taxes to customers in `not_collecting` jurisdictions (FF)

### DIFF
--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -182,6 +182,7 @@ export class PurchaseOperationHelper {
           countryCode,
           postalCode,
         );
+
       return {
         error: undefined,
         data: checkoutCalculateTaxResponse,

--- a/src/stories/fixtures.ts
+++ b/src/stories/fixtures.ts
@@ -300,6 +300,17 @@ export const priceBreakdownTaxDisabled: PriceBreakdown = {
   taxBreakdown: null,
 };
 
+export const priceBreakdownNotCollectingTax: PriceBreakdown = {
+  currency: "USD",
+  totalAmountInMicros: 9900000,
+  totalExcludingTaxInMicros: 9900000,
+  taxCollectionEnabled: true,
+  taxCalculationStatus: "calculated",
+  taxAmountInMicros: 0,
+  pendingReason: null,
+  taxBreakdown: [],
+};
+
 export const priceBreakdownTaxInclusive: PriceBreakdown = {
   ...priceBreakdownTaxDisabled,
   totalAmountInMicros: 1718000 + 8180000,

--- a/src/stories/fixtures.ts
+++ b/src/stories/fixtures.ts
@@ -193,16 +193,29 @@ export const checkoutCalculateTaxResponse: CheckoutCalculateTaxResponse = {
   operation_session_id: "operation-session-id",
   currency: "USD",
   tax_inclusive: false,
-  total_amount_in_micros: 9900000 + 2450000,
-  total_excluding_tax_in_micros: 9900000,
-  tax_amount_in_micros: 2450000,
+  total_amount_in_micros: 9990000 + 400000,
+  total_excluding_tax_in_micros: 9990000,
+  tax_amount_in_micros: 400000,
   pricing_phases: {
     base: {
-      tax_breakdown: [],
+      tax_breakdown: [
+        {
+          tax_type: "sales_tax",
+          tax_amount_in_micros: 400000,
+          tax_rate_in_micros: 40000,
+          country: "US",
+          state: "NY",
+          taxable_amount_in_micros: 9990000,
+          display_name: "Sales Tax - New York (4%)",
+        },
+      ],
     },
   },
   gateway_params: {
-    elements_configuration: stripeElementsConfiguration,
+    elements_configuration: {
+      ...stripeElementsConfiguration,
+      amount: 999 + 40,
+    },
   },
 };
 
@@ -281,7 +294,7 @@ export const priceBreakdownTaxDisabled: PriceBreakdown = {
   totalAmountInMicros: 9900000,
   totalExcludingTaxInMicros: 9900000,
   taxCollectionEnabled: false,
-  taxCalculationStatus: "calculated",
+  taxCalculationStatus: null,
   taxAmountInMicros: 0,
   pendingReason: null,
   taxBreakdown: null,

--- a/src/stories/molecules/pricing-table.stories.svelte
+++ b/src/stories/molecules/pricing-table.stories.svelte
@@ -8,6 +8,7 @@
   import { withNavbar } from "../decorators/with-navbar";
   import { brandingModes } from "../../../.storybook/modes";
   import {
+    priceBreakdownNotCollectingTax,
     priceBreakdownTaxDisabled,
     priceBreakdownTaxExclusive,
     priceBreakdownTaxExclusiveWithMultipleTaxItems,
@@ -45,6 +46,17 @@
 <Story
   name="Disabled Tax Trial"
   args={{
+    trialPhase: subscriptionOptionWithTrial.trial,
+  }}
+/>
+<Story
+  name="Not collecting tax"
+  args={{ priceBreakdown: priceBreakdownNotCollectingTax }}
+/>
+<Story
+  name="Not collecting tax Trial"
+  args={{
+    priceBreakdown: priceBreakdownNotCollectingTax,
     trialPhase: subscriptionOptionWithTrial.trial,
   }}
 />

--- a/src/ui/molecules/pricing-table.svelte
+++ b/src/ui/molecules/pricing-table.svelte
@@ -23,11 +23,17 @@
   }
 
   const translator: Writable<Translator> = getContext(translatorContextKey);
+
+  let showTaxBreakdown = $derived(
+    priceBreakdown.taxCollectionEnabled &&
+      priceBreakdown.taxBreakdown &&
+      priceBreakdown.taxBreakdown.length > 0,
+  );
 </script>
 
 {#snippet pricingTable()}
   <div class="rcb-pricing-table">
-    {#if priceBreakdown.taxCollectionEnabled}
+    {#if showTaxBreakdown}
       <div class="rcb-pricing-table-row">
         <div class="rcb-pricing-table-header">
           {$translator.translate(LocalizationKeys.PricingTotalExcludingTax)}
@@ -127,7 +133,7 @@
   </div>
 {/snippet}
 
-{#if priceBreakdown.taxCollectionEnabled}
+{#if showTaxBreakdown}
   <PricingDropdown>
     {@render pricingTable()}
   </PricingDropdown>

--- a/src/ui/purchases-ui.svelte
+++ b/src/ui/purchases-ui.svelte
@@ -214,6 +214,7 @@
       taxCustomerDetails?.countryCode,
       taxCustomerDetails?.postalCode,
     );
+
     if (taxCalculation.error) {
       switch (taxCalculation.error) {
         case TaxCalculationError.Pending:
@@ -238,18 +239,17 @@
       return;
     }
 
+    const { data } = taxCalculation;
     priceBreakdown.taxCalculationStatus = "calculated";
-    priceBreakdown.totalAmountInMicros =
-      taxCalculation.data.total_amount_in_micros;
-    priceBreakdown.taxAmountInMicros = taxCalculation.data.tax_amount_in_micros;
+    priceBreakdown.totalAmountInMicros = data.total_amount_in_micros;
+    priceBreakdown.taxAmountInMicros = data.tax_amount_in_micros;
     priceBreakdown.totalExcludingTaxInMicros =
-      taxCalculation.data.total_excluding_tax_in_micros;
-    priceBreakdown.taxBreakdown =
-      taxCalculation.data.pricing_phases.base.tax_breakdown;
+      data.total_excluding_tax_in_micros;
+    priceBreakdown.taxBreakdown = data.pricing_phases.base.tax_breakdown;
     priceBreakdown.pendingReason = null;
 
     gatewayParams.elements_configuration =
-      taxCalculation.data.gateway_params.elements_configuration;
+      data.gateway_params.elements_configuration;
   }
 
   const handleError = (e: PurchaseFlowError) => {


### PR DESCRIPTION
## Motivation / Description

The backend discards tax breakdown items from not-collecting jurisdictions. The SDK should omit the tax breakdown if the list of tax items is empty.

## Changes introduced

29068e4 - chore: Add tax collection disabled stories for the pricing table
b4cb62a - chore: Increase test coverage for the helper method `checkoutCalculateTax`
3332c87 - fix: Do not present taxes if `tax_breakdown` is empty

## Linear ticket (if any)

[WEB-2398](https://linear.app/revenuecat/issue/WEB-2398/[sdk]-do-not-present-taxes-to-customers-in-not-collecting)

## Additional comments
