### PR TITLE
Fire CheckoutPaymentFormImpression event only when stripe loaded

### DIFF
--- a/src/tests/ui/pages/payment-entry-page.test.ts
+++ b/src/tests/ui/pages/payment-entry-page.test.ts
@@ -125,11 +125,13 @@ describe("PurchasesUI", () => {
     vi.mocked(StripeService.isStripeHandledFormError).mockReturnValue(false);
   });
 
-  test("tracks the PaymentEntryImpression event when the payment entry is displayed", async () => {
+  test("tracks the CheckoutPaymentFormImpression event when the payment entry is displayed and form loaded", async () => {
     render(PaymentEntryPage, {
       props: { ...basicProps },
       context: defaultContext,
     });
+
+    await vi.advanceTimersToNextTimerAsync();
 
     expect(eventsTrackerMock.trackSDKEvent).toHaveBeenCalledWith({
       eventName: SDKEventName.CheckoutPaymentFormImpression,

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -151,12 +151,6 @@
     onPriceBreakdownUpdated(priceBreakdown);
   });
 
-  onMount(() => {
-    eventsTracker.trackSDKEvent({
-      eventName: SDKEventName.CheckoutPaymentFormImpression,
-    });
-  });
-
   onMount(async () => {
     if (taxCalculationStatus === "unavailable") {
       await recalculatePriceBreakdown(null).catch(handleErrors);
@@ -223,6 +217,9 @@
   }
 
   function handleStripeLoadingComplete() {
+    eventsTracker.trackSDKEvent({
+      eventName: SDKEventName.CheckoutPaymentFormImpression,
+    });
     isStripeLoading = false;
   }
 


### PR DESCRIPTION
## Motivation / Description

The event CheckoutPaymentFormImpression was being fired when the payment entry page was mounted but not waiting for the stripe form to load.