### PR TITLE
Update the copy for the Paddle success screen button

### DIFF
--- a/src/stories/pages/success-page.stories.svelte
+++ b/src/stories/pages/success-page.stories.svelte
@@ -83,22 +83,14 @@
     {@const title = translator.translate(
       LocalizationKeys.PaymentEntryPageSubscriptionInfo,
     )}
-    {@const closeButtonTitle = translator.translate(
-      LocalizationKeys.SuccessPageButtonReturnToApp,
-      { appName: brandingInfo?.app_name ?? "App" },
-    )}
+
     <FullscreenTemplate
       {brandingInfo}
       isInElement={context.globals.viewport === "embedded"}
       isSandbox={false}
     >
       {#snippet mainContent()}
-        <SuccessPage
-          {title}
-          {closeButtonTitle}
-          onContinue={() => {}}
-          fullWidth={true}
-        />
+        <SuccessPage {title} onContinue={() => {}} fullWidth={true} />
       {/snippet}
     </FullscreenTemplate>
   {/snippet}

--- a/src/tests/ui/paddle-purchases-ui.test.ts
+++ b/src/tests/ui/paddle-purchases-ui.test.ts
@@ -77,7 +77,7 @@ const baseProps: ComponentProps<PaddlePurchasesUI> = {
   paddleService: createPaddleServiceMock(),
 };
 
-const continueButtonRegex = /return to some fantastic cat, inc\./i;
+const continueButtonRegex = /continue/i;
 
 describe("PaddlePurchasesUI", () => {
   beforeEach(() => {

--- a/src/ui/localization/keys_context.json
+++ b/src/ui/localization/keys_context.json
@@ -57,7 +57,6 @@
   "loading_page.keep_page_open": "Instructional message on the loading page advising the user to keep the browser tab open while the payment process completes.",
   "success_page.purchase_successful": "Message confirming that payment was successfully completed.",
   "success_page.button_close": "Button text to close or continue from a success screen.",
-  "success_page.button_return_to_app": "Button text to return to the app.",
   "error_page.if_error_persists": "A message preceding the support e-mail of the app, advising the user to contact support if the error continues.",
   "error_page.trouble_accessing": "A message preceding the support e-mail of the app, shown when the user has already subscribed/purchased the product.",
   "error_page.error_title_already_subscribed": "Error title displayed when the user has already subscribed to this product.",

--- a/src/ui/localization/locale/ar.json
+++ b/src/ui/localization/locale/ar.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "الشروط",
   "payment_entry_page.subscription_terms_info": "بالاشتراك، فإنك توافق على السماح لـ {{appName}} بتحصيل رسوم منك وفقًا لشروطها حتى تقوم بالإلغاء.",
   "loading_page.keep_page_open": "العملية شارفت على الانتهاء. أبقِ هذه الصفحة مفتوحة.",
-  "loading_page.processing_payment": "جاري معالجة الدفع",
-  "success_page.button_return_to_app": "العودة إلى {{appName}}"
+  "loading_page.processing_payment": "جاري معالجة الدفع"
 }

--- a/src/ui/localization/locale/ca.json
+++ b/src/ui/localization/locale/ca.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Condicions",
   "payment_entry_page.subscription_terms_info": "En subscriure-us, accepteu que {{appName}} us cobri d'acord amb les seves condicions fins que ho cancel·leu.",
   "loading_page.keep_page_open": "El procés està gairebé acabat. Mantingueu aquesta pàgina oberta.",
-  "loading_page.processing_payment": "S'està processant el pagament",
-  "success_page.button_return_to_app": "Torna a {{appName}}"
+  "loading_page.processing_payment": "S'està processant el pagament"
 }

--- a/src/ui/localization/locale/cs.json
+++ b/src/ui/localization/locale/cs.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Podmínky",
   "payment_entry_page.subscription_terms_info": "Přihlášením k odběru souhlasíte s tím, že společnost {{appName}} vám bude účtovat poplatky v souladu s jejími podmínkami, dokud odběr nezrušíte.",
   "loading_page.keep_page_open": "Probíhá dokončování procesu. Nechte tuto stránku otevřenou.",
-  "loading_page.processing_payment": "Probíhá zpracování platby",
-  "success_page.button_return_to_app": "Zpět do aplikace {{appName}}"
+  "loading_page.processing_payment": "Probíhá zpracování platby"
 }

--- a/src/ui/localization/locale/da.json
+++ b/src/ui/localization/locale/da.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Vilkår",
   "payment_entry_page.subscription_terms_info": "Ved at abonnere accepterer du, at {{appName}} kan opkræve dig i henhold til deres vilkår, indtil du opsiger.",
   "loading_page.keep_page_open": "Processen er næsten færdig. Hold denne side åben.",
-  "loading_page.processing_payment": "Behandler betaling",
-  "success_page.button_return_to_app": "Vend tilbage til {{appName}}"
+  "loading_page.processing_payment": "Behandler betaling"
 }

--- a/src/ui/localization/locale/de.json
+++ b/src/ui/localization/locale/de.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Bedingungen",
   "payment_entry_page.subscription_terms_info": "Mit dem Abonnieren erklären Sie sich damit einverstanden, dass {{appName}} Ihnen gemäß ihren Bedingungen Gebühren berechnet, bis Sie kündigen.",
   "loading_page.keep_page_open": "Der Vorgang ist fast abgeschlossen. Bitte lassen Sie diese Seite geöffnet.",
-  "loading_page.processing_payment": "Zahlung wird verarbeitet",
-  "success_page.button_return_to_app": "Zurück zu {{appName}}"
+  "loading_page.processing_payment": "Zahlung wird verarbeitet"
 }

