### PR TITLE
[WEB-2744] Add object-based configuration for Purchases SDK initialization

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -5142,6 +5142,56 @@
             {
               "kind": "Method",
               "canonicalReference": "@revenuecat/purchases-js!Purchases.configure:member(1)",
+              "docComment": "/**\n * Configures the Purchases SDK. This should be called as soon as your app has a unique user id for your user. You should only call this once, and keep the returned instance around for use throughout your application.\n *\n * @param config - Configuration object containing apiKey, appUserId, and optional configurations.\n *\n * @throws\n *\n * {@link PurchasesError} if the API key or user id are invalid.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "static configure(config: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PurchasesConfig",
+                  "canonicalReference": "@revenuecat/purchases-js!PurchasesConfig:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Purchases",
+                  "canonicalReference": "@revenuecat/purchases-js!Purchases:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": true,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "config",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "configure"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@revenuecat/purchases-js!Purchases.configure:member(2)",
               "docComment": "/**\n * Configures the Purchases SDK. This should be called as soon as your app has a unique user id for your user. You should only call this once, and keep the returned instance around for use throughout your application.\n *\n * @param apiKey - RevenueCat API Key. Can be obtained from the RevenueCat dashboard.\n *\n * @param appUserId - Your unique id for identifying the user.\n *\n * @param httpConfig - Advanced http configuration to customise the SDK usage {@link HttpConfig}.\n *\n * @param flags - Advanced functionality configuration {@link FlagsConfig}.\n *\n * @throws\n *\n * {@link PurchasesError} if the API key or user id are invalid.\n */\n",
               "excerptTokens": [
                 {
@@ -5199,7 +5249,7 @@
               },
               "releaseTag": "Public",
               "isProtected": false,
-              "overloadIndex": 1,
+              "overloadIndex": 2,
               "parameters": [
                 {
                   "parameterName": "apiKey",
@@ -5490,7 +5540,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@revenuecat/purchases-js!Purchases.getSharedInstance:member(1)",
-              "docComment": "/**\n * Get the singleton instance of Purchases. It's preferred to use the instance obtained from the {@link Purchases.configure} method when possible.\n *\n * @throws\n *\n * {@link UninitializedPurchasesError} if the instance has not been initialized yet.\n */\n",
+              "docComment": "/**\n * Get the singleton instance of Purchases. It's preferred to use the instance obtained from the `configure` method when possible.\n *\n * @throws\n *\n * {@link UninitializedPurchasesError} if the instance has not been initialized yet.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -5871,7 +5921,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "{\n               [key: string | "
+                  "text": "{\n                [key: string | "
                 },
                 {
                   "kind": "Reference",
@@ -5880,7 +5930,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "]: string | null;\n           }"
+                  "text": "]: string | null;\n            }"
                 },
                 {
                   "kind": "Content",
@@ -6024,6 +6074,134 @@
           "implementsTokenRanges": []
         },
         {
+          "kind": "Interface",
+          "canonicalReference": "@revenuecat/purchases-js!PurchasesConfig:interface",
+          "docComment": "/**\n * Configuration object for initializing the Purchases SDK.\n *\n * @example\n * ```typescript\n * // Object-based configuration (recommended)\n * const purchases = Purchases.configure({\n *   apiKey: \"your_api_key\",\n *   appUserId: \"user_123\",\n *   httpConfig: { additionalHeaders: { \"Custom-Header\": \"value\" } },\n *   flags: { autoCollectUTMAsMetadata: true }\n * });\n *\n * // Legacy separate arguments (still supported)\n * const purchases = Purchases.configure(\n *   \"your_api_key\",\n *   \"user_123\",\n *   { additionalHeaders: { \"Custom-Header\": \"value\" } },\n *   { autoCollectUTMAsMetadata: true }\n * );\n * ```\n *\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare interface PurchasesConfig "
+            }
+          ],
+          "fileUrlPath": "dist/Purchases.es.d.ts",
+          "releaseTag": "Public",
+          "name": "PurchasesConfig",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PurchasesConfig#apiKey:member",
+              "docComment": "/**\n * RevenueCat API Key. Can be obtained from the RevenueCat dashboard.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "apiKey: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "apiKey",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PurchasesConfig#appUserId:member",
+              "docComment": "/**\n * Your unique id for identifying the user.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "appUserId: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "appUserId",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PurchasesConfig#flags:member",
+              "docComment": "/**\n * Advanced functionality configuration {@link FlagsConfig}.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "flags?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "FlagsConfig",
+                  "canonicalReference": "@revenuecat/purchases-js!FlagsConfig:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "flags",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PurchasesConfig#httpConfig:member",
+              "docComment": "/**\n * Advanced http configuration to customise the SDK usage {@link HttpConfig}.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "httpConfig?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "HttpConfig",
+                  "canonicalReference": "@revenuecat/purchases-js!HttpConfig:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "httpConfig",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
+          "extendsTokenRanges": []
+        },
+        {
           "kind": "Class",
           "canonicalReference": "@revenuecat/purchases-js!PurchasesError:class",
           "docComment": "/**\n * Error class for Purchases SDK. You should handle these errors and react accordingly in your app.\n *\n * @public\n */\n",
@@ -6055,7 +6233,7 @@
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "constructor(\n              errorCode: "
+                  "text": "constructor(\n               errorCode: "
                 },
                 {
                   "kind": "Reference",
@@ -6064,7 +6242,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ", \n              message?: "
+                  "text": ", \n               message?: "
                 },
                 {
                   "kind": "Content",
@@ -6072,7 +6250,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ", \n              underlyingErrorMessage?: "
+                  "text": ", \n               underlyingErrorMessage?: "
                 },
                 {
                   "kind": "Content",
@@ -6080,7 +6258,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ", \n              extra?: "
+                  "text": ", \n               extra?: "
                 },
                 {
                   "kind": "Reference",

--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -5192,7 +5192,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@revenuecat/purchases-js!Purchases.configure:member(2)",
-              "docComment": "/**\n * Configures the Purchases SDK. This should be called as soon as your app has a unique user id for your user. You should only call this once, and keep the returned instance around for use throughout your application.\n *\n * @param apiKey - RevenueCat API Key. Can be obtained from the RevenueCat dashboard.\n *\n * @param appUserId - Your unique id for identifying the user.\n *\n * @param httpConfig - Advanced http configuration to customise the SDK usage {@link HttpConfig}.\n *\n * @param flags - Advanced functionality configuration {@link FlagsConfig}.\n *\n * @throws\n *\n * {@link PurchasesError} if the API key or user id are invalid.\n */\n",
+              "docComment": "/**\n * Legacy method to configure the Purchases SDK. This method is deprecated and will be removed in a future version.\n *\n * @deprecated\n *\n * - please use the `configure` method with a {@link PurchasesConfig} object instead.\n *\n * @param apiKey - RevenueCat API Key. Can be obtained from the RevenueCat dashboard.\n *\n * @param appUserId - Your unique id for identifying the user.\n *\n * @param httpConfig - Advanced http configuration to customise the SDK usage {@link HttpConfig}.\n *\n * @param flags - Advanced functionality configuration {@link FlagsConfig}.\n *\n * @throws\n *\n * {@link PurchasesError} if the API key or user id are invalid.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -6076,7 +6076,7 @@
         {
           "kind": "Interface",
           "canonicalReference": "@revenuecat/purchases-js!PurchasesConfig:interface",
-          "docComment": "/**\n * Configuration object for initializing the Purchases SDK.\n *\n * @example\n * ```typescript\n * // Object-based configuration (recommended)\n * const purchases = Purchases.configure({\n *   apiKey: \"your_api_key\",\n *   appUserId: \"user_123\",\n *   httpConfig: { additionalHeaders: { \"Custom-Header\": \"value\" } },\n *   flags: { autoCollectUTMAsMetadata: true }\n * });\n *\n * // Legacy separate arguments (still supported)\n * const purchases = Purchases.configure(\n *   \"your_api_key\",\n *   \"user_123\",\n *   { additionalHeaders: { \"Custom-Header\": \"value\" } },\n *   { autoCollectUTMAsMetadata: true }\n * );\n * ```\n *\n * @public\n */\n",
+          "docComment": "/**\n * Configuration object for initializing the Purchases SDK.\n *\n * @example\n * ```typescript\n * // Object-based configuration (recommended)\n * const purchases = Purchases.configure({\n *   apiKey: \"your_api_key\",\n *   appUserId: \"user_123\",\n *   httpConfig: { additionalHeaders: { \"Custom-Header\": \"value\" } },\n *   flags: { autoCollectUTMAsMetadata: true }\n * });\n *\n * // Legacy separate arguments (deprecated)\n * const purchases = Purchases.configure(\n *   \"your_api_key\",\n *   \"user_123\",\n *   { additionalHeaders: { \"Custom-Header\": \"value\" } },\n *   { autoCollectUTMAsMetadata: true }\n * );\n * ```\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -353,6 +353,7 @@ export class Purchases {
     changeUser(newAppUserId: string): Promise<CustomerInfo>;
     close(): void;
     static configure(config: PurchasesConfig): Purchases;
+    // @deprecated
     static configure(apiKey: string, appUserId: string, httpConfig?: HttpConfig, flags?: FlagsConfig): Purchases;
     static generateRevenueCatAnonymousAppUserId(): string;
     getAppUserId(): string;

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -352,6 +352,7 @@ export interface PurchaseResult {
 export class Purchases {
     changeUser(newAppUserId: string): Promise<CustomerInfo>;
     close(): void;
+    static configure(config: PurchasesConfig): Purchases;
     static configure(apiKey: string, appUserId: string, httpConfig?: HttpConfig, flags?: FlagsConfig): Purchases;
     static generateRevenueCatAnonymousAppUserId(): string;
     getAppUserId(): string;
@@ -374,6 +375,14 @@ export class Purchases {
     }): Promise<void>;
     static setLogLevel(logLevel: LogLevel): void;
     static setPlatformInfo(platformInfo: PlatformInfo): void;
+}
+
+// @public
+export interface PurchasesConfig {
+    apiKey: string;
+    appUserId: string;
+    flags?: FlagsConfig;
+    httpConfig?: HttpConfig;
 }
 
 // @public

--- a/examples/webbilling-demo/src/util/PurchasesLoader.ts
+++ b/examples/webbilling-demo/src/util/PurchasesLoader.ts
@@ -54,14 +54,12 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
   Purchases.setLogLevel(LogLevel.Verbose);
   try {
     if (!Purchases.isConfigured()) {
-      Purchases.configure(
+      Purchases.configure({
         apiKey,
         appUserId,
-        {
-          additionalHeaders,
-        },
-        flagsConfig,
-      );
+        httpConfig: additionalHeaders,
+        flags: flagsConfig,
+      });
     } else {
       await Purchases.getSharedInstance().changeUser(appUserId);
     }

--- a/src/entities/purchases-config.ts
+++ b/src/entities/purchases-config.ts
@@ -1,0 +1,45 @@
+import type { FlagsConfig } from "./flags-config";
+import type { HttpConfig } from "./http-config";
+
+/**
+ * Configuration object for initializing the Purchases SDK.
+ *
+ * @example
+ * ```typescript
+ * // Object-based configuration (recommended)
+ * const purchases = Purchases.configure({
+ *   apiKey: "your_api_key",
+ *   appUserId: "user_123",
+ *   httpConfig: { additionalHeaders: { "Custom-Header": "value" } },
+ *   flags: { autoCollectUTMAsMetadata: true }
+ * });
+ *
+ * // Legacy separate arguments (deprecated)
+ * const purchases = Purchases.configure(
+ *   "your_api_key",
+ *   "user_123",
+ *   { additionalHeaders: { "Custom-Header": "value" } },
+ *   { autoCollectUTMAsMetadata: true }
+ * );
+ * ```
+ *
+ * @public
+ */
+export interface PurchasesConfig {
+  /**
+   * RevenueCat API Key. Can be obtained from the RevenueCat dashboard.
+   */
+  apiKey: string;
+  /**
+   * Your unique id for identifying the user.
+   */
+  appUserId: string;
+  /**
+   * Advanced http configuration to customise the SDK usage {@link HttpConfig}.
+   */
+  httpConfig?: HttpConfig;
+  /**
+   * Advanced functionality configuration {@link FlagsConfig}.
+   */
+  flags?: FlagsConfig;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -245,7 +245,7 @@ export class Purchases {
       // Object-based configuration
       config = configOrApiKey;
     } else {
-      // Traditional separate arguments - convert to PurchasesConfig
+      // Legacy positional arguments - convert to PurchasesConfig
       if (typeof configOrApiKey !== "string") {
         throw new PurchasesError(
           ErrorCode.ConfigurationError,
@@ -266,17 +266,22 @@ export class Purchases {
       };
     }
 
-    Purchases.instance = Purchases.configureInternal(config);
+    Purchases.configureInternal(config);
     return Purchases.getSharedInstance();
   }
 
-  private static configureInternal(config: PurchasesConfig): Purchases {
+  private static configureInternal(config: PurchasesConfig): void {
     const { apiKey, appUserId, httpConfig, flags } = config;
     const finalHttpConfig = httpConfig ?? defaultHttpConfig;
     const finalFlags = flags ?? defaultFlagsConfig;
 
     Purchases.validateConfig(config);
-    return new Purchases(apiKey, appUserId, finalHttpConfig, finalFlags);
+    Purchases.instance = new Purchases(
+      apiKey,
+      appUserId,
+      finalHttpConfig,
+      finalFlags,
+    );
   }
 
   private static validateConfig(config: PurchasesConfig) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -67,6 +67,7 @@ import {
   type FlagsConfig,
   supportedRCSources,
 } from "./entities/flags-config";
+import { type PurchasesConfig } from "./entities/purchases-config";
 import { generateUUID } from "./helpers/uuid-helper";
 import type { PlatformInfo } from "./entities/platform-info";
 import type { ReservedCustomerAttribute } from "./entities/attributes";
@@ -116,51 +117,9 @@ export type { RedemptionInfo } from "./entities/redemption-info";
 export type { PurchaseResult } from "./entities/purchase-result";
 export type { BrandingAppearance } from "./entities/branding";
 export type { PlatformInfo } from "./entities/platform-info";
+export type { PurchasesConfig } from "./entities/purchases-config";
 
 const ANONYMOUS_PREFIX = "$RCAnonymousID:";
-
-/**
- * Configuration object for initializing the Purchases SDK.
- *
- * @example
- * ```typescript
- * // Object-based configuration (recommended)
- * const purchases = Purchases.configure({
- *   apiKey: "your_api_key",
- *   appUserId: "user_123",
- *   httpConfig: { additionalHeaders: { "Custom-Header": "value" } },
- *   flags: { autoCollectUTMAsMetadata: true }
- * });
- *
- * // Legacy separate arguments (deprecated)
- * const purchases = Purchases.configure(
- *   "your_api_key",
- *   "user_123",
- *   { additionalHeaders: { "Custom-Header": "value" } },
- *   { autoCollectUTMAsMetadata: true }
- * );
- * ```
- *
- * @public
- */
-export interface PurchasesConfig {
-  /**
-   * RevenueCat API Key. Can be obtained from the RevenueCat dashboard.
-   */
-  apiKey: string;
-  /**
-   * Your unique id for identifying the user.
-   */
-  appUserId: string;
-  /**
-   * Advanced http configuration to customise the SDK usage {@link HttpConfig}.
-   */
-  httpConfig?: HttpConfig;
-  /**
-   * Advanced functionality configuration {@link FlagsConfig}.
-   */
-  flags?: FlagsConfig;
-}
 
 /**
  * Entry point for Purchases SDK. It should be instantiated as soon as your

--- a/src/main.ts
+++ b/src/main.ts
@@ -132,7 +132,7 @@ const ANONYMOUS_PREFIX = "$RCAnonymousID:";
  *   flags: { autoCollectUTMAsMetadata: true }
  * });
  *
- * // Legacy separate arguments (still supported)
+ * // Legacy separate arguments (deprecated)
  * const purchases = Purchases.configure(
  *   "your_api_key",
  *   "user_123",
@@ -251,9 +251,8 @@ export class Purchases {
   static configure(config: PurchasesConfig): Purchases;
 
   /**
-   * Configures the Purchases SDK. This should be called as soon as your app
-   * has a unique user id for your user. You should only call this once, and
-   * keep the returned instance around for use throughout your application.
+   * Legacy method to configure the Purchases SDK. This method is deprecated and will be removed in a future version.
+   * @deprecated - please use the `configure` method with a {@link PurchasesConfig} object instead.
    * @param apiKey - RevenueCat API Key. Can be obtained from the RevenueCat dashboard.
    * @param appUserId - Your unique id for identifying the user.
    * @param httpConfig - Advanced http configuration to customise the SDK usage {@link HttpConfig}.

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -25,7 +25,7 @@ import { http, HttpResponse } from "msw";
 import { expectPromiseToError } from "./test-helpers";
 import { StatusCodes } from "http-status-codes";
 
-describe("Purchases.configure()", () => {
+describe("Purchases.configure() legacy", () => {
   test("throws error if given invalid api key", () => {
     expect(() => Purchases.configure("goog_api_key", "appUserId")).toThrowError(
       PurchasesError,
@@ -73,8 +73,10 @@ describe("Purchases.configure()", () => {
     );
     expect(purchases).not.toEqual(purchases2);
   });
+});
 
-  test("configures successfully with object syntax", () => {
+describe("Purchases.configure()", () => {
+  test("configures successfully", () => {
     const purchases = Purchases.configure({
       apiKey: testApiKey,
       appUserId: testUserId,
@@ -82,7 +84,7 @@ describe("Purchases.configure()", () => {
     expect(purchases).toBeDefined();
   });
 
-  test("configures successfully with object syntax and optional parameters", () => {
+  test("configures successfully with optional parameters", () => {
     const purchases = Purchases.configure({
       apiKey: testApiKey,
       appUserId: testUserId,
@@ -92,7 +94,7 @@ describe("Purchases.configure()", () => {
     expect(purchases).toBeDefined();
   });
 
-  test("throws error if given invalid api key with object syntax", () => {
+  test("throws error if given invalid api key", () => {
     expect(() =>
       Purchases.configure({
         apiKey: "goog_api_key",
@@ -108,7 +110,7 @@ describe("Purchases.configure()", () => {
     ).toThrowError(PurchasesError);
   });
 
-  test("throws error if given invalid user id with object syntax", () => {
+  test("throws error if given invalid user id", () => {
     expect(() =>
       Purchases.configure({
         apiKey: testApiKey,
@@ -124,7 +126,7 @@ describe("Purchases.configure()", () => {
     ).toThrowError(PurchasesError);
   });
 
-  test("throws error if given invalid proxy url with object syntax", () => {
+  test("throws error if given invalid proxy url", () => {
     expect(() =>
       Purchases.configure({
         apiKey: testApiKey,
@@ -136,7 +138,7 @@ describe("Purchases.configure()", () => {
     ).toThrowError(PurchasesError);
   });
 
-  test("throws error if given reserved additional header with object syntax", () => {
+  test("throws error if given reserved additional header", () => {
     expect(() =>
       Purchases.configure({
         apiKey: testApiKey,
@@ -148,7 +150,7 @@ describe("Purchases.configure()", () => {
     ).toThrowError(PurchasesError);
   });
 
-  test("configure multiple times returns different instances with object syntax", () => {
+  test("configure multiple times returns different instances", () => {
     const purchases = Purchases.configure({
       apiKey: testApiKey,
       appUserId: testUserId,

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -4,6 +4,7 @@ import {
   type CustomerInfo,
   type EntitlementInfo,
   Purchases,
+  type PurchasesConfig,
   PurchasesError,
   ReservedCustomerAttribute,
 } from "../main";
@@ -71,6 +72,109 @@ describe("Purchases.configure()", () => {
       "another_user_id",
     );
     expect(purchases).not.toEqual(purchases2);
+  });
+
+  // Tests for the new object-based configuration API
+  test("configures successfully with object syntax", () => {
+    const purchases = Purchases.configure({
+      apiKey: testApiKey,
+      appUserId: testUserId,
+    });
+    expect(purchases).toBeDefined();
+  });
+
+  test("configures successfully with object syntax and optional parameters", () => {
+    const purchases = Purchases.configure({
+      apiKey: testApiKey,
+      appUserId: testUserId,
+      httpConfig: {},
+      flags: { autoCollectUTMAsMetadata: false },
+    });
+    expect(purchases).toBeDefined();
+  });
+
+  test("throws error if given invalid api key with object syntax", () => {
+    expect(() =>
+      Purchases.configure({
+        apiKey: "goog_api_key",
+        appUserId: testUserId,
+      }),
+    ).toThrowError(PurchasesError);
+
+    expect(() =>
+      Purchases.configure({
+        apiKey: "rcb_test invalidchar",
+        appUserId: testUserId,
+      }),
+    ).toThrowError(PurchasesError);
+  });
+
+  test("throws error if given invalid user id with object syntax", () => {
+    expect(() =>
+      Purchases.configure({
+        apiKey: testApiKey,
+        appUserId: "",
+      }),
+    ).toThrowError(PurchasesError);
+
+    expect(() =>
+      Purchases.configure({
+        apiKey: testApiKey,
+        appUserId: "some/AppUserId",
+      }),
+    ).toThrowError(PurchasesError);
+  });
+
+  test("throws error if given invalid proxy url with object syntax", () => {
+    expect(() =>
+      Purchases.configure({
+        apiKey: testApiKey,
+        appUserId: testUserId,
+        httpConfig: {
+          proxyURL: "https://test.revenuecat.com/",
+        },
+      }),
+    ).toThrowError(PurchasesError);
+  });
+
+  test("throws error if given reserved additional header with object syntax", () => {
+    expect(() =>
+      Purchases.configure({
+        apiKey: testApiKey,
+        appUserId: testUserId,
+        httpConfig: {
+          additionalHeaders: { "X-Version": "123" },
+        },
+      }),
+    ).toThrowError(PurchasesError);
+  });
+
+  test("configure multiple times returns different instances with object syntax", () => {
+    const purchases = Purchases.configure({
+      apiKey: testApiKey,
+      appUserId: testUserId,
+    });
+    const purchases2 = Purchases.configure({
+      apiKey: "rcb_another_api_key",
+      appUserId: "another_user_id",
+    });
+    expect(purchases).not.toEqual(purchases2);
+  });
+
+  test("throws error if api key is not provided in object", () => {
+    expect(() =>
+      Purchases.configure({
+        appUserId: testUserId,
+      } as PurchasesConfig),
+    ).toThrowError(PurchasesError);
+  });
+
+  test("throws error if app user id is not provided in object", () => {
+    expect(() =>
+      Purchases.configure({
+        apiKey: testApiKey,
+      } as PurchasesConfig),
+    ).toThrowError(PurchasesError);
   });
 });
 

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -74,7 +74,6 @@ describe("Purchases.configure()", () => {
     expect(purchases).not.toEqual(purchases2);
   });
 
-  // Tests for the new object-based configuration API
   test("configures successfully with object syntax", () => {
     const purchases = Purchases.configure({
       apiKey: testApiKey,


### PR DESCRIPTION
## Motivation / Description

- We added a new way to configure the Purchases SDK using an object. This makes it easier to pass configuration parameters, especially when dealing with many optional settings.

## Changes introduced

- Introduced a new `PurchasesConfig` interface for object-based configuration.
- Updated the `configure` method to accept either the new configuration object or the previous positional parameters.
- Made changes to the API documentation to reflect these updates.
- Added tests for the new object-based configuration to ensure it works as expected.

## Linear ticket (if any)

- https://linear.app/revenuecat/issue/WEB-2744/improve-sdk-configuration-by-using-an-object
