### PR TITLE
Fail posting simulated receipt if not using test api key

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -829,6 +829,12 @@ export class Purchases {
   public async _postSimulatedStoreReceipt(
     product: Product,
   ): Promise<PurchaseResult> {
+    if (!isSimulatedStoreApiKey(this._API_KEY)) {
+      throw new PurchasesError(
+        ErrorCode.ConfigurationError,
+        "Posting a test store receipt is only available for RC Test Store API keys.",
+      );
+    }
     return await postSimulatedStoreReceipt(
       product,
       this.backend,

--- a/src/main.ts
+++ b/src/main.ts
@@ -821,6 +821,14 @@ export class Purchases {
   }
 
   /**
+   * Used by internal RC code to detect if used a test store API key.
+   * @internal
+   */
+  public _isConfiguredWithSimulatedStore(): boolean {
+    return isSimulatedStoreApiKey(this._API_KEY);
+  }
+
+  /**
    * Posts a simulated store receipt to the server.
    * @internal
    * @param product - The product for which we want to post the receipt for.


### PR DESCRIPTION
## Motivation / Description
This PR has 2 changes:
- It immediately fails if trying to post a simulated store receipt with a non-test API key.
- It exposes an internal method to detect whether the SDK was configured with a test API key

## Changes introduced

## Linear ticket (if any)

## Additional comments
