### PR TITLE
Add `currency` property to simulated store post receipt

### DIFF
--- a/src/helpers/simulated-store-post-receipt-helper.ts
+++ b/src/helpers/simulated-store-post-receipt-helper.ts
@@ -24,6 +24,7 @@ export async function postSimulatedStoreReceipt(
   const subscriberResponse = await backend.postReceipt(
     appUserId,
     product.identifier,
+    product.price.currency,
     fetchToken,
     product.presentedOfferingContext,
     "purchase",

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -257,6 +257,7 @@ export class Backend {
   async postReceipt(
     appUserId: string,
     productId: string,
+    currency: string,
     fetchToken: string,
     presentedOfferingContext: PresentedOfferingContext,
     initiationSource: string,
@@ -268,6 +269,7 @@ export class Backend {
     type PostReceiptRequestBody = {
       fetch_token: string;
       product_id: string;
+      currency: string;
       app_user_id: string;
       presented_offering_identifier: string;
       presented_placement_identifier: string | null;
@@ -286,6 +288,7 @@ export class Backend {
     const requestBody: PostReceiptRequestBody = {
       fetch_token: fetchToken,
       product_id: productId,
+      currency: currency,
       app_user_id: appUserId,
       presented_offering_identifier:
         presentedOfferingContext.offeringIdentifier,

--- a/src/tests/helpers/simulated-store-post-receipt-helper.test.ts
+++ b/src/tests/helpers/simulated-store-post-receipt-helper.test.ts
@@ -71,6 +71,7 @@ describe("postSimulatedStoreReceipt", () => {
     expect(mockBackend.postReceipt).toHaveBeenCalledWith(
       "test-user-id",
       "monthly_trial_intro",
+      "USD",
       expect.stringMatching(/^test_.*test-uuid-123$/),
       mockProduct.presentedOfferingContext,
       "purchase",
@@ -113,6 +114,7 @@ describe("postSimulatedStoreReceipt", () => {
     expect(mockBackend.postReceipt).toHaveBeenCalledWith(
       "test-user-id",
       "test-consumable-product",
+      "USD",
       expect.stringMatching(/^test_.*test-uuid-123$/),
       consumableProduct.presentedOfferingContext,
       "purchase",

--- a/src/tests/helpers/simulated-store-purchase-helper.test.ts
+++ b/src/tests/helpers/simulated-store-purchase-helper.test.ts
@@ -126,6 +126,7 @@ describe("purchaseSimulatedStoreProduct", () => {
     expect(mockBackend.postReceipt).toHaveBeenCalledWith(
       "test-user-id",
       "monthly_trial_intro",
+      "USD",
       expect.stringMatching(/^test_.*test-uuid-123$/),
       mockPurchaseParams.rcPackage.webBillingProduct.presentedOfferingContext,
       "purchase",

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -873,6 +873,7 @@ describe("postReceipt request", () => {
     const result = await backend.postReceipt(
       "someAppUserId",
       "monthly",
+      "EUR",
       "test_fetch_token",
       {
         offeringIdentifier: "offering_1",
@@ -891,6 +892,7 @@ describe("postReceipt request", () => {
     expect(requestBody).toEqual({
       fetch_token: "test_fetch_token",
       product_id: "monthly",
+      currency: "EUR",
       app_user_id: "someAppUserId",
       presented_offering_identifier: "offering_1",
       presented_placement_identifier: null,
@@ -909,6 +911,7 @@ describe("postReceipt request", () => {
     const result = await backend.postReceipt(
       "someAppUserId",
       "monthly",
+      "EUR",
       "test_fetch_token",
       {
         offeringIdentifier: "offering_1",
@@ -927,6 +930,7 @@ describe("postReceipt request", () => {
     expect(requestBody).toEqual({
       fetch_token: "test_fetch_token",
       product_id: "monthly",
+      currency: "EUR",
       app_user_id: "someAppUserId",
       presented_offering_identifier: "offering_1",
       presented_placement_identifier: "placement_1",
@@ -948,6 +952,7 @@ describe("postReceipt request", () => {
     await backend.postReceipt(
       "someAppUserId",
       "monthly",
+      "EUR",
       "test_fetch_token",
       {
         offeringIdentifier: "offering_1",
@@ -970,6 +975,7 @@ describe("postReceipt request", () => {
       backend.postReceipt(
         "someAppUserId",
         "monthly",
+        "EUR",
         "test_fetch_token",
         {
           offeringIdentifier: "offering_1",
@@ -1000,6 +1006,7 @@ describe("postReceipt request", () => {
       backend.postReceipt(
         "someAppUserId",
         "monthly",
+        "EUR",
         "test_fetch_token",
         {
           offeringIdentifier: "offering_1",
@@ -1022,6 +1029,7 @@ describe("postReceipt request", () => {
       backend.postReceipt(
         "someAppUserId",
         "monthly",
+        "EUR",
         "test_fetch_token",
         {
           offeringIdentifier: "offering_1",
@@ -1052,6 +1060,7 @@ describe("postReceipt request", () => {
       backend.postReceipt(
         "someAppUserId",
         "monthly",
+        "EUR",
         "invalid_token",
         {
           offeringIdentifier: "offering_1",


### PR DESCRIPTION
## Motivation / Description
This adds a `currency` property in the POST /receipt performed by simulated store purchases. This could potentially be useful in the future to correctly attribute the purchased currency.

## Changes introduced

## Linear ticket (if any)

## Additional comments
