### PR TITLE
Fix Expo Go compatibility

### DIFF
--- a/src/behavioural-events/event.ts
+++ b/src/behavioural-events/event.ts
@@ -1,5 +1,5 @@
 import { camelToUnderscore } from "../helpers/camel-to-underscore";
-import { v4 as uuidv4 } from "uuid";
+import { generateUUID } from "../helpers/uuid-helper";
 
 export type EventData = {
   eventName: string;
@@ -49,7 +49,7 @@ export class Event {
   public readonly data: EventData;
 
   public constructor(data: EventData) {
-    this.id = uuidv4();
+    this.id = generateUUID();
     this.timestampMs = Date.now();
     this.data = data;
   }

--- a/src/behavioural-events/events-tracker.ts
+++ b/src/behavioural-events/events-tracker.ts
@@ -1,4 +1,4 @@
-import { v4 as uuid } from "uuid";
+import { generateUUID } from "../helpers/uuid-helper";
 import { RC_ANALYTICS_ENDPOINT } from "../helpers/constants";
 import { HttpMethods } from "msw";
 import { getHeaders } from "../networking/http-client";
@@ -45,7 +45,7 @@ export default class EventsTracker implements IEventsTracker {
   private readonly eventsQueue: Array<Event> = [];
   private readonly eventsUrl: string;
   private readonly flushManager: FlushManager;
-  private readonly traceId: string = uuid();
+  private readonly traceId: string = generateUUID();
   private appUserId: string;
   private readonly isSilent: boolean;
   private rcSource: string | null;

--- a/src/helpers/uuid-helper.ts
+++ b/src/helpers/uuid-helper.ts
@@ -1,20 +1,39 @@
 /**
+ * Fills the provided byte array with random values using Math.random
+ * @param bytes The byte array to fill with random values
+ */
+function fillBytesWithMathRandom(bytes: Uint8Array): void {
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = Math.floor(Math.random() * 256);
+  }
+}
+
+/**
  * Generates a UUID v4 string.
  * Uses crypto.randomUUID if available, otherwise falls back to a manual implementation.
  * @returns A UUID v4 string in the format xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
  */
 export function generateUUID(): string {
-  if (crypto && crypto.randomUUID) {
-    return crypto.randomUUID();
+  // Check if crypto is available
+  // (not available in React Native Expo Go by default)
+  const cryptoObj = typeof crypto !== "undefined" ? crypto : globalThis.crypto;
+
+  if (cryptoObj && cryptoObj.randomUUID) {
+    return cryptoObj.randomUUID();
   }
 
   const bytes = new Uint8Array(16);
-  if (crypto && crypto.getRandomValues) {
-    crypto.getRandomValues(bytes);
-  } else {
-    for (let i = 0; i < 16; i++) {
-      bytes[i] = Math.floor(Math.random() * 256);
+  try {
+    if (cryptoObj && cryptoObj.getRandomValues) {
+      cryptoObj.getRandomValues(bytes);
+    } else {
+      fillBytesWithMathRandom(bytes);
     }
+  } catch (error) {
+    console.log(
+      `Error using crypto.getRandomValues(), falling back to Math.random. + ${error}`,
+    );
+    fillBytesWithMathRandom(bytes);
   }
 
   // Set version (4) and variant bits

--- a/src/tests/behavioral-events/events-tracker.test.ts
+++ b/src/tests/behavioral-events/events-tracker.test.ts
@@ -23,8 +23,8 @@ const MAX_JITTER_MULTIPLIER = 1 + 0.1;
 
 describe("EventsTracker", (test) => {
   const date = new Date(1988, 10, 18, 13, 37, 0);
-  vi.mock("uuid", () => ({
-    v4: () => "c1365463-ce59-4b83-b61b-ef0d883e9047",
+  vi.mock("../../helpers/uuid-helper", () => ({
+    generateUUID: () => "c1365463-ce59-4b83-b61b-ef0d883e9047",
   }));
   const loggerMock = vi
     .spyOn(Logger, "debugLog")

--- a/src/tests/purchase.events.test.ts
+++ b/src/tests/purchase.events.test.ts
@@ -10,8 +10,8 @@ vi.mock("svelte", () => ({
   mount: vi.fn(),
 }));
 
-vi.mock("uuid", () => ({
-  v4: () => "c1365463-ce59-4b83-b61b-ef0d883e9047",
+vi.mock("../helpers/uuid-helper", () => ({
+  generateUUID: () => "c1365463-ce59-4b83-b61b-ef0d883e9047",
 }));
 
 describe("Purchases.configure()", () => {


### PR DESCRIPTION
## Motivation / Description
We were running into issues in Expo Go in react-native-purchases because it wasn't able to find the `crypto` library, and when importing the `uuid` library it was saying that it couldn't find the crypto library.

This refactors the code to handle missing `crypto` definition + use our custom code to generate UUIDs, instead of using the `UUID` library directly, which fails because it internally uses `crypto` when importing it.

Note that this means that in Expo Go, we will only have pseudo-random UUID generation.

## Changes introduced

## Linear ticket (if any)

## Additional comments
