### PR TITLE
Persist trace_id across SDK reinitializations

### DIFF
--- a/src/helpers/trace-id-manager.ts
+++ b/src/helpers/trace-id-manager.ts
@@ -1,0 +1,177 @@
+import { generateUUID } from "./uuid-helper";
+import { Logger } from "./logger";
+
+const TRACE_ID_PREFIX = "rc_trace_id";
+const TRACE_ID_TTL_MS = 60 * 60 * 1000; // 1 hour in milliseconds
+
+interface StoredTraceId {
+  trace_id: string;
+  expires_at: number;
+}
+
+/**
+ * Manages trace_id persistence in localStorage with TTL support.
+ * Each trace_id is keyed by workflow identifier and has a 1-hour TTL
+ * that refreshes on each interaction.
+ * @internal
+ */
+export class TraceIdManager {
+  private readonly workflowIdentifier?: string;
+  private currentTraceId: string;
+
+  constructor(workflowIdentifier?: string) {
+    this.workflowIdentifier = workflowIdentifier;
+    this.currentTraceId = this.initializeTraceId();
+  }
+
+  /**
+   * Gets the current trace_id for this workflow.
+   * Automatically refreshes the TTL on each call since accessing the trace_id
+   * indicates an active session.
+   */
+  public getTraceId(): string {
+    this.refreshTTL();
+    return this.currentTraceId;
+  }
+
+  /**
+   * Updates the TTL for the current trace_id, extending its lifetime by another hour.
+   * Called automatically by getTraceId() to keep the trace_id "alive" during active use.
+   */
+  private refreshTTL(): void {
+    if (!this.workflowIdentifier) {
+      // No workflow identifier means no persistence (ephemeral trace_id)
+      return;
+    }
+
+    try {
+      const key = this.getStorageKey();
+      const expiresAt = Date.now() + TRACE_ID_TTL_MS;
+      const data: StoredTraceId = {
+        trace_id: this.currentTraceId,
+        expires_at: expiresAt,
+      };
+      localStorage.setItem(key, JSON.stringify(data));
+      Logger.verboseLog(
+        `Refreshed trace_id TTL for workflow ${this.workflowIdentifier}`,
+      );
+    } catch (error) {
+      Logger.debugLog(
+        `Failed to refresh trace_id TTL in localStorage: ${error}`,
+      );
+      // Continue without errors - trace_id remains valid even if TTL refresh fails
+    }
+  }
+
+  /**
+   * Initializes the trace_id by either loading from localStorage or generating a new one.
+   */
+  private initializeTraceId(): string {
+    if (!this.workflowIdentifier) {
+      // No workflow identifier means ephemeral trace_id (current behavior)
+      Logger.verboseLog(
+        "No workflow identifier provided, generating ephemeral trace_id",
+      );
+      return generateUUID();
+    }
+
+    const storedTraceId = this.loadFromStorage();
+    if (storedTraceId) {
+      Logger.verboseLog(
+        `Loaded existing trace_id for workflow ${this.workflowIdentifier}`,
+      );
+      return storedTraceId;
+    }
+
+    // No valid stored trace_id, generate a new one and persist it
+    const newTraceId = generateUUID();
+    this.currentTraceId = newTraceId;
+    this.refreshTTL();
+    Logger.verboseLog(
+      `Generated new trace_id for workflow ${this.workflowIdentifier}`,
+    );
+    return newTraceId;
+  }
+
+  /**
+   * Attempts to load a valid trace_id from localStorage.
+   * Returns null if no valid trace_id is found (expired or missing).
+   */
+  private loadFromStorage(): string | null {
+    if (!this.workflowIdentifier) {
+      return null;
+    }
+
+    try {
+      const key = this.getStorageKey();
+      const stored = localStorage.getItem(key);
+
+      if (!stored) {
+        Logger.verboseLog(
+          `No stored trace_id found for workflow ${this.workflowIdentifier}`,
+        );
+        return null;
+      }
+
+      const data: StoredTraceId = JSON.parse(stored);
+
+      // Validate stored data structure
+      if (
+        !data.trace_id ||
+        typeof data.trace_id !== "string" ||
+        typeof data.expires_at !== "number"
+      ) {
+        Logger.verboseLog(
+          `Invalid stored trace_id data for workflow ${this.workflowIdentifier}`,
+        );
+        localStorage.removeItem(key);
+        return null;
+      }
+
+      const now = Date.now();
+
+      if (now > data.expires_at) {
+        Logger.verboseLog(
+          `Stored trace_id for workflow ${this.workflowIdentifier} has expired`,
+        );
+        // Clean up expired entry
+        localStorage.removeItem(key);
+        return null;
+      }
+
+      return data.trace_id;
+    } catch (error) {
+      Logger.debugLog(`Failed to load trace_id from localStorage: ${error}`);
+      // Fall back to generating new trace_id if storage fails
+      return null;
+    }
+  }
+
+  /**
+   * Generates the localStorage key for this workflow's trace_id.
+   */
+  private getStorageKey(): string {
+    return `${TRACE_ID_PREFIX}_${this.workflowIdentifier}`;
+  }
+
+  /**
+   * Clears the stored trace_id for this workflow from localStorage.
+   * Useful for testing or manual cleanup.
+   * @internal
+   */
+  public clear(): void {
+    if (!this.workflowIdentifier) {
+      return;
+    }
+
+    try {
+      const key = this.getStorageKey();
+      localStorage.removeItem(key);
+      Logger.verboseLog(
+        `Cleared trace_id for workflow ${this.workflowIdentifier}`,
+      );
+    } catch (error) {
+      Logger.debugLog(`Failed to clear trace_id from localStorage: ${error}`);
+    }
+  }
+}

