### PR TITLE
Added the customization of the stripe checkout element given a subscription option product

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@storybook/svelte": "^8.5.0",
         "@storybook/sveltekit": "^8.5.0",
         "@storybook/test": "^8.5.0",
-        "@stripe/stripe-js": "^4.9.0",
+        "@stripe/stripe-js": "^7.3.1",
         "@sveltejs/vite-plugin-svelte": "^5.0.2",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/svelte": "^5.2.6",
@@ -2295,9 +2295,9 @@
       }
     },
     "node_modules/@stripe/stripe-js": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-4.10.0.tgz",
-      "integrity": "sha512-KrMOL+sH69htCIXCaZ4JluJ35bchuCCznyPyrbN8JXSGQfwBI1SuIEMZNwvy8L8ykj29t6sa5BAAiL7fNoLZ8A==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-7.3.1.tgz",
+      "integrity": "sha512-pTzb864TQWDRQBPLgSPFRoyjSDUqpCkbEgTzpsjiTjGz1Z5SxZNXJek28w1s6Dyry4CyW4/Izj5jHE/J9hCJYQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@storybook/svelte": "^8.5.0",
     "@storybook/sveltekit": "^8.5.0",
     "@storybook/test": "^8.5.0",
-    "@stripe/stripe-js": "^4.9.0",
+    "@stripe/stripe-js": "^7.3.1",
     "@sveltejs/vite-plugin-svelte": "^5.0.2",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/svelte": "^5.2.6",

--- a/src/networking/responses/stripe-elements.ts
+++ b/src/networking/responses/stripe-elements.ts
@@ -16,8 +16,45 @@ export interface StripeElementsConfiguration {
   currency?: string;
 }
 
+export interface StripeExpressCheckoutOptions {
+  applePay?: {
+    recurringPaymentRequest?: {
+      paymentDescription: string;
+      managementURL: string;
+      regularBilling: {
+        amount: number;
+        label: string;
+        recurringPaymentStartDate?: Date;
+        recurringPaymentEndDate?: Date;
+        recurringPaymentIntervalUnit?:
+          | "year"
+          | "month"
+          | "day"
+          | "hour"
+          | "minute";
+        recurringPaymentIntervalCount?: number;
+      };
+      trialBilling?: {
+        amount: number;
+        label?: string;
+        recurringPaymentStartDate?: Date;
+        recurringPaymentEndDate?: Date;
+        recurringPaymentIntervalUnit?:
+          | "year"
+          | "month"
+          | "day"
+          | "hour"
+          | "minute";
+        recurringPaymentIntervalCount?: number;
+      };
+      billingAgreement?: string;
+    };
+  };
+}
+
 export interface GatewayParams {
   stripe_account_id?: string;
   publishable_api_key?: string;
   elements_configuration?: StripeElementsConfiguration;
+  express_checkout_configuration?: StripeElementsConfiguration;
 }

--- a/src/ui/localization/keys_context.json
+++ b/src/ui/localization/keys_context.json
@@ -62,5 +62,6 @@
   "paywall_variables.sub_relative_discount": "Shows the discount percentage for a subscription. {{discount}} is replaced by the discount percentage.",
   "paywall_variables.total_price_and_per_month": "Combines total price information with an equivalent monthly price. {{formattedPrice}} is replaced by the total price, {{formattedPricePerMonth}} is the monthly breakdown, and {{monthPeriod}} is the time unit for the monthly breakdown.",
   "navbar_header.details": "Text for a button that displays more information about the product.",
-  "navbar_header.back_button": "Text for a button that allows the user to go back."
+  "navbar_header.back_button": "Text for a button that allows the user to go back.",
+  "apple_pay.free_trial": "A 'Free Trial' label"
 }

