### PR TITLE
Fix concurrent call in `StrictMode`

### DIFF
--- a/examples/webbilling-demo/src/pages/paywall/index.tsx
+++ b/examples/webbilling-demo/src/pages/paywall/index.tsx
@@ -116,9 +116,10 @@ const PaywallPage: React.FC = () => {
 
       if (Object.keys(attributes).length > 0) {
         try {
-          await purchases.setAttributes(attributes);
           attributesSetRef.current = true;
+          await purchases.setAttributes(attributes);
         } catch (error) {
+          attributesSetRef.current = false;
           console.error("Error setting attributes:", error);
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@revenuecat/purchases-js",
-  "version": "1.3.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@revenuecat/purchases-js",
-      "version": "1.3.0",
+      "version": "1.4.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.16.0",


### PR DESCRIPTION
## Motivation / Description

Follow-up #501. The previous fix did not actually prevent the duplicate request to set attributes when React's `StrictMode` was enabled. I was able to reproduce locally and this PR should fix it. 

## Changes introduced

## Linear ticket (if any)

## Additional comments
