### PR TITLE
Bump purchases-ui-js to 3.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@eslint/js": "^9.16.0",
     "@microsoft/api-extractor": "^7.48.0",
     "@paddle/paddle-js": "^1.5.1",
-    "@revenuecat/purchases-ui-js": "3.6.3",
+    "@revenuecat/purchases-ui-js": "3.7.0",
     "@storybook/addon-essentials": "^8.6.15",
     "@storybook/addon-interactions": "^8.6.15",
     "@storybook/addon-links": "^8.6.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1
       "@revenuecat/purchases-ui-js":
-        specifier: 3.6.3
-        version: 3.6.3(svelte@5.46.4)
+        specifier: 3.7.0
+        version: 3.7.0(svelte@5.46.4)
       "@storybook/addon-essentials":
         specifier: ^8.6.15
         version: 8.6.15(@types/react@19.0.10)(storybook@8.6.15(prettier@3.4.2))
@@ -722,10 +722,10 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
 
-  "@revenuecat/purchases-ui-js@3.6.3":
+  "@revenuecat/purchases-ui-js@3.7.0":
     resolution:
       {
-        integrity: sha512-DU5BEACwEILNEH3Kdhk8SLrecoh/5EBNpjDXU0Zmrnt6MNXRtnEa+6c3YOqb2NMq3FO6Fgx9EosFh+o0V+uDbw==,
+        integrity: sha512-8d2vw/UVFCmq0ZJ48tkDM8mDi5DHRV3T8pY1lAsiqB6uvYBY4DwdBlu7RnJDw2xS9++aRP/31rruNMNR0VusPw==,
       }
     engines: { node: ^22.18 || ^24.11 }
     peerDependencies:
@@ -6155,7 +6155,7 @@ snapshots:
 
   "@pkgr/core@0.1.1": {}
 
-  "@revenuecat/purchases-ui-js@3.6.3(svelte@5.46.4)":
+  "@revenuecat/purchases-ui-js@3.7.0(svelte@5.46.4)":
     dependencies:
       qrcode: 1.5.4
       svelte: 5.46.4


### PR DESCRIPTION
## Description
Bump @revenuecat/purchases-ui-js dependency to latest version

## What changed?
This PR updates the @revenuecat/purchases-ui-js package to the latest version (3.7.0) in both the package.json and pnpm-lock.yaml files.