--- a/src/ui/localization/locale/ar.json
+++ b/src/ui/localization/locale/ar.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "تظهر هذه الرسالة فقط في البيئة التجريبية.",
   "error_page.error_message_stripe_missing_required_permission": "فشلت عملية الشراء لأن تطبيق Stripe يفتقر إلى إذن مطلوب. في مرحلة الإنتاج، ستعمل عمليات الشراء بدون تطبيق الضرائب.",
   "error_page.error_title_stripe_tax_not_active": "ضريبة Stripe غير نشطة",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "عنوان منشأ ضريبي غير صالح"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "عنوان منشأ ضريبي غير صالح",
+  "apple_pay.free_trial": "تجربة مجانية"
 }

--- a/src/ui/localization/locale/ca.json
+++ b/src/ui/localization/locale/ca.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Aquest missatge apareix només a l'entorn de proves.",
   "error_page.error_message_stripe_missing_required_permission": "La compra ha fallat perquè l'aplicació Stripe no té un permís necessari. En producció, les compres funcionaran sense impostos aplicats.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax no està actiu",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Adreça d'origen fiscal no vàlida"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Adreça d'origen fiscal no vàlida",
+  "apple_pay.free_trial": "Prova gratuïta"
 }

--- a/src/ui/localization/locale/cs.json
+++ b/src/ui/localization/locale/cs.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Tato zpráva se zobrazuje pouze v sandboxu.",
   "error_page.error_message_stripe_missing_required_permission": "Nákup se nezdařil, protože aplikaci Stripe chybí požadované oprávnění. V produkčním prostředí budou nákupy fungovat bez uplatnění daní.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax není aktivní",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Neplatná adresa původu daně"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Neplatná adresa původu daně",
+  "apple_pay.free_trial": "Zkušební verze zdarma"
 }

--- a/src/ui/localization/locale/da.json
+++ b/src/ui/localization/locale/da.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Denne meddelelse vises kun i sandkassen.",
   "error_page.error_message_stripe_missing_required_permission": "Købet mislykkedes, fordi Stripe-appen mangler en påkrævet tilladelse. I produktion vil køb fungere uden påførte skatter.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax er ikke aktiv",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Ugyldig skatteoprindelsesadresse"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Ugyldig skatteoprindelsesadresse",
+  "apple_pay.free_trial": "Gratis prøveperiode"
 }

--- a/src/ui/localization/locale/de.json
+++ b/src/ui/localization/locale/de.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Diese Meldung wird nur in der Sandbox angezeigt.",
   "error_page.error_message_stripe_missing_required_permission": "Der Kauf ist fehlgeschlagen, da der Stripe-App eine erforderliche Berechtigung fehlt. In der Produktion funktionieren Käufe ohne angewendete Steuern.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax ist nicht aktiv",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Ungültige Steuerursprungsadresse"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Ungültige Steuerursprungsadresse",
+  "apple_pay.free_trial": "Kostenlose Testversion"
 }

--- a/src/ui/localization/locale/el.json
+++ b/src/ui/localization/locale/el.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Αυτό το μήνυμα εμφανίζεται μόνο στο sandbox.",
   "error_page.error_message_stripe_missing_required_permission": "Η αγορά απέτυχε επειδή η εφαρμογή Stripe δεν διαθέτει την απαιτούμενη άδεια. Στην παραγωγή, οι αγορές θα λειτουργούν χωρίς να εφαρμόζονται φόροι.",
   "error_page.error_title_stripe_tax_not_active": "Το Stripe Tax δεν είναι ενεργό",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Μη έγκυρη διεύθυνση προέλευσης φόρου"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Μη έγκυρη διεύθυνση προέλευσης φόρου",
+  "apple_pay.free_trial": "Δωρεάν δοκιμή"
 }

--- a/src/ui/localization/locale/en.json
+++ b/src/ui/localization/locale/en.json
@@ -85,5 +85,6 @@
   "navbar_header.back_button": "Back",
   "price_update.title": "Price update",
   "price_update.base_message": "The total price was updated with tax based on your billing address. Please review and try again. Your card will only be charged once.",
