### PR TITLE
Support branded fonts in typography

### DIFF
--- a/src/networking/responses/branding-response.ts
+++ b/src/networking/responses/branding-response.ts
@@ -1,3 +1,4 @@
+import type { BrandFontConfig } from "src/ui/theme/text";
 import type { BrandingAppearance } from "../../entities/branding";
 
 export type BrandingInfoResponse = {
@@ -10,4 +11,5 @@ export type BrandingInfoResponse = {
   app_name: string | null;
   support_email?: string | null;
   gateway_tax_collection_enabled: boolean;
+  brand_font_config: BrandFontConfig | null;
 };

--- a/src/stories/atoms/typography.stories.svelte
+++ b/src/stories/atoms/typography.stories.svelte
@@ -113,6 +113,12 @@
   </Typography>
 </Story>
 
+<Story name="Branded">
+  <Typography size="heading-xl" branded>
+    Branded - {baseContent}
+  </Typography>
+</Story>
+
 <!-- Story showing all variants -->
 <Story name="All Variants">
   <div class="story-container">
@@ -174,6 +180,12 @@
       <div class="variant-name">caption-link</div>
       <Typography size="caption-link">
         Caption Link - {baseContent}
+      </Typography>
+    </div>
+    <div class="variant-row">
+      <div class="variant-name">Brand Custom Font</div>
+      <Typography size="heading-xl" branded>
+        Brand Custom Font - {baseContent}
       </Typography>
     </div>
   </div>

--- a/src/stories/fixtures.ts
+++ b/src/stories/fixtures.ts
@@ -158,6 +158,7 @@ export const brandingInfo: BrandingInfoResponse = {
   app_wordmark_webp: null,
   appearance: null,
   gateway_tax_collection_enabled: false,
+  brand_font_config: null,
 };
 
 export const purchaseFlowError = new PurchaseFlowError(1);
@@ -252,6 +253,7 @@ export const brandingInfos: Record<string, BrandingInfoResponse> = {
       show_product_description: true,
     },
     gateway_tax_collection_enabled: false,
+    brand_font_config: null,
   },
   Igify: {
     id: "app7e12a2a4b3",
@@ -273,6 +275,7 @@ export const brandingInfos: Record<string, BrandingInfoResponse> = {
       show_product_description: true,
     },
     gateway_tax_collection_enabled: false,
+    brand_font_config: null,
   },
   Dipsea: {
     id: "appd458f1e3a2",
@@ -294,6 +297,11 @@ export const brandingInfos: Record<string, BrandingInfoResponse> = {
       show_product_description: false,
     },
     gateway_tax_collection_enabled: false,
+    brand_font_config: {
+      font_url: "QueensCondensed-Light.ttf",
+      mobile: { font_weight: 300, font_size: "28px" },
+      desktop: { font_weight: 300, font_size: "36px" },
+    },
   },
 };
 

--- a/src/ui/atoms/typography.svelte
+++ b/src/ui/atoms/typography.svelte
@@ -16,14 +16,19 @@
   type Props = {
     size?: Size;
     children?: Snippet;
+    branded?: boolean;
   };
 </script>
 
 <script lang="ts">
-  const { children, size = "body-base" }: Props = $props();
+  const { children, size = "body-base", branded = false }: Props = $props();
 </script>
 
-<span class="rcb-typography rcb-typography-{size}">
+<span
+  class="rcb-typography rcb-typography-{size} {branded
+    ? 'rcb-typography-branded'
+    : ''}"
+>
   {@render children?.()}
 </span>
 
@@ -38,9 +43,17 @@
     font: var(--rc-text-heading2xl-mobile);
   }
 
+  .rcb-typography-heading-2xl.rcb-typography-branded {
+    font: var(--rc-text-heading2xl-branded-mobile);
+  }
+
   /* svelte-ignore css-unused-selector */
   .rcb-typography-heading-xl {
     font: var(--rc-text-headingXl-mobile);
+  }
+
+  .rcb-typography-heading-xl.rcb-typography-branded {
+    font: var(--rc-text-headingXl-branded-mobile);
   }
 
   /* svelte-ignore css-unused-selector */
