### PR TITLE
[WEB-2451] Simplify Tax Calculation Error Handling

### DIFF
--- a/src/entities/errors.ts
+++ b/src/entities/errors.ts
@@ -153,7 +153,6 @@ export class ErrorCodeUtils {
       case BackendErrorCode.BackendInvalidAppleSubscriptionKey:
       case BackendErrorCode.BackendBadRequest:
       case BackendErrorCode.BackendInternalServerError:
-      case BackendErrorCode.BackendTaxCalculationRequiresPostalCode:
         return ErrorCode.UnexpectedBackendResponseError;
       case BackendErrorCode.BackendProductIDsMalformed:
         return ErrorCode.UnsupportedError;
@@ -161,13 +160,6 @@ export class ErrorCodeUtils {
       case BackendErrorCode.BackendNoMXRecordsFound:
       case BackendErrorCode.BackendEmailIsRequired:
         return ErrorCode.InvalidEmailError;
-
-      // These error codes should never be exposed to developers, as they are handled internally within the purchase flow.
-      // We map them to UnknownError because a mapping is required.
-      case BackendErrorCode.BackendTaxLocationCannotBeDetermined:
-      case BackendErrorCode.BackendInvalidTaxLocation:
-      case BackendErrorCode.BackendTaxCollectionNotEnabled:
-        return ErrorCode.UnknownError;
     }
   }
 
