### PR TITLE
WEB-3390: presentPaywall method.

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -3876,6 +3876,243 @@
         },
         {
           "kind": "Interface",
+          "canonicalReference": "@revenuecat/purchases-js!~PresentPaywallParams:interface",
+          "docComment": "/**\n * Parameters for the {@link Purchases.presentPaywall} method.\n *\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "declare interface PresentPaywallParams "
+            }
+          ],
+          "fileUrlPath": "dist/Purchases.es.d.ts",
+          "releaseTag": "Public",
+          "name": "PresentPaywallParams",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!~PresentPaywallParams#customerEmail:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly customerEmail?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "customerEmail",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!~PresentPaywallParams#htmlTarget:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly htmlTarget?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "HTMLElement",
+                  "canonicalReference": "!HTMLElement:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "htmlTarget",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!~PresentPaywallParams#offering:member",
+              "docComment": "/**\n * The identifier of the offering to fetch the paywall for. Can be a string identifier or one of the predefined keywords.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly offering: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Offering",
+                  "canonicalReference": "@revenuecat/purchases-js!Offering:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "offering",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!~PresentPaywallParams#onBack:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly onBack?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "onBack",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!~PresentPaywallParams#onNavigateToUrl:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly onNavigateToUrl?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(url: string) => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "onNavigateToUrl",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!~PresentPaywallParams#onVisitCustomerCenter:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly onVisitCustomerCenter?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "onVisitCustomerCenter",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!~PresentPaywallParams#purchaseHtmlTarget:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly purchaseHtmlTarget?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "HTMLElement",
+                  "canonicalReference": "!HTMLElement:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "purchaseHtmlTarget",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!~PresentPaywallParams#selectedLocale:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly selectedLocale?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "selectedLocale",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
+          "extendsTokenRanges": []
+        },
+        {
+          "kind": "Interface",
           "canonicalReference": "@revenuecat/purchases-js!Price:interface",
           "docComment": "/**\n * Price information for a product.\n *\n * @public\n */\n",
           "excerptTokens": [
@@ -6203,6 +6440,69 @@
             },
             {
               "kind": "Method",
+              "canonicalReference": "@revenuecat/purchases-js!Purchases#presentPaywall:member(1)",
+              "docComment": "/**\n * Renders an RC Paywall and allows the user to purchase from it using Web Billing.\n *\n * @param paywallParams - The parameters object to customise the paywall render. Check {@link PresentPaywallParams}\n *\n * @returns Promise<PurchaseResult>\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "presentPaywall(paywallParams: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PresentPaywallParams",
+                  "canonicalReference": "@revenuecat/purchases-js!~PresentPaywallParams:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PurchaseResult",
+                  "canonicalReference": "@revenuecat/purchases-js!PurchaseResult:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ">"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 7
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "paywallParams",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "presentPaywall"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "@revenuecat/purchases-js!Purchases#purchase:member(1)",
               "docComment": "/**\n * Method to perform a purchase for a given package. You can obtain the package from {@link Purchases.getOfferings}. This method will present the purchase form on your site, using the given HTML element as the mount point, if provided, or as a modal if not.\n *\n * @param params - The parameters object to customise the purchase flow. Check {@link PurchaseParams}\n *\n * @returns a Promise for the customer and redemption info after the purchase is completed successfully.\n *\n * @throws\n *\n * {@link PurchasesError} if there is an error while performing the purchase. If the {@link PurchasesError.errorCode} is {@link ErrorCode.UserCancelledError}, the user cancelled the purchase.\n */\n",
               "excerptTokens": [
@@ -6359,69 +6659,6 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "purchasePackage"
-            },
-            {
-              "kind": "Method",
-              "canonicalReference": "@revenuecat/purchases-js!Purchases#purchaseUsingPaywall:member(1)",
-              "docComment": "/**\n * Renders an RC Paywall and allows the user to purchase from it using Web Billing.\n *\n * @param paywallParams - The parameters object to customise the paywall render. Check {@link RenderPaywallParams}\n *\n * @returns Promise<PurchaseResult>\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "purchaseUsingPaywall(paywallParams: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "RenderPaywallParams",
-                  "canonicalReference": "@revenuecat/purchases-js!~RenderPaywallParams:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": "): "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "Promise",
-                  "canonicalReference": "!Promise:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": "<"
-                },
-                {
-                  "kind": "Reference",
-                  "text": "PurchaseResult",
-                  "canonicalReference": "@revenuecat/purchases-js!PurchaseResult:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ">"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isStatic": false,
-              "returnTypeTokenRange": {
-                "startIndex": 3,
-                "endIndex": 7
-              },
-              "releaseTag": "Public",
-              "isProtected": false,
-              "overloadIndex": 1,
-              "parameters": [
-                {
-                  "parameterName": "paywallParams",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 1,
-                    "endIndex": 2
-                  },
-                  "isOptional": false
-                }
-              ],
-              "isOptional": false,
-              "isAbstract": false,
-              "name": "purchaseUsingPaywall"
             },
             {
               "kind": "Method",
@@ -7120,243 +7357,6 @@
               "isOptional": false,
               "releaseTag": "Public",
               "name": "redeemUrl",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            }
-          ],
-          "extendsTokenRanges": []
-        },
-        {
-          "kind": "Interface",
-          "canonicalReference": "@revenuecat/purchases-js!~RenderPaywallParams:interface",
-          "docComment": "/**\n * Parameters for the {@link Purchases.purchaseUsingPaywall} method.\n *\n * @public\n */\n",
-          "excerptTokens": [
-            {
-              "kind": "Content",
-              "text": "declare interface RenderPaywallParams "
-            }
-          ],
-          "fileUrlPath": "dist/Purchases.es.d.ts",
-          "releaseTag": "Public",
-          "name": "RenderPaywallParams",
-          "preserveMemberOrder": false,
-          "members": [
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!~RenderPaywallParams#customerEmail:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "readonly customerEmail?: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "string"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": true,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "customerEmail",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!~RenderPaywallParams#htmlTarget:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "readonly htmlTarget?: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "HTMLElement",
-                  "canonicalReference": "!HTMLElement:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": true,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "htmlTarget",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!~RenderPaywallParams#offering:member",
-              "docComment": "/**\n * The identifier of the offering to fetch the paywall for. Can be a string identifier or one of the predefined keywords.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "readonly offering: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "Offering",
-                  "canonicalReference": "@revenuecat/purchases-js!Offering:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": true,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "offering",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!~RenderPaywallParams#onBack:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "readonly onBack?: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "() => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": true,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "onBack",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!~RenderPaywallParams#onNavigateToUrl:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "readonly onNavigateToUrl?: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "(url: string) => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": true,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "onNavigateToUrl",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!~RenderPaywallParams#onVisitCustomerCenter:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "readonly onVisitCustomerCenter?: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "() => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": true,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "onVisitCustomerCenter",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!~RenderPaywallParams#purchaseHtmlTarget:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "readonly purchaseHtmlTarget?: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "HTMLElement",
-                  "canonicalReference": "!HTMLElement:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": true,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "purchaseHtmlTarget",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!~RenderPaywallParams#selectedLocale:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "readonly selectedLocale?: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "string"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": true,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "selectedLocale",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -281,6 +281,25 @@ export interface PresentedOfferingContext {
 }
 
 // @public
+interface PresentPaywallParams {
+    // (undocumented)
+    readonly customerEmail?: string;
+    // (undocumented)
+    readonly htmlTarget?: HTMLElement;
+    readonly offering: Offering;
+    // (undocumented)
+    readonly onBack?: () => void;
+    // (undocumented)
+    readonly onNavigateToUrl?: (url: string) => void;
+    // (undocumented)
+    readonly onVisitCustomerCenter?: () => void;
+    // (undocumented)
+    readonly purchaseHtmlTarget?: HTMLElement;
+    // (undocumented)
+    readonly selectedLocale?: string;
+}
+
+// @public
 export interface Price {
     // @deprecated
     readonly amount: number;
@@ -386,11 +405,11 @@ export class Purchases {
     // (undocumented)
     isSandbox(): boolean;
     preload(): Promise<void>;
+    // Warning: (ae-forgotten-export) The symbol "PresentPaywallParams" needs to be exported by the entry point Purchases.es.d.ts
+    presentPaywall(paywallParams: PresentPaywallParams): Promise<PurchaseResult>;
     purchase(params: PurchaseParams): Promise<PurchaseResult>;
     // @deprecated
     purchasePackage(rcPackage: Package, customerEmail?: string, htmlTarget?: HTMLElement): Promise<PurchaseResult>;
-    // Warning: (ae-forgotten-export) The symbol "RenderPaywallParams" needs to be exported by the entry point Purchases.es.d.ts
-    purchaseUsingPaywall(paywallParams: RenderPaywallParams): Promise<PurchaseResult>;
     setAttributes(attributes: {
         [key: string | ReservedCustomerAttribute]: string | null;
     }): Promise<void>;
@@ -430,25 +449,6 @@ export interface PurchasesErrorExtra {
 // @public
 export interface RedemptionInfo {
     readonly redeemUrl: string | null;
-}
-
-// @public
-interface RenderPaywallParams {
-    // (undocumented)
-    readonly customerEmail?: string;
-    // (undocumented)
-    readonly htmlTarget?: HTMLElement;
-    readonly offering: Offering;
-    // (undocumented)
-    readonly onBack?: () => void;
-    // (undocumented)
-    readonly onNavigateToUrl?: (url: string) => void;
-    // (undocumented)
-    readonly onVisitCustomerCenter?: () => void;
-    // (undocumented)
-    readonly purchaseHtmlTarget?: HTMLElement;
-    // (undocumented)
-    readonly selectedLocale?: string;
 }
 
 // @public

--- a/examples/webbilling-demo/src/pages/rc_paywall/index.tsx
+++ b/examples/webbilling-demo/src/pages/rc_paywall/index.tsx
@@ -19,7 +19,7 @@ const RCPaywallPage: React.FC = () => {
     const purchases = Purchases.getSharedInstance();
 
     purchases
-      .purchaseUsingPaywall({
+      .presentPaywall({
         offering: offering,
         htmlTarget: document.getElementById("paywall") || undefined,
         selectedLocale: lang || undefined,

--- a/src/entities/present-paywall-params.ts
+++ b/src/entities/present-paywall-params.ts
@@ -1,10 +1,10 @@
 import type { Offering } from "./offerings";
 
 /**
- * Parameters for the {@link Purchases.purchaseUsingPaywall} method.
+ * Parameters for the {@link Purchases.presentPaywall} method.
  * @public
  */
-export interface PurchaseUsingPaywallParams {
+export interface PresentPaywallParams {
   /**
    * The identifier of the offering to fetch the paywall for.
    * Can be a string identifier or one of the predefined keywords.

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,7 +52,7 @@ import {
 } from "./helpers/offerings-parser";
 import { type PurchaseResult } from "./entities/purchase-result";
 import { mount, unmount } from "svelte";
-import { type PurchaseUsingPaywallParams } from "./entities/purchase-using-paywall-params";
+import { type PresentPaywallParams } from "./entities/present-paywall-params";
 import { Paywall } from "@revenuecat/purchases-ui-js";
 import { PaywallDefaultContainerZIndex } from "./ui/theme/constants";
 import { parseOfferingIntoVariables } from "./helpers/paywall-variables-helpers";
@@ -410,11 +410,11 @@ export class Purchases {
 
   /**
    * Renders an RC Paywall and allows the user to purchase from it using Web Billing.
-   * @param paywallParams - The parameters object to customise the paywall render. Check {@link PurchaseUsingPaywallParams}
+   * @param paywallParams - The parameters object to customise the paywall render. Check {@link PresentPaywallParams}
    * @returns Promise<PurchaseResult>
    */
-  public async purchaseUsingPaywall(
-    paywallParams: PurchaseUsingPaywallParams,
+  public async presentPaywall(
+    paywallParams: PresentPaywallParams,
   ): Promise<PurchaseResult> {
     const htmlTarget = paywallParams.htmlTarget;
 


### PR DESCRIPTION
## Motivation / Description
Renamed the internal method with the same name we use in the other platforms.
Made the method public.

## Changes introduced
* Renamed the internal method with the same name we use in the other platforms.
* Made the method public.
* Updated the demo app to use the new name
* Removed the ts-ignore needed to use an @internal method.
* Updated the public API docs.
