### PR TITLE
Allow for Canary testing with ENV vars.

### DIFF
--- a/examples/webbilling-demo/package-lock.json
+++ b/examples/webbilling-demo/package-lock.json
@@ -45,7 +45,7 @@
     },
     "../..": {
       "name": "@revenuecat/purchases-js",
-      "version": "1.4.1",
+      "version": "1.4.3",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.16.0",

--- a/examples/webbilling-demo/src/util/PurchasesLoader.ts
+++ b/examples/webbilling-demo/src/util/PurchasesLoader.ts
@@ -10,6 +10,7 @@ declare global {
 }
 
 const apiKey = window.__RC_API_KEY__ || import.meta.env.VITE_RC_API_KEY;
+const canary = import.meta.env.VITE_RC_CANARY;
 
 type IPurchasesLoaderData = {
   purchases: Purchases;
@@ -31,13 +32,20 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
   if (!appUserId) {
     throw redirect("/");
   }
+  const additionalHeaders: Record<string, string> = {};
+  if (canary) {
+    additionalHeaders["X-RC-Canary"] = canary;
+  }
+
   Purchases.setLogLevel(LogLevel.Verbose);
   try {
     if (!Purchases.isConfigured()) {
       Purchases.configure(
         apiKey,
         appUserId,
-        {},
+        {
+          additionalHeaders: additionalHeaders,
+        },
         { autoCollectUTMAsMetadata: !optOutOfAutoUTM },
       );
     } else {


### PR DESCRIPTION
## Motivation / Description
I needed to run the E2E tests against a canary and we didn't have a way to do it without modifying the code.

## Changes introduced
Added a new env var that can be used to run tests on a canary with the demo app