### PR TITLE
Fix flakey Email Deliverability test

### DIFF
--- a/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
+++ b/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
@@ -157,7 +157,7 @@ export async function enterCreditCardDetails(
   const expiration = cardInfo?.expiration || `01 / ${expirationYear}`;
   const securityCode = cardInfo?.securityCode || "123";
 
-  await page.waitForSelector("button[data-testid='PayButton']");
+  page.locator("button[data-testid='PayButton']").waitFor();
   const checkoutTitle = page.getByText("Secure Checkout");
 
   await expect(checkoutTitle).toBeVisible();
@@ -182,10 +182,10 @@ export async function enterCreditCardDetails(
 }
 
 export async function clickPayButton(page: Page) {
-  await page.waitForTimeout(100);
-  const button = await page.waitForSelector(
+  const button = page.locator(
     "button[data-testid='PayButton']:not([disabled])",
   );
+  await button.waitFor();
   await button.click();
 }
 
@@ -237,8 +237,6 @@ export async function confirmStripeEmailFieldVisible(page: Page) {
 }
 
 export async function confirmPayButtonDisabled(page: Page) {
-  const button = await page.waitForSelector(
-    "button[data-testid='PayButton'][disabled]",
-  );
-  await expect(button).toBeDefined();
+  const button = page.locator("button[data-testid='PayButton'][disabled]");
+  await expect(button).toBeVisible();
 }

--- a/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
+++ b/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
@@ -182,7 +182,7 @@ export async function enterCreditCardDetails(
 }
 
 export async function clickPayButton(page: Page) {
-  //await page.waitForTimeout(100);
+  await page.waitForTimeout(100);
   const button = await page.waitForSelector(
     "button[data-testid='PayButton']:not([disabled])",
   );

--- a/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
+++ b/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
@@ -182,6 +182,7 @@ export async function enterCreditCardDetails(
 }
 
 export async function clickPayButton(page: Page) {
+  //await page.waitForTimeout(100);
   const button = await page.waitForSelector(
     "button[data-testid='PayButton']:not([disabled])",
   );

--- a/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
+++ b/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
@@ -99,26 +99,26 @@ export async function navigateToLandingUrl(
 }
 
 async function getAllElementsByLocator(
-  page: Page,
-  locator: string,
+  locator: Locator,
   containsText?: string,
 ) {
-  await page.waitForSelector(locator);
-  let locatorResult = page.locator(locator);
+  // Wait for at least one element to be visible
+  await expect(locator.first()).toBeVisible();
+
   if (containsText !== undefined) {
-    locatorResult = locatorResult.filter({ hasText: containsText });
+    locator = locator.filter({ hasText: containsText });
   }
-  return await locatorResult.all();
+  return await locator.all();
 }
 
 export const getPackageCards = (page: Page, text?: string) =>
-  getAllElementsByLocator(page, CARD_SELECTOR, text);
+  getAllElementsByLocator(page.locator(CARD_SELECTOR), text);
 
 export const getPaywallPackageCards = (page: Page, text?: string) =>
-  getAllElementsByLocator(page, PACKAGE_SELECTOR, text);
+  getAllElementsByLocator(page.locator(PACKAGE_SELECTOR), text);
 
 export const getPaywallPurchaseButtons = (page: Page) =>
-  getAllElementsByLocator(page, "button.rc-pw-purchase-button");
+  getAllElementsByLocator(page.locator("button.rc-pw-purchase-button"));
 
 export const getStripePaymentFrame = (page: Page) =>
   page.frameLocator(


### PR DESCRIPTION
## Motivation / Description

Fix flakey email deliverability test, failing run example: https://app.circleci.com/pipelines/github/RevenueCat/purchases-js/2602/workflows/c8106d2f-4ae8-4f78-8453-c77ac06034f6/jobs/7812
This is [blocking another PR](https://github.com/RevenueCat/purchases-js/pull/478): 
![Screenshot 2025-05-15 at 14 34 32](https://github.com/user-attachments/assets/b4cf8efc-9ef8-422f-b1df-24502ad0a956)


Before
https://app.circleci.com/pipelines/github/RevenueCat/purchases-js/2604/workflows/c81ca2a9-945e-408c-9967-3fb8e898b9be/jobs/7818
![Screenshot 2025-05-15 at 14 33 15](https://github.com/user-attachments/assets/5dfcf911-632c-42a0-8e6d-7bb770de2f32)

After
https://app.circleci.com/pipelines/github/RevenueCat/purchases-js/2605/workflows/beb98293-36b9-421b-bbef-dc6d69a4db1b/jobs/7820
![Screenshot 2025-05-15 at 14 33 32](https://github.com/user-attachments/assets/800abdf8-d748-4254-aede-cc232c473868)
(A different set of warnings, but not the same one 🙃)
I don't understand why it's marked flakey (and only warns) in this PR but is a full error in the blocked PR.

I've tried various options without success other than the short timeout. It seems like the button is marked as not-disabled _just_ before the form can actually be submitted?

Super open to ideas that avoid needing a timeout, since it's never a great solution.