-  "price_update.trial_message": "The subscription price was updated to include tax based on your billing address. Free trial still applies. Review and try again."
+  "price_update.trial_message": "The subscription price was updated to include tax based on your billing address. Free trial still applies. Review and try again.",
+  "apple_pay.free_trial": "Free Trial"
 }

--- a/src/ui/localization/locale/es.json
+++ b/src/ui/localization/locale/es.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Este mensaje aparece solo en el entorno de pruebas.",
   "error_page.error_message_stripe_missing_required_permission": "La compra falló porque la aplicación Stripe carece de un permiso necesario. En producción, las compras funcionarán sin impuestos aplicados.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax no está activo",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Dirección de origen fiscal no válida"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Dirección de origen fiscal no válida",
+  "apple_pay.free_trial": "Prueba gratuita"
 }

--- a/src/ui/localization/locale/fi.json
+++ b/src/ui/localization/locale/fi.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Tämä viesti näkyy vain hiekkalaatikossa.",
   "error_page.error_message_stripe_missing_required_permission": "Osto epäonnistui, koska Stripe-sovellukselta puuttuu vaadittu käyttöoikeus. Tuotantoympäristössä ostot toimivat ilman veroja.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax ei ole aktiivinen",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Virheellinen veron alkuperäosoite"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Virheellinen veron alkuperäosoite",
+  "apple_pay.free_trial": "Ilmainen kokeilu"
 }

--- a/src/ui/localization/locale/fr.json
+++ b/src/ui/localization/locale/fr.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Ce message apparaît uniquement dans l'environnement de test.",
   "error_page.error_message_stripe_missing_required_permission": "L'achat a échoué car l'application Stripe ne dispose pas d'une autorisation requise. En production, les achats fonctionneront sans taxes appliquées.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax non actif",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Adresse d'origine de la taxe non valide"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Adresse d'origine de la taxe non valide",
+  "apple_pay.free_trial": "Essai gratuit"
 }

--- a/src/ui/localization/locale/he.json
+++ b/src/ui/localization/locale/he.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "הודעה זו מופיעה רק בארגז חול.",
   "error_page.error_message_stripe_missing_required_permission": "הרכישה נכשלה מכיוון שלאפליקציית Stripe חסרה הרשאה נדרשת. בייצור, רכישות יעבדו ללא מסים.",
   "error_page.error_title_stripe_tax_not_active": "מס Stripe לא פעיל",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "כתובת מקור מס לא חוקית"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "כתובת מקור מס לא חוקית",
+  "apple_pay.free_trial": "תקופת ניסיון בחינם"
 }

--- a/src/ui/localization/locale/hi.json
+++ b/src/ui/localization/locale/hi.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "यह संदेश केवल सैंडबॉक्स में दिखाई देता है.",
   "error_page.error_message_stripe_missing_required_permission": "खरीदारी विफल रही क्योंकि स्ट्राइप ऐप में आवश्यक अनुमति नहीं है. उत्पादन में, खरीदारी बिना करों के लागू किए काम करेगी.",
   "error_page.error_title_stripe_tax_not_active": "स्ट्राइप टैक्स सक्रिय नहीं है",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "अमान्य कर उत्पत्ति पता"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "अमान्य कर उत्पत्ति पता",
+  "apple_pay.free_trial": "मुफ़्त ट्रायल"
 }

--- a/src/ui/localization/locale/hr.json
+++ b/src/ui/localization/locale/hr.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Ova se poruka pojavljuje samo u sandboxu.",
   "error_page.error_message_stripe_missing_required_permission": "Kupnja nije uspjela jer Stripe aplikaciji nedostaje potrebno dopuštenje. U produkciji će kupnje funkcionirati bez primijenjenih poreza.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax nije aktivan",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Nevažeća adresa poreznog podrijetla"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Nevažeća adresa poreznog podrijetla",
+  "apple_pay.free_trial": "Besplatna proba"
 }

