### PR TITLE
Fix paywall types

### DIFF
--- a/src/entities/offerings.ts
+++ b/src/entities/offerings.ts
@@ -769,9 +769,7 @@ export const toOffering = (
     twoMonth: packagesById[PackageType.TwoMonth] ?? null,
     monthly: packagesById[PackageType.Monthly] ?? null,
     weekly: packagesById[PackageType.Weekly] ?? null,
-    paywall_components: offeringsData.paywall_components
-      ? (offeringsData.paywall_components as PaywallData)
-      : null,
+    paywall_components: offeringsData.paywall_components,
   };
 };
 

--- a/src/networking/responses/offerings-response.ts
+++ b/src/networking/responses/offerings-response.ts
@@ -1,3 +1,5 @@
+import type { PaywallData } from "@revenuecat/purchases-ui-js";
+
 export interface PackageResponse {
   identifier: string;
   platform_product_identifier: string;
@@ -8,7 +10,7 @@ export interface OfferingResponse {
   description: string;
   packages: PackageResponse[];
   metadata: { [key: string]: unknown } | null;
-  paywall_components: { [key: string]: unknown } | null;
+  paywall_components: PaywallData | null;
 }
 
 export interface TargetingResponse {


### PR DESCRIPTION
## Motivation / Description

Response type used an unknown for paywall fields, hence required casting and was error-prone.

## Changes introduced

* Use `PaywallData` type in Offering response

## Linear ticket (if any)

https://linear.app/revenuecat/issue/MON-1232/update-paywall-types

## Additional comments
