### PR TITLE
Updated purchases-ui-js to support the Express Checkout stack properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@eslint/js": "^9.16.0",
     "@microsoft/api-extractor": "^7.48.0",
     "@paddle/paddle-js": "^1.5.1",
-    "@revenuecat/purchases-ui-js": "file://../purchases-ui-js",
+    "@revenuecat/purchases-ui-js": "3.5.4",
     "@storybook/addon-essentials": "^8.5.0",
     "@storybook/addon-interactions": "^8.5.0",
     "@storybook/addon-links": "^8.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1
       "@revenuecat/purchases-ui-js":
-        specifier: file://../purchases-ui-js
-        version: file:../purchases-ui-js(svelte@5.45.2)
+        specifier: 3.5.4
+        version: 3.5.4(svelte@5.45.2)
       "@storybook/addon-essentials":
         specifier: ^8.5.0
         version: 8.6.4(@types/react@19.0.10)(storybook@8.6.4(prettier@3.4.2))
@@ -716,8 +716,11 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
 
-  "@revenuecat/purchases-ui-js@file:../purchases-ui-js":
-    resolution: { directory: ../purchases-ui-js, type: directory }
+  "@revenuecat/purchases-ui-js@3.5.4":
+    resolution:
+      {
+        integrity: sha512-SmOERxPGpm0yR39Bhw+PE4z3B/qXEhrg18iVZ7Gu7MrzEOtE+SseWloR7aZWB/Mh4pD0JHIraeZSIZmA8EncYA==,
+      }
     engines: { node: ^22.18 || ^24.11 }
     peerDependencies:
       svelte: ^5.12.0
@@ -6146,7 +6149,7 @@ snapshots:
 
   "@pkgr/core@0.1.1": {}
 
-  "@revenuecat/purchases-ui-js@file:../purchases-ui-js(svelte@5.45.2)":
+  "@revenuecat/purchases-ui-js@3.5.4(svelte@5.45.2)":
     dependencies:
       qrcode: 1.5.4
       svelte: 5.45.2


### PR DESCRIPTION
## Motivation / Description
Updated `purchases-ui-js` to support the changes shipped with[ this PR](https://github.com/RevenueCat/purchases-ui-js/pull/198) 