### PR TITLE
Add controls to PricingSummary stories

### DIFF
--- a/src/stories/molecules/pricing-summary.stories.svelte
+++ b/src/stories/molecules/pricing-summary.stories.svelte
@@ -1,27 +1,51 @@
 <script module>
   import { brandingModes } from "../../../.storybook/modes";
-  import { defineMeta, setTemplate } from "@storybook/addon-svelte-csf";
+  import {
+    type Args,
+    defineMeta,
+    setTemplate,
+  } from "@storybook/addon-svelte-csf";
   import { renderInsideNavbarBody } from "../decorators/layout-decorators";
   import PricingSummary from "../../ui/molecules/pricing-summary.svelte";
   import {
-    product,
     subscriptionOption,
     subscriptionOptionWithTrial,
     subscriptionOptionWithIntroPricePaidUpfront,
     subscriptionOptionWithIntroPriceRecurring,
     subscriptionOptionWithTrialAndIntroPricePaidUpfront,
     subscriptionOptionWithTrialAndIntroPriceRecurring,
-    nonSubscriptionOption,
-    consumableProduct,
     priceBreakdownTaxDisabled,
     priceBreakdownTaxDisabledIntroPriceRecurring,
     priceBreakdownTaxDisabledIntroPricePaidUpfront,
   } from "../fixtures";