@@ -48,9 +61,17 @@
     font: var(--rc-text-headingLg-mobile);
   }
 
+  .rcb-typography-heading-lg.rcb-typography-branded {
+    font: var(--rc-text-headingLg-branded-mobile);
+  }
+
   /* svelte-ignore css-unused-selector */
   .rcb-typography-heading-md {
     font: var(--rc-text-headingMd-mobile);
+  }
+
+  .rcb-typography-heading-md.rcb-typography-branded {
+    font: var(--rc-text-headingMd-branded-mobile);
   }
 
   /* svelte-ignore css-unused-selector */
@@ -58,9 +79,17 @@
     font: var(--rc-text-bodyBase-mobile);
   }
 
+  .rcb-typography-body-base.rcb-typography-branded {
+    font: var(--rc-text-bodyBase-branded-mobile);
+  }
+
   /* svelte-ignore css-unused-selector */
   .rcb-typography-body-small {
     font: var(--rc-text-bodySmall-mobile);
+  }
+
+  .rcb-typography-body-small.rcb-typography-branded {
+    font: var(--rc-text-bodySmall-branded-mobile);
   }
 
   /* svelte-ignore css-unused-selector */
@@ -68,9 +97,17 @@
     font: var(--rc-text-labelButton-mobile);
   }
 
+  .rcb-typography-label-button.rcb-typography-branded {
+    font: var(--rc-text-labelButton-branded-mobile);
+  }
+
   /* svelte-ignore css-unused-selector */
   .rcb-typography-label-default {
     font: var(--rc-text-labelDefault-mobile);
+  }
+
+  .rcb-typography-label-default.rcb-typography-branded {
+    font: var(--rc-text-labelDefault-branded-mobile);
   }
 
   /* svelte-ignore css-unused-selector */
@@ -78,15 +115,31 @@
     font: var(--rc-text-captionDefault-mobile);
   }
 
+  .rcb-typography-caption-default.rcb-typography-branded {
+    font: var(--rc-text-captionDefault-branded-mobile);
+  }
+
   /* svelte-ignore css-unused-selector */
   .rcb-typography-caption-link {
     font: var(--rc-text-captionLink-mobile);
   }
 
+  .rcb-typography-caption-link.rcb-typography-branded {
+    font: var(--rc-text-captionLink-branded-mobile);
+  }
+
   @container layout-query-container (width >= 768px) {
+    span.rcb-typography-branded {
+      font: var(--rc-text-brandedText-font-style-desktop);
+    }
+
     /* svelte-ignore css-unused-selector */
     .rcb-typography-heading-2xl {
       font: var(--rc-text-heading2xl-desktop);
+    }
+
+    .rcb-typography-heading-2xl.rcb-typography-branded {
+      font: var(--rc-text-heading2xl-branded-desktop);
     }
 
     /* svelte-ignore css-unused-selector */
@@ -94,9 +147,17 @@
       font: var(--rc-text-headingXl-desktop);
     }
 
+    .rcb-typography-heading-xl.rcb-typography-branded {
+      font: var(--rc-text-headingXl-branded-desktop);
+    }
+
     /* svelte-ignore css-unused-selector */
     .rcb-typography-heading-lg {
       font: var(--rc-text-headingLg-desktop);
+    }
+
+    .rcb-typography-heading-lg.rcb-typography-branded {
+      font: var(--rc-text-headingLg-branded-desktop);
     }
 
     /* svelte-ignore css-unused-selector */
@@ -104,9 +165,17 @@
       font: var(--rc-text-headingMd-desktop);
     }
 
+    .rcb-typography-heading-md.rcb-typography-branded {
+      font: var(--rc-text-headingMd-branded-desktop);
+    }
+
     /* svelte-ignore css-unused-selector */
     .rcb-typography-body-base {
       font: var(--rc-text-bodyBase-desktop);
+    }
+
+    .rcb-typography-body-base.rcb-typography-branded {
+      font: var(--rc-text-bodyBase-branded-desktop);
     }
 
     /* svelte-ignore css-unused-selector */
