### PR TITLE
Fixed modal errors appearing below the form on mobile

### DIFF
--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -1,4 +1,4 @@
-<script module>
+<script module lang="ts">
   import { getContext, onDestroy, onMount } from "svelte";
   import type { Product, PurchaseOption } from "../../entities/offerings";
   import { type BrandingInfoResponse } from "../../networking/responses/branding-response";
@@ -47,6 +47,7 @@
   } from "../../stripe/stripe-service";
   import StripeElementsComponent from "../molecules/stripe-elements.svelte";
   import PriceUpdateInfo from "../molecules/price-update-info.svelte";
+
   interface Props {
     gatewayParams: GatewayParams;
     processing: boolean;
@@ -490,7 +491,7 @@
     class="rc-checkout-form"
     class:hidden={isStripeLoading || processing}
   >
-    <div class="rc-checkout-form-container" hidden={!!modalErrorMessage}>
+    <div class="rc-checkout-form-container" class:hidden={!!modalErrorMessage}>
       <div class="rc-elements-container">
         <StripeElementsComponent
           bind:stripe
@@ -585,6 +586,11 @@
 
   .hidden {
     visibility: hidden;
+  }
+
+  .rc-checkout-form-container.hidden {
+    display: none;
+    height: 0;
   }
 
   @container layout-query-container (width <= 767px) {


### PR DESCRIPTION
## Motivation / Description
On mobile, for modal errors, the error was appearing below the form and the form was not disappearing.

## Before/After video
https://github.com/user-attachments/assets/14083035-6edb-4163-87ec-c8fa3da88a58

It still works also on desktop
https://github.com/user-attachments/assets/6b53839a-dfad-42b1-bece-f120d3367b9f


## Changes introduced
* Added display:none and height:0 to hide the rc-checkout-form-container since is a display:flex element and it would keep the height otherwise.
* Fixed the class addition in svelte using class:hidden

## Linear ticket (if any)

## Additional comments
