### PR TITLE
Pass operation_session_id property to all events when available

### DIFF
--- a/src/tests/behavioral-events/events-tracker.test.ts
+++ b/src/tests/behavioral-events/events-tracker.test.ts
@@ -154,6 +154,31 @@ describe("EventsTracker", (test) => {
     );
   });
 
+  test<EventsTrackerFixtures>("passes the operation session id to the event", async ({
+    eventsTracker,
+  }) => {
+    eventsTracker.updateOperationSessionId("operationSessionId");
+    eventsTracker.trackExternalEvent({
+      eventName: "external",
+      source: "sdk",
+    });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(APIPostRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        json: expect.objectContaining({
+          events: expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                operation_session_id: "operationSessionId",
+              }),
+            }),
+          ]),
+        }),
+      }),
+    );
+  });
+
   test<EventsTrackerFixtures>("retries tracking events exponentially", async ({
     eventsTracker,
   }) => {

--- a/src/tests/helpers/purchase-operation-helper.test.ts
+++ b/src/tests/helpers/purchase-operation-helper.test.ts
@@ -42,6 +42,7 @@ describe("PurchaseOperationHelper", () => {
     const eventsTrackerMock: IEventsTracker = {
       getTraceId: () => testTraceId,
       updateUser: () => Promise.resolve(),
+      updateOperationSessionId: () => Promise.resolve(),
       trackSDKEvent: () => {},
       trackExternalEvent: () => {},
       dispose: () => {},

--- a/src/tests/mocks/events-tracker-mock-provider.ts
+++ b/src/tests/mocks/events-tracker-mock-provider.ts
@@ -4,6 +4,7 @@ import { vi } from "vitest";
 export function createEventsTrackerMock() {
   return {
     updateUser: vi.fn(),
+    updateOperationSessionId: vi.fn(),
     trackSDKEvent: vi.fn(),
     trackExternalEvent: vi.fn(),
     dispose: vi.fn(),

--- a/src/ui/purchases-ui.svelte
+++ b/src/ui/purchases-ui.svelte
@@ -133,6 +133,7 @@
       .then((result) => {
         lastError = null;
         currentPage = "payment-entry";
+        eventsTracker.updateOperationSessionId(result.operation_session_id);
         gatewayParams = result.gateway_params;
       })
       .catch((e: PurchaseFlowError) => {
@@ -169,6 +170,7 @@
           currentPage = "success";
           redemptionInfo = pollResult.redemptionInfo;
           operationSessionId = pollResult.operationSessionId;
+          eventsTracker.updateOperationSessionId(operationSessionId);
         })
         .catch((error: PurchaseFlowError) => {
           handleError(error);


### PR DESCRIPTION
## Motivation / Description

Depends on https://github.com/RevenueCat/khepri/pull/12875

Adds property `operation_session_id` to all events when available.