@@ -114,9 +183,17 @@
       font: var(--rc-text-bodySmall-desktop);
     }
 
+    .rcb-typography-body-small.rcb-typography-branded {
+      font: var(--rc-text-bodySmall-branded-desktop);
+    }
+
     /* svelte-ignore css-unused-selector */
     .rcb-typography-label-button {
       font: var(--rc-text-labelButton-desktop);
+    }
+
+    .rcb-typography-label-button.rcb-typography-branded {
+      font: var(--rc-text-labelButton-branded-desktop);
     }
 
     /* svelte-ignore css-unused-selector */
@@ -124,14 +201,26 @@
       font: var(--rc-text-labelDefault-desktop);
     }
 
+    .rcb-typography-label-default.rcb-typography-branded {
+      font: var(--rc-text-labelDefault-branded-desktop);
+    }
+
     /* svelte-ignore css-unused-selector */
     .rcb-typography-caption-default {
       font: var(--rc-text-captionDefault-desktop);
     }
 
+    .rcb-typography-caption-default.rcb-typography-branded {
+      font: var(--rc-text-captionDefault-branded-desktop);
+    }
+
     /* svelte-ignore css-unused-selector */
     .rcb-typography-caption-link {
       font: var(--rc-text-captionLink-desktop);
+    }
+
+    .rcb-typography-caption-link.rcb-typography-branded {
+      font: var(--rc-text-captionLink-branded-desktop);
     }
   }
 </style>

--- a/src/ui/layout/template.svelte
+++ b/src/ui/layout/template.svelte
@@ -31,7 +31,11 @@
   );
 </script>
 
