### PR TITLE
chore: isolate tax calculation e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
       - run:
           name: Update ENV for E2E test
           command: |
-            echo 'export VITE_RC_API_KEY=${E2E_RC_API_KEY}; export VITE_RC_TAX_E2E_API_KEY=${E2E_RC_TAX_E2E_API_KEY}; export VITE_ALLOW_TAX_CALCULATION_FF=${E2E_ALLOW_TAX_CALCULATION}; export VITE_ALLOW_PAYWALLS_TESTS=${E2E_ALLOW_PAYWALLS_TESTS}' >> "$BASH_ENV"
+            echo 'export VITE_RC_API_KEY=${E2E_RC_API_KEY}; export VITE_RC_TAX_E2E_API_KEY=${E2E_RC_TAX_E2E_API_KEY}; export VITE_ALLOW_TAX_CALCULATION_FF=true; export VITE_ALLOW_PAYWALLS_TESTS=${E2E_ALLOW_PAYWALLS_TESTS}' >> "$BASH_ENV"
             source "$BASH_ENV"
       - install-dependencies
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
       - run:
           name: Update ENV for E2E test
           command: |
-            echo 'export VITE_RC_API_KEY=${E2E_RC_API_KEY}; export VITE_ALLOW_TAX_CALCULATION_FF=${E2E_ALLOW_TAX_CALCULATION}; export VITE_ALLOW_PAYWALLS_TESTS=${E2E_ALLOW_PAYWALLS_TESTS}' >> "$BASH_ENV"
+            echo 'export VITE_RC_API_KEY=${E2E_RC_API_KEY}; export VITE_RC_TAX_E2E_API_KEY=${E2E_RC_TAX_E2E_API_KEY}; export VITE_ALLOW_TAX_CALCULATION_FF=${E2E_ALLOW_TAX_CALCULATION}; export VITE_ALLOW_PAYWALLS_TESTS=${E2E_ALLOW_PAYWALLS_TESTS}' >> "$BASH_ENV"
             source "$BASH_ENV"
       - install-dependencies
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
       - run:
           name: Update ENV for E2E test
           command: |
-            echo 'export VITE_RC_API_KEY=${E2E_RC_API_KEY}; export VITE_RC_TAX_E2E_API_KEY=${E2E_RC_TAX_E2E_API_KEY}; export VITE_ALLOW_TAX_CALCULATION_FF=true; export VITE_ALLOW_PAYWALLS_TESTS=${E2E_ALLOW_PAYWALLS_TESTS}' >> "$BASH_ENV"
+            echo 'export VITE_RC_API_KEY=${E2E_RC_API_KEY}; export VITE_RC_TAX_E2E_API_KEY=${E2E_RC_TAX_E2E_API_KEY}; export VITE_ALLOW_TAX_CALCULATION_FF=${E2E_ALLOW_TAX_CALCULATION}; export VITE_ALLOW_PAYWALLS_TESTS=${E2E_ALLOW_PAYWALLS_TESTS}' >> "$BASH_ENV"
             source "$BASH_ENV"
       - install-dependencies
       - run:

--- a/examples/webbilling-demo/playwright.config.ts
+++ b/examples/webbilling-demo/playwright.config.ts
@@ -14,6 +14,11 @@ dotenv.config({
   path: resolve(__dirname, ".env"),
 });
 
+dotenv.config({
+  path: resolve(__dirname, ".env.local"),
+  override: true,
+});
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */

