### PR TITLE
Prefer provided email for wallet payments

### DIFF
--- a/examples/webbilling-demo/package.json
+++ b/examples/webbilling-demo/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev-fake-https": "vite ",
+    "dev-fake-https": "vite --config vite-https.config.ts",
     "build": "tsc && vite build",
     "lint": "eslint \"**/*.{ts,tsx}\" --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -280,7 +280,9 @@
     emailValue: string,
   ) {
     selectedPaymentMethod = paymentMethod;
-    email = emailValue;
+    // If the customerEmail parameter was provided when starting the purchase
+    // flow, prefer that value over the email returned by the wallet
+    email = customerEmail ?? emailValue;
     await handleSubmit();
   }
 


### PR DESCRIPTION
## Summary
- avoid overwriting user-provided email when using Apple Pay / Google Pay

## Tests
* Existing unit tests
* I tested manually with the fake https certs demo app that it works with Apple Pay