-<Container brandingAppearance={brandingInfo?.appearance} {isInElement}>
+<Container
+  brandingAppearance={brandingInfo?.appearance}
+  brandFontConfig={brandingInfo?.brand_font_config}
+  {isInElement}
+>
   {#if isSandbox}
     <SandboxBanner style={colorVariables} {isInElement} />
   {/if}

--- a/src/ui/molecules/product-header.svelte
+++ b/src/ui/molecules/product-header.svelte
@@ -23,7 +23,7 @@
     </div>
   {/if}
   <div class="rcb-product-title">
-    <Typography size="heading-lg">
+    <Typography size="heading-lg" branded>
       <Localized
         key={LocalizationKeys.ProductInfoProductTitle}
         variables={{ productTitle: productDetails.title }}

--- a/src/ui/theme/text.ts
+++ b/src/ui/theme/text.ts
@@ -10,6 +10,12 @@ export interface TextStyle {
   letterSpacing?: string;
 }
 
+export interface BrandFontConfig {
+  font_url: string;
+  mobile: { font_weight: number; font_size: string };
+  desktop: { font_weight: number; font_size: string };
+}
+
 export type ScreenType = "mobile" | "desktop";
 
 export type ScreenTextStyle = Record<TextStyleKey, TextStyle>;
@@ -36,6 +42,9 @@ export type TextStyles = Record<
 
 export const DEFAULT_FONT_FAMILY =
   "-apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif";
+
+export const BRANDED_FONT_NAME = "BrandCustomFont";
+export const BRANDED_FONT_FAMILY = `${BRANDED_FONT_NAME}, ${DEFAULT_FONT_FAMILY}`;
 
 const FONT_WEIGHTS = {
   regular: "400",

--- a/src/ui/theme/theme.ts
+++ b/src/ui/theme/theme.ts
@@ -8,6 +8,7 @@ import {
 } from "./utils";
 import type { Shape } from "./shapes";
 import type { Colors } from "./colors";
+import type { BrandFontConfig } from "./text";
 import { DEFAULT_TEXT_STYLES } from "./text";
 import { DEFAULT_SPACING } from "./spacing";
 import type { BrandingAppearance } from "../../entities/branding";
@@ -47,8 +48,8 @@ export class Theme {
     return DEFAULT_TEXT_STYLES;
   }
 
-  get textStyleVars() {
-    return toTextStyleVar("text", this.textStyles);
+  getTextStyleVars(brand_font_config: BrandFontConfig | null | undefined) {
+    return toTextStyleVar("text", this.textStyles, brand_font_config);
   }
 
   get spacingStyleVars() {

--- a/src/ui/theme/utils.ts
+++ b/src/ui/theme/utils.ts
@@ -12,7 +12,13 @@ import {
   RoundedShape,
   type Shape,
 } from "./shapes";
-import { DEFAULT_FONT_FAMILY, type TextStyles } from "./text";
+
+import type { BrandFontConfig } from "./text";
+import {
+  BRANDED_FONT_FAMILY,
+  DEFAULT_FONT_FAMILY,
+  type TextStyles,
+} from "./text";
 import type { Spacing } from "./spacing";
 import type { BrandingAppearance } from "../../entities/branding";
 
@@ -301,15 +307,29 @@ export const toFormStyleVar = (appearance?: BrandingAppearance | null) => {
 /**
  * Convert text styles into CSS variables for both desktop and mobile.
  */
-export const toTextStyleVar = (prefix: string = "", textStyles: TextStyles) =>
-  Object.entries(textStyles)
-    .flatMap(([key, { desktop, mobile }]) => [
-      `--rc-${prefix}-${key}-desktop: normal normal ${desktop.fontWeight} ${desktop.fontSize}/${desktop.lineHeight} ${DEFAULT_FONT_FAMILY}`,
-      `--rc-${prefix}-${key}-mobile: normal normal ${mobile.fontWeight} ${mobile.fontSize}/${mobile.lineHeight} ${DEFAULT_FONT_FAMILY}`,
-      `--rc-${prefix}-${key}-desktop-font-size: ${desktop.fontSize}`,
-      `--rc-${prefix}-${key}-mobile-font-size: ${mobile.fontSize}`,
-    ])
+export const toTextStyleVar = (
+  prefix: string = "",
+  textStyles: TextStyles,
+  brand_font_config: BrandFontConfig | null | undefined,
+) => {
+  return Object.entries(textStyles)
+    .flatMap(([key, { desktop, mobile }]) => {
+      const desktopFontStyle = `normal normal ${desktop.fontWeight} ${desktop.fontSize}/${desktop.lineHeight} ${DEFAULT_FONT_FAMILY}`;
+      const mobileFontStyle = `normal normal ${mobile.fontWeight} ${mobile.fontSize}/${mobile.lineHeight} ${DEFAULT_FONT_FAMILY}`;
+      const brandedDesktopFontStyle = `normal normal ${brand_font_config?.desktop.font_weight} ${brand_font_config?.desktop.font_size} ${BRANDED_FONT_FAMILY}`;
+      const brandedMobileFontStyle = `normal normal ${brand_font_config?.mobile.font_weight} ${brand_font_config?.mobile.font_size} ${BRANDED_FONT_FAMILY}`;
+
+      return [
+        `--rc-${prefix}-${key}-desktop: ${desktopFontStyle}`,
+        `--rc-${prefix}-${key}-mobile: ${mobileFontStyle}`,
+        `--rc-${prefix}-${key}-branded-desktop: ${brand_font_config ? brandedDesktopFontStyle : desktopFontStyle}`,
+        `--rc-${prefix}-${key}-branded-mobile: ${brand_font_config ? brandedMobileFontStyle : mobileFontStyle}`,
+        `--rc-${prefix}-${key}-desktop-font-size: ${desktop.fontSize}`,
+        `--rc-${prefix}-${key}-mobile-font-size: ${mobile.fontSize}`,
+      ];
+    })
     .join("; ");
+};
 
 /**
  * Generates CSS variables for the spacing system.


### PR DESCRIPTION
## Motivation / Description
Typography accepts a new prop "branded" that will make the text use the font provided in brandFontURL in the /branding request.

## Changes introduced
- When brandFrontURL is non null, load the fontFace
- Define new css variables for the font family of branded texts. We need to return the non branded version by default if brand config is not available
- Typography uses that css variable when "branded" prop is passed 

## Linear ticket (if any)

## Additional comments
