### PR TITLE
Remove unnecessary min release age exclusions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -6,5 +6,3 @@ minimum-release-age=1440
 # We are pinning the purchases-ui-js version that we are developing.
 # We can exclude it from the minimum-release-age check.
 minimum-release-age-exclude[]=@revenuecat/purchases-ui-js
-minimum-release-age-exclude[]=svelte
-minimum-release-age-exclude[]=devalue


### PR DESCRIPTION
## Motivation / Description

Follows up on https://github.com/RevenueCat/purchases-js/pull/719 now that the versions have been out for long enough.

<img width="1192" height="827" alt="Screenshot 2026-01-16 at 15 33 12" src="https://github.com/user-attachments/assets/51f26d4b-519b-4075-9599-b06fc85ca9e1" />


## Changes introduced

## Linear ticket (if any)

## Additional comments
