### PR TITLE
chore: Paddle Support Limitation and API Key Restriction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@revenuecat/purchases-js",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@revenuecat/purchases-js",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@revenuecat/purchases-js",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@revenuecat/purchases-js",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.16.0",

--- a/src/entities/flags-config.ts
+++ b/src/entities/flags-config.ts
@@ -24,6 +24,13 @@ export interface FlagsConfig {
    * @internal
    */
   rcSource?: string;
+
+  /**
+   * If set to true, the SDK will allow Paddle API keys. Paddle is not fully supported yet, only some features are available.
+   * @defaultValue false
+   * @internal
+   */
+  allowPaddleAPIKey?: boolean;
 }
 
 export const defaultFlagsConfig: FlagsConfig = {

--- a/src/helpers/api-key-helper.ts
+++ b/src/helpers/api-key-helper.ts
@@ -1,7 +1,19 @@
-export function isSandboxApiKey(apiKey: string): boolean {
+const rc_api_key_regex = /^rcb_[a-zA-Z0-9_.-]+$/;
+const paddle_api_key_regex = /^pdl_[a-zA-Z0-9_.-]+$/;
+const rc_simulated_store_api_key_regex = /^test_[a-zA-Z0-9_.-]+$/;
+
+export function isWebBillingSandboxApiKey(apiKey: string): boolean {
   return apiKey ? apiKey.startsWith("rcb_sb_") : false;
 }
 
+export function isWebBillingApiKey(apiKey: string): boolean {
+  return apiKey ? rc_api_key_regex.test(apiKey) : false;
+}
+
+export function isPaddleApiKey(apiKey: string): boolean {
+  return apiKey ? paddle_api_key_regex.test(apiKey) : false;
+}
+
 export function isSimulatedStoreApiKey(apiKey: string): boolean {
-  return apiKey ? apiKey.startsWith("test_") : false;
+  return apiKey ? rc_simulated_store_api_key_regex.test(apiKey) : false;
 }

--- a/src/helpers/configuration-validators.ts
+++ b/src/helpers/configuration-validators.ts
@@ -1,3 +1,4 @@
+import type { FlagsConfig } from "../main";
 import { ErrorCode, PurchasesError } from "../entities/errors";
 import { SDK_HEADERS } from "../networking/http-client";
 import {
@@ -6,15 +7,16 @@ import {
   isWebBillingApiKey,
 } from "./api-key-helper";
 
-export function validateApiKey(apiKey: string) {
-  if (
-    !isWebBillingApiKey(apiKey) &&
-    !isPaddleApiKey(apiKey) &&
-    !isSimulatedStoreApiKey(apiKey)
-  ) {
+export function validateApiKey(apiKey: string, flags?: FlagsConfig) {
+  const isValidApiKey =
+    isWebBillingApiKey(apiKey) ||
+    isSimulatedStoreApiKey(apiKey) ||
+    (isPaddleApiKey(apiKey) && flags?.allowPaddleAPIKey);
+
+  if (!isValidApiKey) {
     throw new PurchasesError(
       ErrorCode.InvalidCredentialsError,
-      "Invalid API key. Use your Web Billing or Paddle API key.",
+      "Invalid API key. Use your Web Billing API key.",
     );
   }
 }

--- a/src/helpers/configuration-validators.ts
+++ b/src/helpers/configuration-validators.ts
@@ -1,14 +1,16 @@
 import { ErrorCode, PurchasesError } from "../entities/errors";
 import { SDK_HEADERS } from "../networking/http-client";
+import {
+  isPaddleApiKey,
+  isSimulatedStoreApiKey,
+  isWebBillingApiKey,
+} from "./api-key-helper";
 
 export function validateApiKey(apiKey: string) {
-  const rc_api_key_regex = /^rcb_[a-zA-Z0-9_.-]+$/;
-  const paddle_api_key_regex = /^pdl_[a-zA-Z0-9_.-]+$/;
-  const rc_simulated_store_api_key_regex = /^test_[a-zA-Z0-9_.-]+$/;
   if (
-    !rc_api_key_regex.test(apiKey) &&
-    !paddle_api_key_regex.test(apiKey) &&
-    !rc_simulated_store_api_key_regex.test(apiKey)
+    !isWebBillingApiKey(apiKey) &&
+    !isPaddleApiKey(apiKey) &&
+    !isSimulatedStoreApiKey(apiKey)
   ) {
     throw new PurchasesError(
       ErrorCode.InvalidCredentialsError,

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ import { RC_ENDPOINT } from "./helpers/constants";
 import { Backend } from "./networking/backend";
 import {
   isSimulatedStoreApiKey,
-  isSandboxApiKey,
+  isWebBillingSandboxApiKey,
 } from "./helpers/api-key-helper";
 import {
   type OperationSessionSuccessfulResult,
@@ -357,7 +357,7 @@ export class Purchases {
         "Project was build without some of the environment variables set",
       );
     }
-    if (isSandboxApiKey(apiKey)) {
+    if (isWebBillingSandboxApiKey(apiKey)) {
       Logger.debugLog(
         "Initializing Purchases SDK with Web billing sandbox API Key",
       );
@@ -884,7 +884,8 @@ export class Purchases {
    */
   public isSandbox(): boolean {
     return (
-      isSandboxApiKey(this._API_KEY) || isSimulatedStoreApiKey(this._API_KEY)
+      isWebBillingSandboxApiKey(this._API_KEY) ||
+      isSimulatedStoreApiKey(this._API_KEY)
     );
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -290,7 +290,7 @@ export class Purchases {
   }
 
   private static validateConfig(config: PurchasesConfig) {
-    validateApiKey(config.apiKey);
+    validateApiKey(config.apiKey, config.flags);
     validateAppUserId(config.appUserId);
     validateProxyUrl(config.httpConfig?.proxyURL);
     validateAdditionalHeaders(config.httpConfig?.additionalHeaders);

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -24,8 +24,8 @@ import type {
 } from "../entities/offerings";
 import type { CheckoutCompleteResponse } from "./responses/checkout-complete-response";
 import type { CheckoutCalculateTaxResponse } from "./responses/checkout-calculate-tax-response";
-import { isSandboxApiKey } from "../helpers/api-key-helper";
 import { SetAttributesEndpoint } from "./endpoints";
+import { isWebBillingSandboxApiKey } from "../helpers/api-key-helper";
 
 export class Backend {
   private readonly API_KEY: string;
@@ -35,7 +35,7 @@ export class Backend {
   constructor(API_KEY: string, httpConfig: HttpConfig = defaultHttpConfig) {
     this.API_KEY = API_KEY;
     this.httpConfig = httpConfig;
-    this.isSandbox = isSandboxApiKey(API_KEY);
+    this.isSandbox = isWebBillingSandboxApiKey(API_KEY);
   }
 
   getIsSandbox(): boolean {

--- a/src/networking/http-client.ts
+++ b/src/networking/http-client.ts
@@ -3,7 +3,7 @@ import type { BackendErrorCode } from "../entities/errors";
 import { ErrorCode, ErrorCodeUtils, PurchasesError } from "../entities/errors";
 import { RC_ENDPOINT, VERSION } from "../helpers/constants";
 import { StatusCodes } from "http-status-codes";
-import { isSandboxApiKey } from "../helpers/api-key-helper";
+import { isWebBillingSandboxApiKey } from "../helpers/api-key-helper";
 import type { HttpConfig } from "../entities/http-config";
 import { Purchases } from "../main";
 
@@ -131,7 +131,7 @@ export function getHeaders(
     [ACCEPT_HEADER]: "application/json",
     [PLATFORM_HEADER]: "web",
     [VERSION_HEADER]: VERSION,
-    [IS_SANDBOX_HEADER]: `${isSandboxApiKey(apiKey)}`,
+    [IS_SANDBOX_HEADER]: `${isWebBillingSandboxApiKey(apiKey)}`,
   };
   const platformInfo = Purchases.getPlatformInfo();
   if (platformInfo) {

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -110,6 +110,54 @@ describe("Purchases.configure()", () => {
     ).toThrowError(PurchasesError);
   });
 
+  test("throws error if given invalid paddle api key", () => {
+    expect(() =>
+      Purchases.configure({
+        apiKey: "pdl_invalid_key",
+        appUserId: testUserId,
+      }),
+    ).toThrowError(PurchasesError);
+  });
+
+  test("throws error if given valid paddle api key but allowPaddleAPIKey is false", () => {
+    expect(() =>
+      Purchases.configure({
+        apiKey: "pdl_valid_key",
+        appUserId: testUserId,
+      }),
+    ).toThrowError(PurchasesError);
+  });
+
+  test("does not throw error if given valid paddle api key but allowPaddleAPIKey is true", () => {
+    expect(() =>
+      Purchases.configure({
+        apiKey: "pdl_valid_key",
+        appUserId: testUserId,
+        flags: {
+          allowPaddleAPIKey: true,
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  test("does not throw error if given valid web billing api key", () => {
+    expect(() =>
+      Purchases.configure({
+        apiKey: testApiKey,
+        appUserId: testUserId,
+      }),
+    ).not.toThrow();
+  });
+
+  test("does not throw error if given valid simulated store api key", () => {
+    expect(() =>
+      Purchases.configure({
+        apiKey: "test_valid_key",
+        appUserId: testUserId,
+      }),
+    ).not.toThrow();
+  });
+
   test("throws error if given invalid user id", () => {
     expect(() =>
       Purchases.configure({


### PR DESCRIPTION
## Motivation / Description

While this SDK technically supports Paddle API keys, Paddle integration is still in development with limited feature availability. To prevent potential issues and confusion for developers, we're implementing stricter controls around Paddle API key usage.

## Changes introduced

- **Updated Error Message:** The invalid API key error message now only recommends using "Web Billing API key" instead of "Web Billing or Paddle API key," removing the suggestion to use Paddle.
- **Code Refactoring:** Improved API key validation by extracting detection logic into dedicated helper functions (`isPaddleApiKey`, `isWebBillingApiKey`, etc.).
- Updated API key validation to reject Paddle API keys by default
