### PR TITLE
[Draft][WEB-2510] Pass brandingAppearance to Buttons

### DIFF
--- a/src/stories/decorators/global-decorator.svelte
+++ b/src/stories/decorators/global-decorator.svelte
@@ -4,6 +4,9 @@
   import { eventsTrackerContextKey } from "../../ui/constants";
   import { setContext, type Snippet } from "svelte";
   import { writable, type Writable } from "svelte/store";
+  import { brandingInfos } from "../fixtures";
+  import { brandingContextKey } from "../../ui/constants";
+  import type { BrandingAppearance } from "../../entities/branding";
 </script>
 
 <script lang="ts">
@@ -12,6 +15,7 @@
     globals: {
       locale: string;
       viewport: string;
+      brandingName: string;
     };
   }
 
@@ -21,7 +25,12 @@
   const initiaLocale = globals.locale || "en";
   const translator = new Translator({}, initiaLocale, initiaLocale);
   const translatorStore: Writable<Translator> = writable(translator);
+  const brandingInfo = brandingInfos[globals.brandingName];
+  const brandingAppearanceStore: Writable<BrandingAppearance | null> = writable(
+    brandingInfo.appearance,
+  );
 
+  setContext(brandingContextKey, brandingAppearanceStore);
   setContext(translatorContextKey, translatorStore);
   setContext(eventsTrackerContextKey, { trackSDKEvent: () => {} });
 
@@ -29,6 +38,9 @@
     const newLocale = globals.locale;
     const newTranslator = new Translator({}, newLocale, newLocale);
     translatorStore.set(newTranslator);
+
+    const brandingInfo = brandingInfos[globals.brandingName];
+    brandingAppearanceStore.set(brandingInfo.appearance);
   });
 </script>
 

--- a/src/ui/constants.ts
+++ b/src/ui/constants.ts
@@ -1,1 +1,2 @@
 export const eventsTrackerContextKey = "rcb-ui-events-tracker";
+export const brandingContextKey = "branding";

--- a/src/ui/layout/message-layout.svelte
+++ b/src/ui/layout/message-layout.svelte
@@ -4,13 +4,23 @@
   import ModalSection from "./modal-section.svelte";
   import RowLayout from "./row-layout.svelte";
   import Typography from "../atoms/typography.svelte";
+  import { getContext } from "svelte";
+  import { brandingContextKey } from "../constants";
+  import type { BrandingAppearance } from "../../entities/branding";
+  import { type Writable } from "svelte/store";
 
-  export let onDismiss: () => void;
-  export let title: string | null = null;
-  export let type: string;
-  export let closeButtonTitle: string = "Go back to app";
-  export let icon: (() => any) | null = null;
-  export let message;
+  let {
+    onDismiss,
+    title = null,
+    type,
+    closeButtonTitle = "Go back to app",
+    icon = null,
+    message,
+  } = $props();
+
+  const brandingAppearanceStore =
+    getContext<Writable<BrandingAppearance>>(brandingContextKey);
+  const brandingAppearance = $derived($brandingAppearanceStore);
 
   function handleClick() {
     onDismiss();
@@ -45,7 +55,9 @@
   </div>
   <div class="message-layout-footer">
     <ModalFooter>
-      <Button onclick={handleClick} type="submit">{closeButtonTitle}</Button>
+      <Button onclick={handleClick} type="submit" {brandingAppearance}
+        >{closeButtonTitle}</Button
+      >
     </ModalFooter>
   </div>
 </div>

--- a/src/ui/molecules/payment-button.svelte
+++ b/src/ui/molecules/payment-button.svelte
@@ -8,6 +8,8 @@
   import { Translator } from "../localization/translator";
   import { translatorContextKey } from "../../ui/localization/constants";
   import { getContext } from "svelte";
+  import { brandingContextKey } from "../constants";
+  import type { BrandingAppearance } from "../../entities/branding";
 
   type Props = {
     disabled: boolean;
@@ -24,6 +26,10 @@
   }: Props = $props();
 
   const translator: Writable<Translator> = getContext(translatorContextKey);
+
+  const brandingAppearanceStore =
+    getContext<Writable<BrandingAppearance>>(brandingContextKey);
+  const brandingAppearance = $derived($brandingAppearanceStore);
 
   function paymentMethodDisplayName(
     method: string | undefined,
@@ -52,7 +58,7 @@
   );
 </script>
 
-<Button {disabled} testId="PayButton">
+<Button {disabled} testId="PayButton" {brandingAppearance}>
   {#if subscriptionOption?.trial}
     <Localized key={LocalizationKeys.PaymentEntryPageButtonStartTrial} />
   {:else if formattedPrice && paymentMethod}

--- a/src/ui/purchases-ui.svelte
+++ b/src/ui/purchases-ui.svelte
@@ -23,7 +23,7 @@
   import { type CurrentPage } from "./ui-types";
   import PurchasesUiInner from "./purchases-ui-inner.svelte";
   import { type IEventsTracker } from "../behavioural-events/events-tracker";
-  import { eventsTrackerContextKey } from "./constants";
+  import { eventsTrackerContextKey, brandingContextKey } from "./constants";
   import { createCheckoutFlowErrorEvent } from "../behavioural-events/sdk-event-helpers";
   import type { PurchaseMetadata } from "../entities/offerings";
   import { writable } from "svelte/store";
@@ -91,6 +91,7 @@
   );
   var translatorStore = writable(translator);
   setContext(translatorContextKey, translatorStore);
+  setContext(brandingContextKey, brandingInfo?.appearance);
 
   onMount(() => {
     if (!isInElement) {


### PR DESCRIPTION
## Motivation / Description

Undetermined if we'll actually proceed with this, but there is an issue with regards to fallback styles with our web component approach.

In the Svelte App (SDK), we don't currently pass brandingAppearance - styles are inherited through the theme set at the top level and the UI Library Button Component just consumes these.

In the React App, since we render in the shadow DOM, we need to pass the brandingAppearance to create the styles via the Theme class. But if brandingAppearance is empty, it will need to create default styles. However if we do that, then when it's empty for the Svelte App then default styles will always be applied.

Solution A: Add an "isSvelte/isReact" prop

I worry about this being a bit of a red flag, I don't want every shared component to have a bunch of conditionals if possible

Solution B: Enforce always passing brandingAppearance, even in the Svelte App

This is awkward in terms of prop drilling and overall migration effort - but maybe sets a clearer differentiation of the library and enforces the brandingAppearance API?

This PR is a proposal/spike for solution B.

## Changes introduced

## Linear ticket (if any)

## Additional comments
