### PR TITLE
Track rcSource

### DIFF
--- a/src/behavioural-events/events-tracker.ts
+++ b/src/behavioural-events/events-tracker.ts
@@ -24,6 +24,7 @@ export interface TrackEventProps {
 export interface EventsTrackerProps {
   apiKey: string;
   appUserId: string;
+  rcSource: string | null;
   silent?: boolean;
 }
 
@@ -47,12 +48,14 @@ export default class EventsTracker implements IEventsTracker {
   private readonly traceId: string = uuid();
   private appUserId: string;
   private readonly isSilent: boolean;
+  private rcSource: string | null;
 
   constructor(props: EventsTrackerProps) {
     this.apiKey = props.apiKey;
     this.eventsUrl = `${RC_ANALYTICS_ENDPOINT}/v1/events`;
     this.appUserId = props.appUserId;
     this.isSilent = props.silent || false;
+    this.rcSource = props.rcSource;
     this.flushManager = new FlushManager(
       MIN_INTERVAL_RETRY,
       MAX_INTERVAL_RETRY,
@@ -87,7 +90,7 @@ export default class EventsTracker implements IEventsTracker {
         eventName: props.eventName,
         traceId: this.traceId,
         appUserId: this.appUserId,
-        context: buildEventContext(props.source),
+        context: buildEventContext(props.source, this.rcSource),
         properties: props.properties || {},
       });
       this.eventsQueue.push(event);

--- a/src/behavioural-events/sdk-event-context.ts
+++ b/src/behavioural-events/sdk-event-context.ts
@@ -19,11 +19,13 @@ export interface SDKEventContext {
   pageReferrer: string;
   pageUrl: string;
   pageTitle: string;
-  source: SDKEventContextSource;
+  source: SDKEventContextSource; // Describes where the event was triggered from
+  rcSource: string | null; // Describes where the purchase was originated
 }
 
 export function buildEventContext(
   source: SDKEventContextSource,
+  rcSource: string | null,
 ): SDKEventContext & EventContext {
   const urlParams = new URLSearchParams(window.location.search);
 
@@ -44,5 +46,6 @@ export function buildEventContext(
     pageUrl: `${window.location.origin}${window.location.pathname}`,
     pageTitle: document.title,
     source: source,
+    rcSource: rcSource,
   };
 }

--- a/src/entities/flags-config.ts
+++ b/src/entities/flags-config.ts
@@ -14,6 +14,14 @@ export interface FlagsConfig {
    * @defaultValue true
    */
   collectAnalyticsEvents?: boolean;
+
+  /**
+   * Describes the platform that originated the purchase.
+   * This does not technically belong here but since the public Purchase configuration
+   * does not use objects, it is the easiest way to pass this internal parameter.
+   * @internal
+   */
+  rcSource?: string;
 }
 
 export const defaultFlagsConfig: FlagsConfig = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -286,6 +286,7 @@ export class Purchases {
       apiKey: this._API_KEY,
       appUserId: this._appUserId,
       silent: !this._flags.collectAnalyticsEvents,
+      rcSource: this._flags.rcSource ?? null,
     });
     this.backend = new Backend(this._API_KEY, httpConfig);
     this.purchaseOperationHelper = new PurchaseOperationHelper(

--- a/src/tests/base.purchases_test.ts
+++ b/src/tests/base.purchases_test.ts
@@ -6,6 +6,7 @@ import {
   getRequestHandlers,
 } from "./test-responses";
 import { afterAll, beforeAll, beforeEach } from "vitest";
+import { defaultHttpConfig } from "../entities/http-config";
 
 export const testApiKey = "rcb_test_api_key";
 export const testUserId = "someAppUserId";
@@ -27,5 +28,7 @@ beforeEach(() => {
 afterAll(() => server.close());
 
 export function configurePurchases(appUserId: string = testUserId): Purchases {
-  return Purchases.configure(testApiKey, appUserId);
+  return Purchases.configure(testApiKey, appUserId, defaultHttpConfig, {
+    rcSource: "rcSource",
+  });
 }

--- a/src/tests/behavioral-events/sdk-event-context.test.ts
+++ b/src/tests/behavioral-events/sdk-event-context.test.ts
@@ -51,7 +51,7 @@ describe("buildEventContext", () => {
   });
 
   it("should build the correct event context", () => {
-    const context = buildEventContext("sdk");
+    const context = buildEventContext("sdk", "rcSource");
 
     expect(context).toEqual({
       libraryName: "purchases-js",
@@ -70,6 +70,7 @@ describe("buildEventContext", () => {
       pageUrl: "https://example.com/home",
       pageTitle: "Example Page",
       source: "sdk",
+      rcSource: "rcSource",
     });
   });
 });

--- a/src/tests/purchase.events.test.ts
+++ b/src/tests/purchase.events.test.ts
@@ -20,7 +20,10 @@ describe("Purchases.configure()", () => {
   beforeEach(async () => {
     vi.spyOn(Logger, "debugLog").mockImplementation(() => undefined);
     vi.mock("../behavioural-events/sdk-event-context", () => ({
-      buildEventContext: vi.fn().mockReturnValue({}),
+      buildEventContext: vi.fn((source, rcSource) => ({
+        source,
+        rc_source: rcSource,
+      })),
     }));
     vi.useFakeTimers();
     vi.setSystemTime(date);
@@ -45,7 +48,10 @@ describe("Purchases.configure()", () => {
             event_name: "sdk_initialized",
             timestamp_ms: date.getTime(),
             app_user_id: "someAppUserId",
-            context: {},
+            context: {
+              source: "sdk",
+              rc_source: "rcSource",
+            },
             properties: {
               trace_id: "c1365463-ce59-4b83-b61b-ef0d883e9047",
             },
@@ -76,7 +82,10 @@ describe("Purchases.configure()", () => {
             event_name: "checkout_session_start",
             timestamp_ms: date.getTime(),
             app_user_id: "someAppUserId",
-            context: {},
+            context: {
+              source: "sdk",
+              rc_source: "rcSource",
+            },
             properties: {
               trace_id: "c1365463-ce59-4b83-b61b-ef0d883e9047",
               customer_email_provided_by_developer: false,
@@ -128,7 +137,10 @@ describe("Purchases.configure()", () => {
             event_name: "checkout_session_end",
             timestamp_ms: date.getTime(),
             app_user_id: "someAppUserId",
-            context: {},
+            context: {
+              source: "sdk",
+              rc_source: "rcSource",
+            },
             properties: {
               trace_id: "c1365463-ce59-4b83-b61b-ef0d883e9047",
               outcome: "finished",
@@ -172,7 +184,10 @@ describe("Purchases.configure()", () => {
             event_name: "checkout_session_end",
             timestamp_ms: date.getTime(),
             app_user_id: "someAppUserId",
-            context: {},
+            context: {
+              source: "sdk",
+              rc_source: "rcSource",
+            },
             properties: {
               trace_id: "c1365463-ce59-4b83-b61b-ef0d883e9047",
               outcome: "closed",
@@ -217,7 +232,10 @@ describe("Purchases.configure()", () => {
             event_name: "checkout_session_end",
             timestamp_ms: date.getTime(),
             app_user_id: "someAppUserId",
-            context: {},
+            context: {
+              source: "sdk",
+              rc_source: "rcSource",
+            },
             properties: {
               trace_id: "c1365463-ce59-4b83-b61b-ef0d883e9047",
               outcome: "errored",


### PR DESCRIPTION
## Motivation / Description

Adds tracking for `rcSource`. Passes it via an @internal flag option in order to avoid adding new parameters to public signatures.

Merge after deploying https://github.com/RevenueCat/khepri/pull/12881