--- a/src/ui/localization/locale/hu.json
+++ b/src/ui/localization/locale/hu.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Ez az üzenet csak a tesztkörnyezetben jelenik meg.",
   "error_page.error_message_stripe_missing_required_permission": "A vásárlás sikertelen volt, mert a Stripe alkalmazásból hiányzik egy szükséges engedély. Éles környezetben a vásárlások adók alkalmazása nélkül fognak működni.",
   "error_page.error_title_stripe_tax_not_active": "A Stripe adó nincs aktiválva",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Érvénytelen adókiindulási cím"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Érvénytelen adókiindulási cím",
+  "apple_pay.free_trial": "Ingyenes próbaidőszak"
 }

--- a/src/ui/localization/locale/id.json
+++ b/src/ui/localization/locale/id.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Pesan ini hanya muncul di sandbox.",
   "error_page.error_message_stripe_missing_required_permission": "Pembelian gagal karena aplikasi Stripe tidak memiliki izin yang diperlukan. Dalam produksi, pembelian akan berfungsi tanpa pajak yang diterapkan.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax tidak aktif",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Alamat asal pajak tidak valid"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Alamat asal pajak tidak valid",
+  "apple_pay.free_trial": "Uji Coba Gratis"
 }

--- a/src/ui/localization/locale/it.json
+++ b/src/ui/localization/locale/it.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Questo messaggio viene visualizzato solo in sandbox.",
   "error_page.error_message_stripe_missing_required_permission": "L'acquisto non è andato a buon fine perché l'app Stripe non dispone dell'autorizzazione necessaria. In produzione, gli acquisti verranno effettuati senza l'applicazione delle imposte e questo errore non sarà visibile.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax non attivo",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Indirizzo di origine fiscale non valido"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Indirizzo di origine fiscale non valido",
+  "apple_pay.free_trial": "Prova gratuita"
 }

--- a/src/ui/localization/locale/ja.json
+++ b/src/ui/localization/locale/ja.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "このメッセージはサンドボックスでのみ表示されます。",
   "error_page.error_message_stripe_missing_required_permission": "Stripeアプリに必要な権限がないため、購入に失敗しました。 本番環境では、税金が適用されなくても購入は可能です。",
   "error_page.error_title_stripe_tax_not_active": "Stripe Taxが有効ではありません",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "税の原産地住所が無効です"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "税の原産地住所が無効です",
+  "apple_pay.free_trial": "無料トライアル"
 }

--- a/src/ui/localization/locale/ko.json
+++ b/src/ui/localization/locale/ko.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "이 메시지는 샌드박스에서만 표시됩니다.",
   "error_page.error_message_stripe_missing_required_permission": "Stripe 앱에 필요한 권한이 없어 구매에 실패했습니다. 프로덕션 환경에서는 세금이 적용되지 않은 상태로 구매가 진행됩니다.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax가 활성화되지 않음",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "잘못된 세금 원산지 주소"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "잘못된 세금 원산지 주소",
+  "apple_pay.free_trial": "무료 체험"
 }

--- a/src/ui/localization/locale/ms.json
+++ b/src/ui/localization/locale/ms.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Mesej ini hanya muncul dalam kotak pasir.",
   "error_page.error_message_stripe_missing_required_permission": "Pembelian gagal kerana aplikasi Stripe kekurangan kebenaran yang diperlukan. Dalam pengeluaran, pembelian akan berfungsi tanpa cukai dikenakan.",
   "error_page.error_title_stripe_tax_not_active": "Cukai Stripe tidak aktif",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Alamat asal cukai Stripe tidak sah"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Alamat asal cukai Stripe tidak sah",
+  "apple_pay.free_trial": "Percubaan Percuma"
 }