--- a/src/ui/localization/locale/el.json
+++ b/src/ui/localization/locale/el.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Όροι",
   "payment_entry_page.subscription_terms_info": "Με την εγγραφή σας, συμφωνείτε να επιτρέψετε στην εφαρμογή {{appName}} να σας χρεώνει σύμφωνα με τους όρους της έως ότου ακυρώσετε.",
   "loading_page.keep_page_open": "Η διαδικασία σχεδόν ολοκληρώθηκε. Κρατήστε αυτή τη σελίδα ανοιχτή.",
-  "loading_page.processing_payment": "Επεξεργασία πληρωμής",
-  "success_page.button_return_to_app": "Επιστροφή στο {{appName}}"
+  "loading_page.processing_payment": "Επεξεργασία πληρωμής"
 }

--- a/src/ui/localization/locale/en.json
+++ b/src/ui/localization/locale/en.json
@@ -56,7 +56,6 @@
   "loading_page.keep_page_open": "The process is almost done. Keep this page open.",
   "success_page.purchase_successful": "Payment complete",
   "success_page.button_close": "Continue",
-  "success_page.button_return_to_app": "Return to {{appName}}",
   "error_page.close_button_title": "Go to {{appName}}",
   "error_page.if_error_persists": "If it persists, please contact ",
   "error_page.trouble_accessing": "If you're having trouble accessing your purchase, reach out to support on ",

--- a/src/ui/localization/locale/es.json
+++ b/src/ui/localization/locale/es.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Términos",
   "payment_entry_page.subscription_terms_info": "Al suscribirte, aceptas que {{appName}} te cobre de acuerdo con sus términos hasta que canceles.",
   "loading_page.keep_page_open": "El proceso está casi terminado. Mantén esta página abierta.",
-  "loading_page.processing_payment": "Procesando el pago",
-  "success_page.button_return_to_app": "Volver a {{appName}}"
+  "loading_page.processing_payment": "Procesando el pago"
 }

--- a/src/ui/localization/locale/fi.json
+++ b/src/ui/localization/locale/fi.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Ehdot",
   "payment_entry_page.subscription_terms_info": "Tilaamalla hyväksyt, että {{appName}} veloittaa sinulta ehtojensa mukaisesti, kunnes peruutat tilauksen.",
   "loading_page.keep_page_open": "Prosessi on melkein valmis. Pidä tämä sivu auki.",
-  "loading_page.processing_payment": "Maksua käsitellään",
-  "success_page.button_return_to_app": "Palaa sovellukseen {{appName}}"
+  "loading_page.processing_payment": "Maksua käsitellään"
 }

--- a/src/ui/localization/locale/fr.json
+++ b/src/ui/localization/locale/fr.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Conditions",
   "payment_entry_page.subscription_terms_info": "En vous abonnant, vous acceptez d'autoriser {{appName}} à vous facturer conformément à ses conditions jusqu'à ce que vous annuliez.",
   "loading_page.keep_page_open": "Le processus est presque terminé. Veuillez garder cette page ouverte.",
