### PR TITLE
Fix `identifyUser` wasCreated

### DIFF
--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -1,5 +1,5 @@
 import { type OfferingsResponse } from "./responses/offerings-response";
-import { performRequest } from "./http-client";
+import { performRequest, performRequestWithStatus } from "./http-client";
 import {
   CheckoutCalculateTaxEndpoint,
   CheckoutCompleteEndpoint,
@@ -87,14 +87,22 @@ export class Backend {
       new_app_user_id: newAppUserId,
     };
 
-    return await performRequest<IdentifyRequestBody, IdentifyResponse>(
-      new IdentifyEndpoint(),
-      {
-        apiKey: this.API_KEY,
-        body: body,
-        httpConfig: this.httpConfig,
-      },
-    );
+    const result = await performRequestWithStatus<
+      IdentifyRequestBody,
+      SubscriberResponse
+    >(new IdentifyEndpoint(), {
+      apiKey: this.API_KEY,
+      body: body,
+      httpConfig: this.httpConfig,
+    });
+
+    // HTTP 201 indicates the user was created, 200 indicates it already existed
+    const was_created = result.statusCode === 201;
+
+    return {
+      ...result.data,
+      was_created,
+    };
   }
 
   async getProducts(

--- a/src/networking/responses/identify-response.ts
+++ b/src/networking/responses/identify-response.ts
@@ -1,5 +1,12 @@
 import type { SubscriberResponse } from "./subscriber-response";
 
+/**
+ * Response from the identify endpoint.
+ * Note: The backend returns a standard SubscriberResponse without a was_created field.
+ * The was_created field is derived client-side from the HTTP status code:
+ * - 201: User was created (was_created = true)
+ * - 200: User already existed (was_created = false)
+ */
 export interface IdentifyResponse extends SubscriberResponse {
   was_created: boolean;
 }

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -9,7 +9,6 @@ import {
   productsResponse,
   getVirtualCurrenciesResponseWith3Currencies,
   getVirtualCurrenciesResponseWithNoCurrencies,
-  identifyResponse,
 } from "../test-responses";
 import { Backend } from "../../networking/backend";
 import { StatusCodes } from "http-status-codes";
@@ -240,13 +239,32 @@ describe("identify request", () => {
     );
   }
 
-  test("can get customer info successfully", async () => {
-    setIdentifyResponse(HttpResponse.json(identifyResponse, { status: 200 }));
+  test("returns was_created: false when backend returns 200", async () => {
+    setIdentifyResponse(
+      HttpResponse.json(customerInfoResponse, { status: 200 }),
+    );
     const backendResponse = await backend.identify(
       "oldAppUserId",
       "newAppUserId",
     );
-    expect(backendResponse).toEqual(identifyResponse);
+    expect(backendResponse).toEqual({
+      ...customerInfoResponse,
+      was_created: false,
+    });
+  });
+
+  test("returns was_created: true when backend returns 201", async () => {
+    setIdentifyResponse(
+      HttpResponse.json(customerInfoResponse, { status: 201 }),
+    );
+    const backendResponse = await backend.identify(
+      "oldAppUserId",
+      "newAppUserId",
+    );
+    expect(backendResponse).toEqual({
+      ...customerInfoResponse,
+      was_created: true,
+    });
   });
 
   test("throws an error if the backend returns a server error", async () => {

--- a/src/tests/test-responses.ts
+++ b/src/tests/test-responses.ts
@@ -286,11 +286,6 @@ export const customerInfoResponse: SubscriberResponse = {
   },
 };
 
-export const identifyResponse = {
-  ...customerInfoResponse,
-  was_created: true,
-};
-
 export const newAppUserIdCustomerInfoResponse = {
   request_date: "2024-01-22T13:23:07Z",
   request_date_ms: 1705929787636,
@@ -528,7 +523,7 @@ export function getRequestHandlers(): RequestHandler[] {
     http.post(identify, async ({ request }) => {
       const json = await request.json();
       APIPostRequest({ url: identify, json });
-      return HttpResponse.json(identifyResponse, { status: 200 });
+      return HttpResponse.json(customerInfoResponse, { status: 200 });
     }),
   );
 


### PR DESCRIPTION
## Motivation / Description
We were incorrectly obtaining the was_created field from the response. We should have used the response code instead. This fixes that and should deal with https://github.com/RevenueCat/purchases-flutter/issues/1539

## Changes introduced

## Linear ticket (if any)

## Additional comments