--- a/src/ui/localization/locale/nl.json
+++ b/src/ui/localization/locale/nl.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Dit bericht verschijnt alleen in de sandbox.",
   "error_page.error_message_stripe_missing_required_permission": "De aankoop is mislukt omdat de Stripe-app een vereiste toestemming mist. In productie werken aankopen zonder toegepaste belastingen.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax niet actief",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Ongeldig belastingoorsprongadres"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Ongeldig belastingoorsprongadres",
+  "apple_pay.free_trial": "Gratis proefperiode"
 }

--- a/src/ui/localization/locale/no.json
+++ b/src/ui/localization/locale/no.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Denne meldingen vises bare i sandkassen.",
   "error_page.error_message_stripe_missing_required_permission": "Kjøpet mislyktes fordi Stripe-appen mangler en nødvendig tillatelse. I produksjon vil kjøp fungere uten at skatter brukes.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax er ikke aktivt",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Ugyldig skatteopprinnelsesadresse"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Ugyldig skatteopprinnelsesadresse",
+  "apple_pay.free_trial": "Gratis prøveperiode"
 }

--- a/src/ui/localization/locale/pl.json
+++ b/src/ui/localization/locale/pl.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Ta wiadomość pojawia się tylko w środowisku testowym.",
   "error_page.error_message_stripe_missing_required_permission": "Zakup nie powiódł się, ponieważ aplikacja Stripe nie ma wymaganego uprawnienia. W środowisku produkcyjnym zakupy będą działać bez naliczania podatków.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax nieaktywny",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Nieprawidłowy adres pochodzenia podatku"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Nieprawidłowy adres pochodzenia podatku",
+  "apple_pay.free_trial": "Okres próbny"
 }

--- a/src/ui/localization/locale/pt.json
+++ b/src/ui/localization/locale/pt.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Esta mensagem aparece apenas na sandbox.",
   "error_page.error_message_stripe_missing_required_permission": "A compra falhou porque o aplicativo Stripe não tem uma permissão necessária. Em produção, as compras funcionarão sem impostos aplicados.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax não está ativo",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Endereço de origem fiscal inválido"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Endereço de origem fiscal inválido",
+  "apple_pay.free_trial": "Teste Gratuito"
 }

--- a/src/ui/localization/locale/ro.json
+++ b/src/ui/localization/locale/ro.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Acest mesaj apare doar în sandbox.",
   "error_page.error_message_stripe_missing_required_permission": "Achiziția a eșuat deoarece aplicației Stripe îi lipsește o permisiune necesară. În producție, achizițiile vor funcționa fără taxe aplicate.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax nu este activ",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Adresă de origine fiscală Stripe nevalidă"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Adresă de origine fiscală Stripe nevalidă",
+  "apple_pay.free_trial": "Perioadă de probă gratuită"
 }

--- a/src/ui/localization/locale/ru.json
+++ b/src/ui/localization/locale/ru.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Это сообщение появляется только в песочнице.",
   "error_page.error_message_stripe_missing_required_permission": "Покупка не удалась, так как у приложения Stripe отсутствует необходимое разрешение. В рабочей среде покупки будут работать без применения налогов.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax не активен",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Недействительный адрес отправления налога"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Недействительный адрес отправления налога",
+  "apple_pay.free_trial": "Бесплатная пробная версия"
 }

--- a/src/ui/localization/locale/sk.json
+++ b/src/ui/localization/locale/sk.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Táto správa sa zobrazuje iba v testovacom prostredí (sandbox).",
   "error_page.error_message_stripe_missing_required_permission": "Nákup sa nepodaril, pretože aplikácii Stripe chýba požadované povolenie. V produkčnom prostredí budú nákupy fungovať bez uplatnenia daní.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax nie je aktívny",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Neplatná adresa pôvodu dane"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Neplatná adresa pôvodu dane",
+  "apple_pay.free_trial": "Skúšobná verzia zdarma"
 }