-  "loading_page.processing_payment": "Paiement en cours",
-  "success_page.button_return_to_app": "Retourner à {{appName}}"
+  "loading_page.processing_payment": "Paiement en cours"
 }

--- a/src/ui/localization/locale/he.json
+++ b/src/ui/localization/locale/he.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "תנאים",
   "payment_entry_page.subscription_terms_info": "על ידי הרשמה כמנוי, אתה מסכים לאפשר ל-{{appName}} לחייב אותך בהתאם לתנאים שלהם עד שתבטל.",
   "loading_page.keep_page_open": "התהליך כמעט הסתיים. השאר דף זה פתוח.",
-  "loading_page.processing_payment": "מעבד תשלום תבעה",
-  "success_page.button_return_to_app": "חזור אל {{appName}}"
+  "loading_page.processing_payment": "מעבד תשלום תבעה"
 }

--- a/src/ui/localization/locale/hi.json
+++ b/src/ui/localization/locale/hi.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "नियम",
   "payment_entry_page.subscription_terms_info": "सदस्यता लेकर, आप {{appName}} को रद्द करने तक उनकी शर्तों के अनुसार आपसे शुल्क लेने की अनुमति देने के लिए सहमत हैं.",
   "loading_page.keep_page_open": "प्रक्रिया लगभग पूरी हो चुकी है. इस पृष्ठ को खुला रखें.",
-  "loading_page.processing_payment": "भुगतान संसाधित किया जा रहा है",
-  "success_page.button_return_to_app": "{{appName}} पर वापस जाएं"
+  "loading_page.processing_payment": "भुगतान संसाधित किया जा रहा है"
 }

--- a/src/ui/localization/locale/hr.json
+++ b/src/ui/localization/locale/hr.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Uvjeti",
   "payment_entry_page.subscription_terms_info": "Pretplatom se slažete da ćete dopustiti {{appName}} da vam naplaćuje u skladu s njihovim uvjetima dok ne otkažete.",
   "loading_page.keep_page_open": "Proces je skoro gotov. Ostavite ovu stranicu otvorenom.",
-  "loading_page.processing_payment": "Obrada uplate",
-  "success_page.button_return_to_app": "Povratak na {{appName}}"
+  "loading_page.processing_payment": "Obrada uplate"
 }

--- a/src/ui/localization/locale/hu.json
+++ b/src/ui/localization/locale/hu.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Feltételek",
   "payment_entry_page.subscription_terms_info": "A feliratkozással elfogadod, hogy a {{appName}} az általa meghatározott feltételek szerint terheljen, amíg le nem mondod.",
   "loading_page.keep_page_open": "A folyamat majdnem befejeződött. Tartsa nyitva ezt az oldalt.",
-  "loading_page.processing_payment": "Fizetés feldolgozása",
-  "success_page.button_return_to_app": "Visszatérés a(z) {{appName}} alkalmazáshoz"
+  "loading_page.processing_payment": "Fizetés feldolgozása"
 }

--- a/src/ui/localization/locale/id.json
+++ b/src/ui/localization/locale/id.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Ketentuan",
   "payment_entry_page.subscription_terms_info": "Dengan berlangganan, Anda setuju untuk mengizinkan {{appName}} mengenakan biaya sesuai dengan ketentuan mereka hingga Anda membatalkan.",
   "loading_page.keep_page_open": "Prosesnya hampir selesai. Jangan tutup halaman ini.",
-  "loading_page.processing_payment": "Pembayaran sedang diproses",
-  "success_page.button_return_to_app": "Kembali ke {{appName}}"
+  "loading_page.processing_payment": "Pembayaran sedang diproses"
 }

--- a/src/ui/localization/locale/it.json
+++ b/src/ui/localization/locale/it.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Termini",
   "payment_entry_page.subscription_terms_info": "Abbonandoti, accetti che {{appName}} ti addebiti l'importo secondo i suoi termini fino all'annullamento.",
   "loading_page.keep_page_open": "Il processo è quasi terminato. Mantieni questa pagina aperta.",
-  "loading_page.processing_payment": "Elaborazione del pagamento",
-  "success_page.button_return_to_app": "Torna a {{appName}}"
+  "loading_page.processing_payment": "Elaborazione del pagamento"
 }