--- a/examples/webbilling-demo/src/tests/tax-calculation.test.ts
+++ b/examples/webbilling-demo/src/tests/tax-calculation.test.ts
@@ -10,10 +10,14 @@ import {
 
 const CARD_SELECTOR = "div.card";
 
+const TAXES_TEST_OFFERING_ID = "rcb_e2e_taxes";
+
 // Assuming there's a selector or some identifiable locator for the tax breakdown UI element
 const TAX_BREAKDOWN_ITEM_SELECTOR = ".rcb-pricing-table-row";
 const ALLOW_TAX_CALCULATION_FF =
   process.env.VITE_ALLOW_TAX_CALCULATION_FF === "true";
+
+const TAX_TEST_API_KEY = process.env.VITE_RC_TAX_E2E_API_KEY;
 
 test.describe("Tax calculation breakdown", () => {
   test.skip(
@@ -28,7 +32,14 @@ test.describe("Tax calculation breakdown", () => {
     const userId = getUserId(browserName);
 
     // Set up the page (standard user, location, default params)
-    const page = await setupTest(browser, userId);
+    const page = await setupTest(
+      browser,
+      userId,
+      {
+        offeringId: TAXES_TEST_OFFERING_ID,
+      },
+      TAX_TEST_API_KEY,
+    );
 
     // Select and make a purchase of the first available product card
     const cards = await getAllElementsByLocator(page, CARD_SELECTOR);
@@ -47,7 +58,14 @@ test.describe("Tax calculation breakdown", () => {
     const userId = getUserId(browserName);
 
     // Set up the page (standard user, location, default params)
-    const page = await setupTest(browser, userId);
+    const page = await setupTest(
+      browser,
+      userId,
+      {
+        offeringId: TAXES_TEST_OFFERING_ID,
+      },
+      TAX_TEST_API_KEY,
+    );
 
     // Select and make a purchase of the first available product card
     const cards = await getAllElementsByLocator(page, CARD_SELECTOR);
@@ -68,7 +86,14 @@ test.describe("Tax calculation breakdown", () => {
     const userId = getUserId(browserName);
 
     // Set up the page (standard user, location, default params)
-    const page = await setupTest(browser, userId);
+    const page = await setupTest(
+      browser,
+      userId,
+      {
+        offeringId: TAXES_TEST_OFFERING_ID,
+      },
+      TAX_TEST_API_KEY,
+    );
 
     // Select and make a purchase of the first available product card
     const cards = await getAllElementsByLocator(page, CARD_SELECTOR);
@@ -100,7 +125,14 @@ test.describe("Tax calculation breakdown", () => {
     const userId = getUserId(browserName);
 
     // Set up the page (standard user, location, default params)
-    const page = await setupTest(browser, userId);
+    const page = await setupTest(
+      browser,
+      userId,
+      {
+        offeringId: TAXES_TEST_OFFERING_ID,
+      },
+      TAX_TEST_API_KEY,
+    );
 
     // Select and make a purchase of the first available product card
     const cards = await getAllElementsByLocator(page, CARD_SELECTOR);
@@ -121,20 +153,17 @@ test.describe("Tax calculation breakdown", () => {
     await expect(
       priceBreakdownLines[0].getByText(/Total excluding tax/),
     ).toBeVisible();
-    await expect(priceBreakdownLines[0].getByText("$24.59")).toBeVisible();
+    await expect(priceBreakdownLines[0].getByText("$8.19")).toBeVisible();
 
     await expect(priceBreakdownLines[1].getByText(/VAT - Italy/)).toBeVisible();
-    await expect(priceBreakdownLines[1].getByText("$5.41")).toBeVisible();
-
-    await expect(page.getByText(/After trial ends/)).toBeVisible();
-    await expect(priceBreakdownLines[2].getByText("$30.00")).toBeVisible();
+    await expect(priceBreakdownLines[1].getByText("$1.80")).toBeVisible();
 
     const totalDueTodayLine = page.locator(
       `${TAX_BREAKDOWN_ITEM_SELECTOR}.rcb-header`,
     );
 
     await expect(totalDueTodayLine.getByText(/Total due today/)).toBeVisible();
-    await expect(totalDueTodayLine.getByText("$0")).toBeVisible();
+    await expect(totalDueTodayLine.getByText("$9.99")).toBeVisible();
   });
 
   test("should show error message when the postal code was not recognized", async ({
@@ -144,7 +173,14 @@ test.describe("Tax calculation breakdown", () => {
     const userId = getUserId(browserName);
 
     // Set up the page (standard user, location, default params)
-    const page = await setupTest(browser, userId);
+    const page = await setupTest(
+      browser,
+      userId,
+      {
+        offeringId: TAXES_TEST_OFFERING_ID,
+      },
+      TAX_TEST_API_KEY,
+    );
 
     // Select and make a purchase of the first available product card
     const cards = await getAllElementsByLocator(page, CARD_SELECTOR);

--- a/examples/webbilling-demo/src/tests/tax-calculation.test.ts
+++ b/examples/webbilling-demo/src/tests/tax-calculation.test.ts
@@ -118,6 +118,45 @@ test.describe("Tax calculation breakdown", () => {
     await expect(page.getByText("Total due today")).toBeVisible();
   });
 
+  test("should not display the tax breakdown if not collecting location is selected", async ({
+    browser,
+    browserName,
+  }) => {
+    const userId = getUserId(browserName);
+
+    // Set up the page (standard user, location, default params)
+    const page = await setupTest(
+      browser,
+      userId,
+      {
+        offeringId: TAXES_TEST_OFFERING_ID,
+      },
+      TAX_TEST_API_KEY,
+    );
+
+    // Select and make a purchase of the first available product card
+    const cards = await getAllElementsByLocator(page, CARD_SELECTOR);
+    const targetCard = cards[0];
+
+    // Perform a purchase action
+    await startPurchaseFlow(targetCard);
+    await enterEmailAndContinue(page, userId);
+
+    // Expecting the first calculation to be done.
+    await expect(page.getByText("Total excluding tax")).toBeVisible();
+    await expect(page.getByText(/Sales Tax - New York/)).not.toBeVisible();
+    await expect(page.getByText("Total due today")).toBeVisible();
+
+    await enterCreditCardDetails(page, "4242 4242 4242 4242", {
+      countryCode: "US",
+      postalCode: "33125", // Miami, FL
+    });
+
+    await expect(page.getByText("Total excluding tax")).not.toBeVisible();
+    await expect(page.getByText(/Sales Tax - New York/)).not.toBeVisible();
+    await expect(page.getByText("Total due today")).toBeVisible();
+  });
+
   test("product price and total should match for inclusive taxes", async ({
     browser,
     browserName,

--- a/examples/webbilling-demo/src/tests/utils.ts
+++ b/examples/webbilling-demo/src/tests/utils.ts
@@ -62,8 +62,12 @@ export async function setupTest(
     utm_content?: string;
     optOutOfAutoUTM?: boolean;
   },
+  apiKey?: string,
 ) {
   const page = await browser.newPage();
+  if (apiKey) {
+    await page.addInitScript(`window.__RC_API_KEY__ = "${apiKey}";`);
+  }
   await navigateToUrl(page, userId, queryString);
 
   return page;

--- a/examples/webbilling-demo/src/util/PurchasesLoader.ts
+++ b/examples/webbilling-demo/src/util/PurchasesLoader.ts
@@ -3,7 +3,13 @@ import { LogLevel, Purchases } from "@revenuecat/purchases-js";
 import type { LoaderFunction } from "react-router-dom";
 import { redirect, useLoaderData } from "react-router-dom";
 
-const apiKey = import.meta.env.VITE_RC_API_KEY as string;
+declare global {
+  interface Window {
+    __RC_API_KEY__?: string;
+  }
+}
+
+const apiKey = window.__RC_API_KEY__ || import.meta.env.VITE_RC_API_KEY;
 
 type IPurchasesLoaderData = {
   purchases: Purchases;


### PR DESCRIPTION
## Motivation / Description

Isolate tax calculation E2E tests to use a different Web App associated with a specific Stripe account for SDK E2E tests.

### Benefits:
 - The main Web App has the tax collection setting disabled. Therefore, if we reach the Stripe rate limit for test tax calculations, we can simply deactivate the tax-related tests without losing coverage in the rest of the test suite.
 - Tax calculation tests use non-renewing products; thus, no tax calculation occurs upon renewal, reducing the probability of exceeding the rate limit for calculations.

## Changes introduced

## Linear ticket (if any)

## Additional comments
