### PR TITLE
Simplify 'Already Subscribed'

### DIFF
--- a/src/ui/pages/error-page.svelte
+++ b/src/ui/pages/error-page.svelte
@@ -105,25 +105,28 @@
   }
 </script>
 
-<MessageLayout
-  title={getTranslatedErrorTitle()}
-  {onDismiss}
-  type="error"
-  closeButtonTitle={$translator.translate(LocalizationKeys.ErrorButtonTryAgain)}
->
-  {#snippet icon()}
-    <IconError />
-  {/snippet}
+{#if error.errorCode === PurchaseFlowErrorCode.AlreadyPurchasedError}
+  <MessageLayout title={getTranslatedErrorTitle()} {onDismiss} type="error">
+    {#snippet message()}
+      {getTranslatedErrorMessage()}
+    {/snippet}
+  </MessageLayout>
+{:else}
+  <MessageLayout title={getTranslatedErrorTitle()} {onDismiss} type="error">
+    {#snippet icon()}
+      <IconError />
+    {/snippet}
 
-  {#snippet message()}
-    {getTranslatedErrorMessage()}
-    {#if supportEmail}
-      <br />
-      <Localized key={LocalizationKeys.ErrorPageIfErrorPersists} />
-      <a href="mailto:{supportEmail}">{supportEmail}</a>.
-    {/if}
-  {/snippet}
-</MessageLayout>
+    {#snippet message()}
+      {getTranslatedErrorMessage()}
+      {#if supportEmail}
+        <br />
+        <Localized key={LocalizationKeys.ErrorPageIfErrorPersists} />
+        <a href="mailto:{supportEmail}">{supportEmail}</a>.
+      {/if}
+    {/snippet}
+  </MessageLayout>
+{/if}
 
 <style>
   a {


### PR DESCRIPTION
## Motivation / Description

The "already purchased" error page, should not show "try again" messaging and shouldn't show a "X" error icon.

Not working from a design, just sharing a first pass to prompt conversation :)

Before:
<img width="1728" alt="Screenshot 2025-05-07 at 08 41 29" src="https://github.com/user-attachments/assets/91c21b4b-fa7d-4808-85b2-43ce95aa72ad" />


After:
<img width="1728" alt="Screenshot 2025-05-07 at 08 41 54" src="https://github.com/user-attachments/assets/776a706d-1a42-4b88-bbd6-cbd26bc2c742" />


The spacing looks a little off, but matches similar cases e.g confirmation:

<img width="1727" alt="Screenshot 2025-05-07 at 08 43 22" src="https://github.com/user-attachments/assets/f03a80a7-d095-4389-a213-8a12b378184c" />

