### PR TITLE
WEB-3903: Stripe Checkout branding support

### DIFF
--- a/examples/webbilling-demo/src/tests/stripe-checkout/purchase-flow.test.ts
+++ b/examples/webbilling-demo/src/tests/stripe-checkout/purchase-flow.test.ts
@@ -33,6 +33,11 @@ integrationTest.describe("Stripe Checkout flow", () => {
     "Stripe Checkout E2E tests require VITE_RC_STRIPE_CHECKOUT_E2E_API_KEY.",
   );
 
+  integrationTest.afterEach(async () => {
+    // Sleep between tests to avoid hitting the rate limit of the Stripe Checkout API.
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  });
+
   integrationTest(
     "Purchases a product with embedded Stripe Checkout",
     async ({ page, userId, email }) => {

--- a/src/helpers/api-key-helper.ts
+++ b/src/helpers/api-key-helper.ts
@@ -16,11 +16,7 @@ export function isPaddleApiKey(apiKey: string): boolean {
 }
 
 export function isStripeApiKey(apiKey: string): boolean {
-  const isStripeApiKey = apiKey ? stripe_api_key_regex.test(apiKey) : false;
-  const isSandboxStripeApiKey = apiKey ? apiKey.startsWith("strp_sb_") : false;
-  // Supporting only sandbox api keys for now, we'll add support for live api keys
-  // when we make the feature generally available
-  return isStripeApiKey && isSandboxStripeApiKey;
+  return apiKey ? stripe_api_key_regex.test(apiKey) : false;
 }
 
 export function isSimulatedStoreApiKey(apiKey: string): boolean {

--- a/src/networking/responses/checkout-start-response.ts
+++ b/src/networking/responses/checkout-start-response.ts
@@ -1,21 +1,10 @@
 import type { GatewayParams } from "./stripe-elements";
-import type { BrandingAppearance } from "../../entities/branding";
 
 export interface StripeBillingParams {
   client_secret: string;
   environment: string;
   publishable_api_key: string;
   stripe_account_id: string;
-  branding_settings?: {
-    background_color?: string;
-    border_style?: string;
-    button_color?: string;
-    display_name?: string;
-    font_family?: string;
-    icon?: { file?: string; type?: string };
-    logo?: { file?: string; type?: string };
-  } | null;
-  appearance?: Partial<BrandingAppearance> | null;
 }
 
 export interface WebBillingCheckoutStartResponse {

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -194,7 +194,7 @@ describe("Purchases.configure()", () => {
         apiKey: "strp_valid_key",
         appUserId: testUserId,
       }),
-    ).toThrow();
+    ).not.toThrow();
   });
 
   test("does not throw error if given valid stripe sandbox api key", () => {
@@ -770,11 +770,11 @@ describe("Purchases.purchase()", () => {
     expect(performWebBillingPurchaseSpy).not.toHaveBeenCalled();
   });
 
-  test("routes purchases to Stripe Checkout flow for strp_sb_ api keys", async () => {
+  test("routes purchases to Stripe Checkout flow for strp_ api keys", async () => {
     const purchases = configurePurchases(
       testUserId,
       "rcSource",
-      "strp_sb_test_key",
+      "strp_test_key",
     );
     const purchasesInternal = purchases as unknown as PurchaseRouterMethods;
     const performStripePurchaseSpy = vi
@@ -796,15 +796,6 @@ describe("Purchases.purchase()", () => {
     expect(performStripePurchaseSpy).toHaveBeenCalledOnce();
     expect(performPaddlePurchaseSpy).not.toHaveBeenCalled();
     expect(performWebBillingPurchaseSpy).not.toHaveBeenCalled();
-  });
-
-  test("throws error if api key Stripe prod", () => {
-    expect(() =>
-      Purchases.configure({
-        apiKey: "strp_test_key",
-        appUserId: "someUser",
-      }),
-    ).toThrowError(PurchasesError);
   });
 
   test("routes purchases to web billing flow for rcb_ api keys", async () => {

--- a/src/ui/layout/fullscreen-template.svelte
+++ b/src/ui/layout/fullscreen-template.svelte
@@ -23,7 +23,7 @@
       brandingContextKey,
     );
   const derivedBrandingAppearance = $derived(
-    $brandingAppearanceStore ?? undefined,
+    $brandingAppearanceStore ?? brandingInfo?.appearance ?? null,
   );
 
   const colorVariables = $derived(

--- a/src/ui/layout/fullscreen-template.svelte
+++ b/src/ui/layout/fullscreen-template.svelte
@@ -4,10 +4,6 @@
   import { type BrandingInfoResponse } from "../../networking/responses/branding-response";
   import { type Snippet } from "svelte";
   import { Theme } from "../theme/theme";
-  import AppWordmark from "../atoms/app-wordmark.svelte";
-  import { buildBrandingSources } from "../../helpers/build-branding-sources";
-  import AppLogo from "../atoms/app-logo.svelte";
-  import Typography from "../atoms/typography.svelte";
   import type { BrandingAppearance } from "../../entities/branding";
 
   export interface Props {
@@ -16,6 +12,7 @@
     isInElement: boolean;
     isSandbox: boolean;
     mainContent?: Snippet<[]>;
+    hideHeader?: boolean;
   }
 
   const {
@@ -34,12 +31,8 @@
     new Theme(derivedBrandingAppearance).pageStyleVars,
   );
 
-  const pageBgColor = $derived(
+  const pageBackground = $derived(
     derivedBrandingAppearance?.color_page_bg ?? "#ffffff",
-  );
-
-  const { wordmarkSrc, wordmarkSrcWebp, src, srcWebp } = $derived(
-    buildBrandingSources(brandingInfo),
   );
 </script>
 
@@ -53,17 +46,8 @@
   {/if}
   <div
     class="rcb-fullscreen-wrapper"
-    style="{colorVariables}; background-color: {pageBgColor}"
+    style="{colorVariables}; background-color: {pageBackground}"
   >
-    <div class="rcb-fullscreen-header" class:static-header={isInElement}>
-      {#if wordmarkSrc !== null}
-        <AppWordmark src={wordmarkSrc} srcWebp={wordmarkSrcWebp} />
-      {:else if src !== null && srcWebp !== null}
-        <AppLogo {src} {srcWebp} />
-      {:else if brandingInfo?.app_name}
-        <Typography size="body-base">{brandingInfo.app_name}</Typography>
-      {/if}
-    </div>
     <div class="rcb-fullscreen-content">
       {@render mainContent?.()}
     </div>
@@ -73,24 +57,10 @@
 <style>
   .rcb-fullscreen-wrapper {
     width: 100%;
-    height: 100%;
+    min-height: 100%;
     display: flex;
     flex-direction: column;
     align-items: center;
-  }
-
-  .rcb-fullscreen-header {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding-top: var(--rc-spacing-gapXXLarge-mobile);
-    padding-bottom: var(--rc-spacing-gapMedium-mobile);
-    flex-shrink: 0;
-    position: absolute;
-  }
-
-  .rcb-fullscreen-header.static-header {
-    position: static;
   }
 
   .rcb-fullscreen-content {
@@ -101,26 +71,6 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: 0 var(--rc-spacing-outerPadding-mobile)
-      var(--rc-spacing-outerPadding-mobile);
     color: var(--rc-color-grey-text-dark);
-  }
-
-  /* On short screens, don't position the header on top of the content */
-  @media (max-height: 500px) {
-    .rcb-fullscreen-header {
-      position: static;
-    }
-  }
-
-  @media (min-width: 768px) {
-    .rcb-fullscreen-header {
-      padding-top: var(--rc-spacing-gapXXLarge-desktop);
-    }
-
-    .rcb-fullscreen-content {
-      padding: 0 var(--rc-spacing-outerPadding-desktop)
-        var(--rc-spacing-outerPadding-desktop);
-    }
   }
 </style>

--- a/src/ui/layout/fullscreen-template.svelte
+++ b/src/ui/layout/fullscreen-template.svelte
@@ -2,35 +2,33 @@
   import Container from "./container.svelte";
   import SandboxBanner from "../molecules/sandbox-banner.svelte";
   import { type BrandingInfoResponse } from "../../networking/responses/branding-response";
-  import { type Snippet } from "svelte";
+  import { getContext, type Snippet } from "svelte";
   import { Theme } from "../theme/theme";
   import type { BrandingAppearance } from "../../entities/branding";
+  import type { Writable } from "svelte/store";
+  import { brandingContextKey } from "../constants";
 
   export interface Props {
     brandingInfo: BrandingInfoResponse | null;
-    brandingAppearance?: BrandingAppearance | null;
     isInElement: boolean;
     isSandbox: boolean;
     mainContent?: Snippet<[]>;
     hideHeader?: boolean;
   }
 
-  const {
-    brandingInfo,
-    brandingAppearance,
-    isInElement,
-    isSandbox,
-    mainContent,
-  }: Props = $props();
+  const { brandingInfo, isInElement, isSandbox, mainContent }: Props = $props();
 
+  const brandingAppearanceStore =
+    getContext<Writable<BrandingAppearance | null | undefined>>(
+      brandingContextKey,
+    );
   const derivedBrandingAppearance = $derived(
-    brandingAppearance ?? brandingInfo?.appearance ?? null,
+    $brandingAppearanceStore ?? undefined,
   );
 
   const colorVariables = $derived(
     new Theme(derivedBrandingAppearance).pageStyleVars,
   );
-
   const pageBackground = $derived(
     derivedBrandingAppearance?.color_page_bg ?? "#ffffff",
   );

--- a/src/ui/layout/message-layout.svelte
+++ b/src/ui/layout/message-layout.svelte
@@ -4,10 +4,10 @@
   import ModalSection from "./modal-section.svelte";
   import MessageLayoutError from "./message-layout-error.svelte";
   import MessageLayoutSuccess from "./message-layout-success.svelte";
+  import type { Snippet } from "svelte";
   import { getContext } from "svelte";
   import { brandingContextKey } from "../constants";
   import type { BrandingAppearance } from "../../entities/branding";
-  import type { Snippet } from "svelte";
   import type { Writable } from "svelte/store";
 
   let {
@@ -69,6 +69,13 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
+    padding-left: var(--rc-spacing-outerPadding-mobile);
+    padding-right: var(--rc-spacing-outerPadding-mobile);
+  }
+
+  .message-layout-footer {
+    padding-left: var(--rc-spacing-outerPadding-mobile);
+    padding-right: var(--rc-spacing-outerPadding-mobile);
   }
 
   @container layout-query-container (width < 768px) {
@@ -83,6 +90,7 @@
       min-height: 354px;
       gap: var(--rc-spacing-gapXXLarge-desktop);
     }
+
     .message-layout-content {
       justify-content: flex-start;
       flex-grow: 1;

--- a/src/ui/layout/message-layout.svelte
+++ b/src/ui/layout/message-layout.svelte
@@ -40,7 +40,10 @@
 </script>
 
 <div class="message-layout" class:message-layout-full-width={fullWidth}>
-  <div class="message-layout-content">
+  <div
+    class="message-layout-content"
+    class:message-layout-content-full-width={fullWidth}
+  >
     <ModalSection>
       {#if type === "success"}
         <MessageLayoutSuccess {title} {icon} />
@@ -49,7 +52,10 @@
       {/if}
     </ModalSection>
   </div>
-  <div class="message-layout-footer">
+  <div
+    class="message-layout-footer"
+    class:message-layout-footer-full-width={fullWidth}
+  >
     <ModalFooter>
       <Button onclick={handleClick} type="submit" {brandingAppearance}
         >{closeButtonTitle}</Button
@@ -69,11 +75,14 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
+  }
+
+  .message-layout-content-full-width {
     padding-left: var(--rc-spacing-outerPadding-mobile);
     padding-right: var(--rc-spacing-outerPadding-mobile);
   }
 
-  .message-layout-footer {
+  .message-layout-footer-full-width {
     padding-left: var(--rc-spacing-outerPadding-mobile);
     padding-right: var(--rc-spacing-outerPadding-mobile);
   }

--- a/src/ui/pages/stripe-checkout-page.svelte
+++ b/src/ui/pages/stripe-checkout-page.svelte
@@ -89,7 +89,6 @@
   .stripe-checkout-container {
     width: 100%;
     min-height: 400px;
-    flex: 1;
     display: flex;
     flex-direction: column;
   }

--- a/src/ui/stripe-checkout-purchases-ui-inner.svelte
+++ b/src/ui/stripe-checkout-purchases-ui-inner.svelte
@@ -16,6 +16,7 @@
   import ColLayout from "./layout/col-layout.svelte";
   import type { StripeBillingParams } from "../networking/responses/checkout-start-response";
   import type { BrandingAppearance } from "../entities/branding";
+  import { Theme } from "./theme/theme";
 
   interface Props {
     currentPage: "loading" | "stripe-checkout" | "success" | "error";
@@ -45,6 +46,12 @@
     closeWithError,
   }: Props = $props();
 
+  const colorVariables = $derived(new Theme(brandingAppearance).pageStyleVars);
+
+  const productInfoBg = $derived(
+    brandingAppearance?.color_product_info_bg ?? "#ffffff",
+  );
+
   const translator: Writable<Translator> = getContext(translatorContextKey);
 </script>
 
@@ -57,7 +64,10 @@
   {#snippet mainContent()}
     {#if currentPage === "stripe-checkout"}
       {#if stripeBillingParams}
-        <div class="stripe-checkout-wrapper">
+        <div
+          class="stripe-checkout-wrapper"
+          style="{colorVariables}; background-color: {productInfoBg}"
+        >
           <StripeCheckoutPage {stripeBillingParams} {onContinue} {onError} />
         </div>
       {:else}
@@ -74,8 +84,8 @@
               >{$translator.translate(
                 LocalizationKeys.LoadingPageKeepPageOpen,
               )}</Typography
-            ></ColLayout
-          >
+            >
+          </ColLayout>
         </div>
       {/if}
     {:else if currentPage === "loading"}
@@ -92,8 +102,8 @@
             >{$translator.translate(
               LocalizationKeys.LoadingPageKeepPageOpen,
             )}</Typography
-          ></ColLayout
-        >
+          >
+        </ColLayout>
       </div>
     {:else if currentPage === "success"}
       <SuccessPage {onContinue} fullWidth={true} />
@@ -119,9 +129,17 @@
 
   .stripe-checkout-wrapper {
     width: 100%;
-    height: 100%;
+    min-height: 100%;
     display: flex;
     flex-direction: column;
     overflow: hidden auto;
+  }
+
+  /* 991px is the breakpoint for the mobile layout in Stripe Checkout */
+  @media (min-width: 991px) {
+    .stripe-checkout-wrapper {
+      justify-content: center;
+      align-items: center;
+    }
   }
 </style>

--- a/src/ui/stripe-checkout-purchases-ui-inner.svelte
+++ b/src/ui/stripe-checkout-purchases-ui-inner.svelte
@@ -4,7 +4,7 @@
   import StripeCheckoutPage from "./pages/stripe-checkout-page.svelte";
   import FullscreenTemplate from "./layout/fullscreen-template.svelte";
   import { type BrandingInfoResponse } from "../networking/responses/branding-response";
-  import type { Product } from "../main";
+  import type { BrandingAppearance, Product } from "../main";
   import { PurchaseFlowError } from "../helpers/purchase-operation-helper";
   import Typography from "./atoms/typography.svelte";
   import Spinner from "./atoms/spinner.svelte";
@@ -15,13 +15,17 @@
   import { type Writable } from "svelte/store";
   import ColLayout from "./layout/col-layout.svelte";
   import type { StripeBillingParams } from "../networking/responses/checkout-start-response";
-  import type { BrandingAppearance } from "../entities/branding";
   import { Theme } from "./theme/theme";
+  import { brandingContextKey } from "./constants";
 
   interface Props {
-    currentPage: "loading" | "stripe-checkout" | "success" | "error";
+    currentPage:
+      | "loading"
+      | "stripe-checkout"
+      | "success"
+      | "error"
+      | "purchasing";
     brandingInfo: BrandingInfoResponse | null;
-    brandingAppearance: BrandingAppearance | null;
     productDetails: Product;
     isSandbox: boolean;
     lastError: PurchaseFlowError | null;
@@ -35,7 +39,6 @@
   const {
     currentPage,
     brandingInfo,
-    brandingAppearance,
     productDetails,
     isSandbox,
     lastError,
@@ -46,21 +49,25 @@
     closeWithError,
   }: Props = $props();
 
-  const colorVariables = $derived(new Theme(brandingAppearance).pageStyleVars);
+  const brandingAppearanceStore =
+    getContext<Writable<BrandingAppearance | null | undefined>>(
+      brandingContextKey,
+    );
+  const derivedBrandingAppearance = $derived(
+    $brandingAppearanceStore ?? undefined,
+  );
 
+  const colorVariables = $derived(
+    new Theme(derivedBrandingAppearance).pageStyleVars,
+  );
   const productInfoBg = $derived(
-    brandingAppearance?.color_product_info_bg ?? "#ffffff",
+    derivedBrandingAppearance?.color_product_info_bg ?? "#ffffff",
   );
 
   const translator: Writable<Translator> = getContext(translatorContextKey);
 </script>
 
-<FullscreenTemplate
-  {brandingInfo}
-  {brandingAppearance}
-  {isInElement}
-  {isSandbox}
->
+<FullscreenTemplate {brandingInfo} {isInElement} {isSandbox}>
   {#snippet mainContent()}
     {#if currentPage === "stripe-checkout"}
       {#if stripeBillingParams}
@@ -70,10 +77,12 @@
         >
           <StripeCheckoutPage {stripeBillingParams} {onContinue} {onError} />
         </div>
-      {:else}
-        <div class="rcb-ui-loading-container">
-          <ColLayout gap="medium" align="center">
-            <Spinner color="var(--rc-color-grey-text-dark)" />
+      {/if}
+    {:else if currentPage === "loading" || currentPage === "purchasing"}
+      <div class="rcb-ui-loading-container">
+        <ColLayout gap="medium" align="center">
+          <Spinner color="var(--rc-color-grey-text-dark)" />
+          {#if currentPage === "purchasing"}
             <Typography size="heading-md"
               >{$translator.translate(
                 LocalizationKeys.LoadingPageProcessingPayment,
@@ -85,24 +94,7 @@
                 LocalizationKeys.LoadingPageKeepPageOpen,
               )}</Typography
             >
-          </ColLayout>
-        </div>
-      {/if}
-    {:else if currentPage === "loading"}
-      <div class="rcb-ui-loading-container">
-        <ColLayout gap="medium" align="center">
-          <Spinner color="var(--rc-color-grey-text-dark)" />
-          <Typography size="heading-md"
-            >{$translator.translate(
-              LocalizationKeys.LoadingPageProcessingPayment,
-            )}</Typography
-          >
-
-          <Typography size="body-small"
-            >{$translator.translate(
-              LocalizationKeys.LoadingPageKeepPageOpen,
-            )}</Typography
-          >
+          {/if}
         </ColLayout>
       </div>
     {:else if currentPage === "success"}

--- a/src/ui/stripe-checkout-purchases-ui.svelte
+++ b/src/ui/stripe-checkout-purchases-ui.svelte
@@ -100,7 +100,7 @@
 
   const handleContinue = () => {
     if (currentPage === "stripe-checkout") {
-      currentPage = "loading";
+      currentPage = "purchasing";
       purchaseOperationHelper
         .pollCurrentPurchaseForCompletion()
         .then((pollResult) => {

--- a/src/ui/stripe-checkout-purchases-ui.svelte
+++ b/src/ui/stripe-checkout-purchases-ui.svelte
@@ -74,29 +74,18 @@
   setContext(translatorContextKey, translatorStore);
   setContext(eventsTrackerContextKey, eventsTracker);
 
+  const brandingAppearanceStore = writable<BrandingAppearance | null>(
+    brandingInfo?.appearance ?? null,
+  );
+  setContext(brandingContextKey, brandingAppearanceStore);
+
   let isSandbox = $state(false);
   let operationResult = $state<OperationSessionSuccessfulResult | null>(null);
   let error = $state<PurchaseFlowError | null>(null);
-  let currentPage = $state<"loading" | "stripe-checkout" | "success" | "error">(
-    "loading",
-  );
+  let currentPage = $state<
+    "loading" | "stripe-checkout" | "success" | "error" | "purchasing"
+  >("loading");
   let stripeBillingParams = $state<StripeBillingParams | null>(null);
-
-  // Update branding store when stripeBillingParams are returned
-  const mergedBrandingAppearance = $derived(
-    (stripeBillingParams?.appearance ?? null) as BrandingAppearance | null,
-  );
-  const brandingAppearanceStore = writable<BrandingAppearance | null>(null);
-  setContext(brandingContextKey, brandingAppearanceStore);
-  $effect(() => {
-    brandingAppearanceStore.set(mergedBrandingAppearance);
-  });
-
-  $effect(() => {
-    if (currentPage === "success" && operationResult && skipSuccessPage) {
-      onFinished(operationResult);
-    }
-  });
 
   const handleContinue = () => {
     if (currentPage === "stripe-checkout") {
@@ -227,7 +216,6 @@
 <StripeCheckoutPurchasesUiInner
   {currentPage}
   {brandingInfo}
-  brandingAppearance={mergedBrandingAppearance}
   {productDetails}
   {isSandbox}
   lastError={error}


### PR DESCRIPTION
## Motivation / Description
Stripe Checkout branding and layout handling in `purchases-js` had drifted from the backend contract and introduced redundant/unused data paths.  
This PR simplifies the Stripe flow so UI branding comes from the shared branding context (backend source of truth), improves fullscreen/mobile behavior, and removes the temporary sandbox-only Stripe key restriction.


## Changes introduced
- Enabled Stripe for all valid `strp_` API keys (not only `strp_sb_` sandbox keys).
- Updated API-key validation/routing tests to reflect live Stripe key support.
- Removed unused Stripe checkout response fields from client typings:
  - `stripe_billing_params.branding_settings`
  - `stripe_billing_params.appearance`
- Simplified Stripe branding handling in UI:
  - stop merging/overriding branding from checkout-start response fields that are no longer used
  - rely on the shared branding context for appearance theming.
- Refactored Stripe fullscreen layout behavior:
  - removed unused fullscreen header rendering logic
  - kept fullscreen content centered and responsive
  - improved wrapper sizing behavior (`min-height` flow).
- Added mobile horizontal padding to message layout content/footer to avoid full-bleed CTA/controls on narrow screens.
- Introduced explicit `"purchasing"` page state and adjusted loading display logic accordingly.
- Minor checkout container cleanup (removed unnecessary `flex: 1` in Stripe checkout page container).
## Linear ticket (if any)
WEB-3903