+  import { parseISODuration } from "../../helpers/duration-helper";
+
+  const billingDurations = ["P1W", "P1M", "P3M", "P6M", "P1Y"];
+  const introDurations = ["P1W", "P1M", "P3M", "P6M", "P1Y"];
+  const trialDurations = ["P3D", "P1W", "P2W", "P1M"];
 
   const { Story } = defineMeta({
     component: PricingSummary,
     title: "Molecules/PricingSummary",
     decorators: [renderInsideNavbarBody],
+    args: {
+      billingDuration: subscriptionOption.base.periodDuration,
+      hasIntroOffer: false,
+      introDuration: subscriptionOptionWithIntroPriceRecurring.introPrice.periodDuration,
+      introCycles: subscriptionOptionWithIntroPriceRecurring.introPrice.cycleCount,
+      hasTrial: false,
+      trialDuration: subscriptionOptionWithTrial.trial.periodDuration,
+    },
+    argTypes: {
+      billingDuration: { control: "select", options: billingDurations },
+      hasIntroOffer: { control: "boolean" },
+      introDuration: { control: "select", options: introDurations },
+      introCycles: {
+        control: { type: "number", min: 1, max: 12, step: 1 },
+      },
+      hasTrial: { control: "boolean" },
+      trialDuration: { control: "select", options: trialDurations },
+    },
     parameters: {
       chromatic: {
         modes: brandingModes,
@@ -30,11 +54,77 @@
   });
 </script>
 
+<script lang="ts">
+  setTemplate(template);
+</script>
+
+{#snippet template(args: Args<typeof Story>)}
+  {@const basePhase = args.billingDuration
+    ? {
+        ...subscriptionOption.base,
+        periodDuration: args.billingDuration,
+        period: parseISODuration(args.billingDuration),
+      }
+    : null}
+
+  {@const trialPhase = args.hasTrial
+    ? {
+        ...subscriptionOptionWithTrial.trial,
+        periodDuration: args.trialDuration ?? subscriptionOptionWithTrial.trial.periodDuration,
+        period: parseISODuration(
+          args.trialDuration ?? subscriptionOptionWithTrial.trial.periodDuration,
+        ),
+      }
+    : null}
+
+  {@const introPricePhase = args.hasIntroOffer
+    ? {
+        ...
+          (args.introCycles === 1
+            ? subscriptionOptionWithIntroPricePaidUpfront.introPrice
+            : subscriptionOptionWithIntroPriceRecurring.introPrice),
+        periodDuration:
+          args.introDuration ??
+          (args.introCycles === 1
+            ? subscriptionOptionWithIntroPricePaidUpfront.introPrice.periodDuration
+            : subscriptionOptionWithIntroPriceRecurring.introPrice.periodDuration),
+        period: parseISODuration(
+          args.introDuration ??
+            (args.introCycles === 1
+              ? subscriptionOptionWithIntroPricePaidUpfront.introPrice.periodDuration
+              : subscriptionOptionWithIntroPriceRecurring.introPrice.periodDuration),
+        ),
+        cycleCount:
+          args.introCycles ??
+          (args.introCycles === 1
+            ? subscriptionOptionWithIntroPricePaidUpfront.introPrice.cycleCount
+            : subscriptionOptionWithIntroPriceRecurring.introPrice.cycleCount),
+      }
+    : null}
+
+  {@const priceBreakdown =
+    args.priceBreakdown ??
+    (args.hasIntroOffer
+      ? args.introCycles > 1
+        ? priceBreakdownTaxDisabledIntroPriceRecurring
+        : priceBreakdownTaxDisabledIntroPricePaidUpfront
+      : priceBreakdownTaxDisabled)}
+
+  <PricingSummary
+    {priceBreakdown}
+    {basePhase}
+    {trialPhase}
+    introPricePhase={introPricePhase}
+  />
+{/snippet}
+
 <Story
   name="Subscription"
   args={{
     priceBreakdown: priceBreakdownTaxDisabled,
-    basePhase: subscriptionOption.base,
+    billingDuration: subscriptionOption.base.periodDuration,
+    hasTrial: false,
+    hasIntroOffer: false,
   }}
 />
 
@@ -42,8 +132,10 @@
   name="Trial"
   args={{
     priceBreakdown: priceBreakdownTaxDisabled,
-    basePhase: subscriptionOption.base,
-    trialPhase: subscriptionOptionWithTrial.trial,
+    billingDuration: subscriptionOption.base.periodDuration,
+    hasTrial: true,
+    trialDuration: subscriptionOptionWithTrial.trial.periodDuration,
+    hasIntroOffer: false,
   }}
 />
 
@@ -51,8 +143,11 @@
   name="Intro Price - Paid Upfront"
   args={{
     priceBreakdown: priceBreakdownTaxDisabledIntroPricePaidUpfront,
-    basePhase: subscriptionOptionWithIntroPricePaidUpfront.base,
-    introPricePhase: subscriptionOptionWithIntroPricePaidUpfront.introPrice,
+    billingDuration: subscriptionOptionWithIntroPricePaidUpfront.base.periodDuration,
+    hasIntroOffer: true,
+    introDuration: subscriptionOptionWithIntroPricePaidUpfront.introPrice.periodDuration,
+    introCycles: subscriptionOptionWithIntroPricePaidUpfront.introPrice.cycleCount,
+    hasTrial: false,
   }}
 />
 
@@ -60,8 +155,11 @@
   name="Intro Price - Recurring"
   args={{
     priceBreakdown: priceBreakdownTaxDisabledIntroPriceRecurring,
-    basePhase: subscriptionOptionWithIntroPriceRecurring.base,
-    introPricePhase: subscriptionOptionWithIntroPriceRecurring.introPrice,
+    billingDuration: subscriptionOptionWithIntroPriceRecurring.base.periodDuration,
+    hasIntroOffer: true,
+    introDuration: subscriptionOptionWithIntroPriceRecurring.introPrice.periodDuration,
+    introCycles: subscriptionOptionWithIntroPriceRecurring.introPrice.cycleCount,
+    hasTrial: false,
   }}
 />
 
@@ -69,10 +167,12 @@
   name="Trial + Intro Price - Paid Upfront"
   args={{
     priceBreakdown: priceBreakdownTaxDisabledIntroPricePaidUpfront,
-    basePhase: subscriptionOptionWithTrialAndIntroPricePaidUpfront.base,
-    trialPhase: subscriptionOptionWithTrialAndIntroPricePaidUpfront.trial,
-    introPricePhase:
-      subscriptionOptionWithTrialAndIntroPricePaidUpfront.introPrice,
+    billingDuration: subscriptionOptionWithTrialAndIntroPricePaidUpfront.base.periodDuration,
+    hasTrial: true,
+    trialDuration: subscriptionOptionWithTrialAndIntroPricePaidUpfront.trial.periodDuration,
+    hasIntroOffer: true,
+    introDuration: subscriptionOptionWithTrialAndIntroPricePaidUpfront.introPrice.periodDuration,
+    introCycles: subscriptionOptionWithTrialAndIntroPricePaidUpfront.introPrice.cycleCount,
   }}
 />
 
@@ -80,10 +180,12 @@
   name="Trial + Intro Price - Recurring"
   args={{
     priceBreakdown: priceBreakdownTaxDisabledIntroPriceRecurring,
-    basePhase: subscriptionOptionWithTrialAndIntroPriceRecurring.base,
-    trialPhase: subscriptionOptionWithTrialAndIntroPriceRecurring.trial,
-    introPricePhase:
-      subscriptionOptionWithTrialAndIntroPriceRecurring.introPrice,
+    billingDuration: subscriptionOptionWithTrialAndIntroPriceRecurring.base.periodDuration,
+    hasTrial: true,
+    trialDuration: subscriptionOptionWithTrialAndIntroPriceRecurring.trial.periodDuration,
+    hasIntroOffer: true,
+    introDuration: subscriptionOptionWithTrialAndIntroPriceRecurring.introPrice.periodDuration,
+    introCycles: subscriptionOptionWithTrialAndIntroPriceRecurring.introPrice.cycleCount,
   }}
 />
 
@@ -91,5 +193,8 @@
   name="Non Subscription"
   args={{
     priceBreakdown: priceBreakdownTaxDisabled,
+    hasTrial: false,
+    hasIntroOffer: false,
+    billingDuration: null,
   }}
 />

--- a/src/stories/molecules/pricing-summary.stories.svelte
+++ b/src/stories/molecules/pricing-summary.stories.svelte
@@ -31,8 +31,10 @@
     args: {
       billingDuration: subscriptionOption.base.periodDuration,
       hasIntroOffer: false,
-      introDuration: subscriptionOptionWithIntroPriceRecurring.introPrice.periodDuration,
-      introCycles: subscriptionOptionWithIntroPriceRecurring.introPrice.cycleCount,
+      introDuration:
+        subscriptionOptionWithIntroPriceRecurring.introPrice.periodDuration,
+      introCycles:
+        subscriptionOptionWithIntroPriceRecurring.introPrice.cycleCount,
       hasTrial: false,
       trialDuration: subscriptionOptionWithTrial.trial.periodDuration,
     },
@@ -70,29 +72,35 @@
   {@const trialPhase = args.hasTrial
     ? {
         ...subscriptionOptionWithTrial.trial,
-        periodDuration: args.trialDuration ?? subscriptionOptionWithTrial.trial.periodDuration,
+        periodDuration:
+          args.trialDuration ??
+          subscriptionOptionWithTrial.trial.periodDuration,
         period: parseISODuration(
-          args.trialDuration ?? subscriptionOptionWithTrial.trial.periodDuration,
+          args.trialDuration ??
+            subscriptionOptionWithTrial.trial.periodDuration,
         ),
       }
     : null}
 
   {@const introPricePhase = args.hasIntroOffer
     ? {
-        ...
-          (args.introCycles === 1
-            ? subscriptionOptionWithIntroPricePaidUpfront.introPrice
-            : subscriptionOptionWithIntroPriceRecurring.introPrice),
+        ...(args.introCycles === 1
+          ? subscriptionOptionWithIntroPricePaidUpfront.introPrice
+          : subscriptionOptionWithIntroPriceRecurring.introPrice),
         periodDuration:
           args.introDuration ??
           (args.introCycles === 1
-            ? subscriptionOptionWithIntroPricePaidUpfront.introPrice.periodDuration
-            : subscriptionOptionWithIntroPriceRecurring.introPrice.periodDuration),
+            ? subscriptionOptionWithIntroPricePaidUpfront.introPrice
+                .periodDuration
+            : subscriptionOptionWithIntroPriceRecurring.introPrice
+                .periodDuration),
         period: parseISODuration(
           args.introDuration ??
             (args.introCycles === 1
-              ? subscriptionOptionWithIntroPricePaidUpfront.introPrice.periodDuration
-              : subscriptionOptionWithIntroPriceRecurring.introPrice.periodDuration),
+              ? subscriptionOptionWithIntroPricePaidUpfront.introPrice
+                  .periodDuration
+              : subscriptionOptionWithIntroPriceRecurring.introPrice
+                  .periodDuration),
         ),
         cycleCount:
           args.introCycles ??
@@ -110,12 +118,7 @@
         : priceBreakdownTaxDisabledIntroPricePaidUpfront
       : priceBreakdownTaxDisabled)}
 
-  <PricingSummary
-    {priceBreakdown}
-    {basePhase}
-    {trialPhase}
-    introPricePhase={introPricePhase}
-  />
+  <PricingSummary {priceBreakdown} {basePhase} {trialPhase} {introPricePhase} />
 {/snippet}
 
 <Story
@@ -143,10 +146,13 @@
   name="Intro Price - Paid Upfront"
   args={{
     priceBreakdown: priceBreakdownTaxDisabledIntroPricePaidUpfront,
-    billingDuration: subscriptionOptionWithIntroPricePaidUpfront.base.periodDuration,
+    billingDuration:
+      subscriptionOptionWithIntroPricePaidUpfront.base.periodDuration,
     hasIntroOffer: true,
-    introDuration: subscriptionOptionWithIntroPricePaidUpfront.introPrice.periodDuration,
-    introCycles: subscriptionOptionWithIntroPricePaidUpfront.introPrice.cycleCount,
+    introDuration:
+      subscriptionOptionWithIntroPricePaidUpfront.introPrice.periodDuration,
+    introCycles:
+      subscriptionOptionWithIntroPricePaidUpfront.introPrice.cycleCount,
     hasTrial: false,
   }}
 />
@@ -155,10 +161,13 @@
   name="Intro Price - Recurring"
   args={{
     priceBreakdown: priceBreakdownTaxDisabledIntroPriceRecurring,
-    billingDuration: subscriptionOptionWithIntroPriceRecurring.base.periodDuration,
+    billingDuration:
+      subscriptionOptionWithIntroPriceRecurring.base.periodDuration,
     hasIntroOffer: true,
-    introDuration: subscriptionOptionWithIntroPriceRecurring.introPrice.periodDuration,
-    introCycles: subscriptionOptionWithIntroPriceRecurring.introPrice.cycleCount,
+    introDuration:
+      subscriptionOptionWithIntroPriceRecurring.introPrice.periodDuration,
+    introCycles:
+      subscriptionOptionWithIntroPriceRecurring.introPrice.cycleCount,
     hasTrial: false,
   }}
 />
@@ -167,12 +176,17 @@
   name="Trial + Intro Price - Paid Upfront"
   args={{
     priceBreakdown: priceBreakdownTaxDisabledIntroPricePaidUpfront,
-    billingDuration: subscriptionOptionWithTrialAndIntroPricePaidUpfront.base.periodDuration,
+    billingDuration:
+      subscriptionOptionWithTrialAndIntroPricePaidUpfront.base.periodDuration,
     hasTrial: true,
-    trialDuration: subscriptionOptionWithTrialAndIntroPricePaidUpfront.trial.periodDuration,
+    trialDuration:
+      subscriptionOptionWithTrialAndIntroPricePaidUpfront.trial.periodDuration,
     hasIntroOffer: true,
-    introDuration: subscriptionOptionWithTrialAndIntroPricePaidUpfront.introPrice.periodDuration,
-    introCycles: subscriptionOptionWithTrialAndIntroPricePaidUpfront.introPrice.cycleCount,
+    introDuration:
+      subscriptionOptionWithTrialAndIntroPricePaidUpfront.introPrice
+        .periodDuration,
+    introCycles:
+      subscriptionOptionWithTrialAndIntroPricePaidUpfront.introPrice.cycleCount,
   }}
 />
 
@@ -180,12 +194,17 @@
   name="Trial + Intro Price - Recurring"
   args={{
     priceBreakdown: priceBreakdownTaxDisabledIntroPriceRecurring,
-    billingDuration: subscriptionOptionWithTrialAndIntroPriceRecurring.base.periodDuration,
+    billingDuration:
+      subscriptionOptionWithTrialAndIntroPriceRecurring.base.periodDuration,
     hasTrial: true,
-    trialDuration: subscriptionOptionWithTrialAndIntroPriceRecurring.trial.periodDuration,
+    trialDuration:
+      subscriptionOptionWithTrialAndIntroPriceRecurring.trial.periodDuration,
     hasIntroOffer: true,
-    introDuration: subscriptionOptionWithTrialAndIntroPriceRecurring.introPrice.periodDuration,
-    introCycles: subscriptionOptionWithTrialAndIntroPriceRecurring.introPrice.cycleCount,
+    introDuration:
+      subscriptionOptionWithTrialAndIntroPriceRecurring.introPrice
+        .periodDuration,
+    introCycles:
+      subscriptionOptionWithTrialAndIntroPriceRecurring.introPrice.cycleCount,
   }}
 />
 

--- a/src/stories/molecules/pricing-summary.stories.svelte
+++ b/src/stories/molecules/pricing-summary.stories.svelte
@@ -1,122 +1,112 @@
-<script module>
+<script module lang="ts">
   import { brandingModes } from "../../../.storybook/modes";
-  import {
-    type Args,
-    defineMeta,
-    setTemplate,
-  } from "@storybook/addon-svelte-csf";
+  import { defineMeta, setTemplate } from "@storybook/addon-svelte-csf";
   import { renderInsideNavbarBody } from "../decorators/layout-decorators";
   import PricingSummary from "../../ui/molecules/pricing-summary.svelte";
   import {
+    priceBreakdownTaxDisabled,
+    priceBreakdownTaxDisabledIntroPricePaidUpfront,
+    priceBreakdownTaxDisabledIntroPriceRecurring,
     subscriptionOption,
-    subscriptionOptionWithTrial,
     subscriptionOptionWithIntroPricePaidUpfront,
     subscriptionOptionWithIntroPriceRecurring,
+    subscriptionOptionWithTrial,
     subscriptionOptionWithTrialAndIntroPricePaidUpfront,
     subscriptionOptionWithTrialAndIntroPriceRecurring,
-    priceBreakdownTaxDisabled,
-    priceBreakdownTaxDisabledIntroPriceRecurring,
-    priceBreakdownTaxDisabledIntroPricePaidUpfront,
   } from "../fixtures";
-  import { parseISODuration } from "../../helpers/duration-helper";
 
-  const billingDurations = ["P1W", "P1M", "P3M", "P6M", "P1Y"];
-  const introDurations = ["P1W", "P1M", "P3M", "P6M", "P1Y"];
-  const trialDurations = ["P3D", "P1W", "P2W", "P1M"];
+  import { parseISODuration } from "../../helpers/duration-helper";
+  import type { PricingPhase } from "../../entities/offerings";
+
+  const billingDurations = ["P1W", "P1M", "P3M", "P6M", "P1Y", null];
+  const introDurations = ["P1W", "P1M", "P3M", "P6M", "P1Y", null];
+  const trialDurations = ["P3D", "P1W", "P2W", "P1M", null];
 
   const { Story } = defineMeta({
     component: PricingSummary,
     title: "Molecules/PricingSummary",
+    // @ts-expect-error ignore typing of decorator
     decorators: [renderInsideNavbarBody],
+    // The args of this story define custom controls to make it easier to use it.
+    // I didn't find a way to define the custom controls for the child attributes.
     args: {
-      billingDuration: subscriptionOption.base.periodDuration,
-      hasIntroOffer: false,
-      introDuration:
-        subscriptionOptionWithIntroPriceRecurring.introPrice.periodDuration,
-      introCycles:
-        subscriptionOptionWithIntroPriceRecurring.introPrice.cycleCount,
-      hasTrial: false,
-      trialDuration: subscriptionOptionWithTrial.trial.periodDuration,
-    },
+      billingDuration: null,
+      introDuration: null,
+      introCycles: null,
+      trialDuration: null,
+    } as any,
     argTypes: {
       billingDuration: { control: "select", options: billingDurations },
-      hasIntroOffer: { control: "boolean" },
       introDuration: { control: "select", options: introDurations },
       introCycles: {
         control: { type: "number", min: 1, max: 12, step: 1 },
       },
-      hasTrial: { control: "boolean" },
       trialDuration: { control: "select", options: trialDurations },
-    },
+    } as any,
     parameters: {
       chromatic: {
         modes: brandingModes,
       },
     },
   });