--- a/src/ui/localization/locale/ja.json
+++ b/src/ui/localization/locale/ja.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "利用規約",
   "payment_entry_page.subscription_terms_info": "サブスクリプションに登録すると、キャンセルするまで{{appName}}が利用規約に従って課金することを許可することに同意したことになります。",
   "loading_page.keep_page_open": "プロセスはほぼ完了です。このページを開いたままにしてください。",
-  "loading_page.processing_payment": "お支払い手続き中",
-  "success_page.button_return_to_app": "{{appName}}に戻る"
+  "loading_page.processing_payment": "お支払い手続き中"
 }

--- a/src/ui/localization/locale/ko.json
+++ b/src/ui/localization/locale/ko.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "약관",
   "payment_entry_page.subscription_terms_info": "구독하면 취소할 때까지 {{appName}}이 약관에 따라 요금을 청구하는 데 동의하는 것입니다.",
   "loading_page.keep_page_open": "거의 완료되었습니다. 이 페이지를 계속 열어 두세요.",
-  "loading_page.processing_payment": "결제 처리 중",
-  "success_page.button_return_to_app": "{{appName}}으로 돌아가기"
+  "loading_page.processing_payment": "결제 처리 중"
 }

--- a/src/ui/localization/locale/ms.json
+++ b/src/ui/localization/locale/ms.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Terma",
   "payment_entry_page.subscription_terms_info": "Dengan melanggan, anda bersetuju untuk membenarkan {{appName}} mengenakan bayaran kepada anda mengikut terma mereka sehingga anda membatalkan.",
   "loading_page.keep_page_open": "Proses hampir selesai. Pastikan halaman ini dibuka.",
-  "loading_page.processing_payment": "Memproses pembayaran",
-  "success_page.button_return_to_app": "Kembali ke {{appName}}"
+  "loading_page.processing_payment": "Memproses pembayaran"
 }

--- a/src/ui/localization/locale/nl.json
+++ b/src/ui/localization/locale/nl.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Voorwaarden",
   "payment_entry_page.subscription_terms_info": "Door u te abonneren, stemt u ermee in dat {{appName}} u kosten in rekening brengt volgens hun voorwaarden totdat u annuleert.",
   "loading_page.keep_page_open": "Het proces is bijna voltooid. Houd deze pagina open.",
-  "loading_page.processing_payment": "Betaling verwerken",
-  "success_page.button_return_to_app": "Terug naar {{appName}}"
+  "loading_page.processing_payment": "Betaling verwerken"
 }

--- a/src/ui/localization/locale/no.json
+++ b/src/ui/localization/locale/no.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Vilkår",
   "payment_entry_page.subscription_terms_info": "Ved å abonnere godtar du at {{appName}} belaster deg i henhold til deres vilkår til du kansellerer.",
   "loading_page.keep_page_open": "Prosessen er nesten ferdig. Hold denne siden åpen.",
-  "loading_page.processing_payment": "Behandler betaling",
-  "success_page.button_return_to_app": "Gå tilbake til {{appName}}"
+  "loading_page.processing_payment": "Behandler betaling"
 }

--- a/src/ui/localization/locale/pl.json
+++ b/src/ui/localization/locale/pl.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Warunki",
   "payment_entry_page.subscription_terms_info": "Subskrybując, zgadzasz się na obciążanie przez {{appName}} zgodnie z ich warunkami do momentu anulowania.",
   "loading_page.keep_page_open": "Proces jest prawie zakończony. Pozostaw tę stronę otwartą.",
-  "loading_page.processing_payment": "Przetwarzanie płatności",
-  "success_page.button_return_to_app": "Wróć do {{appName}}"
+  "loading_page.processing_payment": "Przetwarzanie płatności"
 }

--- a/src/ui/localization/locale/pt.json
+++ b/src/ui/localization/locale/pt.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Termos",
   "payment_entry_page.subscription_terms_info": "Ao subscrever, concorda em permitir que a {{appName}} lhe cobre de acordo com os seus termos até cancelar.",
   "loading_page.keep_page_open": "O processo está quase concluído. Mantenha esta página aberta.",
-  "loading_page.processing_payment": "Processando o pagamento",
-  "success_page.button_return_to_app": "Voltar para {{appName}}"
+  "loading_page.processing_payment": "Processando o pagamento"
 }

