### PR TITLE
Prioritize apple_pay in payment list if available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@revenuecat/purchases-js",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@revenuecat/purchases-js",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.16.0",

--- a/src/stripe/stripe-service.ts
+++ b/src/stripe/stripe-service.ts
@@ -230,6 +230,7 @@ export class StripeService {
       business: appName ? { name: appName } : undefined,
       layout: {
         type: "tabs",
+        defaultCollapsed: true,
       },
       paymentMethodOrder: ["apple_pay", "google_pay"],
       terms: {

--- a/src/stripe/stripe-service.ts
+++ b/src/stripe/stripe-service.ts
@@ -231,6 +231,7 @@ export class StripeService {
       layout: {
         type: "tabs",
       },
+      paymentMethodOrder: ["apple_pay", "google_pay"],
       terms: {
         applePay: "never",
         auBecsDebit: "never",

--- a/src/tests/stripe/stripe-service.test.ts
+++ b/src/tests/stripe/stripe-service.test.ts
@@ -259,6 +259,7 @@ describe("StripeService", () => {
         business: { name: "Test App" },
         layout: {
           type: "tabs",
+          defaultCollapsed: true,
         },
         paymentMethodOrder: ["apple_pay", "google_pay"],
         terms: {
@@ -287,6 +288,7 @@ describe("StripeService", () => {
       expect(mockElements.create).toHaveBeenCalledWith("payment", {
         layout: {
           type: "tabs",
+          defaultCollapsed: true,
         },
         paymentMethodOrder: ["apple_pay", "google_pay"],
         terms: expect.any(Object),

--- a/src/tests/stripe/stripe-service.test.ts
+++ b/src/tests/stripe/stripe-service.test.ts
@@ -260,6 +260,7 @@ describe("StripeService", () => {
         layout: {
           type: "tabs",
         },
+        paymentMethodOrder: ["apple_pay", "google_pay"],
         terms: {
           applePay: "never",
           auBecsDebit: "never",
@@ -287,6 +288,7 @@ describe("StripeService", () => {
         layout: {
           type: "tabs",
         },
+        paymentMethodOrder: ["apple_pay", "google_pay"],
         terms: expect.any(Object),
       });
     });

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -234,7 +234,18 @@
   }) {
     selectedPaymentMethod = paymentMethod;
     isPaymentInfoComplete = complete;
-    await refreshTaxes();
+
+    const isWallet =
+      paymentMethod === "apple_pay" || paymentMethod === "google_pay";
+
+    if (isEmailComplete && isPaymentInfoComplete && isWallet) {
+      // Since a calculation for taxes is triggered and
+      // matching totals are checked in the handleSubmit
+      // we do not have to refresh taxes beforehand.
+      handleSubmit(new Event("submit"));
+    } else {
+      await refreshTaxes();
+    }
   }
 
   async function handleSubmit(e: Event): Promise<void> {

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -234,18 +234,7 @@
   }) {
     selectedPaymentMethod = paymentMethod;
     isPaymentInfoComplete = complete;
-
-    const isWallet =
-      paymentMethod === "apple_pay" || paymentMethod === "google_pay";
-
-    if (isEmailComplete && isPaymentInfoComplete && isWallet) {
-      // Since a calculation for taxes is triggered and
-      // matching totals are checked in the handleSubmit
-      // we do not have to refresh taxes beforehand.
-      handleSubmit(new Event("submit"));
-    } else {
-      await refreshTaxes();
-    }
+    await refreshTaxes();
   }
 
   async function handleSubmit(e: Event): Promise<void> {


### PR DESCRIPTION
## Motivation / Description

This update prioritizes `apple_pay` and `google_pay` in the list of payment methods. This only has an effect if a wallet is is supported and displayed to the current viewer. Also updates the `defaultCollapsed` to `true` so that the `card` payment method does not get pre-selected and expanded when a wallet is available.