### PR TITLE
Reject with UserCancelledError when the user closes the Paddle payment modal

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1071,6 +1071,13 @@ export class Purchases {
         certainHTMLTarget.innerHTML = "";
       };
 
+      const onClose =
+        this.createCheckoutOnCloseHandler(reject, unmountPaddlePurchaseUi) ??
+        // Always unmount PaddlePurchaseUi when the user closes the checkout modal
+        (() => {
+          unmountPaddlePurchaseUi();
+        });
+
       const onFinished = this.createCheckoutOnFinishedHandler(
         resolve,
         appUserId,
@@ -1092,6 +1099,7 @@ export class Purchases {
             defaultLocale,
             customTranslations: params.labelsOverride,
             isInElement,
+            onClose,
             onFinished,
             onError,
             skipSuccessPage,

--- a/src/paddle/paddle-service.ts
+++ b/src/paddle/paddle-service.ts
@@ -46,7 +46,7 @@ interface PaddlePurchase {
   transactionId: string;
   onCheckoutLoaded: () => void;
   params: PaddlePurchaseParams;
-  unmountPaddlePurchaseUi: () => void;
+  onClose: () => void;
 }
 
 interface PaddleStartCheckoutParams {
@@ -167,7 +167,7 @@ export class PaddleService {
     operationSessionId,
     transactionId,
     onCheckoutLoaded,
-    unmountPaddlePurchaseUi,
+    onClose,
     params,
   }: PaddlePurchase): Promise<OperationSessionSuccessfulResult> {
     const paddleInstance = this.getPaddleInstance();
@@ -194,7 +194,7 @@ export class PaddleService {
               // not when this code calls paddleInstance.Checkout.close()
               const paddleInitiatedCheckoutClosedEvent = !!data?.status;
               if (paddleInitiatedCheckoutClosedEvent) {
-                unmountPaddlePurchaseUi();
+                onClose();
               }
             }
           } catch (error) {

--- a/src/tests/paddle/paddle-service.test.ts
+++ b/src/tests/paddle/paddle-service.test.ts
@@ -325,13 +325,13 @@ describe("PaddleService", () => {
 
     test("opens checkout and calls onCheckoutLoaded when CHECKOUT_LOADED event fires", async () => {
       const onCheckoutLoaded = vi.fn();
-      const unmountPaddlePurchaseUi = vi.fn();
+      const onClose = vi.fn();
 
       const purchasePromise = paddleService.purchase({
         operationSessionId,
         transactionId,
         onCheckoutLoaded,
-        unmountPaddlePurchaseUi,
+        onClose,
         params: purchaseParams,
       });
 
@@ -354,7 +354,7 @@ describe("PaddleService", () => {
         operationSessionId,
         transactionId,
         onCheckoutLoaded: vi.fn(),
-        unmountPaddlePurchaseUi: vi.fn(),
+        onClose: vi.fn(),
         params: { ...purchaseParams, locale: "es" },
       });
 
@@ -372,7 +372,7 @@ describe("PaddleService", () => {
         operationSessionId,
         transactionId,
         onCheckoutLoaded: vi.fn(),
-        unmountPaddlePurchaseUi: vi.fn(),
+        onClose: vi.fn(),
         params: { ...purchaseParams, customerEmail: "test@example.com" },
       });
 
@@ -411,7 +411,7 @@ describe("PaddleService", () => {
         operationSessionId,
         transactionId,
         onCheckoutLoaded: vi.fn(),
-        unmountPaddlePurchaseUi: vi.fn(),
+        onClose: vi.fn(),
         params: purchaseParams,
       });
 
@@ -431,14 +431,14 @@ describe("PaddleService", () => {
       });
     });
 
-    test("calls unmountPaddlePurchaseUi when user closes checkout", async () => {
-      const unmountPaddlePurchaseUi = vi.fn();
+    test("calls onClose when user closes checkout", async () => {
+      const onClose = vi.fn();
 
       const purchasePromise = paddleService.purchase({
         operationSessionId,
         transactionId,
         onCheckoutLoaded: vi.fn(),
-        unmountPaddlePurchaseUi,
+        onClose,
         params: purchaseParams,
       });
 
@@ -447,25 +447,25 @@ describe("PaddleService", () => {
         data: { status: "draft" } as PaddleEventData["data"],
       });
 
-      expect(unmountPaddlePurchaseUi).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalled();
 
       purchasePromise.catch(() => {});
     });
 
-    test("does not call unmountPaddlePurchaseUi when code closes checkout", async () => {
-      const unmountPaddlePurchaseUi = vi.fn();
+    test("does not call onClose when code closes checkout", async () => {
+      const onClose = vi.fn();
 
       const purchasePromise = paddleService.purchase({
         operationSessionId,
         transactionId,
         onCheckoutLoaded: vi.fn(),
-        unmountPaddlePurchaseUi,
+        onClose,
         params: purchaseParams,
       });
 
       await paddleEventCallback({ name: CheckoutEventNames.CHECKOUT_CLOSED });
 
-      expect(unmountPaddlePurchaseUi).not.toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
 
       purchasePromise.catch(() => {});
     });
@@ -480,7 +480,7 @@ describe("PaddleService", () => {
           operationSessionId,
           transactionId,
           onCheckoutLoaded: vi.fn(),
-          unmountPaddlePurchaseUi: vi.fn(),
+          onClose: vi.fn(),
           params: purchaseParams,
         }),
       ).rejects.toThrow(
@@ -505,7 +505,7 @@ describe("PaddleService", () => {
           operationSessionId,
           transactionId,
           onCheckoutLoaded: vi.fn(),
-          unmountPaddlePurchaseUi: vi.fn(),
+          onClose: vi.fn(),
           params: purchaseParams,
         }),
       ).rejects.toThrow(
@@ -562,7 +562,7 @@ describe("PaddleService", () => {
         operationSessionId,
         transactionId,
         onCheckoutLoaded: vi.fn(),
-        unmountPaddlePurchaseUi: vi.fn(),
+        onClose: vi.fn(),
         params: purchaseParams,
       });
 
@@ -605,7 +605,7 @@ describe("PaddleService", () => {
         operationSessionId,
         transactionId,
         onCheckoutLoaded: vi.fn(),
-        unmountPaddlePurchaseUi: vi.fn(),
+        onClose: vi.fn(),
         params: purchaseParams,
       });
 
@@ -662,7 +662,7 @@ describe("PaddleService", () => {
         operationSessionId,
         transactionId,
         onCheckoutLoaded: vi.fn(),
-        unmountPaddlePurchaseUi: vi.fn(),
+        onClose: vi.fn(),
         params: purchaseParams,
       });
 
@@ -701,7 +701,7 @@ describe("PaddleService", () => {
         operationSessionId,
         transactionId,
         onCheckoutLoaded: vi.fn(),
-        unmountPaddlePurchaseUi: vi.fn(),
+        onClose: vi.fn(),
         params: purchaseParams,
       });
 
@@ -728,7 +728,7 @@ describe("PaddleService", () => {
         operationSessionId,
         transactionId,
         onCheckoutLoaded: vi.fn(),
-        unmountPaddlePurchaseUi: vi.fn(),
+        onClose: vi.fn(),
         params: purchaseParams,
       });
 
@@ -760,7 +760,7 @@ describe("PaddleService", () => {
         operationSessionId,
         transactionId,
         onCheckoutLoaded: vi.fn(),
-        unmountPaddlePurchaseUi: vi.fn(),
+        onClose: vi.fn(),
         params: purchaseParams,
       });
 
@@ -801,7 +801,7 @@ describe("PaddleService", () => {
         operationSessionId,
         transactionId,
         onCheckoutLoaded: vi.fn(),
-        unmountPaddlePurchaseUi: vi.fn(),
+        onClose: vi.fn(),
         params: {
           rcPackage: createMonthlyPackageMock(),
           purchaseOption: { id: "test-option-id", priceId: "test-price-id" },

--- a/src/tests/ui/paddle-purchases-ui.test.ts
+++ b/src/tests/ui/paddle-purchases-ui.test.ts
@@ -64,6 +64,7 @@ const baseProps: ComponentProps<PaddlePurchasesUI> = {
   customTranslations: {},
   isInElement: false,
   skipSuccessPage: false,
+  onClose: vi.fn(),
   onFinished: vi.fn(),
   onError: vi.fn(),
   productDetails: rcPackage.webBillingProduct,
@@ -123,7 +124,7 @@ describe("PaddlePurchasesUI", () => {
         operationSessionId: "test-operation-session-id",
         transactionId: "test-transaction-id",
         onCheckoutLoaded: expect.any(Function),
-        unmountPaddlePurchaseUi: expect.any(Function),
+        onClose: expect.any(Function),
         params: {
           rcPackage: rcPackage,
           purchaseOption: subscriptionOption,

--- a/src/ui/paddle-purchases-ui.svelte
+++ b/src/ui/paddle-purchases-ui.svelte
@@ -31,6 +31,7 @@
     customTranslations?: Record<string, Record<string, string>>;
     isInElement: boolean;
     skipSuccessPage: boolean;
+    onClose: () => void;
     onFinished: (operationResult: OperationSessionSuccessfulResult) => void;
     onError: (error: PurchaseFlowError) => void;
     productDetails: Product;
@@ -51,6 +52,7 @@
     customTranslations = {},
     isInElement,
     skipSuccessPage = false,
+    onClose,
     onFinished,
     onError,
     productDetails,
@@ -176,7 +178,7 @@
         operationSessionId: startResponse.operation_session_id,
         transactionId: startResponse.paddle_billing_params?.transaction_id,
         onCheckoutLoaded,
-        unmountPaddlePurchaseUi,
+        onClose,
         params: {
           rcPackage,
           purchaseOption,


### PR DESCRIPTION
## Motivation / Description

The onClose function should be called when the user closes the Paddle payment modal. This allows `.purchase` to be rejected with the UserCancelledError error, which matches the web billing behavior.

## Changes introduced

## Linear ticket (if any)

## Additional comments
