### PR TITLE
Add workflowIdentifier to PresentedOfferingContext interface

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -408,7 +408,7 @@ export class Purchases {
       rcSource: this._flags.rcSource ?? null,
       workflowContext: this._context?.workflowContext,
     });
-    this.backend = new Backend(this._API_KEY, httpConfig);
+    this.backend = new Backend(this._API_KEY, httpConfig, this._context);
     this.inMemoryCache = new InMemoryCache();
     this.purchaseOperationHelper = new PurchaseOperationHelper(
       this.backend,


### PR DESCRIPTION
## Motivation / Description
Pass workflow_identifier when making a purchase. This will be added in the backend to the purchase session and will let us identify that a puchase came from navigating a workflow.

## Changes introduced
Using the workflow is present in the purchases context to send it in the checkout request

## Linear ticket (if any)

## Additional comments
