### PR TITLE
Hide card fields until express checkout unavailable

### DIFF
--- a/src/ui/molecules/stripe-elements.svelte
+++ b/src/ui/molecules/stripe-elements.svelte
@@ -73,6 +73,7 @@
   let paymentElementReadyForSubmission = $state(false);
   let emailElementReadyForSubmission = $state(skipEmail);
   let expressCheckoutElementReadyForSubmission = $state(false);
+  let showCardFields = $state(!expressCheckoutOptions);
 
   let stripeVariables: undefined | Appearance["variables"] = $state(undefined);
   let viewport: "mobile" | "desktop" = $state("mobile");
@@ -138,6 +139,19 @@
         onLoadingComplete();
       }
     }
+  };
+
+  const onExpressCheckoutAvailabilityChange = (available: boolean) => {
+    if (!available) {
+      showCardFields = true;
+      return;
+    }
+
+    showCardFields = false;
+  };
+
+  const onShowCardFieldsRequest = () => {
+    showCardFields = true;
   };
 
   const onPaymentElementReady = async () => {
@@ -223,22 +237,26 @@
       onSubmit={onExpressCheckoutElementSubmit}
       {expressCheckoutOptions}
       {billingAddressRequired}
+      onAvailabilityChange={onExpressCheckoutAvailabilityChange}
+      {onShowCardFieldsRequest}
     />
-    {#if !skipEmail}
-      <LinkAuthenticationElement
+    <div class:collapsed={!showCardFields} class="rc-card-fields">
+      {#if !skipEmail}
+        <LinkAuthenticationElement
+          {elements}
+          onReady={onLinkAuthenticationElementReady}
+          onChange={onLinkAuthenticationElementChange}
+          onError={onStripeElementsLoadingError}
+        />
+      {/if}
+      <PaymentElement
         {elements}
-        onReady={onLinkAuthenticationElementReady}
-        onChange={onLinkAuthenticationElementChange}
+        {brandingInfo}
+        onReady={onPaymentElementReady}
+        onChange={onPaymentElementChange}
         onError={onStripeElementsLoadingError}
       />
-    {/if}
-    <PaymentElement
-      {elements}
-      {brandingInfo}
-      onReady={onPaymentElementReady}
-      onChange={onPaymentElementChange}
-      onError={onStripeElementsLoadingError}
-    />
+    </div>
   </div>
 {/if}
 
@@ -247,6 +265,22 @@
     display: flex;
     flex-direction: column;
     gap: var(--rc-spacing-gapXLarge-mobile);
+    position: relative;
+  }
+
+  .rc-card-fields {
+    display: flex;
+    flex-direction: column;
+    gap: var(--rc-spacing-gapXLarge-mobile);
+  }
+
+  .rc-card-fields.collapsed {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    opacity: 0;
+    pointer-events: none;
   }
 
   @container layout-query-container (width >= 768px) {

--- a/src/ui/molecules/stripe-express-checkout-element.svelte
+++ b/src/ui/molecules/stripe-express-checkout-element.svelte
@@ -31,6 +31,8 @@
       paymentMethod: string,
       emailValue: string,
     ) => void | Promise<void>;
+    onAvailabilityChange?: (available: boolean) => void | Promise<void>;
+    onShowCardFieldsRequest?: () => void | Promise<void>;
     elements: StripeElements;
     billingAddressRequired: boolean;
     expressCheckoutOptions?: StripeExpressCheckoutConfiguration;
@@ -40,6 +42,8 @@
     onError,
     onReady,
     onSubmit,
+    onAvailabilityChange,
+    onShowCardFieldsRequest,
     elements,
     billingAddressRequired,
     expressCheckoutOptions,
@@ -77,6 +81,7 @@
     event: StripeExpressCheckoutElementReadyEvent,
   ) => {
     hideExpressCheckoutElement = !event.availablePaymentMethods;
+    await onAvailabilityChange?.(event.availablePaymentMethods);
     onReady();
   };
 
@@ -109,5 +114,6 @@
     text={$translator.translate(
       LocalizationKeys.PaymentEntryPageExpressCheckoutDivider,
     )}
+    on:click={onShowCardFieldsRequest}
   />
 {/if}


### PR DESCRIPTION
## Summary
- collapse card payment fields when express checkout is available, only revealing them on user request
- notify the parent when express checkout is unavailable so card details show automatically
- keep the hidden card section out of layout while preserving Stripe element readiness

## Testing
- npm run test -- --run src/tests/ui/pages/payment-entry-page.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691f51ef9be48329aa7fd0886b53a655)