### PR TITLE
Fix tax calculation mistakenly launched

### DIFF
--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -279,12 +279,14 @@
    * when multiple tax refresh requests are triggered in quick succession.
    */
   async function refreshTaxes(): Promise<void> {
-    if (selectedPaymentMethod !== "card") return;
-
-    if (!isEmailComplete || !isPaymentInfoComplete) {
+    if (
+      selectedPaymentMethod !== "card" ||
+      !isEmailComplete ||
+      !isPaymentInfoComplete ||
+      processing ||
+      taxCalculationStatus === "disabled"
+    )
       return;
-    }
-    if (processing) return;
 
     if (taxCalculationStatus !== "loading") {
       previousTaxCalculationStatus = taxCalculationStatus;


### PR DESCRIPTION
## Motivation / Description

Condition got lost at some point, probably when adding the check on loading to then revert it to the previous state if something when wrong. Tested manually, automated test will be added separately.