+
+  const setPeriodDuration = (
+    periodDuration: string,
+    pricingPhase: PricingPhase,
+    defaultP: PricingPhase,
+  ) => {
+    if (!periodDuration) {
+      return pricingPhase;
+    }
+    if (!pricingPhase) {
+      return {
+        ...defaultP,
+        period: parseISODuration(periodDuration),
+        periodDuration: periodDuration,
+      };
+    }
+    return {
+      ...pricingPhase,
+      period: parseISODuration(periodDuration) || pricingPhase.periodDuration,
+      periodDuration: periodDuration,
+    } as PricingPhase;
+  };
+  const setCyclesCount = (cyclesCount: number, pricingPhase: PricingPhase) => {
+    if (!cyclesCount) {
+      return pricingPhase;
+    }
+    return {
+      ...pricingPhase,
+      cycleCount: cyclesCount || pricingPhase.cycleCount,
+    } as PricingPhase;
+  };
 </script>
 
 <script lang="ts">
+  // Using a template to translate the custom controls into props.
   setTemplate(template);
 </script>
 
-{#snippet template(args: Args<typeof Story>)}
-  {@const basePhase = args.billingDuration
-    ? {
-        ...subscriptionOption.base,
-        periodDuration: args.billingDuration,
-        period: parseISODuration(args.billingDuration),
-      }
-    : null}
-
-  {@const trialPhase = args.hasTrial
-    ? {
-        ...subscriptionOptionWithTrial.trial,
-        periodDuration:
-          args.trialDuration ??
-          subscriptionOptionWithTrial.trial.periodDuration,
-        period: parseISODuration(
-          args.trialDuration ??
-            subscriptionOptionWithTrial.trial.periodDuration,
-        ),
-      }
-    : null}
-
-  {@const introPricePhase = args.hasIntroOffer
-    ? {
-        ...(args.introCycles === 1
-          ? subscriptionOptionWithIntroPricePaidUpfront.introPrice
-          : subscriptionOptionWithIntroPriceRecurring.introPrice),
-        periodDuration:
-          args.introDuration ??
-          (args.introCycles === 1
-            ? subscriptionOptionWithIntroPricePaidUpfront.introPrice
-                .periodDuration
-            : subscriptionOptionWithIntroPriceRecurring.introPrice
-                .periodDuration),
-        period: parseISODuration(
-          args.introDuration ??
-            (args.introCycles === 1
-              ? subscriptionOptionWithIntroPricePaidUpfront.introPrice
-                  .periodDuration
-              : subscriptionOptionWithIntroPriceRecurring.introPrice
-                  .periodDuration),
-        ),
-        cycleCount:
-          args.introCycles ??
-          (args.introCycles === 1
-            ? subscriptionOptionWithIntroPricePaidUpfront.introPrice.cycleCount
-            : subscriptionOptionWithIntroPriceRecurring.introPrice.cycleCount),
-      }
-    : null}
-
-  {@const priceBreakdown =
-    args.priceBreakdown ??
-    (args.hasIntroOffer
-      ? args.introCycles > 1
-        ? priceBreakdownTaxDisabledIntroPriceRecurring
-        : priceBreakdownTaxDisabledIntroPricePaidUpfront
-      : priceBreakdownTaxDisabled)}
+{#snippet template(args: any)}
+  {@const priceBreakdown = args.priceBreakdown}
+  {@const basePhase = setPeriodDuration(
+    args.billingDuration,
+    args.basePhase,
+    subscriptionOption.base,
+  )}
+  {@const trialPhase = setPeriodDuration(
+    args.trialDuration,
+    args.trialPhase,
+    subscriptionOptionWithTrial.trial!,
+  )}
+  {@const introPricePhase = setCyclesCount(
+    args.introCycles,
+    setPeriodDuration(
+      args.introDuration,
+      args.trialPhase,
+      subscriptionOptionWithIntroPriceRecurring.introPrice!,
+    ),
+  )}
 
   <PricingSummary {priceBreakdown} {basePhase} {trialPhase} {introPricePhase} />
 {/snippet}
@@ -125,9 +115,7 @@
   name="Subscription"
   args={{
     priceBreakdown: priceBreakdownTaxDisabled,
-    billingDuration: subscriptionOption.base.periodDuration,
-    hasTrial: false,
-    hasIntroOffer: false,
+    basePhase: subscriptionOption.base,
   }}
 />
 
@@ -135,10 +123,8 @@
   name="Trial"
   args={{
     priceBreakdown: priceBreakdownTaxDisabled,
-    billingDuration: subscriptionOption.base.periodDuration,
-    hasTrial: true,
-    trialDuration: subscriptionOptionWithTrial.trial.periodDuration,
-    hasIntroOffer: false,
+    basePhase: subscriptionOption.base,
+    trialPhase: subscriptionOptionWithTrial.trial,
   }}
 />
 
@@ -146,14 +132,8 @@
   name="Intro Price - Paid Upfront"
   args={{
     priceBreakdown: priceBreakdownTaxDisabledIntroPricePaidUpfront,
-    billingDuration:
-      subscriptionOptionWithIntroPricePaidUpfront.base.periodDuration,
-    hasIntroOffer: true,
-    introDuration:
-      subscriptionOptionWithIntroPricePaidUpfront.introPrice.periodDuration,
-    introCycles:
-      subscriptionOptionWithIntroPricePaidUpfront.introPrice.cycleCount,
-    hasTrial: false,
+    basePhase: subscriptionOptionWithIntroPricePaidUpfront.base,
+    introPricePhase: subscriptionOptionWithIntroPricePaidUpfront.introPrice,
   }}
 />
 
@@ -161,14 +141,8 @@
   name="Intro Price - Recurring"
   args={{
     priceBreakdown: priceBreakdownTaxDisabledIntroPriceRecurring,
-    billingDuration:
-      subscriptionOptionWithIntroPriceRecurring.base.periodDuration,
-    hasIntroOffer: true,
-    introDuration:
-      subscriptionOptionWithIntroPriceRecurring.introPrice.periodDuration,
-    introCycles:
-      subscriptionOptionWithIntroPriceRecurring.introPrice.cycleCount,
-    hasTrial: false,
+    basePhase: subscriptionOptionWithIntroPriceRecurring.base,
+    introPricePhase: subscriptionOptionWithIntroPriceRecurring.introPrice,
   }}
 />
 
@@ -176,17 +150,10 @@
   name="Trial + Intro Price - Paid Upfront"
   args={{
     priceBreakdown: priceBreakdownTaxDisabledIntroPricePaidUpfront,
-    billingDuration:
-      subscriptionOptionWithTrialAndIntroPricePaidUpfront.base.periodDuration,
-    hasTrial: true,
-    trialDuration:
-      subscriptionOptionWithTrialAndIntroPricePaidUpfront.trial.periodDuration,
-    hasIntroOffer: true,
-    introDuration:
-      subscriptionOptionWithTrialAndIntroPricePaidUpfront.introPrice
-        .periodDuration,
-    introCycles:
-      subscriptionOptionWithTrialAndIntroPricePaidUpfront.introPrice.cycleCount,
+    basePhase: subscriptionOptionWithTrialAndIntroPricePaidUpfront.base,
+    trialPhase: subscriptionOptionWithTrialAndIntroPricePaidUpfront.trial,
+    introPricePhase:
+      subscriptionOptionWithTrialAndIntroPricePaidUpfront.introPrice,
   }}
 />
 
@@ -194,17 +161,10 @@
   name="Trial + Intro Price - Recurring"
   args={{
     priceBreakdown: priceBreakdownTaxDisabledIntroPriceRecurring,
-    billingDuration:
-      subscriptionOptionWithTrialAndIntroPriceRecurring.base.periodDuration,
-    hasTrial: true,
-    trialDuration:
-      subscriptionOptionWithTrialAndIntroPriceRecurring.trial.periodDuration,
-    hasIntroOffer: true,
-    introDuration:
-      subscriptionOptionWithTrialAndIntroPriceRecurring.introPrice
-        .periodDuration,
-    introCycles:
-      subscriptionOptionWithTrialAndIntroPriceRecurring.introPrice.cycleCount,
+    basePhase: subscriptionOptionWithTrialAndIntroPriceRecurring.base,
+    trialPhase: subscriptionOptionWithTrialAndIntroPriceRecurring.trial,
+    introPricePhase:
+      subscriptionOptionWithTrialAndIntroPriceRecurring.introPrice,
   }}
 />
 
@@ -212,8 +172,5 @@
   name="Non Subscription"
   args={{
     priceBreakdown: priceBreakdownTaxDisabled,
-    hasTrial: false,
-    hasIntroOffer: false,
-    billingDuration: null,
   }}
 />


### PR DESCRIPTION
Task
Add Storybook controls to PricingSummary for intro offer, billing cycle, and trial settings.

Context
Testing how intro offer duration displays alongside billing cycles and trials.

Summary
	•	Add args for billing cycle, intro offer, and trial duration
	•	Support toggling trial on/off