--- a/src/ui/localization/locale/sv.json
+++ b/src/ui/localization/locale/sv.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Det här meddelandet visas bara i sandlådan.",
   "error_page.error_message_stripe_missing_required_permission": "Köpet misslyckades eftersom Stripe-appen saknar en nödvändig behörighet. I produktion kommer köp att fungera utan att skatter tillämpas.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax är inte aktivt",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Ogiltig skatteursprungsadress"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Ogiltig skatteursprungsadress",
+  "apple_pay.free_trial": "Gratis provperiod"
 }

--- a/src/ui/localization/locale/th.json
+++ b/src/ui/localization/locale/th.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "ข้อความนี้จะปรากฏเฉพาะใน sandbox เท่านั้น",
   "error_page.error_message_stripe_missing_required_permission": "การซื้อล้มเหลวเนื่องจากแอป Stripe ขาดสิทธิ์ที่จำเป็น ในสภาพแวดล้อมจริง การซื้อจะทำงานได้โดยไม่มีการเรียกเก็บภาษี",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax ไม่เปิดใช้งาน",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "ที่อยู่ต้นทางภาษีไม่ถูกต้อง"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "ที่อยู่ต้นทางภาษีไม่ถูกต้อง",
+  "apple_pay.free_trial": "ทดลองใช้ฟรี"
 }

--- a/src/ui/localization/locale/tr.json
+++ b/src/ui/localization/locale/tr.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Bu mesaj yalnızca sanal ortamda görünür.",
   "error_page.error_message_stripe_missing_required_permission": "Stripe uygulamasında gerekli bir izin eksik olduğu için satın alma başarısız oldu. Üretimde, satın alımlar vergi uygulanmadan çalışacaktır.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Vergi aktif değil",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Geçersiz vergi başlangıç adresi"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Geçersiz vergi başlangıç adresi",
+  "apple_pay.free_trial": "Ücretsiz Deneme"
 }

--- a/src/ui/localization/locale/uk.json
+++ b/src/ui/localization/locale/uk.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Це повідомлення з’являється лише в пісочниці.",
   "error_page.error_message_stripe_missing_required_permission": "Покупка не вдалася, оскільки програмі Stripe не вистачає необхідного дозволу. У виробництві покупки працюватимуть без застосування податків.",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax не активовано",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Недійсна адреса походження податку"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Недійсна адреса походження податку",
+  "apple_pay.free_trial": "Безкоштовна пробна версія"
 }

--- a/src/ui/localization/locale/vi.json
+++ b/src/ui/localization/locale/vi.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "Thông báo này chỉ xuất hiện trong môi trường thử nghiệm.",
   "error_page.error_message_stripe_missing_required_permission": "Giao dịch mua không thành công vì ứng dụng Stripe thiếu một quyền cần thiết. Trong môi trường thực tế, giao dịch mua sẽ hoạt động mà không áp dụng thuế.",
   "error_page.error_title_stripe_tax_not_active": "Thuế Stripe chưa hoạt động",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "Địa chỉ gốc thuế không hợp lệ"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "Địa chỉ gốc thuế không hợp lệ",
+  "apple_pay.free_trial": "Dùng thử miễn phí"
 }

--- a/src/ui/localization/locale/zh_Hans.json
+++ b/src/ui/localization/locale/zh_Hans.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "此消息仅在沙盒中显示。",
   "error_page.error_message_stripe_missing_required_permission": "购买失败，因为Stripe应用程序缺少必需的权限。在生产环境中，购买将在不应用税款的情况下进行。",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax未激活",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "税务起始地址无效"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "税务起始地址无效",
+  "apple_pay.free_trial": "免费试用"
 }

--- a/src/ui/localization/locale/zh_Hant.json
+++ b/src/ui/localization/locale/zh_Hant.json
@@ -85,5 +85,6 @@
   "error_page.error_only_in_sandbox": "此訊息僅在沙盒中顯示。",
   "error_page.error_message_stripe_missing_required_permission": "購買失敗，因為 Stripe 應用程式缺少必要的權限。在正式環境中，購買將在不套用稅金的情況下運作。",
   "error_page.error_title_stripe_tax_not_active": "Stripe Tax 未啟用",