--- a/src/ui/localization/locale/ro.json
+++ b/src/ui/localization/locale/ro.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Termeni",
   "payment_entry_page.subscription_terms_info": "Prin abonare, sunteți de acord să permiteți {{appName}} să vă taxeze conform termenilor săi până la anulare.",
   "loading_page.keep_page_open": "Procesul este aproape finalizat. Păstrați această pagină deschisă.",
-  "loading_page.processing_payment": "Se procesează plata",
-  "success_page.button_return_to_app": "Întoarce-te la {{appName}}"
+  "loading_page.processing_payment": "Se procesează plata"
 }

--- a/src/ui/localization/locale/ru.json
+++ b/src/ui/localization/locale/ru.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Условия",
   "payment_entry_page.subscription_terms_info": "Подписываясь, вы соглашаетесь с тем, что {{appName}} будет взимать с вас плату в соответствии с их условиями до тех пор, пока вы не отмените подписку.",
   "loading_page.keep_page_open": "Процесс почти завершен. Не закрывайте эту страницу.",
-  "loading_page.processing_payment": "Обработка платежа",
-  "success_page.button_return_to_app": "Вернуться в {{appName}}"
+  "loading_page.processing_payment": "Обработка платежа"
 }

--- a/src/ui/localization/locale/sk.json
+++ b/src/ui/localization/locale/sk.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Podmienky",
   "payment_entry_page.subscription_terms_info": "Prihlásením na odber súhlasíte s tým, že spoločnosť {{appName}} vám bude účtovať poplatky podľa svojich podmienok, až kým odber nezrušíte.",
   "loading_page.keep_page_open": "Proces sa takmer dokončil. Nechajte túto stránku otvorenú.",
-  "loading_page.processing_payment": "Spracováva sa platba",
-  "success_page.button_return_to_app": "Späť do aplikácie {{appName}}"
+  "loading_page.processing_payment": "Spracováva sa platba"
 }

--- a/src/ui/localization/locale/sv.json
+++ b/src/ui/localization/locale/sv.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Villkor",
   "payment_entry_page.subscription_terms_info": "Genom att prenumerera godkänner du att {{appName}} debiterar dig i enlighet med deras villkor tills du avbryter.",
   "loading_page.keep_page_open": "Processen är nästan klar. Håll den här sidan öppen.",
-  "loading_page.processing_payment": "Behandlar betalning",
-  "success_page.button_return_to_app": "Återgå till {{appName}}"
+  "loading_page.processing_payment": "Behandlar betalning"
 }

--- a/src/ui/localization/locale/th.json
+++ b/src/ui/localization/locale/th.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "ข้อกำหนด",
   "payment_entry_page.subscription_terms_info": "เมื่อสมัครรับข้อมูล แสดงว่าคุณยินยอมให้ {{appName}} เรียกเก็บเงินจากคุณตามข้อกำหนดจนกว่าคุณจะยกเลิก",
   "loading_page.keep_page_open": "กระบวนการเกือบเสร็จสมบูรณ์แล้ว โปรดเปิดหน้านี้ไว้",
-  "loading_page.processing_payment": "กำลังดำเนินการชำระเงิน",
-  "success_page.button_return_to_app": "กลับไปที่ {{appName}}"
+  "loading_page.processing_payment": "กำลังดำเนินการชำระเงิน"
 }

--- a/src/ui/localization/locale/tr.json
+++ b/src/ui/localization/locale/tr.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Koşullar",
   "payment_entry_page.subscription_terms_info": "Abone olarak, iptal edene kadar {{appName}}'in sizi şartlarına göre ücretlendirmesine izin vermeyi kabul edersiniz.",
   "loading_page.keep_page_open": "İşlem neredeyse tamamlandı. Bu sayfayı açık tutun.",
-  "loading_page.processing_payment": "Ödeme işleniyor",
-  "success_page.button_return_to_app": "{{appName}}'e geri dön"
+  "loading_page.processing_payment": "Ödeme işleniyor"
 }

--- a/src/ui/localization/locale/uk.json
+++ b/src/ui/localization/locale/uk.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Умови",
   "payment_entry_page.subscription_terms_info": "Підписуючись, ви погоджуєтеся дозволити {{appName}} стягувати з вас плату відповідно до їхніх умов, поки ви не скасуєте підписку.",
   "loading_page.keep_page_open": "Процес майже завершено. Залиште цю сторінку відкритою.",
