### PR TITLE
Add getVirtualCurrencies backend network request

### DIFF
--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -10,12 +10,14 @@ import {
   GetOfferingsEndpoint,
   GetProductsEndpoint,
   PostReceiptEndpoint,
+  GetVirtualCurrenciesEndpoint,
 } from "./endpoints";
 import { type SubscriberResponse } from "./responses/subscriber-response";
 import type { CheckoutStartResponse } from "./responses/checkout-start-response";
 import { type ProductsResponse } from "./responses/products-response";
 import { type BrandingInfoResponse } from "./responses/branding-response";
 import { type CheckoutStatusResponse } from "./responses/checkout-status-response";
+import { type VirtualCurrenciesResponse } from "./responses/virtual-currencies-response";
 import { defaultHttpConfig, type HttpConfig } from "../entities/http-config";
 import type {
   PresentedOfferingContext,
@@ -298,6 +300,18 @@ export class Backend {
       {
         apiKey: this.API_KEY,
         body: requestBody,
+        httpConfig: this.httpConfig,
+      },
+    );
+  }
+
+  async getVirtualCurrencies(
+    appUserId: string,
+  ): Promise<VirtualCurrenciesResponse> {
+    return await performRequest<null, VirtualCurrenciesResponse>(
+      new GetVirtualCurrenciesEndpoint(appUserId),
+      {
+        apiKey: this.API_KEY,
         httpConfig: this.httpConfig,
       },
     );

--- a/src/networking/endpoints.ts
+++ b/src/networking/endpoints.ts
@@ -155,6 +155,21 @@ export class PostReceiptEndpoint implements Endpoint {
   }
 }
 
+export class GetVirtualCurrenciesEndpoint implements Endpoint {
+  method: HttpMethodType = "GET";
+  name: string = "getVirtualCurrencies";
+  private readonly appUserId: string;
+
+  constructor(appUserId: string) {
+    this.appUserId = appUserId;
+  }
+
+  urlPath(): string {
+    const encodedAppUserId = encodeURIComponent(this.appUserId);
+    return `${SUBSCRIBERS_PATH}/${encodedAppUserId}/virtual_currencies`;
+  }
+}
+
 export type SupportedEndpoint =
   | GetOfferingsEndpoint
   | PurchaseEndpoint
@@ -163,4 +178,5 @@ export type SupportedEndpoint =
   | GetBrandingInfoEndpoint
   | GetCheckoutStatusEndpoint
   | SetAttributesEndpoint
-  | PostReceiptEndpoint;
+  | PostReceiptEndpoint
+  | GetVirtualCurrenciesEndpoint;

--- a/src/networking/responses/virtual-currencies-response.ts
+++ b/src/networking/responses/virtual-currencies-response.ts
@@ -1,0 +1,10 @@
+export interface VirtualCurrencyResponse {
+  balance: number;
+  code: string;
+  description: string | null;
+  name: string;
+}
+
+export interface VirtualCurrenciesResponse {
+  virtual_currencies: { [currencyCode: string]: VirtualCurrencyResponse };
+}

--- a/src/tests/networking/endpoints.test.ts
+++ b/src/tests/networking/endpoints.test.ts
@@ -5,6 +5,7 @@ import {
   GetCustomerInfoEndpoint,
   GetOfferingsEndpoint,
   GetProductsEndpoint,
+  GetVirtualCurrenciesEndpoint,
   PostReceiptEndpoint,
   PurchaseEndpoint,
   SetAttributesEndpoint,
@@ -147,5 +148,29 @@ describe("postReceipt endopint", () => {
 
   test("has correct urlPath", () => {
     expect(endpoint.urlPath()).toBe("/v1/receipts");
+  });
+});
+
+describe("getVirtualCurrencies endpoint", () => {
+  const endpoint = new GetVirtualCurrenciesEndpoint("someAppUserId");
+
+  test("uses correct method", () => {
+    expect(endpoint.method).toBe("GET");
+  });
+
+  test("has correct urlPath for common app user id", () => {
+    expect(endpoint.urlPath()).toBe(
+      "/v1/subscribers/someAppUserId/virtual_currencies",
+    );
+  });
+
+  test("correctly encodes app user id", () => {
+    expect(
+      new GetVirtualCurrenciesEndpoint(
+        "some+User/id#That$Requires&Encoding",
+      ).urlPath(),
+    ).toBe(
+      "/v1/subscribers/some%2BUser%2Fid%23That%24Requires%26Encoding/virtual_currencies",
+    );
   });
 });

--- a/src/tests/test-responses.ts
+++ b/src/tests/test-responses.ts
@@ -398,6 +398,32 @@ export const checkoutCompleteResponse: CheckoutCompleteResponse = {
   },
 };
 
+export const getVirtualCurrenciesResponseWith3Currencies = {
+  virtual_currencies: {
+    GLD: {
+      balance: 100,
+      code: "GLD",
+      description: "It's gold",
+      name: "Gold",
+    },
+    SLV: {
+      balance: 100,
+      code: "SLV",
+      name: "Silver",
+    },
+    BRNZ: {
+      balance: -1,
+      code: "BRNZ",
+      description: "It's bronze",
+      name: "Bronze",
+    },
+  },
+};
+
+export const getVirtualCurrenciesResponseWithNoCurrencies = {
+  virtual_currencies: {},
+};
+
 export interface GetRequest {
   url: string;
 }


### PR DESCRIPTION
### Context
We're working on adding the ability to fetch virtual currency balances to the `purchases-js` SDK. To keep the size of the PRs down, we're breaking this functionality down into multiple PRs, and we'll expose the functionality the developers through the SDK's API when it's all ready.

### Description
This PR adds the ability for the SDK to call the backend's `v1/subscribers/{APP_USER_ID}/virtual_currencies` endpoint to fetch the virtual currencies for a given app user ID.

Specifically, this PR:
- Creates a new `GetVirtualCurrenciesEndpoint` object to describe the endpoint
- Adds a new function to the backend class to support calling this endpoint:
```typescript
async getVirtualCurrencies(
  appUserId: string,
): Promise<VirtualCurrenciesResponse>
```
- Adds unit tests for both the `GetVirtualCurrenciesEndpoint` object and the `backend.getVirtualCurrencies` function

No new public facing APIs or functionality is added by this PR.

### Next Steps
Next up, we'll:
- Create the public `VirtualCurrency` / `VirtualCurrencies` classes and build mappers to them from the `VirtualCurrenciesResponse` object. These objects will mirror those found in the mobile SDKs.
- Investigate caching the responses from the `backend.getVirtualCurrencies` calls like we do in the mobile SDKs