### PR TITLE
fix: Importing loadStripe without side effects

### DIFF
--- a/src/stripe/stripe-service.ts
+++ b/src/stripe/stripe-service.ts
@@ -18,7 +18,7 @@ import type { StripeExpressCheckoutElementOptions } from "@stripe/stripe-js/dist
 import { type Period, PeriodUnit } from "../helpers/duration-helper";
 import type { StripeExpressCheckoutConfiguration } from "./stripe-express-checkout-configuration";
 import type { PriceBreakdown } from "../ui/ui-types";
-import { loadStripe } from "@stripe/stripe-js";
+import { loadStripe } from "@stripe/stripe-js/pure";
 
 export enum StripeServiceErrorCode {
   ErrorLoadingStripe = 0,

--- a/src/tests/stripe/stripe-service.test.ts
+++ b/src/tests/stripe/stripe-service.test.ts
@@ -9,14 +9,14 @@ import type {
   StripeElements,
   StripeError,
 } from "@stripe/stripe-js";
-import { loadStripe } from "@stripe/stripe-js";
+import { loadStripe } from "@stripe/stripe-js/pure";
 import type { StripeElementsConfiguration } from "../../networking/responses/stripe-elements";
 import type { BrandingInfoResponse } from "../../networking/responses/branding-response";
 import { Translator } from "../../ui/localization/translator";
 import { product, trialProduct } from "../../stories/fixtures";
 import type { PriceBreakdown } from "../../ui/ui-types";
 
-vi.mock("@stripe/stripe-js", () => ({
+vi.mock("@stripe/stripe-js/pure", () => ({
   loadStripe: vi.fn(),
 }));
 


### PR DESCRIPTION
## Motivation / Description
Do not prematurely load the Stripe module before it is called 
Fixing #578 and  #311 

## Changes introduced
Using [`stripe-js/pure`](https://github.com/stripe/stripe-js?tab=readme-ov-file#importing-loadstripe-without-side-effects) to load stripe module without side effects 

> If you would like to use loadStripe in your application, but defer loading the Stripe.js script until loadStripe is first called, use the alternative @stripe/stripe-js/pure import module:

