### PR TITLE
WEB-3866: fix embedded checkout layout and add E2E coverage

### DIFF
--- a/examples/webbilling-demo/src/App.tsx
+++ b/examples/webbilling-demo/src/App.tsx
@@ -18,6 +18,7 @@ import RedemptionLinksTester from "./pages/redemption_links_tester";
 import RCPaywallLauncherPage from "./pages/rc_paywall_launcher";
 import ExpressPurchaseButtonsPackageSelector from "./pages/express_purchase_buttons";
 import RCPaywallSettingsPage from "./pages/rc_paywall_settings";
+import RCPaywallInElementPage from "./pages/rc_paywall_in_element";
 
 const router = createBrowserRouter([
   {
@@ -58,6 +59,15 @@ const router = createBrowserRouter([
     element: (
       <WithoutEntitlement>
         <RCPaywallLauncherPage />
+      </WithoutEntitlement>
+    ),
+  },
+  {
+    path: "/rc_paywall_in_element/:app_user_id",
+    loader: loadPurchases,
+    element: (
+      <WithoutEntitlement>
+        <RCPaywallInElementPage />
       </WithoutEntitlement>
     ),
   },

--- a/examples/webbilling-demo/src/pages/rc_paywall_in_element/index.tsx
+++ b/examples/webbilling-demo/src/pages/rc_paywall_in_element/index.tsx
@@ -1,0 +1,82 @@
+import type { PurchaseResult } from "@revenuecat/purchases-js";
+import { Purchases } from "@revenuecat/purchases-js";
+import React, { useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { usePurchasesLoaderData } from "../../util/PurchasesLoader";
+
+const RCPaywallInElementPage: React.FC = () => {
+  const { offering } = usePurchasesLoaderData();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const lang = searchParams.get("lang");
+  const hideBackButtons = searchParams.get("hideBackButtons") === "true";
+
+  useEffect(() => {
+    const target = document.getElementById("rc-paywall-in-element-target");
+    if (!offering || !target || target.innerHTML !== "") {
+      return;
+    }
+
+    const purchases = Purchases.getSharedInstance();
+
+    purchases
+      .presentPaywall({
+        offering,
+        htmlTarget: target,
+        selectedLocale: lang || undefined,
+        hideBackButtons,
+      })
+      .then((purchaseResult: PurchaseResult) => {
+        const { customerInfo, redemptionInfo } = purchaseResult;
+        console.log(`CustomerInfo after purchase: ${customerInfo}`);
+        console.log(
+          `RedemptionInfo after purchase: ${JSON.stringify(redemptionInfo)}`,
+        );
+
+        navigate(`/success/${purchases.getAppUserId()}`);
+      })
+      .catch((err: Error) => console.log(`Error: ${err}`));
+  }, [offering, navigate, lang, hideBackButtons]);
+
+  if (!offering) {
+    return <>No offering found!</>;
+  }
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        boxSizing: "border-box",
+        padding: "24px",
+        background: "#f4f6fb",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <div
+        data-testid="embedded-paywall-shell"
+        style={{
+          width: "80vw",
+          maxWidth: "1000px",
+          minWidth: "320px",
+          height: "80vh",
+          minHeight: "640px",
+          borderRadius: "20px",
+          overflow: "hidden",
+          border: "1px solid #cfd8ea",
+          background: "#ffffff",
+          boxShadow: "0 18px 40px rgba(17, 24, 39, 0.12)",
+        }}
+      >
+        <div
+          id="rc-paywall-in-element-target"
+          data-testid="embedded-paywall-target"
+          style={{ width: "100%", height: "100%" }}
+        ></div>
+      </div>
+    </div>
+  );
+};
+
+export default RCPaywallInElementPage;

--- a/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
+++ b/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
@@ -14,6 +14,23 @@ export type RouteFulfillOptions = {
   status?: number | undefined;
 };
 
+type NavigationQueryString = {
+  offeringId?: string;
+  useRcPaywall?: boolean;
+  lang?: string;
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_term?: string;
+  utm_content?: string;
+  optOutOfAutoUTM?: boolean;
+  email?: string;
+  $displayName?: string;
+  nickname?: string;
+  hideBackButtons?: boolean;
+  discountCode?: string;
+};
+
 // Infer from the demo paywall that the only button with an svg is the back button.
 export const getBackButtons = (page: Page) =>
   page.locator("[data-testid='button-navigate_back']");
@@ -65,22 +82,7 @@ export const getEmailFromUserId = (userId: string) =>
 export async function navigateToLandingUrl(
   page: Page,
   userId: string,
-  queryString?: {
-    offeringId?: string;
-    useRcPaywall?: boolean;
-    lang?: string;
-    utm_source?: string;
-    utm_medium?: string;
-    utm_campaign?: string;
-    utm_term?: string;
-    utm_content?: string;
-    optOutOfAutoUTM?: boolean;
-    email?: string;
-    $displayName?: string;
-    nickname?: string;
-    hideBackButtons?: boolean;
-    discountCode?: string;
-  },
+  queryString?: NavigationQueryString,
   apiKey?: string,
 ) {
   const key = apiKey ?? NON_TAX_TEST_API_KEY;
@@ -148,6 +150,56 @@ export async function navigateToLandingUrl(
   const rcPaywallPath = offeringId ? "rc_paywall" : "rc_paywall_no_offering";
 
   const url = `${BASE_URL}${useRcPaywall ? rcPaywallPath : "paywall"}/${encodeURIComponent(userId)}?${params.toString()}`;
+  await page.goto(url);
+
+  return page;
+}
+
+export async function navigateToInElementPaywallUrl(
+  page: Page,
+  userId: string,
+  queryString?: NavigationQueryString,
+  apiKey?: string,
+) {
+  const key = apiKey ?? NON_TAX_TEST_API_KEY;
+  if (key) {
+    await page.addInitScript(`window.__RC_API_KEY__ = "${key}";`);
+  }
+
+  const {
+    offeringId,
+    lang,
+    hideBackButtons,
+    email,
+    $displayName,
+    nickname,
+    discountCode,
+  } = queryString ?? {};
+
+  const params = new URLSearchParams();
+  if (offeringId) {
+    params.append("offeringId", offeringId);
+  }
+  if (lang) {
+    params.append("lang", lang);
+  }
+  if (hideBackButtons !== undefined) {
+    params.append("hideBackButtons", hideBackButtons.toString());
+  }
+  if (email) {
+    params.append("email", email);
+  }
+  if ($displayName) {
+    params.append("$displayName", $displayName);
+  }
+  if (nickname) {
+    params.append("nickname", nickname);
+  }
+  if (discountCode) {
+    params.append("discountCode", discountCode);
+  }
+
+  const url = `${BASE_URL}rc_paywall_in_element/${encodeURIComponent(userId)}?${params.toString()}`;
   await page.goto(url);
 
   return page;

--- a/examples/webbilling-demo/src/tests/in-element-layout.test.ts
+++ b/examples/webbilling-demo/src/tests/in-element-layout.test.ts
@@ -1,0 +1,94 @@
+import { expect } from "@playwright/test";
+import { integrationTest } from "./helpers/integration-test";
+import {
+  navigateToInElementPaywallUrl,
+  skipPaywallsTestIfDisabled,
+} from "./helpers/test-helpers";
+import { RC_PAYWALL_TEST_OFFERING_ID } from "./helpers/fixtures";
+
+integrationTest(
+  "Embedded paywall uses in-element layout in desktop mode",
+  async ({ page, userId }) => {
+    skipPaywallsTestIfDisabled(integrationTest);
+
+    await page.setViewportSize({ width: 1440, height: 1100 });
+    page = await navigateToInElementPaywallUrl(page, userId, {
+      offeringId: RC_PAYWALL_TEST_OFFERING_ID,
+    });
+
+    await expect(page.getByText("E2E Tests for Purchases JS")).toBeVisible();
+    await expect(page.locator(".rcb-ui-container.inside")).toBeVisible();
+
+    const layoutBehavior = await page.locator("#layout-query-container").evaluate(
+      (layoutQueryContainer) => {
+        const computedStyle = window.getComputedStyle(layoutQueryContainer);
+        const layout =
+          layoutQueryContainer.querySelector<HTMLElement>(".rcb-ui-layout");
+        const navbar =
+          layoutQueryContainer.querySelector<HTMLElement>(".rcb-ui-navbar");
+        const main =
+          layoutQueryContainer.querySelector<HTMLElement>(".rcb-ui-main");
+
+        if (!layout || !navbar || !main) {
+          throw new Error("Failed to find paywall layout elements");
+        }
+
+        const navbarWidth = navbar.getBoundingClientRect().width;
+        const mainWidth = main.getBoundingClientRect().width;
+        const totalWidth = navbarWidth + mainWidth;
+
+        return {
+          overflowY: computedStyle.overflowY,
+          flexDirection: window.getComputedStyle(layout).flexDirection,
+          navbarRatio: totalWidth > 0 ? navbarWidth / totalWidth : 0,
+        };
+      },
+    );
+
+    expect(layoutBehavior.overflowY).toBe("hidden");
+    expect(layoutBehavior.flexDirection).toBe("row");
+    expect(layoutBehavior.navbarRatio).toBeGreaterThan(0.43);
+    expect(layoutBehavior.navbarRatio).toBeLessThan(0.47);
+  },
+);
+
+integrationTest(
+  "Embedded paywall keeps single-column layout on small widths",
+  async ({ page, userId }) => {
+    skipPaywallsTestIfDisabled(integrationTest);
+
+    await page.setViewportSize({ width: 640, height: 1100 });
+    page = await navigateToInElementPaywallUrl(page, userId, {
+      offeringId: RC_PAYWALL_TEST_OFFERING_ID,
+    });
+
+    await expect(page.getByText("E2E Tests for Purchases JS")).toBeVisible();
+
+    const layoutBehavior = await page.locator("#layout-query-container").evaluate(
+      (layoutQueryContainer) => {
+        const layout =
+          layoutQueryContainer.querySelector<HTMLElement>(".rcb-ui-layout");
+        const navbar =
+          layoutQueryContainer.querySelector<HTMLElement>(".rcb-ui-navbar");
+        const shell = document.querySelector<HTMLElement>(
+          "[data-testid='embedded-paywall-shell']",
+        );
+
+        if (!layout || !navbar || !shell) {
+          throw new Error("Failed to find in-element paywall containers");
+        }
+
+        const navbarWidth = navbar.getBoundingClientRect().width;
+        const shellWidth = shell.getBoundingClientRect().width;
+
+        return {
+          flexDirection: window.getComputedStyle(layout).flexDirection,
+          navbarToShellRatio: shellWidth > 0 ? navbarWidth / shellWidth : 0,
+        };
+      },
+    );
+
+    expect(layoutBehavior.flexDirection).toBe("column");
+    expect(layoutBehavior.navbarToShellRatio).toBeGreaterThan(0.95);
+  },
+);

--- a/src/ui/layout/layout.svelte
+++ b/src/ui/layout/layout.svelte
@@ -2,10 +2,14 @@
   import { type Snippet } from "svelte";
 
   export let style = "";
+  export let isInElement = false;
   export let children: Snippet;
 </script>
 
-<div id="layout-query-container">
+<div
+  id="layout-query-container"
+  class:layout-query-container-in-element={isInElement}
+>
   <div class="rcb-ui-layout" {style}>
     {@render children?.()}
   </div>
@@ -19,6 +23,10 @@
     container-name: layout-query-container;
     overflow-y: auto;
     overscroll-behavior: none;
+  }
+
+  #layout-query-container.layout-query-container-in-element {
+    overflow: hidden;
   }
 
   .rcb-ui-layout {

--- a/src/ui/layout/main-block.svelte
+++ b/src/ui/layout/main-block.svelte
@@ -7,14 +7,15 @@
   type Props = {
     children: Snippet;
     brandingAppearance: BrandingAppearance | null | undefined;
+    isInElement: boolean;
   };
 
-  const { children, brandingAppearance }: Props = $props();
+  const { children, brandingAppearance, isInElement }: Props = $props();
   const style = $derived(new Theme(brandingAppearance).formStyleVars);
 </script>
 
-<div class="rcb-ui-main" {style}>
-  <SectionLayout location="main-block">
+<div class="rcb-ui-main" class:rcb-ui-main-in-element={isInElement} {style}>
+  <SectionLayout location="main-block" {isInElement}>
     {@render children?.()}
   </SectionLayout>
 </div>
@@ -24,5 +25,9 @@
     flex: 1;
     display: flex;
     background-color: var(--rc-color-background);
+  }
+
+  .rcb-ui-main.rcb-ui-main-in-element {
+    flex: 1 1 0%;
   }
 </style>

--- a/src/ui/layout/navbar.svelte
+++ b/src/ui/layout/navbar.svelte
@@ -8,19 +8,21 @@
     headerContent?: Snippet<[]>;
     bodyContent?: Snippet<[]>;
     brandingAppearance?: BrandingAppearance | null;
+    isInElement: boolean;
   };
 
   const {
     headerContent,
     bodyContent,
     brandingAppearance = undefined,
+    isInElement,
   }: Props = $props();
 
   const style = $derived(new Theme(brandingAppearance).productInfoStyleVars);
 </script>
 
-<div class="rcb-ui-navbar" {style}>
-  <SectionLayout location="navbar">
+<div class="rcb-ui-navbar" class:rcb-ui-navbar-in-element={isInElement} {style}>
+  <SectionLayout location="navbar" {isInElement}>
     <div class="navbar-header">
       {@render headerContent?.()}
     </div>
@@ -52,6 +54,11 @@
       width: 50vw;
       display: flex;
       justify-content: flex-end;
+    }
+
+    .rcb-ui-navbar.rcb-ui-navbar-in-element {
+      width: 45%;
+      flex: 0 0 45%;
     }
 
     .navbar-header {

--- a/src/ui/layout/section-layout.svelte
+++ b/src/ui/layout/section-layout.svelte
@@ -5,14 +5,18 @@
   type Props = {
     location: "navbar" | "main-block";
     children?: Snippet<[]>;
+    isInElement?: boolean;
   };
 
-  const { location, children }: Props = $props();
+  const { location, children, isInElement = false }: Props = $props();
 
   const locationClass = `rcb-${location}`;
 </script>
 
-<div class="layout-wrapper-outer {locationClass}">
+<div
+  class="layout-wrapper-outer {locationClass}"
+  class:layout-wrapper-outer-in-element={isInElement}
+>
   <div class="layout-wrapper">
     <div
       class="layout-content {locationClass}"
@@ -91,6 +95,10 @@
     .layout-wrapper-outer {
       padding-top: var(--rc-spacing-outerPaddingTop-desktop);
       padding-bottom: var(--rc-spacing-outerPadding-desktop);
+    }
+
+    .layout-wrapper-outer.rcb-navbar.layout-wrapper-outer-in-element {
+      padding-top: 48px;
     }
   }
 </style>

--- a/src/ui/layout/template.svelte
+++ b/src/ui/layout/template.svelte
@@ -39,15 +39,16 @@
   {#if isSandbox}
     <SandboxBanner style={colorVariables} {isInElement} {brandingInfo} />
   {/if}
-  <Layout style={colorVariables}>
+  <Layout {isInElement} style={colorVariables}>
     {#if navbarHeaderContent || navbarBodyContent}
       <NavBar
+        {isInElement}
         brandingAppearance={brandingInfo?.appearance}
         headerContent={navbarHeaderContent}
         bodyContent={navbarBodyContent}
       />
     {/if}
-    <Main brandingAppearance={brandingInfo?.appearance}>
+    <Main {isInElement} brandingAppearance={brandingInfo?.appearance}>
       {@render mainContent?.()}
     </Main>
   </Layout>


### PR DESCRIPTION
## Summary
- scope checkout layout overrides to `isInElement` so fullscreen behavior remains unchanged from `main`
- keep embedded desktop two-column sizing (45/55) while preserving mobile single-column behavior
- add a dedicated webbilling-demo in-element page and Playwright tests that validate embedded layout behavior across desktop and narrow widths

## Testing
- Not run (Playwright E2E not executed in this session)