### PR TITLE
Bump purchases-ui-js to 3.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@eslint/js": "^9.16.0",
     "@microsoft/api-extractor": "^7.48.0",
     "@paddle/paddle-js": "^1.5.1",
-    "@revenuecat/purchases-ui-js": "3.6.2",
+    "@revenuecat/purchases-ui-js": "3.6.3",
     "@storybook/addon-essentials": "^8.5.0",
     "@storybook/addon-interactions": "^8.5.0",
     "@storybook/addon-links": "^8.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1
       "@revenuecat/purchases-ui-js":
-        specifier: 3.6.2
-        version: 3.6.2(svelte@5.46.4)
+        specifier: 3.6.3
+        version: 3.6.3(svelte@5.46.4)
       "@storybook/addon-essentials":
         specifier: ^8.5.0
         version: 8.6.4(@types/react@19.0.10)(storybook@8.6.4(prettier@3.4.2))
@@ -716,10 +716,10 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
 
-  "@revenuecat/purchases-ui-js@3.6.2":
+  "@revenuecat/purchases-ui-js@3.6.3":
     resolution:
       {
-        integrity: sha512-bgq5Ysjcl0FAXo2A+DGtL012aVeMX04UducnXsQJK/FWAdN8a9IlJdHvgu2NwXMimQPHhZtf/WNv1cuyed6IEA==,
+        integrity: sha512-DU5BEACwEILNEH3Kdhk8SLrecoh/5EBNpjDXU0Zmrnt6MNXRtnEa+6c3YOqb2NMq3FO6Fgx9EosFh+o0V+uDbw==,
       }
     engines: { node: ^22.18 || ^24.11 }
     peerDependencies:
@@ -6149,7 +6149,7 @@ snapshots:
 
   "@pkgr/core@0.1.1": {}
 
-  "@revenuecat/purchases-ui-js@3.6.2(svelte@5.46.4)":
+  "@revenuecat/purchases-ui-js@3.6.3(svelte@5.46.4)":
     dependencies:
       qrcode: 1.5.4
       svelte: 5.46.4


### PR DESCRIPTION
### TL;DR

Updated `@revenuecat/purchases-ui-js` dependency from version 3.6.2 to 3.6.3.

### What changed?

This PR updates the `@revenuecat/purchases-ui-js` package to the latest version (3.6.3) in both the `package.json` and `pnpm-lock.yaml` files.

### How to test?

1. Run `pnpm install` to update dependencies
2. Verify that the application builds successfully
3. Test any functionality that relies on the RevenueCat purchases UI to ensure it works as expected