-  "loading_page.processing_payment": "Обробка платежу",
-  "success_page.button_return_to_app": "Повернутися до {{appName}}"
+  "loading_page.processing_payment": "Обробка платежу"
 }

--- a/src/ui/localization/locale/vi.json
+++ b/src/ui/localization/locale/vi.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "Điều khoản",
   "payment_entry_page.subscription_terms_info": "Bằng cách đăng ký, bạn đồng ý cho phép {{appName}} tính phí bạn theo các điều khoản của họ cho đến khi bạn hủy.",
   "loading_page.keep_page_open": "Quá trình gần hoàn tất. Vui lòng giữ trang này mở.",
-  "loading_page.processing_payment": "Đang xử lý thanh toán",
-  "success_page.button_return_to_app": "Quay lại {{appName}}"
+  "loading_page.processing_payment": "Đang xử lý thanh toán"
 }

--- a/src/ui/localization/locale/zh_Hans.json
+++ b/src/ui/localization/locale/zh_Hans.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "条款",
   "payment_entry_page.subscription_terms_info": "订阅即表示您同意允许 {{appName}} 按照其条款向您收费，直到您取消订阅。",
   "loading_page.keep_page_open": "流程即将完成。请保持此页面打开。",
-  "loading_page.processing_payment": "正在处理付款",
-  "success_page.button_return_to_app": "返回到{{appName}}"
+  "loading_page.processing_payment": "正在处理付款"
 }

--- a/src/ui/localization/locale/zh_Hant.json
+++ b/src/ui/localization/locale/zh_Hant.json
@@ -97,6 +97,5 @@
   "payment_entry_page.terms_link_label": "條款",
   "payment_entry_page.subscription_terms_info": "訂閱即表示您同意允許 {{appName}} 根據其條款向您收費，直到您取消為止。",
   "loading_page.keep_page_open": "程序即將完成。請保持此頁面開啟。",
-  "loading_page.processing_payment": "正在處理付款",
-  "success_page.button_return_to_app": "返回 {{appName}}"
+  "loading_page.processing_payment": "正在處理付款"
 }

--- a/src/ui/localization/supportedLanguages.ts
+++ b/src/ui/localization/supportedLanguages.ts
@@ -88,7 +88,6 @@ export enum LocalizationKeys {
   PaymentEntryPageExpressCheckoutDivider = "payment_entry_page.express_checkout_divider",
   SuccessPagePurchaseSuccessful = "success_page.purchase_successful",
   SuccessPageButtonClose = "success_page.button_close",
-  SuccessPageButtonReturnToApp = "success_page.button_return_to_app",
   LoadingPageProcessingPayment = "loading_page.processing_payment",
   LoadingPageKeepPageOpen = "loading_page.keep_page_open",
   ErrorPageCloseButtonTitle = "error_page.close_button_title",

--- a/src/ui/paddle-purchases-ui-inner.svelte
+++ b/src/ui/paddle-purchases-ui-inner.svelte
@@ -59,14 +59,7 @@
         >
       </div>
     {:else if currentPage === "success"}
-      <SuccessPage
-        {onContinue}
-        closeButtonTitle={$translator.translate(
-          LocalizationKeys.SuccessPageButtonReturnToApp,
-          { appName: brandingInfo?.app_name ?? "App" },
-        )}
-        fullWidth={true}
-      />
+      <SuccessPage {onContinue} fullWidth={true} />
     {:else if currentPage === "error"}
       <ErrorPage
         {lastError}


### PR DESCRIPTION
## Motivation / Description

Changes Paddle's success page button to "Continue" (which matches Web Billing).

| Before  | After |
| --- | --- |
| <img width="612" height="727" alt="wpl-sdk-paddle-success-screen" src="https://github.com/user-attachments/assets/5206915e-a53a-46ba-9b6c-cb641238d0eb" /> | <img width="719" height="644" alt="Screenshot 2025-12-03 at 2 12 17 PM" src="https://github.com/user-attachments/assets/de4890cd-9bf7-48b7-bcab-2f945a5f997f" /> |

## Changes introduced

## Linear ticket (if any)

## Additional comments
