### PR TITLE
Fix package.json to reflect correct version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@revenuecat/purchases-js",
   "description": "Web subscriptions made easy. Powered by RevenueCat",
   "private": false,
-  "version": "1.29.1",
+  "version": "1.30.0",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
## Motivation / Description
We had mistakenly modified the version directly in https://github.com/RevenueCat/purchases-js/commit/515bde92bcfaec4dc678e1fcc9add77041b67fa9. This made the release automations later in #819 not modify the version, and instead we deployed 1.30.0 as 1.29.1 in the same exact code in the bundle. This modifies the version in the package.json again to match the latest, so future automations are fixed.

We have now made the same identical release manually, so 1.29.1 matches 1.30.0

## Changes introduced

## Linear ticket (if any)

## Additional comments
