### PR TITLE
Fix customElements not defined error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@revenuecat/purchases-js",
-  "version": "1.4.3",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@revenuecat/purchases-js",
-      "version": "1.4.3",
+      "version": "1.5.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.16.0",
         "@microsoft/api-extractor": "^7.48.0",
-        "@revenuecat/purchases-ui-js": "1.0.2",
+        "@revenuecat/purchases-ui-js": "2.0.0",
         "@storybook/addon-essentials": "^8.5.0",
         "@storybook/addon-interactions": "^8.5.0",
         "@storybook/addon-links": "^8.5.0",
@@ -1175,9 +1175,9 @@
       }
     },
     "node_modules/@revenuecat/purchases-ui-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@revenuecat/purchases-ui-js/-/purchases-ui-js-1.0.2.tgz",
-      "integrity": "sha512-ePbVNsithzwbRSFOwCaIkvTyJlGGAzrFoOUC3Wf/R5cpL5Ez+ylV4NjKFloNUU/wPh5b07z4+6wUUdwH+4TjoQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@revenuecat/purchases-ui-js/-/purchases-ui-js-2.0.0.tgz",
+      "integrity": "sha512-liu0ciGXS7mhVkx3Ikuc+XUh7Hi1hE3attWcI7G48H/ny6HBrpwbtqvl9EPncT+ifINoKT8gCAUDiYLOBsdMag==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@eslint/js": "^9.16.0",
     "@microsoft/api-extractor": "^7.48.0",
-    "@revenuecat/purchases-ui-js": "1.0.2",
+    "@revenuecat/purchases-ui-js": "2.0.0",
     "@storybook/addon-essentials": "^8.5.0",
     "@storybook/addon-interactions": "^8.5.0",
     "@storybook/addon-links": "^8.5.0",


### PR DESCRIPTION
## Motivation / Description

Internal slack thread: https://revenuecat.slack.com/archives/C03UKCQLW1Z/p1749463671615309?thread_ts=1748970917.010049&cid=C03UKCQLW1Z

Github issue: https://github.com/RevenueCat/purchases-js/issues/521

Purchases-ui-js change: https://github.com/RevenueCat/purchases-ui-js/pull/74

The /dist package of purchases-js includes a reference to `customElements` - and will always attempt to access it. But `customElements` will only exist in a browser context so in expo/react native etc this fails. We don't actually need or want the web components stuff anywhere in the SDK anyway - so our longer term goal will be to fully isolate the two builds made in purchases-ui-js.

So we're opting to just temporarily remove the customElement exports in purchases-ui-js directly - this does mean there will be a lot of unnecessary config etc in purchases-ui-js left - but the hope is we can revisit in the near future and tidy everything up properly.

Before (from issue PR):
![image](https://github.com/user-attachments/assets/8757139f-dee1-4b33-bb20-9f142c5d9499)

After (pointing purchases-js at my local purchases-ui-js running this branch):
![Screenshot 2025-06-09 at 14 22 50](https://github.com/user-attachments/assets/24ea9d33-e5b0-4863-b37b-201d41a7f009)
![Screenshot 2025-06-09 at 14 22 57](https://github.com/user-attachments/assets/e49efb9b-66a7-442d-a23b-bea3592bf35a)


i.e customElements is no longer included in the /dist so we shouldn't see this error any more.


- [n/a] If applicable, unit tests
- [n/a] If applicable, create follow-up issues for native and hybrids

