### PR TITLE
Fix errors when running in non-browser environment

### DIFF
--- a/src/behavioural-events/sdk-event-context.ts
+++ b/src/behavioural-events/sdk-event-context.ts
@@ -27,7 +27,12 @@ export function buildEventContext(
   source: SDKEventContextSource,
   rcSource: string | null,
 ): SDKEventContext & EventContext {
-  const urlParams = new URLSearchParams(window.location.search);
+  // Guard against environments where window.location is not available
+  const hasWindowLocation = typeof window !== "undefined" && window.location;
+  const urlParams = hasWindowLocation
+    ? new URLSearchParams(window.location.search)
+    : new URLSearchParams();
+
   let screenWidth: number | null = null;
   let screenHeight: number | null = null;
   if (typeof screen !== "undefined" && screen) {
@@ -55,7 +60,9 @@ export function buildEventContext(
     utmContent: urlParams.get("utm_content") ?? null,
     utmTerm: urlParams.get("utm_term") ?? null,
     pageReferrer: pageReferrer,
-    pageUrl: `${window.location.origin}${window.location.pathname}`,
+    pageUrl: hasWindowLocation
+      ? `${window.location.origin}${window.location.pathname}`
+      : "",
     pageTitle: pageTitle,
     source: source,
     rcSource: rcSource,

--- a/src/helpers/utm-params.ts
+++ b/src/helpers/utm-params.ts
@@ -1,5 +1,9 @@
 export const autoParseUTMParams = () => {
-  const params = new URLSearchParams(window.location.search);
+  // Guard against environments where window.location is not available
+  const hasWindowLocation = typeof window !== "undefined" && window.location;
+  const params = hasWindowLocation
+    ? new URLSearchParams(window.location.search)
+    : new URLSearchParams();
 
   const possibleParams = [
     "utm_source",

--- a/src/tests/behavioral-events/sdk-event-context.test.ts
+++ b/src/tests/behavioral-events/sdk-event-context.test.ts
@@ -73,4 +73,34 @@ describe("buildEventContext", () => {
       rcSource: "rcSource",
     });
   });
+
+  it("should handle missing window.location gracefully", () => {
+    const originalWindow = global.window;
+    // @ts-expect-error - Simulating missing window.location
+    delete global.window.location;
+
+    const context = buildEventContext("sdk", "testSource");
+
+    expect(context).toEqual({
+      libraryName: "purchases-js",
+      libraryVersion: VERSION,
+      locale: "en-US",
+      userAgent: "Mozilla/5.0",
+      timeZone: "America/New_York",
+      screenWidth: 1920,
+      screenHeight: 1080,
+      utmSource: null,
+      utmMedium: null,
+      utmCampaign: null,
+      utmContent: null,
+      utmTerm: null,
+      pageReferrer: "https://referrer.com",
+      pageUrl: "",
+      pageTitle: "Example Page",
+      source: "sdk",
+      rcSource: "testSource",
+    });
+
+    global.window = originalWindow;
+  });
 });

--- a/src/tests/helpers/utm-params.test.ts
+++ b/src/tests/helpers/utm-params.test.ts
@@ -2,6 +2,17 @@ import { describe, expect, test, vi } from "vitest";
 import { autoParseUTMParams } from "../../helpers/utm-params";
 
 describe("autoParseUTMParams", () => {
+  test("Returns an empty object if window.location is undefined", () => {
+    const originalWindow = global.window;
+    // @ts-expect-error - Simulating missing window.location
+    delete global.window.location;
+
+    const utmParams = autoParseUTMParams();
+    expect(utmParams).toEqual({});
+
+    global.window = originalWindow;
+  });
+
   test("Returns an empty object if no utm param is set", () => {
     vi.spyOn(URLSearchParams.prototype, "get").mockImplementation(() => null);
     const utmParams = autoParseUTMParams();


### PR DESCRIPTION
## Motivation / Description
We got reports of some errors in non-browser environments like: 
```
Error while tracking event sdk_initialized: TypeError: Cannot read property 'search' of undefined
```

This should fix those specific errors. We should also try to add more extensive testing for non-browser environments to make sure most of the SDK works fine (purchase methods outside test store do not work, but ideally the rest of the SDK should)

## Changes introduced

## Linear ticket (if any)

## Additional comments
