### PR TITLE
Fix shrinking issue in the section layout

### DIFF
--- a/src/ui/layout/section-layout.svelte
+++ b/src/ui/layout/section-layout.svelte
@@ -28,10 +28,7 @@
     flex: 1;
     display: flex;
     background-color: var(--rc-color-background);
-  }
-
-  .layout-wrapper-outer.rcb-navbar {
-    justify-content: flex-end;
+    justify-content: flex-start;
   }
 
   .layout-wrapper {


### PR DESCRIPTION
## Motivation / Description

The SectionLayout was shrinking in different ways for the navbar and the main content. This fixes this quirk. This only happens when the page is extremely shrinked.

Before
<img width="251" alt="Screenshot 2025-04-24 at 13 50 17" src="https://github.com/user-attachments/assets/1b71807a-3be2-4c72-ad15-097d683d8764" />

After
<img width="180" alt="Screenshot 2025-04-24 at 13 53 03" src="https://github.com/user-attachments/assets/eec407c6-b9e9-440a-b8cc-3a50bfb2266a" />