--- a/src/tests/helpers/trace-id-manager.test.ts
+++ b/src/tests/helpers/trace-id-manager.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { TraceIdManager } from "../../helpers/trace-id-manager";
+
+describe("TraceIdManager", () => {
+  const workflowId = "test-workflow-123";
+  const storageKey = `rc_trace_id_${workflowId}`;
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllTimers();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  describe("With workflowIdentifier", () => {
+    it("persists trace_id across instances", () => {
+      const manager1 = new TraceIdManager(workflowId);
+      const traceId1 = manager1.getTraceId();
+
+      const manager2 = new TraceIdManager(workflowId);
+      const traceId2 = manager2.getTraceId();
+
+      const manager3 = new TraceIdManager(workflowId);
+      const traceId3 = manager3.getTraceId();
+
+      expect(traceId1).toBe(traceId2);
+      expect(traceId2).toBe(traceId3);
+      expect(localStorage.getItem(storageKey)).toBeTruthy();
+    });
+
+    it("refreshes TTL on each getTraceId call", () => {
+      vi.useFakeTimers();
+      const manager = new TraceIdManager(workflowId);
+      const traceId = manager.getTraceId();
+
+      // Simulate activity every 30 minutes for 2.5 hours
+      for (let i = 0; i < 5; i++) {
+        vi.advanceTimersByTime(30 * 60 * 1000);
+        manager.getTraceId(); // Each call refreshes TTL
+      }
+
+      // Should still have same trace_id after 2.5 hours of activity
+      const manager2 = new TraceIdManager(workflowId);
+      expect(manager2.getTraceId()).toBe(traceId);
+
+      vi.useRealTimers();
+    });
+
+    it("generates new trace_id after 1 hour of inactivity", () => {
+      vi.useFakeTimers();
+
+      const manager1 = new TraceIdManager(workflowId);
+      const traceId1 = manager1.getTraceId();
+
+      // Advance time past TTL
+      vi.advanceTimersByTime(61 * 60 * 1000);
+
+      const manager2 = new TraceIdManager(workflowId);
+      const traceId2 = manager2.getTraceId();
+
+      expect(traceId2).not.toBe(traceId1);
+
+      vi.useRealTimers();
+    });
+
+    it("clears stored trace_id", () => {
+      const manager = new TraceIdManager(workflowId);
+      manager.getTraceId();
+
+      expect(localStorage.getItem(storageKey)).toBeTruthy();
+
+      manager.clear();
+
+      expect(localStorage.getItem(storageKey)).toBeNull();
+    });
+  });
+
+  describe("Without workflowIdentifier", () => {
+    it("generates ephemeral trace_id without persistence", () => {
+      const manager1 = new TraceIdManager();
+      const traceId1 = manager1.getTraceId();
+
+      const manager2 = new TraceIdManager();
+      const traceId2 = manager2.getTraceId();
+
+      expect(traceId1).not.toBe(traceId2);
+      expect(localStorage.length).toBe(0);
+    });
+
+    it("maintains same ephemeral trace_id across calls", () => {
+      const manager = new TraceIdManager();
+      const traceId1 = manager.getTraceId();
+      const traceId2 = manager.getTraceId();
+      const traceId3 = manager.getTraceId();
+
+      expect(traceId1).toBe(traceId2);
+      expect(traceId2).toBe(traceId3);
+      expect(localStorage.length).toBe(0);
+    });
+  });
+
+  describe("Multiple workflows", () => {
+    it("maintains separate trace_ids per workflow", () => {
+      const workflow1 = "workflow-1";
+      const workflow2 = "workflow-2";
+      const workflow3 = "workflow-3";
+
+      const manager1 = new TraceIdManager(workflow1);
+      const traceId1 = manager1.getTraceId();
+
+      const manager2 = new TraceIdManager(workflow2);
+      const traceId2 = manager2.getTraceId();
+
+      const manager3 = new TraceIdManager(workflow3);
+      const traceId3 = manager3.getTraceId();
+
+      const uniqueTraceIds = new Set([traceId1, traceId2, traceId3]);
+      expect(uniqueTraceIds.size).toBe(3);
+
+      // Verify each workflow maintains its own trace_id
+      expect(new TraceIdManager(workflow1).getTraceId()).toBe(traceId1);
+      expect(new TraceIdManager(workflow2).getTraceId()).toBe(traceId2);
+      expect(new TraceIdManager(workflow3).getTraceId()).toBe(traceId3);
+    });
+  });
+
+  describe("Data corruption handling", () => {
+    it("handles corrupted JSON data", () => {
+      localStorage.setItem(storageKey, "invalid-json{{{");
+
+      const manager = new TraceIdManager(workflowId);
+      const traceId = manager.getTraceId();
+
+      expect(traceId).toBeTruthy();
+      // Should have valid data now
+      expect(() =>
+        JSON.parse(localStorage.getItem(storageKey) || ""),
+      ).not.toThrow();
+    });
+
+    it("handles missing required fields", () => {
+      const invalidData = { trace_id: "test-id" }; // missing expires_at
+      localStorage.setItem(storageKey, JSON.stringify(invalidData));
+
+      const manager = new TraceIdManager(workflowId);
+      const traceId = manager.getTraceId();
+
+      expect(traceId).not.toBe("test-id");
+    });
+
+    it("handles invalid expires_at type", () => {
+      const invalidData = { trace_id: "test-id", expires_at: "not-a-number" };
+      localStorage.setItem(storageKey, JSON.stringify(invalidData));
+
+      const manager = new TraceIdManager(workflowId);
+      const traceId = manager.getTraceId();
+
+      expect(traceId).not.toBe("test-id");
+    });
+  });
+
+  describe("localStorage availability", () => {
+    it("continues functioning when localStorage throws on read", () => {
+      const originalGetItem = localStorage.getItem;
+      localStorage.getItem = vi.fn(() => {
+        throw new Error("localStorage unavailable");
+      });
+
+      const manager1 = new TraceIdManager(workflowId);
+      const traceId1 = manager1.getTraceId();
+
+      expect(traceId1).toBeTruthy();
+
+      // With localStorage unavailable, each instance generates ephemeral trace_id
+      // Manager already has its trace_id, so we just verify it works
+      expect(() => new TraceIdManager(workflowId).getTraceId()).not.toThrow();
+
+      localStorage.getItem = originalGetItem;
+    });
+
+    it("continues functioning when localStorage throws on write", () => {
+      const originalSetItem = localStorage.setItem;
+      localStorage.setItem = vi.fn(() => {
+        throw new Error("localStorage quota exceeded");
+      });
+
+      const manager = new TraceIdManager(workflowId);
+      const traceId1 = manager.getTraceId();
+      const traceId2 = manager.getTraceId();
+
+      expect(traceId1).toBeTruthy();
+      expect(traceId2).toBe(traceId1); // Same trace_id despite storage errors
+      expect(() => manager.getTraceId()).not.toThrow();
+
+      localStorage.setItem = originalSetItem;
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("treats empty string as ephemeral", () => {
+      const manager1 = new TraceIdManager("");
+      const traceId1 = manager1.getTraceId();
+
+      const manager2 = new TraceIdManager("");
+      const traceId2 = manager2.getTraceId();
+
+      expect(traceId1).not.toBe(traceId2);
+      expect(localStorage.length).toBe(0);
+    });
+
+    it("treats undefined as ephemeral", () => {
+      const manager1 = new TraceIdManager(undefined);
+      const traceId1 = manager1.getTraceId();
+
+      const manager2 = new TraceIdManager(undefined);
+      const traceId2 = manager2.getTraceId();
+
+      expect(traceId1).not.toBe(traceId2);
+      expect(localStorage.length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Motivation / Description

For full context, [see thread](https://revenuecat.slack.com/archives/C09MT80NWF9/p1769632963999749).

Problem: `trace_id` regenerates on each SDK initialization (page reload), breaking funnel tracking continuity.

Solution: Persist `trace_id` in `localStorage` with 1-hour TTL, keyed by `workflowIdentifier`. Each `getTraceId()` call automatically refreshes the TTL.

**Gotchas:**

1. Automatic TTL refresh - getTraceId() implicitly calls refreshTTL() (accessing trace_id = session alive)
2. Empty string = ephemeral - Empty `workflowIdentifier` is falsy, treated as no workflow
  - this preserves all default behaviour for existing non-workflow clients
3. Graceful degradation - localStorage errors fall back to ephemeral `trace_id` without breaking
4. Cross-tab sharing - Same workflow in multiple tabs shares trace_id (localStorage behaviour)       
5. User-agnostic - trace_id persists across changeUser() calls (keyed by workflow, not user)

**[pr-fix] motivation** 

Changes made are backwards compatible and fix a current issue in workflow trace_id management.

## Changes introduced
   
- New TraceIdManager class handles persistence logic
- EventsTracker uses TraceIdManager instead of direct UUID generation
- Backwards compatible: Without workflowIdentifier, maintains current ephemeral behaviour
 
## Linear ticket (if any)

https://linear.app/revenuecat/issue/MON-2010/ensure-trace-id-persists-between-auth-redirects

## Testing

Performed manual testing:

- confirmed `trace_id` persists across the same workflow
- confirmed `trace_id` changes across different workflows