-  "error_page.error_title_stripe_invalid_tax_origin_address": "無效的稅務起始地址"
+  "error_page.error_title_stripe_invalid_tax_origin_address": "無效的稅務起始地址",
+  "apple_pay.free_trial": "免費試用"
 }

--- a/src/ui/localization/supportedLanguages.ts
+++ b/src/ui/localization/supportedLanguages.ts
@@ -120,6 +120,7 @@ export enum LocalizationKeys {
   PriceUpdateTitle = "price_update.title",
   PriceUpdateBaseMessage = "price_update.base_message",
   PriceUpdateTrialMessage = "price_update.trial_message",
+  ApplePayFreeTrial = "apple_pay.free_trial",
 }
 
 export const supportedLanguages: Record<

--- a/src/ui/molecules/stripe-elements.svelte
+++ b/src/ui/molecules/stripe-elements.svelte
@@ -16,7 +16,10 @@
   import { translatorContextKey } from "../localization/constants";
   import { Translator } from "../localization/translator";
 
-  import type { StripeElementsConfiguration } from "../../networking/responses/stripe-elements";
+  import type {
+    StripeElementsConfiguration,
+    StripeExpressCheckoutOptions,
+  } from "../../networking/responses/stripe-elements";
   import { DEFAULT_FONT_FAMILY } from "../theme/text";
   import {
     StripeService,
@@ -30,6 +33,7 @@
     stripeAccountId?: string;
     publishableApiKey?: string;
     elementsConfiguration?: StripeElementsConfiguration;
+    expressCheckoutOptions?: StripeExpressCheckoutOptions;
     brandingInfo: BrandingInfoResponse | null;
     skipEmail: boolean;
     billingAddressRequired: boolean;
@@ -52,6 +56,7 @@
     stripeAccountId,
     publishableApiKey,
     elementsConfiguration,
+    expressCheckoutOptions,
     brandingInfo,
     skipEmail,
     billingAddressRequired,
@@ -218,6 +223,7 @@
       onError={onStripeElementsLoadingError}
       onReady={onExpressCheckoutElementReady}
       onSubmit={onExpressCheckoutElementSubmit}
+      {expressCheckoutOptions}
       {billingAddressRequired}
     />
     {#if !skipEmail}

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -29,8 +29,8 @@
   import { type Writable } from "svelte/store";
   import PaymentButton from "../molecules/payment-button.svelte";
   import type {
-    StripeElementsConfiguration,
     GatewayParams,
+    StripeElementsConfiguration,
   } from "../../networking/responses/stripe-elements";
   import {
     CheckoutCalculateTaxFailedReason,
@@ -145,6 +145,16 @@
       (taxCalculationStatus === "disabled" ||
         taxCalculationStatus === "calculated" ||
         taxCalculationStatus === "miss-match"),
+  );
+
+  let expressCheckoutOptions = $derived(
+    subscriptionOption
+      ? StripeService.buildStripeExpressCheckoutOptionsForSubscription(
+          productDetails,
+          subscriptionOption,
+          $translator,
+        )
+      : undefined,
   );
 
   $effect(() => {
@@ -554,6 +564,7 @@
           onEmailChange={handleEmailChange}
           onPaymentInfoChange={handlePaymentInfoChange}
           onExpressCheckoutElementSubmit={handleExpressCheckoutElementSubmit}
+          {expressCheckoutOptions}
         />
       </div>
 


### PR DESCRIPTION
## Motivation / Description
When using apple pay on a trial purchase  the native modal does not show useful information to understand what the customer is going to pay now.

This PR aims at fixing it.

This PR implements these changes all on the front-end, the idea is to move this to khepri but this can be a good first solution.

## Changes introduced
* Bumped StripeJS to v7.3.1 💣 
* Added the StripeExpressCheckoutOptions
* Propagated them to the Stripe Express Checkout element
