### PR TITLE
Add presented offering context to paywall events

### DIFF
--- a/src/behavioural-events/paywall-event.ts
+++ b/src/behavioural-events/paywall-event.ts
@@ -1,3 +1,4 @@
+import type { PresentedOfferingContext } from "../entities/offerings";
 import { generateUUID } from "../helpers/uuid-helper";
 
 export type PaywallEventType =
@@ -44,6 +45,7 @@ interface BasePaywallEventData {
   offeringId: string;
   paywallRevision: number;
   paywallRcPublicId: string | null;
+  presentedOfferingContext?: PresentedOfferingContext;
 }
 
 interface PaywallDisplayData {
@@ -73,6 +75,12 @@ export type PaywallEventData =
   | PaywallCloseOrCancelEventData
   | PaywallComponentInteractionEventData;
 
+type PresentedOfferingContextPayload = {
+  placement_identifier?: string;
+  targeting_revision?: number;
+  targeting_rule_id?: string;
+};
+
 type CommonPaywallEventPayload = {
   version: 1;
   id: string;
@@ -82,6 +90,7 @@ type CommonPaywallEventPayload = {
   paywall_revision: number;
   timestamp: number;
   paywall_rc_public_id: string | null;
+  presented_offering_context?: PresentedOfferingContextPayload;
 };
 
 type PaywallDisplayPayload = {
@@ -191,6 +200,50 @@ const toComponentInteractionPayload = (
   return payload as PaywallComponentInteractionPayload;
 };
 
+function toPresentedOfferingContextPayload(
+  context: PresentedOfferingContext | undefined,
+): PresentedOfferingContextPayload | undefined {
+  if (!context) return undefined;
+  if (!context.placementIdentifier && !context.targetingContext) {
+    return undefined;
+  }
+  return {
+    ...(context.placementIdentifier
+      ? { placement_identifier: context.placementIdentifier }
+      : {}),
+    ...(context.targetingContext
+      ? {
+          targeting_revision: context.targetingContext.revision,
+          targeting_rule_id: context.targetingContext.ruleId,
+        }
+      : {}),
+  };
+}
+
+const toCommonPayload = (
+  data: BasePaywallEventData,
+  id: string,
+  timestamp: number,
+): CommonPaywallEventPayload => {
+  const payload: CommonPaywallEventPayload = {
+    version: 1,
+    id,
+    app_user_id: data.appUserId,
+    session_id: data.sessionId,
+    offering_id: data.offeringId,
+    paywall_revision: data.paywallRevision,
+    timestamp,
+    paywall_rc_public_id: data.paywallRcPublicId,
+  };
+  const contextPayload = toPresentedOfferingContextPayload(
+    data.presentedOfferingContext,
+  );
+  if (contextPayload) {
+    payload.presented_offering_context = contextPayload;
+  }
+  return payload;
+};
+
 export class PaywallEvent {
   public readonly id: string;
   public readonly timestamp: number;
@@ -203,16 +256,7 @@ export class PaywallEvent {
   }
 
   public toJSON(): PaywallEventPayload {
-    const commonPayload: CommonPaywallEventPayload = {
-      version: 1,
-      id: this.id,
-      app_user_id: this.data.appUserId,
-      session_id: this.data.sessionId,
-      offering_id: this.data.offeringId,
-      paywall_revision: this.data.paywallRevision,
-      timestamp: this.timestamp,
-      paywall_rc_public_id: this.data.paywallRcPublicId,
-    };
+    const commonPayload = toCommonPayload(this.data, this.id, this.timestamp);
 
     switch (this.data.type) {
       case "paywall_impression":

--- a/src/behavioural-events/paywall-event.ts
+++ b/src/behavioural-events/paywall-event.ts
@@ -202,10 +202,10 @@ const toComponentInteractionPayload = (
 
 function toPresentedOfferingContextPayload(
   context: PresentedOfferingContext | undefined,
-): PresentedOfferingContextPayload | undefined {
-  if (!context) return undefined;
+): PresentedOfferingContextPayload | null {
+  if (!context) return null;
   if (!context.placementIdentifier && !context.targetingContext) {
-    return undefined;
+    return null;
   }
   return {
     ...(context.placementIdentifier

--- a/src/main.ts
+++ b/src/main.ts
@@ -624,6 +624,9 @@ export class Purchases {
       offeringId: offering.identifier,
       paywallRevision: 0,
       paywallRcPublicId: offering.paywallComponents?.id ?? null,
+      presentedOfferingContext:
+        offering.availablePackages[0]?.webBillingProduct
+          ?.presentedOfferingContext,
     };
     const paywallDisplayData = {
       displayMode: "full_screen",

--- a/src/tests/behavioral-events/paywall-event.test.ts
+++ b/src/tests/behavioral-events/paywall-event.test.ts
@@ -18,7 +18,7 @@ const baseData: PaywallEventData = {
 };
 
 describe("PaywallEvent", () => {
-  it("serializes impression event with visual fields", () => {
+  it("serializes impression event with visual fields and no context", () => {
     const event = new PaywallEvent({
       ...baseData,
       displayMode: "full_screen",
@@ -38,6 +38,43 @@ describe("PaywallEvent", () => {
       paywall_revision: 0,
       timestamp: expect.any(Number),
       paywall_rc_public_id: "pw-public-id",
+      display_mode: "full_screen",
+      dark_mode: true,
+      locale: "es_ES",
+    });
+    expect(json.presented_offering_context).toBeUndefined();
+  });
+
+  it("serializes full impression event with context and visual fields", () => {
+    const event = new PaywallEvent({
+      ...baseData,
+      displayMode: "full_screen",
+      darkMode: true,
+      locale: "es_ES",
+      presentedOfferingContext: {
+        offeringIdentifier: "offering-789",
+        placementIdentifier: "home_banner",
+        targetingContext: { revision: 3, ruleId: "rule_abc123" },
+      },
+    });
+
+    const json = event.toJSON();
+
+    expect(json).toEqual({
+      type: "paywall_impression",
+      version: 1,
+      id: "test-uuid-1234",
+      app_user_id: "user-123",
+      session_id: "session-456",
+      offering_id: "offering-789",
+      paywall_revision: 0,
+      timestamp: expect.any(Number),
+      paywall_rc_public_id: "pw-public-id",
+      presented_offering_context: {
+        placement_identifier: "home_banner",
+        targeting_revision: 3,
+        targeting_rule_id: "rule_abc123",
+      },
       display_mode: "full_screen",
       dark_mode: true,
       locale: "es_ES",
@@ -160,5 +197,114 @@ describe("PaywallEvent", () => {
       current_product_id: "monthly_product",
       resulting_product_id: "annual_product",
     });
+  });
+
+  it("includes presented_offering_context with placement and targeting", () => {
+    const event = new PaywallEvent({
+      ...baseData,
+      presentedOfferingContext: {
+        offeringIdentifier: "offering-789",
+        placementIdentifier: "home_banner",
+        targetingContext: { revision: 3, ruleId: "rule_abc123" },
+      },
+    });
+
+    expect(event.toJSON().presented_offering_context).toEqual({
+      placement_identifier: "home_banner",
+      targeting_revision: 3,
+      targeting_rule_id: "rule_abc123",
+    });
+  });
+
+  it("includes presented_offering_context with placement only", () => {
+    const event = new PaywallEvent({
+      ...baseData,
+      presentedOfferingContext: {
+        offeringIdentifier: "offering-789",
+        placementIdentifier: "home_banner",
+        targetingContext: null,
+      },
+    });
+
+    expect(event.toJSON().presented_offering_context).toEqual({
+      placement_identifier: "home_banner",
+    });
+  });
+
+  it("includes presented_offering_context with targeting only", () => {
+    const event = new PaywallEvent({
+      ...baseData,
+      presentedOfferingContext: {
+        offeringIdentifier: "offering-789",
+        placementIdentifier: null,
+        targetingContext: { revision: 7, ruleId: "rule_xyz" },
+      },
+    });
+
+    expect(event.toJSON().presented_offering_context).toEqual({
+      targeting_revision: 7,
+      targeting_rule_id: "rule_xyz",
+    });
+  });
+
+  it("omits presented_offering_context when no placement or targeting", () => {
+    const event = new PaywallEvent({
+      ...baseData,
+      presentedOfferingContext: {
+        offeringIdentifier: "offering-789",
+        placementIdentifier: null,
+        targetingContext: null,
+      },
+    });
+
+    expect(event.toJSON().presented_offering_context).toBeUndefined();
+  });
+
+  it("omits presented_offering_context when placementIdentifier is empty string", () => {
+    const event = new PaywallEvent({
+      ...baseData,
+      presentedOfferingContext: {
+        offeringIdentifier: "offering-789",
+        placementIdentifier: "",
+        targetingContext: null,
+      },
+    });
+
+    expect(event.toJSON().presented_offering_context).toBeUndefined();
+  });
+
+  it("omits presented_offering_context when not provided", () => {
+    const event = new PaywallEvent(baseData);
+
+    expect(event.toJSON().presented_offering_context).toBeUndefined();
+  });
+
+  it("JSON.stringify round-trip preserves presented_offering_context", () => {
+    const event = new PaywallEvent({
+      ...baseData,
+      presentedOfferingContext: {
+        offeringIdentifier: "offering-789",
+        placementIdentifier: "home_banner",
+        targetingContext: { revision: 3, ruleId: "rule_abc123" },
+      },
+    });
+
+    const serialized = JSON.stringify(event.toJSON());
+    const parsed = JSON.parse(serialized);
+
+    expect(parsed.presented_offering_context).toEqual({
+      placement_identifier: "home_banner",
+      targeting_revision: 3,
+      targeting_rule_id: "rule_abc123",
+    });
+  });
+
+  it("JSON.stringify omits presented_offering_context when absent", () => {
+    const event = new PaywallEvent(baseData);
+
+    const serialized = JSON.stringify(event.toJSON());
+    const parsed = JSON.parse(serialized);
+
+    expect(parsed.presented_offering_context).toBeUndefined();
   });
 });

--- a/src/tests/present-paywall.events.test.ts
+++ b/src/tests/present-paywall.events.test.ts
@@ -189,6 +189,29 @@ describe("Purchases.presentPaywall() paywall events", () => {
     ).toEqual(["paywall_impression"]);
   });
 
+  test("passes presentedOfferingContext to paywall events", async () => {
+    const purchases = configurePurchases();
+    const offering = createOfferingWithPaywall();
+    const trackPaywallEventSpy = vi.spyOn(
+      purchases["eventsTracker"],
+      "trackPaywallEvent",
+    );
+
+    const paywallPromise = purchases.presentPaywall({ offering });
+    void paywallPromise.catch(() => undefined);
+
+    expect(trackPaywallEventSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "paywall_impression",
+        presentedOfferingContext: {
+          offeringIdentifier: "offering_1",
+          targetingContext: { ruleId: "test_rule_id", revision: 123 },
+          placementIdentifier: null,
+        },
+      }),
+    );
+  });
+
   test("fires paywall_close when external code clears the paywall container", async () => {
     const purchases = configurePurchases();
     const offering = createOfferingWithPaywall();


### PR DESCRIPTION
## Summary
- Include `placement_identifier`, `targeting_revision`, and `targeting_rule_id` in paywall events under a `presented_offering_context` nested object
- Field is omitted when no placement or targeting data exists
- Consistent with iOS and Android implementations

## Related PRs
- iOS: RevenueCat/purchases-ios#6476
- Android: RevenueCat/purchases-android#3253

## Test plan
- [x] Unit tests for all context permutations (full, placement-only, targeting-only, none, empty string)
- [x] JSON round-trip serialization tests
- [x] Integration test verifying context flows from offering to event payload
- [x] Manual testing with targeting rules and placements in demo app