### PR TITLE
Internally track embedded usages

### DIFF
--- a/examples/webbilling-demo/package-lock.json
+++ b/examples/webbilling-demo/package-lock.json
@@ -45,7 +45,7 @@
     },
     "../..": {
       "name": "@revenuecat/purchases-js",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.16.0",

--- a/examples/webbilling-demo/src/util/PurchasesLoader.ts
+++ b/examples/webbilling-demo/src/util/PurchasesLoader.ts
@@ -2,6 +2,7 @@ import type { CustomerInfo, Offering } from "@revenuecat/purchases-js";
 import { LogLevel, Purchases } from "@revenuecat/purchases-js";
 import type { LoaderFunction } from "react-router-dom";
 import { redirect, useLoaderData } from "react-router-dom";
+import type { FlagsConfig } from "../../../../src/entities/flags-config.ts";
 
 declare global {
   interface Window {
@@ -26,6 +27,7 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
   const searchParams = new URL(request.url).searchParams;
   const currency = searchParams.get("currency");
   const offeringId = searchParams.get("offeringId");
+  const rcSource = searchParams.get("rcSource") || undefined;
   const optOutOfAutoUTM =
     searchParams.get("optOutOfAutoUTM") === "true" || false;
 
@@ -37,6 +39,11 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
     additionalHeaders["X-RC-Canary"] = canary;
   }
 
+  const additionalFlags: FlagsConfig = {};
+  if (rcSource) {
+    additionalFlags["rcSource"] = rcSource;
+  }
+
   Purchases.setLogLevel(LogLevel.Verbose);
   try {
     if (!Purchases.isConfigured()) {
@@ -46,7 +53,7 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
         {
           additionalHeaders,
         },
-        { autoCollectUTMAsMetadata: !optOutOfAutoUTM },
+        { autoCollectUTMAsMetadata: !optOutOfAutoUTM, ...additionalFlags },
       );
     } else {
       await Purchases.getSharedInstance().changeUser(appUserId);

--- a/examples/webbilling-demo/src/util/PurchasesLoader.ts
+++ b/examples/webbilling-demo/src/util/PurchasesLoader.ts
@@ -1,8 +1,11 @@
 import type { CustomerInfo, Offering } from "@revenuecat/purchases-js";
-import { LogLevel, Purchases } from "@revenuecat/purchases-js";
+import {
+  LogLevel,
+  Purchases,
+  type FlagsConfig,
+} from "@revenuecat/purchases-js";
 import type { LoaderFunction } from "react-router-dom";
 import { redirect, useLoaderData } from "react-router-dom";
-import type { FlagsConfig } from "../../../../src/entities/flags-config.ts";
 
 declare global {
   interface Window {
@@ -41,6 +44,8 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
 
   const additionalFlags: FlagsConfig = {};
   if (rcSource) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
     additionalFlags["rcSource"] = rcSource;
   }
 

--- a/examples/webbilling-demo/src/util/PurchasesLoader.ts
+++ b/examples/webbilling-demo/src/util/PurchasesLoader.ts
@@ -1,8 +1,8 @@
 import type { CustomerInfo, Offering } from "@revenuecat/purchases-js";
 import {
+  type FlagsConfig,
   LogLevel,
   Purchases,
-  type FlagsConfig,
 } from "@revenuecat/purchases-js";
 import type { LoaderFunction } from "react-router-dom";
 import { redirect, useLoaderData } from "react-router-dom";
@@ -42,11 +42,13 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
     additionalHeaders["X-RC-Canary"] = canary;
   }
 
-  const additionalFlags: FlagsConfig = {};
+  const flagsConfig: FlagsConfig = {
+    autoCollectUTMAsMetadata: !optOutOfAutoUTM,
+  };
   if (rcSource) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
-    additionalFlags["rcSource"] = rcSource;
+    flagsConfig.rcSource = rcSource;
   }
 
   Purchases.setLogLevel(LogLevel.Verbose);
@@ -58,7 +60,7 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
         {
           additionalHeaders,
         },
-        { autoCollectUTMAsMetadata: !optOutOfAutoUTM, ...additionalFlags },
+        flagsConfig,
       );
     } else {
       await Purchases.getSharedInstance().changeUser(appUserId);

--- a/src/entities/flags-config.ts
+++ b/src/entities/flags-config.ts
@@ -1,3 +1,5 @@
+export const supportedRCSources = ["app", "embedded"];
+
 /**
  * Flags used to enable or disable certain features in the sdk.
  * @public

--- a/src/main.ts
+++ b/src/main.ts
@@ -622,23 +622,25 @@ export class Purchases {
         window.history.pushState({ checkoutOpen: true }, "");
       }
 
-      const onClose =
-        this._flags.rcSource === "app"
-          ? undefined
-          : () => {
-              const event = createCheckoutSessionEndClosedEvent();
-              this.eventsTracker.trackSDKEvent(event);
-              window.removeEventListener("popstate", onClose as EventListener);
+      const shouldPassOnCloseBehaviour =
+        this._flags.rcSource === "app" || this._flags.rcSource === "embedded";
 
-              if (component) {
-                unmount(component);
-              }
+      const onClose = shouldPassOnCloseBehaviour
+        ? undefined
+        : () => {
+            const event = createCheckoutSessionEndClosedEvent();
+            this.eventsTracker.trackSDKEvent(event);
+            window.removeEventListener("popstate", onClose as EventListener);
 
-              certainHTMLTarget.innerHTML = "";
+            if (component) {
+              unmount(component);
+            }
 
-              Logger.debugLog("Purchase cancelled by user");
-              reject(new PurchasesError(ErrorCode.UserCancelledError));
-            };
+            certainHTMLTarget.innerHTML = "";
+
+            Logger.debugLog("Purchase cancelled by user");
+            reject(new PurchasesError(ErrorCode.UserCancelledError));
+          };
 
       if (!isInElement && onClose) {
         window.addEventListener("popstate", onClose as EventListener);

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,7 +62,11 @@ import {
 } from "./behavioural-events/sdk-event-helpers";
 import { SDKEventName } from "./behavioural-events/sdk-events";
 import { autoParseUTMParams } from "./helpers/utm-params";
-import { defaultFlagsConfig, type FlagsConfig } from "./entities/flags-config";
+import {
+  defaultFlagsConfig,
+  type FlagsConfig,
+  supportedRCSources,
+} from "./entities/flags-config";
 import { generateUUID } from "./helpers/uuid-helper";
 import type { PlatformInfo } from "./entities/platform-info";
 import type { ReservedCustomerAttribute } from "./entities/attributes";
@@ -623,7 +627,8 @@ export class Purchases {
       }
 
       const shouldPassOnCloseBehaviour =
-        this._flags.rcSource === "app" || this._flags.rcSource === "embedded";
+        this._flags.rcSource &&
+        supportedRCSources.includes(this._flags.rcSource);
 
       const onClose = shouldPassOnCloseBehaviour
         ? undefined

--- a/src/tests/base.purchases_test.ts
+++ b/src/tests/base.purchases_test.ts
@@ -28,8 +28,11 @@ beforeEach(() => {
 
 afterAll(() => server.close());
 
-export function configurePurchases(appUserId: string = testUserId): Purchases {
+export function configurePurchases(
+  appUserId: string = testUserId,
+  rcSource: string = "rcSource",
+): Purchases {
   return Purchases.configure(testApiKey, appUserId, defaultHttpConfig, {
-    rcSource: "rcSource",
+    rcSource: rcSource,
   });
 }

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -399,7 +399,7 @@ describe("Purchases.purchase()", () => {
     unmountSpy.mockRestore();
   });
 
-  test("does shows the back button", async () => {
+  test("does show the back button", async () => {
     const purchases = configurePurchases(testUserId, "anyOtherValue");
     purchases.purchase({
       rcPackage: createMonthlyPackageMock(),

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import * as svelte from "svelte"; // import the module as a namespace
-
 import {
   type CustomerInfo,
   type EntitlementInfo,
@@ -8,19 +7,21 @@ import {
   PurchasesError,
   ReservedCustomerAttribute,
 } from "../main";
-import { ErrorCode, UninitializedPurchasesError } from "../entities/errors";
+import {
+  BackendErrorCode,
+  ErrorCode,
+  UninitializedPurchasesError,
+} from "../entities/errors";
 import {
   configurePurchases,
+  server,
   testApiKey,
   testUserId,
 } from "./base.purchases_test";
 import { createMonthlyPackageMock } from "./mocks/offering-mock-provider";
 import { waitFor } from "@testing-library/svelte";
-import { server } from "./base.purchases_test";
-import { HttpResponse } from "msw";
-import { BackendErrorCode } from "../entities/errors";
+import { http, HttpResponse } from "msw";
 import { expectPromiseToError } from "./test-helpers";
-import { http } from "msw";
 import { StatusCodes } from "http-status-codes";
 
 describe("Purchases.configure()", () => {
@@ -367,7 +368,7 @@ describe("Purchases._trackEvent", () => {
 });
 
 describe("Purchases.purchase()", () => {
-  test("pressing back button onmounts the component", async () => {
+  test("pressing back button unmounts the component", async () => {
     const unmountSpy = vi.spyOn(svelte, "unmount").mockImplementation(() => {
       return Promise.resolve();
     });
@@ -396,6 +397,57 @@ describe("Purchases.purchase()", () => {
     );
 
     unmountSpy.mockRestore();
+  });
+
+  test("does shows the back button", async () => {
+    const purchases = configurePurchases(testUserId, "anyOtherValue");
+    purchases.purchase({
+      rcPackage: createMonthlyPackageMock(),
+    });
+
+    await waitFor(() => {
+      const container = document.querySelector(".rcb-ui-root");
+      expect(container).not.toBeNull();
+      expect(document.querySelector(".rcb-back-button")).not.toBeNull();
+    });
+
+    purchases.close();
+    // Forcing the body to cleanup to not affect other tests
+    document.body.innerHTML = "";
+  });
+
+  test("does not show the back button for rcSource='app'", async () => {
+    const purchases = configurePurchases(testUserId, "app");
+    purchases.purchase({
+      rcPackage: createMonthlyPackageMock(),
+    });
+
+    await waitFor(() => {
+      const container = document.querySelector(".rcb-ui-root");
+      expect(container).not.toBeNull();
+      expect(document.querySelector(".rcb-back-button")).toBeNull();
+    });
+
+    purchases.close();
+    // Forcing the body to cleanup to not affect other tests
+    document.body.innerHTML = "";
+  });
+
+  test("does not show the back button for rcSource='embedded'", async () => {
+    const purchases = configurePurchases(testUserId, "embedded");
+    purchases.purchase({
+      rcPackage: createMonthlyPackageMock(),
+    });
+
+    await waitFor(() => {
+      const container = document.querySelector(".rcb-ui-root");
+      expect(container).not.toBeNull();
+      expect(document.querySelector(".rcb-back-button")).toBeNull();
+    });
+
+    purchases.close();
+    // Forcing the body to cleanup to not affect other tests
+    document.body.innerHTML = "";
   });
 
   test("throws error if api key is not provided", () => {


### PR DESCRIPTION
## Motivation / Description
We want to hide the close button in some specific scenarios internally.
This PR extends the rcSource flag to distinguish between the WPB scenario and any other scenario.

## Changes introduced
* Added support for a new 'embedded' rcSource value
* Added a test for the new behaviour
* Added support in the example app
