### PR TITLE
[WEB-3575] Fix unmount not a function

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -659,7 +659,7 @@ export class Purchases {
               return;
             }
             if (component !== null) {
-              component?.unmount();
+              unmount(component);
             }
             // Opinionated approach
             // closing the current purchase and emptying the paywall.


### PR DESCRIPTION
## Motivation / Description

Looks like this line was just invalid and hadn't been tested.

Before:

https://github.com/user-attachments/assets/360bd45a-b9ac-4a0a-bdaf-464551c566e0

After:

https://github.com/user-attachments/assets/e35e792d-c4ab-4274-a882-97e4fcc22299


## Changes introduced

## Linear ticket (if any)

https://linear.app/revenuecat/issue/WEB-3575/fix-kunmount-is-not-a-function

## Additional comments
