### PR TITLE
Refactor checkoutStart/postCheckoutStart to use params objects

### DIFF
--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -112,9 +112,9 @@ interface CheckoutStartParams {
   appUserId: string;
   productId: string;
   purchaseOption: PurchaseOption;
-  presentedOfferingContext: PresentedOfferingContext;
 
   // Presentation context
+  presentedOfferingContext: PresentedOfferingContext;
   workflowPurchaseContext?: WorkflowPurchaseContext;
   paywallId?: string;
 

--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -107,6 +107,22 @@ export class PurchaseFlowError extends Error {
   }
 }
 
+interface CheckoutStartParams {
+  // Purchase identity
+  appUserId: string;
+  productId: string;
+  purchaseOption: PurchaseOption;
+  presentedOfferingContext: PresentedOfferingContext;
+
+  // Presentation context
+  workflowPurchaseContext?: WorkflowPurchaseContext;
+  paywallId?: string;
+
+  // Customer data
+  customerEmail?: string;
+  metadata?: PurchaseMetadata;
+}
+
 export interface OperationSessionSuccessfulResult {
   redemptionInfo: RedemptionInfo | null;
   operationSessionId: string;
@@ -159,32 +175,32 @@ export class PurchaseOperationHelper {
     }
   }
 
-  async checkoutStart(
-    appUserId: string,
-    productId: string,
-    purchaseOption: PurchaseOption,
-    presentedOfferingContext: PresentedOfferingContext,
-    email?: string,
-    metadata?: PurchaseMetadata,
-    workflowPurchaseContext?: WorkflowPurchaseContext,
-    paywallId?: string,
-  ): Promise<WebBillingCheckoutStartResponse> {
+  async checkoutStart({
+    appUserId,
+    productId,
+    purchaseOption,
+    presentedOfferingContext,
+    workflowPurchaseContext,
+    paywallId,
+    customerEmail,
+    metadata,
+  }: CheckoutStartParams): Promise<WebBillingCheckoutStartResponse> {
     try {
       const traceId = this.eventsTracker.getTraceId();
-      const stepId = workflowPurchaseContext?.stepId;
+      const presentedStepId = workflowPurchaseContext?.stepId;
 
       const checkoutStartResponse =
-        await this.backend.postCheckoutStart<WebBillingCheckoutStartResponse>(
+        await this.backend.postCheckoutStart<WebBillingCheckoutStartResponse>({
           appUserId,
           productId,
-          presentedOfferingContext,
           purchaseOption,
+          presentedOfferingContext,
           traceId,
-          email,
-          metadata,
-          stepId,
+          presentedStepId,
           paywallId,
-        );
+          customerEmail,
+          metadata,
+        });
       this.operationSessionId = checkoutStartResponse.operation_session_id;
       return checkoutStartResponse;
     } catch (error) {

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -39,10 +39,10 @@ interface CheckoutStartRequestParams {
   appUserId: string;
   productId: string;
   purchaseOption: PurchaseOption;
-  presentedOfferingContext: PresentedOfferingContext;
   traceId: string;
 
   // Presentation context
+  presentedOfferingContext: PresentedOfferingContext;
   presentedStepId?: string;
   paywallId?: string;
 

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -34,6 +34,23 @@ import { isWebBillingSandboxApiKey } from "../helpers/api-key-helper";
 import type { IdentifyResponse } from "./responses/identify-response";
 import type { CheckoutPrepareResponse } from "./responses/checkout-prepare-response";
 
+interface CheckoutStartRequestParams {
+  // Purchase identity
+  appUserId: string;
+  productId: string;
+  purchaseOption: PurchaseOption;
+  presentedOfferingContext: PresentedOfferingContext;
+  traceId: string;
+
+  // Presentation context
+  presentedStepId?: string;
+  paywallId?: string;
+
+  // Customer data
+  customerEmail?: string;
+  metadata?: PurchaseMetadata;
+}
+
 export class Backend {
   private readonly API_KEY: string;
   private readonly httpConfig: HttpConfig;
@@ -162,17 +179,17 @@ export class Backend {
 
   async postCheckoutStart<
     T extends CheckoutStartResponse = CheckoutStartResponse,
-  >(
-    appUserId: string,
-    productId: string,
-    presentedOfferingContext: PresentedOfferingContext,
-    purchaseOption: PurchaseOption,
-    traceId: string,
-    email?: string,
-    metadata: PurchaseMetadata | undefined = undefined,
-    stepId?: string,
-    paywallId?: string,
-  ): Promise<T> {
+  >({
+    appUserId,
+    productId,
+    purchaseOption,
+    presentedOfferingContext,
+    traceId,
+    presentedStepId,
+    paywallId,
+    customerEmail,
+    metadata,
+  }: CheckoutStartRequestParams): Promise<T> {
     type CheckoutStartRequestBody = {
       app_user_id: string;
       product_id: string;
@@ -197,7 +214,7 @@ export class Backend {
     const requestBody: CheckoutStartRequestBody = {
       app_user_id: appUserId,
       product_id: productId,
-      email: email,
+      email: customerEmail,
       price_id: purchaseOption.priceId,
       presented_offering_identifier:
         presentedOfferingContext.offeringIdentifier,
@@ -229,8 +246,8 @@ export class Backend {
         this.purchasesContext.workflowContext.workflowIdentifier;
     }
 
-    if (stepId) {
-      requestBody.presented_step_id = stepId;
+    if (presentedStepId) {
+      requestBody.presented_step_id = presentedStepId;
     }
 
     if (paywallId) {

--- a/src/paddle/paddle-service.ts
+++ b/src/paddle/paddle-service.ts
@@ -131,15 +131,15 @@ export class PaddleService {
     try {
       const traceId = this.eventsTracker.getTraceId();
       const startResponse =
-        await this.backend.postCheckoutStart<PaddleCheckoutStartResponse>(
+        await this.backend.postCheckoutStart<PaddleCheckoutStartResponse>({
           appUserId,
           productId,
-          presentedOfferingContext,
           purchaseOption,
+          presentedOfferingContext,
           traceId,
-          customerEmail ?? undefined,
+          customerEmail: customerEmail ?? undefined,
           metadata,
-        );
+        });
 
       await this.initializePaddle(
         startResponse.paddle_billing_params.client_side_token,

--- a/src/tests/helpers/purchase-operation-helper.test.ts
+++ b/src/tests/helpers/purchase-operation-helper.test.ts
@@ -132,16 +132,16 @@ describe("PurchaseOperationHelper", () => {
       testTraceId,
     );
     await expectPromiseToPurchaseFlowError(
-      purchaseOperationHelper.checkoutStart(
-        "test-app-user-id",
-        "test-product-id",
-        { id: "test-option-id", priceId: "test-price-id" },
-        {
+      purchaseOperationHelper.checkoutStart({
+        appUserId: "test-app-user-id",
+        productId: "test-product-id",
+        purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+        presentedOfferingContext: {
           offeringIdentifier: "test-offering-id",
           targetingContext: null,
           placementIdentifier: null,
         },
-      ),
+      }),
       new PurchaseFlowError(
         PurchaseFlowErrorCode.ErrorSettingUpPurchase,
         "Unknown backend error.",
@@ -162,17 +162,17 @@ describe("PurchaseOperationHelper", () => {
       ),
     );
     await expectPromiseToPurchaseFlowError(
-      purchaseOperationHelper.checkoutStart(
-        "test-app-user-id",
-        "test-product-id",
-        { id: "test-option-id", priceId: "test-price-id" },
-        {
+      purchaseOperationHelper.checkoutStart({
+        appUserId: "test-app-user-id",
+        productId: "test-product-id",
+        purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+        presentedOfferingContext: {
           offeringIdentifier: "test-offering-id",
           targetingContext: null,
           placementIdentifier: null,
         },
-        "test-email@test.com",
-      ),
+        customerEmail: "test-email@test.com",
+      }),
       new PurchaseFlowError(
         PurchaseFlowErrorCode.AlreadyPurchasedError,
         "This product is already active for the user.",
@@ -192,16 +192,16 @@ describe("PurchaseOperationHelper", () => {
       ),
     );
     await expectPromiseToPurchaseFlowError(
-      purchaseOperationHelper.checkoutStart(
-        "test-app-user-id",
-        "test-product-id",
-        { id: "test-option-id", priceId: "test-price-id" },
-        {
+      purchaseOperationHelper.checkoutStart({
+        appUserId: "test-app-user-id",
+        productId: "test-product-id",
+        purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+        presentedOfferingContext: {
           offeringIdentifier: "test-offering-id",
           targetingContext: null,
           placementIdentifier: null,
         },
-      ),
+      }),
       new PurchaseFlowError(
         PurchaseFlowErrorCode.InvalidPaddleAPIKeyError,
         "There was a credentials issue. Check the underlying error for more details.",
@@ -215,36 +215,34 @@ describe("PurchaseOperationHelper", () => {
       .spyOn(backend, "postCheckoutStart")
       .mockResolvedValue(checkoutStartResponse);
 
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
+    await purchaseOperationHelper.checkoutStart({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      presentedOfferingContext: {
         offeringIdentifier: "test-offering-id",
         targetingContext: null,
         placementIdentifier: null,
       },
-      "test@example.com",
-      undefined,
-      undefined,
-      "paywall-abc-123",
-    );
+      customerEmail: "test@example.com",
+      paywallId: "paywall-abc-123",
+    });
 
-    expect(mockPostCheckoutStart).toHaveBeenCalledWith(
-      "test-app-user-id",
-      "test-product-id",
-      {
+    expect(mockPostCheckoutStart).toHaveBeenCalledWith({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      presentedOfferingContext: {
         offeringIdentifier: "test-offering-id",
         targetingContext: null,
         placementIdentifier: null,
       },
-      { id: "test-option-id", priceId: "test-price-id" },
-      testTraceId,
-      "test@example.com",
-      undefined,
-      undefined,
-      "paywall-abc-123",
-    );
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      traceId: testTraceId,
+      customerEmail: "test@example.com",
+      metadata: undefined,
+      presentedStepId: undefined,
+      paywallId: "paywall-abc-123",
+    });
   });
 
   test("prepareCheckout returns the backend response", async () => {
@@ -304,16 +302,16 @@ describe("PurchaseOperationHelper", () => {
       }),
     );
 
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
+    await purchaseOperationHelper.checkoutStart({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      presentedOfferingContext: {
         offeringIdentifier: "test-offering-id",
         targetingContext: null,
         placementIdentifier: null,
       },
-    );
+    });
 
     const result = await purchaseOperationHelper.checkoutCalculateTax();
     expect(result).toEqual(checkoutCalculateTaxResponse);
@@ -335,16 +333,16 @@ describe("PurchaseOperationHelper", () => {
       }),
     );
 
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
+    await purchaseOperationHelper.checkoutStart({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      presentedOfferingContext: {
         offeringIdentifier: "test-offering-id",
         targetingContext: null,
         placementIdentifier: null,
       },
-    );
+    });
 
     const result = await purchaseOperationHelper.checkoutCalculateTax();
     expect(result).toEqual(checkoutCalculateTaxResponse);
@@ -368,16 +366,16 @@ describe("PurchaseOperationHelper", () => {
       ),
     );
 
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
+    await purchaseOperationHelper.checkoutStart({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      presentedOfferingContext: {
         offeringIdentifier: "test-offering-id",
         targetingContext: null,
         placementIdentifier: null,
       },
-    );
+    });
 
     await expectPromiseToPurchaseFlowError(
       purchaseOperationHelper.checkoutCalculateTax(),
@@ -405,16 +403,16 @@ describe("PurchaseOperationHelper", () => {
       ),
     );
 
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
+    await purchaseOperationHelper.checkoutStart({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      presentedOfferingContext: {
         offeringIdentifier: "test-offering-id",
         targetingContext: null,
         placementIdentifier: null,
       },
-    );
+    });
 
     await expectPromiseToPurchaseFlowError(
       purchaseOperationHelper.checkoutCalculateTax(),
@@ -434,16 +432,16 @@ describe("PurchaseOperationHelper", () => {
     );
     setCheckoutCalculateTaxResponse(HttpResponse.error());
 
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
+    await purchaseOperationHelper.checkoutStart({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      presentedOfferingContext: {
         offeringIdentifier: "test-offering-id",
         targetingContext: null,
         placementIdentifier: null,
       },
-    );
+    });
 
     await expectPromiseToPurchaseFlowError(
       purchaseOperationHelper.checkoutCalculateTax(),
@@ -467,16 +465,16 @@ describe("PurchaseOperationHelper", () => {
       }),
     );
 
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
+    await purchaseOperationHelper.checkoutStart({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      presentedOfferingContext: {
         offeringIdentifier: "test-offering-id",
         targetingContext: null,
         placementIdentifier: null,
       },
-    );
+    });
 
     const result = await purchaseOperationHelper.checkoutCalculateTax();
     expect(result).toEqual(checkoutCalculateTaxResponse);
@@ -502,17 +500,17 @@ describe("PurchaseOperationHelper", () => {
       HttpResponse.json(null, { status: StatusCodes.INTERNAL_SERVER_ERROR }),
     );
 
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
+    await purchaseOperationHelper.checkoutStart({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      presentedOfferingContext: {
         offeringIdentifier: "test-offering-id",
         targetingContext: null,
         placementIdentifier: null,
       },
-      "test-email@test.com",
-    );
+      customerEmail: "test-email@test.com",
+    });
 
     await expectPromiseToPurchaseFlowError(
       purchaseOperationHelper.checkoutComplete(),
@@ -540,16 +538,16 @@ describe("PurchaseOperationHelper", () => {
       ),
     );
 
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
+    await purchaseOperationHelper.checkoutStart({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      presentedOfferingContext: {
         offeringIdentifier: "test-offering-id",
         targetingContext: null,
         placementIdentifier: null,
       },
-    );
+    });
 
     await expectPromiseToPurchaseFlowError(
       purchaseOperationHelper.checkoutComplete(),
@@ -577,16 +575,16 @@ describe("PurchaseOperationHelper", () => {
       ),
     );
 
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
+    await purchaseOperationHelper.checkoutStart({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      presentedOfferingContext: {
         offeringIdentifier: "test-offering-id",
         targetingContext: null,
         placementIdentifier: null,
       },
-    );
+    });
 
     await expectPromiseToPurchaseFlowError(
       purchaseOperationHelper.checkoutComplete(),
@@ -614,16 +612,16 @@ describe("PurchaseOperationHelper", () => {
       ),
     );
 
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
+    await purchaseOperationHelper.checkoutStart({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      presentedOfferingContext: {
         offeringIdentifier: "test-offering-id",
         targetingContext: null,
         placementIdentifier: null,
       },
-    );
+    });
 
     await expectPromiseToPurchaseFlowError(
       purchaseOperationHelper.checkoutComplete(),
@@ -655,16 +653,16 @@ describe("PurchaseOperationHelper", () => {
       HttpResponse.json(null, { status: StatusCodes.INTERNAL_SERVER_ERROR }),
     );
 
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
+    await purchaseOperationHelper.checkoutStart({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      presentedOfferingContext: {
         offeringIdentifier: "test-offering-id",
         targetingContext: null,
         placementIdentifier: null,
       },
-    );
+    });
     await expectPromiseToPurchaseFlowError(
       purchaseOperationHelper.pollCurrentPurchaseForCompletion(),
       new PurchaseFlowError(
@@ -695,17 +693,17 @@ describe("PurchaseOperationHelper", () => {
       HttpResponse.json(getCheckoutStatusResponse, { status: StatusCodes.OK }),
     );
 
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
+    await purchaseOperationHelper.checkoutStart({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      presentedOfferingContext: {
         offeringIdentifier: "test-offering-id",
         targetingContext: null,
         placementIdentifier: null,
       },
-      "test-email",
-    );
+      customerEmail: "test-email",
+    });
     await purchaseOperationHelper.pollCurrentPurchaseForCompletion();
   });
 
@@ -732,16 +730,16 @@ describe("PurchaseOperationHelper", () => {
       HttpResponse.json(getCheckoutStatusResponse, { status: StatusCodes.OK }),
     );
 
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
+    await purchaseOperationHelper.checkoutStart({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      presentedOfferingContext: {
         offeringIdentifier: "test-offering-id",
         targetingContext: null,
         placementIdentifier: null,
       },
-    );
+    });
     const pollResult =
       await purchaseOperationHelper.pollCurrentPurchaseForCompletion();
     expect(pollResult.redemptionInfo?.redeemUrl).toEqual(
@@ -775,16 +773,16 @@ describe("PurchaseOperationHelper", () => {
       HttpResponse.json(getCheckoutStatusResponse, { status: StatusCodes.OK }),
     );
 
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
+    await purchaseOperationHelper.checkoutStart({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      presentedOfferingContext: {
         offeringIdentifier: "test-offering-id",
         targetingContext: null,
         placementIdentifier: null,
       },
-    );
+    });
     await expectPromiseToPurchaseFlowError(
       purchaseOperationHelper.pollCurrentPurchaseForCompletion(),
       new PurchaseFlowError(
@@ -824,16 +822,16 @@ describe("PurchaseOperationHelper", () => {
       });
     });
 
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
+    await purchaseOperationHelper.checkoutStart({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      presentedOfferingContext: {
         offeringIdentifier: "test-offering-id",
         targetingContext: null,
         placementIdentifier: null,
       },
-    );
+    });
 
     const pollPromise = expectPromiseToPurchaseFlowError(
       purchaseOperationHelper.pollCurrentPurchaseForCompletion(),
@@ -872,16 +870,16 @@ describe("PurchaseOperationHelper", () => {
       HttpResponse.json(getCheckoutStatusResponse, { status: StatusCodes.OK }),
     );
 
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
+    await purchaseOperationHelper.checkoutStart({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      presentedOfferingContext: {
         offeringIdentifier: "test-offering-id",
         targetingContext: null,
         placementIdentifier: null,
       },
-    );
+    });
     await expectPromiseToPurchaseFlowError(
       purchaseOperationHelper.pollCurrentPurchaseForCompletion(),
       new PurchaseFlowError(
@@ -911,16 +909,16 @@ describe("PurchaseOperationHelper", () => {
       HttpResponse.json(getCheckoutStatusResponse, { status: StatusCodes.OK }),
     );
 
-    await purchaseOperationHelper.checkoutStart(
-      "test-app-user-id",
-      "test-product-id",
-      { id: "test-option-id", priceId: "test-price-id" },
-      {
+    await purchaseOperationHelper.checkoutStart({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      presentedOfferingContext: {
         offeringIdentifier: "test-offering-id",
         targetingContext: null,
         placementIdentifier: null,
       },
-    );
+    });
     await expectPromiseToPurchaseFlowError(
       purchaseOperationHelper.pollCurrentPurchaseForCompletion(),
       new PurchaseFlowError(

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -608,17 +608,17 @@ describe("postCheckoutStart request", () => {
       HttpResponse.json(checkoutStartResponse, { status: 200 }),
     );
 
-    const result = await backend.postCheckoutStart(
-      "someAppUserId",
-      "monthly",
-      {
+    const result = await backend.postCheckoutStart({
+      appUserId: "someAppUserId",
+      productId: "monthly",
+      presentedOfferingContext: {
         offeringIdentifier: "offering_1",
         targetingContext: null,
         placementIdentifier: null,
       },
-      { id: "base_option", priceId: "test_price_id" },
-      "test-trace-id",
-    );
+      purchaseOption: { id: "base_option", priceId: "test_price_id" },
+      traceId: "test-trace-id",
+    });
 
     expect(purchaseMethodAPIMock).toHaveBeenCalledTimes(1);
     const request = purchaseMethodAPIMock.mock.calls[0][0].request;
@@ -642,19 +642,19 @@ describe("postCheckoutStart request", () => {
       HttpResponse.json(checkoutStartResponse, { status: 200 }),
     );
 
-    const result = await backend.postCheckoutStart(
-      "someAppUserId",
-      "monthly",
-      {
+    const result = await backend.postCheckoutStart({
+      appUserId: "someAppUserId",
+      productId: "monthly",
+      presentedOfferingContext: {
         offeringIdentifier: "offering_1",
         targetingContext: null,
         placementIdentifier: null,
       },
-      { id: "base_option", priceId: "test_price_id" },
-      "test-trace-id",
-      "testemail@revenuecat.com",
-      { utm_campaign: "test-campaign" },
-    );
+      purchaseOption: { id: "base_option", priceId: "test_price_id" },
+      traceId: "test-trace-id",
+      customerEmail: "testemail@revenuecat.com",
+      metadata: { utm_campaign: "test-campaign" },
+    });
 
     expect(purchaseMethodAPIMock).toHaveBeenCalledTimes(1);
     const request = purchaseMethodAPIMock.mock.calls[0][0].request;
@@ -684,17 +684,17 @@ describe("postCheckoutStart request", () => {
       HttpResponse.json(checkoutStartResponse, { status: 200 }),
     );
 
-    await backendWithContext.postCheckoutStart(
-      "someAppUserId",
-      "monthly",
-      {
+    await backendWithContext.postCheckoutStart({
+      appUserId: "someAppUserId",
+      productId: "monthly",
+      presentedOfferingContext: {
         offeringIdentifier: "offering_1",
         targetingContext: null,
         placementIdentifier: null,
       },
-      { id: "base_option", priceId: "test_price_id" },
-      "test-trace-id",
-    );
+      purchaseOption: { id: "base_option", priceId: "test_price_id" },
+      traceId: "test-trace-id",
+    });
 
     expect(purchaseMethodAPIMock).toHaveBeenCalledTimes(1);
     const request = purchaseMethodAPIMock.mock.calls[0][0].request;
@@ -707,17 +707,17 @@ describe("postCheckoutStart request", () => {
       HttpResponse.json(checkoutStartResponse, { status: 200 }),
     );
 
-    await backend.postCheckoutStart(
-      "someAppUserId",
-      "monthly",
-      {
+    await backend.postCheckoutStart({
+      appUserId: "someAppUserId",
+      productId: "monthly",
+      presentedOfferingContext: {
         offeringIdentifier: "offering_1",
         targetingContext: null,
         placementIdentifier: null,
       },
-      { id: "base_option", priceId: "test_price_id" },
-      "test-trace-id",
-    );
+      purchaseOption: { id: "base_option", priceId: "test_price_id" },
+      traceId: "test-trace-id",
+    });
 
     expect(purchaseMethodAPIMock).toHaveBeenCalledTimes(1);
     const request = purchaseMethodAPIMock.mock.calls[0][0].request;
@@ -730,20 +730,18 @@ describe("postCheckoutStart request", () => {
       HttpResponse.json(checkoutStartResponse, { status: 200 }),
     );
 
-    await backend.postCheckoutStart(
-      "someAppUserId",
-      "monthly",
-      {
+    await backend.postCheckoutStart({
+      appUserId: "someAppUserId",
+      productId: "monthly",
+      presentedOfferingContext: {
         offeringIdentifier: "offering_1",
         targetingContext: null,
         placementIdentifier: null,
       },
-      { id: "base_option", priceId: "test_price_id" },
-      "test-trace-id",
-      undefined,
-      undefined,
-      "test-step-123",
-    );
+      purchaseOption: { id: "base_option", priceId: "test_price_id" },
+      traceId: "test-trace-id",
+      presentedStepId: "test-step-123",
+    });
 
     expect(purchaseMethodAPIMock).toHaveBeenCalledTimes(1);
     const request = purchaseMethodAPIMock.mock.calls[0][0].request;
@@ -756,17 +754,17 @@ describe("postCheckoutStart request", () => {
       HttpResponse.json(checkoutStartResponse, { status: 200 }),
     );
 
-    await backend.postCheckoutStart(
-      "someAppUserId",
-      "monthly",
-      {
+    await backend.postCheckoutStart({
+      appUserId: "someAppUserId",
+      productId: "monthly",
+      presentedOfferingContext: {
         offeringIdentifier: "offering_1",
         targetingContext: null,
         placementIdentifier: null,
       },
-      { id: "base_option", priceId: "test_price_id" },
-      "test-trace-id",
-    );
+      purchaseOption: { id: "base_option", priceId: "test_price_id" },
+      traceId: "test-trace-id",
+    });
 
     expect(purchaseMethodAPIMock).toHaveBeenCalledTimes(1);
     const request = purchaseMethodAPIMock.mock.calls[0][0].request;
@@ -779,21 +777,18 @@ describe("postCheckoutStart request", () => {
       HttpResponse.json(checkoutStartResponse, { status: 200 }),
     );
 
-    await backend.postCheckoutStart(
-      "someAppUserId",
-      "monthly",
-      {
+    await backend.postCheckoutStart({
+      appUserId: "someAppUserId",
+      productId: "monthly",
+      presentedOfferingContext: {
         offeringIdentifier: "offering_1",
         targetingContext: null,
         placementIdentifier: null,
       },
-      { id: "base_option", priceId: "test_price_id" },
-      "test-trace-id",
-      undefined,
-      undefined,
-      undefined,
-      "test-paywall-123",
-    );
+      purchaseOption: { id: "base_option", priceId: "test_price_id" },
+      traceId: "test-trace-id",
+      paywallId: "test-paywall-123",
+    });
 
     expect(purchaseMethodAPIMock).toHaveBeenCalledTimes(1);
     const request = purchaseMethodAPIMock.mock.calls[0][0].request;
@@ -806,17 +801,17 @@ describe("postCheckoutStart request", () => {
       HttpResponse.json(checkoutStartResponse, { status: 200 }),
     );
 
-    await backend.postCheckoutStart(
-      "someAppUserId",
-      "monthly",
-      {
+    await backend.postCheckoutStart({
+      appUserId: "someAppUserId",
+      productId: "monthly",
+      presentedOfferingContext: {
         offeringIdentifier: "offering_1",
         targetingContext: null,
         placementIdentifier: null,
       },
-      { id: "base_option", priceId: "test_price_id" },
-      "test-trace-id",
-    );
+      purchaseOption: { id: "base_option", priceId: "test_price_id" },
+      traceId: "test-trace-id",
+    });
 
     expect(purchaseMethodAPIMock).toHaveBeenCalledTimes(1);
     const request = purchaseMethodAPIMock.mock.calls[0][0].request;
@@ -829,19 +824,18 @@ describe("postCheckoutStart request", () => {
       HttpResponse.json(null, { status: StatusCodes.INTERNAL_SERVER_ERROR }),
     );
     await expectPromiseToError(
-      backend.postCheckoutStart(
-        "someAppUserId",
-        "monthly",
-        {
+      backend.postCheckoutStart({
+        appUserId: "someAppUserId",
+        productId: "monthly",
+        presentedOfferingContext: {
           offeringIdentifier: "offering_1",
           targetingContext: null,
           placementIdentifier: null,
         },
-        { id: "base_option", priceId: "test_price_id" },
-        "test-trace-id",
-        undefined,
-        { utm_campaign: "test-campaign" },
-      ),
+        purchaseOption: { id: "base_option", priceId: "test_price_id" },
+        traceId: "test-trace-id",
+        metadata: { utm_campaign: "test-campaign" },
+      }),
       new PurchasesError(
         ErrorCode.UnknownBackendError,
         "Unknown backend error.",
@@ -861,19 +855,19 @@ describe("postCheckoutStart request", () => {
       ),
     );
     await expectPromiseToError(
-      backend.postCheckoutStart(
-        "someAppUserId",
-        "monthly",
-        {
+      backend.postCheckoutStart({
+        appUserId: "someAppUserId",
+        productId: "monthly",
+        presentedOfferingContext: {
           offeringIdentifier: "offering_1",
           targetingContext: null,
           placementIdentifier: null,
         },
-        { id: "base_option", priceId: "test_price_id" },
-        "test-trace-id",
-        "testemail@revenuecat.com",
-        { utm_campaign: "test-campaign" },
-      ),
+        purchaseOption: { id: "base_option", priceId: "test_price_id" },
+        traceId: "test-trace-id",
+        customerEmail: "testemail@revenuecat.com",
+        metadata: { utm_campaign: "test-campaign" },
+      }),
       new PurchasesError(
         ErrorCode.InvalidCredentialsError,
         "There was a credentials issue. Check the underlying error for more details.",
@@ -893,19 +887,19 @@ describe("postCheckoutStart request", () => {
       ),
     );
     await expectPromiseToError(
-      backend.postCheckoutStart(
-        "someAppUserId",
-        "monthly",
-        {
+      backend.postCheckoutStart({
+        appUserId: "someAppUserId",
+        productId: "monthly",
+        presentedOfferingContext: {
           offeringIdentifier: "offering_1",
           targetingContext: null,
           placementIdentifier: null,
         },
-        { id: "base_option", priceId: "test_price_id" },
-        "test-trace-id",
-        "testemail@revenuecat.com",
-        { utm_campaign: "test-campaign" },
-      ),
+        purchaseOption: { id: "base_option", priceId: "test_price_id" },
+        traceId: "test-trace-id",
+        customerEmail: "testemail@revenuecat.com",
+        metadata: { utm_campaign: "test-campaign" },
+      }),
       new PurchasesError(
         ErrorCode.PurchaseInvalidError,
         "One or more of the arguments provided are invalid.",
@@ -917,19 +911,18 @@ describe("postCheckoutStart request", () => {
   test("throws network error if cannot reach server", async () => {
     setCheckoutStartResponse(HttpResponse.error());
     await expectPromiseToError(
-      backend.postCheckoutStart(
-        "someAppUserId",
-        "monthly",
-        {
+      backend.postCheckoutStart({
+        appUserId: "someAppUserId",
+        productId: "monthly",
+        presentedOfferingContext: {
           offeringIdentifier: "offering_1",
           targetingContext: null,
           placementIdentifier: null,
         },
-        { id: "base_option", priceId: "test_price_id" },
-        "test-trace-id",
-        undefined,
-        { utm_campaign: "test-campaign" },
-      ),
+        purchaseOption: { id: "base_option", priceId: "test_price_id" },
+        traceId: "test-trace-id",
+        metadata: { utm_campaign: "test-campaign" },
+      }),
       new PurchasesError(
         ErrorCode.NetworkError,
         "Error performing request. Please check your network connection and try again.",

--- a/src/tests/ui/purchases-ui.test.ts
+++ b/src/tests/ui/purchases-ui.test.ts
@@ -183,16 +183,16 @@ describe("PurchasesUI", () => {
 
     await new Promise(process.nextTick);
 
-    expect(checkoutStartSpy).toHaveBeenCalledWith(
-      "app-user-id",
-      rcPackage.webBillingProduct.identifier,
-      subscriptionOption,
-      rcPackage.webBillingProduct.presentedOfferingContext,
-      "test@test.com",
-      { utm_term: "something" },
-      { stepId: "test-step-123" },
-      undefined,
-    );
+    expect(checkoutStartSpy).toHaveBeenCalledWith({
+      appUserId: "app-user-id",
+      productId: rcPackage.webBillingProduct.identifier,
+      purchaseOption: subscriptionOption,
+      presentedOfferingContext:
+        rcPackage.webBillingProduct.presentedOfferingContext,
+      customerEmail: "test@test.com",
+      metadata: { utm_term: "something" },
+      workflowPurchaseContext: { stepId: "test-step-123" },
+    });
   });
 
   test("passes undefined workflowPurchaseContext to checkoutStart when not provided", async () => {
@@ -208,15 +208,14 @@ describe("PurchasesUI", () => {
 
     await new Promise(process.nextTick);
 
-    expect(checkoutStartSpy).toHaveBeenCalledWith(
-      "app-user-id",
-      rcPackage.webBillingProduct.identifier,
-      subscriptionOption,
-      rcPackage.webBillingProduct.presentedOfferingContext,
-      "test@test.com",
-      { utm_term: "something" },
-      undefined,
-      undefined,
-    );
+    expect(checkoutStartSpy).toHaveBeenCalledWith({
+      appUserId: "app-user-id",
+      productId: rcPackage.webBillingProduct.identifier,
+      purchaseOption: subscriptionOption,
+      presentedOfferingContext:
+        rcPackage.webBillingProduct.presentedOfferingContext,
+      customerEmail: "test@test.com",
+      metadata: { utm_term: "something" },
+    });
   });
 });

--- a/src/tests/ui/stripe-checkout-purchases-ui.test.ts
+++ b/src/tests/ui/stripe-checkout-purchases-ui.test.ts
@@ -104,16 +104,16 @@ describe("StripeCheckoutPurchasesUi", () => {
     });
 
     await waitFor(() => {
-      expect(checkoutStartSpy).toHaveBeenCalledWith(
-        "test-app-user-id",
-        rcPackage.webBillingProduct.identifier,
-        subscriptionOption,
-        rcPackage.webBillingProduct.presentedOfferingContext,
-        "test@example.com",
-        { utm_term: "something" },
-        { stepId: "test-step-123" },
-        undefined,
-      );
+      expect(checkoutStartSpy).toHaveBeenCalledWith({
+        appUserId: "test-app-user-id",
+        productId: rcPackage.webBillingProduct.identifier,
+        purchaseOption: subscriptionOption,
+        presentedOfferingContext:
+          rcPackage.webBillingProduct.presentedOfferingContext,
+        customerEmail: "test@example.com",
+        metadata: { utm_term: "something" },
+        workflowPurchaseContext: { stepId: "test-step-123" },
+      });
     });
   });
 
@@ -129,16 +129,15 @@ describe("StripeCheckoutPurchasesUi", () => {
     });
 
     await waitFor(() => {
-      expect(checkoutStartSpy).toHaveBeenCalledWith(
-        "test-app-user-id",
-        rcPackage.webBillingProduct.identifier,
-        subscriptionOption,
-        rcPackage.webBillingProduct.presentedOfferingContext,
-        "test@example.com",
-        { utm_term: "something" },
-        undefined,
-        undefined,
-      );
+      expect(checkoutStartSpy).toHaveBeenCalledWith({
+        appUserId: "test-app-user-id",
+        productId: rcPackage.webBillingProduct.identifier,
+        purchaseOption: subscriptionOption,
+        presentedOfferingContext:
+          rcPackage.webBillingProduct.presentedOfferingContext,
+        customerEmail: "test@example.com",
+        metadata: { utm_term: "something" },
+      });
     });
   });
 
@@ -155,16 +154,15 @@ describe("StripeCheckoutPurchasesUi", () => {
     });
 
     await waitFor(() => {
-      expect(checkoutStartSpy).toHaveBeenCalledWith(
-        "test-app-user-id",
-        rcPackage.webBillingProduct.identifier,
-        subscriptionOption,
-        rcPackage.webBillingProduct.presentedOfferingContext,
-        undefined,
-        { utm_term: "something" },
-        undefined,
-        undefined,
-      );
+      expect(checkoutStartSpy).toHaveBeenCalledWith({
+        appUserId: "test-app-user-id",
+        productId: rcPackage.webBillingProduct.identifier,
+        purchaseOption: subscriptionOption,
+        presentedOfferingContext:
+          rcPackage.webBillingProduct.presentedOfferingContext,
+        customerEmail: undefined,
+        metadata: { utm_term: "something" },
+      });
     });
   });
 
@@ -201,16 +199,16 @@ describe("StripeCheckoutPurchasesUi", () => {
     });
 
     await waitFor(() => {
-      expect(checkoutStartSpy).toHaveBeenCalledWith(
-        "test-app-user-id",
-        rcPackage.webBillingProduct.identifier,
-        subscriptionOption,
-        rcPackage.webBillingProduct.presentedOfferingContext,
-        "test@example.com",
-        { utm_term: "something" },
-        undefined,
-        "paywall-abc-123",
-      );
+      expect(checkoutStartSpy).toHaveBeenCalledWith({
+        appUserId: "test-app-user-id",
+        productId: rcPackage.webBillingProduct.identifier,
+        purchaseOption: subscriptionOption,
+        presentedOfferingContext:
+          rcPackage.webBillingProduct.presentedOfferingContext,
+        customerEmail: "test@example.com",
+        metadata: { utm_term: "something" },
+        paywallId: "paywall-abc-123",
+      });
     });
   });
 
@@ -226,16 +224,15 @@ describe("StripeCheckoutPurchasesUi", () => {
     });
 
     await waitFor(() => {
-      expect(checkoutStartSpy).toHaveBeenCalledWith(
-        "test-app-user-id",
-        rcPackage.webBillingProduct.identifier,
-        subscriptionOption,
-        rcPackage.webBillingProduct.presentedOfferingContext,
-        "test@example.com",
-        { utm_term: "something" },
-        undefined,
-        undefined,
-      );
+      expect(checkoutStartSpy).toHaveBeenCalledWith({
+        appUserId: "test-app-user-id",
+        productId: rcPackage.webBillingProduct.identifier,
+        purchaseOption: subscriptionOption,
+        presentedOfferingContext:
+          rcPackage.webBillingProduct.presentedOfferingContext,
+        customerEmail: "test@example.com",
+        metadata: { utm_term: "something" },
+      });
     });
   });
 

--- a/src/ui/express-purchase-button/express-purchase-button.svelte
+++ b/src/ui/express-purchase-button/express-purchase-button.svelte
@@ -282,14 +282,15 @@
     });
     eventsTracker.trackSDKEvent(sessionStartEvent);
     try {
-      const checkoutStartResult = await purchaseOperationHelper.checkoutStart(
+      const checkoutStartResult = await purchaseOperationHelper.checkoutStart({
         appUserId,
-        rcPackage.webBillingProduct.identifier,
+        productId: rcPackage.webBillingProduct.identifier,
         purchaseOption,
-        rcPackage.webBillingProduct.presentedOfferingContext,
+        presentedOfferingContext:
+          rcPackage.webBillingProduct.presentedOfferingContext,
         customerEmail,
         metadata,
-      );
+      });
 
       const managementUrl = checkoutStartResult.management_url;
 

--- a/src/ui/purchases-ui.svelte
+++ b/src/ui/purchases-ui.svelte
@@ -158,16 +158,17 @@
     }
 
     purchaseOperationHelper
-      .checkoutStart(
+      .checkoutStart({
         appUserId,
         productId,
         purchaseOption,
-        rcPackage.webBillingProduct.presentedOfferingContext,
-        email,
+        presentedOfferingContext:
+          rcPackage.webBillingProduct.presentedOfferingContext,
+        customerEmail: email,
         metadata,
         workflowPurchaseContext,
         paywallId,
-      )
+      })
       .then((result) => {
         lastError = null;
         currentPage = "payment-entry";
@@ -178,16 +179,17 @@
         if (e.errorCode === PurchaseFlowErrorCode.MissingEmailError) {
           email = undefined;
           return purchaseOperationHelper
-            .checkoutStart(
+            .checkoutStart({
               appUserId,
               productId,
               purchaseOption,
-              rcPackage.webBillingProduct.presentedOfferingContext,
-              email,
+              presentedOfferingContext:
+                rcPackage.webBillingProduct.presentedOfferingContext,
+              customerEmail: email,
               metadata,
               workflowPurchaseContext,
               paywallId,
-            )
+            })
             .then((result) => {
               lastError = null;
               currentPage = "payment-entry";

--- a/src/ui/stripe-checkout-purchases-ui.svelte
+++ b/src/ui/stripe-checkout-purchases-ui.svelte
@@ -172,16 +172,17 @@
     }
 
     try {
-      const result = await purchaseOperationHelper.checkoutStart(
+      const result = await purchaseOperationHelper.checkoutStart({
         appUserId,
         productId,
         purchaseOption,
-        rcPackage.webBillingProduct.presentedOfferingContext,
-        email,
+        presentedOfferingContext:
+          rcPackage.webBillingProduct.presentedOfferingContext,
+        customerEmail: email,
         metadata,
         workflowPurchaseContext,
         paywallId,
-      );
+      });
 
       if (!result.stripe_billing_params) {
         handleError(


### PR DESCRIPTION
## Summary

- Replace positional parameters in `checkoutStart` and `postCheckoutStart` with single typed params objects
- Rename `email` → `customerEmail`, `stepId` → `presentedStepId` for clarity
- Group params by domain: purchase identity, presentation context, customer data

Motivated by [WEB-4004](https://linear.app/revenuecat/issue/WEB-4004) (locale passthrough) — adding another optional positional param made call sites unreadable. This cleanup lands first so the locale PR is a clean one-field addition.

Discussed and aligned with the team in [Slack](https://revenuecat.slack.com/archives/C03UKCQLW1Z/p1775051572428789).

## What changed

**`purchase-operation-helper.ts`** — `checkoutStart(params: CheckoutStartParams)`
**`backend.ts`** — `postCheckoutStart(params: CheckoutStartRequestParams)`

All callers (4 Svelte components, PaddleService) and test assertions updated to match.

## Not in scope

- `purchaseOption` / `presentedOfferingContext` param order is inconsistent between `checkoutStart` and `postCheckoutStart` — noted for future cleanup
- Presentation context fields (`presentedStepId`, `paywallId`) could move into `PresentedOfferingContext` for better domain modeling — separate PR

## Breaking changes

None. Both methods are internal — never called directly by SDK consumers. The public API (`purchases.purchase(params)`) is not affected.

## Test plan

- [x] All 547 existing tests pass
- [x] Lint, prettier, eslint, typecheck, svelte-check all pass