@@ -229,10 +221,6 @@ export enum BackendErrorCode {
   BackendInvalidOperationSession = 7877,
   BackendPurchaseCannotBeCompleted = 7878,
   BackendEmailIsRequired = 7879,
-  BackendTaxCollectionNotEnabled = 7886,
-  BackendTaxCalculationRequiresPostalCode = 7887,
-  BackendTaxLocationCannotBeDetermined = 7896,
-  BackendInvalidTaxLocation = 7897,
   BackendGatewaySetupErrorStripeTaxNotActive = 7898,
   BackendGatewaySetupErrorInvalidTaxOriginAddress = 7899,
   BackendGatewaySetupErrorMissingRequiredPermission = 7900,

--- a/src/networking/responses/checkout-calculate-tax-response.ts
+++ b/src/networking/responses/checkout-calculate-tax-response.ts
@@ -1,13 +1,8 @@
 import type { StripeElementsConfiguration } from "./stripe-elements";
 
 export interface TaxBreakdown {
-  taxable_amount_in_micros: number;
   tax_amount_in_micros: number;
   display_name: string;
-  tax_rate_in_micros: number | null;
-  country: string | null;
-  state: string | null;
-  tax_type: string | null;
 }
 
 export interface CheckoutCalculateTaxResponse {
@@ -16,7 +11,6 @@ export interface CheckoutCalculateTaxResponse {
   total_amount_in_micros: number;
   tax_amount_in_micros: number;
   total_excluding_tax_in_micros: number;
-  tax_inclusive: boolean;
   pricing_phases: {
     base: {
       tax_breakdown: TaxBreakdown[];

--- a/src/networking/responses/checkout-calculate-tax-response.ts
+++ b/src/networking/responses/checkout-calculate-tax-response.ts
@@ -5,6 +5,17 @@ export interface TaxBreakdown {
   display_name: string;
 }
 
+// TODO: Not all codes are needed, only 'invalid_tax_location'
+export enum CheckoutCalculateTaxFailedReason {
+  tax_collection_disabled = "tax_collection_disabled",
+  invalid_tax_location = "invalid_tax_location",
+  rate_limit_exceeded = "rate_limit_exceeded",
+  missing_required_permission = "missing_required_permission",
+  invalid_origin_address = "invalid_origin_address",
+  taxes_not_active = "taxes_not_active",
+  unexpected_gateway_error = "unexpected_gateway_error",
+}
+
 export interface CheckoutCalculateTaxResponse {
   operation_session_id: string;
   currency: string;
@@ -19,4 +30,5 @@ export interface CheckoutCalculateTaxResponse {
   gateway_params: {
     elements_configuration: StripeElementsConfiguration;
   };
+  failed_reason?: CheckoutCalculateTaxFailedReason;
 }

--- a/src/stories/fixtures.ts
+++ b/src/stories/fixtures.ts
@@ -192,7 +192,6 @@ export const checkoutStartResponse: CheckoutStartResponse = {
 export const checkoutCalculateTaxResponse: CheckoutCalculateTaxResponse = {
   operation_session_id: "operation-session-id",
   currency: "USD",
-  tax_inclusive: false,
   total_amount_in_micros: 9990000 + 400000,
   total_excluding_tax_in_micros: 9990000,
   tax_amount_in_micros: 400000,
@@ -200,12 +199,7 @@ export const checkoutCalculateTaxResponse: CheckoutCalculateTaxResponse = {
     base: {
       tax_breakdown: [
         {
-          tax_type: "sales_tax",
           tax_amount_in_micros: 400000,
-          tax_rate_in_micros: 40000,
-          country: "US",
-          state: "NY",
-          taxable_amount_in_micros: 9990000,
           display_name: "Sales Tax - New York (4%)",
         },
       ],
@@ -317,12 +311,7 @@ export const priceBreakdownTaxInclusive: PriceBreakdown = {
   taxCalculationStatus: "calculated",
   taxBreakdown: [
     {
-      tax_type: "VAT",
       tax_amount_in_micros: 1718000,
-      tax_rate_in_micros: 210000,
-      country: "ES",
-      state: null,
-      taxable_amount_in_micros: 8180000,
       display_name: "VAT - Spain (21%)",
     },
   ],
@@ -336,12 +325,7 @@ export const priceBreakdownTaxExclusive: PriceBreakdown = {
   taxCalculationStatus: "calculated",
   taxBreakdown: [
     {
-      tax_type: "tax_rate",
       tax_amount_in_micros: 693000,
-      tax_rate_in_micros: 70000,
-      country: "USA",
-      state: "NY",
-      taxable_amount_in_micros: 9900000,
       display_name: "Tax Rate - NY (7%)",
     },
   ],
@@ -368,21 +352,11 @@ export const priceBreakdownTaxExclusiveWithMultipleTaxItems: PriceBreakdown = {
   taxCalculationStatus: "calculated",
   taxBreakdown: [
     {
-      tax_type: "GST",
       tax_amount_in_micros: 495000,
-      tax_rate_in_micros: 50000,
-      country: "CA",
-      state: null,
-      taxable_amount_in_micros: 9900000,
       display_name: "GST - Canada (5%)",
     },
     {
-      tax_type: "QST",
       tax_amount_in_micros: 987525,
-      tax_rate_in_micros: 99750,
-      country: "CA",
-      state: "ON",
-      taxable_amount_in_micros: 9900000,
       display_name: "QST - Ontario (9.975%)",
     },
   ],

--- a/src/tests/helpers/purchase-operation-helper.test.ts
+++ b/src/tests/helpers/purchase-operation-helper.test.ts
@@ -209,24 +209,27 @@ describe("PurchaseOperationHelper", () => {
     );
 
     const result = await purchaseOperationHelper.checkoutCalculateTax();
-    expect(result.error).toBeUndefined();
-    expect(result.data).toEqual(checkoutCalculateTaxResponse);
+    expect(result).toEqual(checkoutCalculateTaxResponse);
   });
 
-  test("checkoutCalculateTax returns pending error when tax location cannot be determined", async () => {
+  test("checkoutCalculateTax returns failed tax calculation error", async () => {
     setCheckoutStartResponse(
       HttpResponse.json(checkoutStartResponse, {
         status: StatusCodes.OK,
       }),
     );
-    setCheckoutCalculateTaxResponse(
-      HttpResponse.json(
-        {
-          code: BackendErrorCode.BackendTaxLocationCannotBeDetermined,
-          message: "Tax location cannot be determined",
+    const checkoutCalculateTaxResponse = {
+      failed_reason: "invalid_tax_location",
+      pricing_phases: {
+        base: {
+          tax_breakdown: [],
         },
-        { status: StatusCodes.BAD_REQUEST },
-      ),
+      },
+    };
+    setCheckoutCalculateTaxResponse(
+      HttpResponse.json(checkoutCalculateTaxResponse, {
+        status: StatusCodes.OK,
+      }),
     );
 
     await purchaseOperationHelper.checkoutStart(
@@ -241,74 +244,7 @@ describe("PurchaseOperationHelper", () => {
     );
 
     const result = await purchaseOperationHelper.checkoutCalculateTax();
-    expect(result.error).toBe("pending");
-    expect(result.data).toBeUndefined();
-  });
-
-  test("checkoutCalculateTax returns invalid location error when tax location is invalid", async () => {
-    setCheckoutStartResponse(
-      HttpResponse.json(checkoutStartResponse, {
-        status: StatusCodes.OK,
-      }),
-    );
-    setCheckoutCalculateTaxResponse(
-      HttpResponse.json(
-        {
-          code: BackendErrorCode.BackendInvalidTaxLocation,
-          message: "Invalid tax location",
-        },
-        { status: StatusCodes.BAD_REQUEST },
-      ),
-    );
-
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
-        offeringIdentifier: "test-offering-id",
-        targetingContext: null,
-        placementIdentifier: null,
-      },
-    );
-
-    const result = await purchaseOperationHelper.checkoutCalculateTax();
-    expect(result.error).toBe("invalid_location");
-    expect(result.data).toBeUndefined();
-  });
-
-  test("checkoutCalculateTax returns disabled error in production mode for unexpected backend errors", async () => {
-    vi.spyOn(backend, "getIsSandbox").mockReturnValue(false);
-
-    setCheckoutStartResponse(
-      HttpResponse.json(checkoutStartResponse, {
-        status: StatusCodes.OK,
-      }),
-    );
-    setCheckoutCalculateTaxResponse(
-      HttpResponse.json(
-        {
-          code: 9999,
-          message: "Unexpected backend error",
-        },
-        { status: StatusCodes.BAD_REQUEST },
-      ),
-    );
-
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
-        offeringIdentifier: "test-offering-id",
-        targetingContext: null,
-        placementIdentifier: null,
-      },
-    );
-
-    const result = await purchaseOperationHelper.checkoutCalculateTax();
-    expect(result.error).toBe("disabled");
-    expect(result.data).toBeUndefined();
+    expect(result).toEqual(checkoutCalculateTaxResponse);
   });
 
   test("checkoutCalculateTax throws error in production mode for sandbox mode only error", async () => {
@@ -350,8 +286,8 @@ describe("PurchaseOperationHelper", () => {
     );
   });
 
-  test("checkoutCalculateTax throws error in sandbox mode for unexpected backend errors", async () => {
-    vi.spyOn(backend, "getIsSandbox").mockReturnValue(true);
+  test("checkoutCalculateTax throws error for unexpected backend errors", async () => {
+    vi.spyOn(backend, "getIsSandbox").mockReturnValue(false);
 
     setCheckoutStartResponse(
       HttpResponse.json(checkoutStartResponse, {
@@ -385,43 +321,6 @@ describe("PurchaseOperationHelper", () => {
         PurchaseFlowErrorCode.ErrorSettingUpPurchase,
         "Unknown backend error.",
         'Request: postCheckoutCalculateTax. Status code: 400. Body: {"code":9999,"message":"Unexpected backend error"}.',
-      ),
-    );
-  });
-
-  test("checkoutCalculateTax throws error for unknown backend error", async () => {
-    setCheckoutStartResponse(
-      HttpResponse.json(checkoutStartResponse, {
-        status: StatusCodes.OK,
-      }),
-    );
-    setCheckoutCalculateTaxResponse(
-      HttpResponse.json(
-        {
-          code: 9999,
-          message: "Unknown error",
-        },
-        { status: StatusCodes.INTERNAL_SERVER_ERROR },
-      ),
-    );
-
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
-        offeringIdentifier: "test-offering-id",
-        targetingContext: null,
-        placementIdentifier: null,
-      },
-    );
-
-    await expectPromiseToPurchaseFlowError(
-      purchaseOperationHelper.checkoutCalculateTax(),
-      new PurchaseFlowError(
-        PurchaseFlowErrorCode.ErrorSettingUpPurchase,
-        "Unknown backend error.",
-        'Request: postCheckoutCalculateTax. Status code: 500. Body: {"code":9999,"message":"Unknown error"}.',
       ),
     );
   });
@@ -479,8 +378,7 @@ describe("PurchaseOperationHelper", () => {
     );
 
     const result = await purchaseOperationHelper.checkoutCalculateTax();
-    expect(result.error).toBeUndefined();
-    expect(result.data).toEqual(checkoutCalculateTaxResponse);
+    expect(result).toEqual(checkoutCalculateTaxResponse);
   });
 
   test("checkoutComplete fails if checkoutStart not called before", async () => {

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -14,7 +14,6 @@
     PurchaseFlowError,
     PurchaseFlowErrorCode,
     PurchaseOperationHelper,
-    TaxCalculationError,
   } from "../../helpers/purchase-operation-helper";
   import type {
     PriceBreakdown,
@@ -37,7 +36,10 @@
     GatewayParams,
   } from "../../networking/responses/stripe-elements";
   import { ALLOW_TAX_CALCULATION_FF } from "../../helpers/constants";
-  import type { TaxBreakdown } from "../../networking/responses/checkout-calculate-tax-response";
+  import {
+    CheckoutCalculateTaxFailedReason,
+    type TaxBreakdown,
+  } from "../../networking/responses/checkout-calculate-tax-response";
   import type { Stripe, StripeElements } from "@stripe/stripe-js";
   import {
     StripeService,
@@ -176,38 +178,31 @@
       .then((taxCalculation) => {
         signal?.throwIfAborted();
 
-        if (taxCalculation.error) {
-          switch (taxCalculation.error) {
-            case TaxCalculationError.Pending:
-              taxCalculationStatus = "pending";
-              pendingReason = null;
-              break;
-            case TaxCalculationError.Disabled:
-              taxCalculationStatus = "disabled";
-              pendingReason = null;
-              break;
-            case TaxCalculationError.InvalidLocation:
-              taxCalculationStatus = "pending";
-              pendingReason = "invalid_postal_code";
-              break;
-            default:
-              throw new PurchaseFlowError(
-                PurchaseFlowErrorCode.ErrorSettingUpPurchase,
-                "Unknown error without state set.",
-              );
+        if (taxCalculation.failed_reason) {
+          const isInitialCalculation = !taxCustomerDetails;
+          if (
+            isInitialCalculation &&
+            CheckoutCalculateTaxFailedReason.invalid_tax_location
+          ) {
+            taxCalculationStatus = "pending";
+            pendingReason = null;
+          } else {
+            taxCalculationStatus = "disabled";
+            pendingReason = null;
           }
         } else {
-          const { data } = taxCalculation;
-
           taxCalculationStatus = "calculated";
-          taxAmountInMicros = data.tax_amount_in_micros;
-          totalExcludingTaxInMicros = data.total_excluding_tax_in_micros;
-          totalAmountInMicros = data.total_amount_in_micros;
-          taxBreakdown = data.pricing_phases.base.tax_breakdown;
           pendingReason = null;
-
-          elementsConfiguration = data.gateway_params.elements_configuration;
         }
+
+        taxAmountInMicros = taxCalculation.tax_amount_in_micros;
+        totalExcludingTaxInMicros =
+          taxCalculation.total_excluding_tax_in_micros;
+        totalAmountInMicros = taxCalculation.total_amount_in_micros;
+        taxBreakdown = taxCalculation.pricing_phases.base.tax_breakdown;
+
+        elementsConfiguration =
+          taxCalculation.gateway_params.elements_configuration;
 
         lastTaxCustomerDetails = taxCustomerDetails;
         onPriceBreakdownUpdated(priceBreakdown);


### PR DESCRIPTION
## Motivation / Description
Refactors the tax calculation system to simplify error handling by removing the nested error/data pattern and consolidating error states into a single response structure.

## Changes introduced
- Removes `TaxCalculationResult` type in favor of direct `CheckoutCalculateTaxResponse`
- Introduces `CheckoutCalculateTaxFailedReason` enum for clearer error states
- Simplifies tax breakdown interface by removing unused fields
- Updates payment entry page to handle new error response structure
- Removes redundant error handling paths in the purchase operation helper

## Linear ticket (if any)
[WEB-2451: \[SDK\] If an unexpected tax calculation error occurs, show the price without taxes and allow the purchase to go through](https://linear.app/revenuecat/issue/WEB-2451/sdk-if-an-unexpected-tax-calculation-error-occurs-show-the-price)

## Additional comments
