### PR TITLE
FUN-2156: Update purchases-js to support new onCompleteWorkflowNavigate param

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -4007,7 +4007,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@revenuecat/purchases-js!PresentPaywallParams#customVariables:member",
-              "docComment": "/**\n * Custom variables to pass to the paywall at runtime, overriding defaults set in the RevenueCat dashboard.\n *\n * Variables must be defined in the dashboard first. Reference them in paywall text using the `custom.` prefix (e.g. `{{ custom.player_name }}`).\n *\n * @example\n * ```ts\n * presentPaywall({\n *   customVariables: {\n *     player_name: CustomVariableValue.string('Ada'),\n *     level: CustomVariableValue.string('42'),\n *   },\n * });\n * ```\n *\n */\n",
+              "docComment": "/**\n * Custom variables to pass to the paywall at runtime, overriding defaults set in the RevenueCat dashboard.\n *\n * Variables must be defined in the dashboard first. Reference them in paywall text using the `custom.` prefix (e.g. `{{ custom.player_name }}`).\n *\n * @example\n * ```ts\n * presentPaywall({\n *   customVariables: {\n *     player_name: CustomVariableValue.string('Ada'),\n *     level: CustomVariableValue.number(42),\n *     is_premium: CustomVariableValue.boolean(true),\n *   },\n * });\n * ```\n *\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@eslint/js": "^9.16.0",
     "@microsoft/api-extractor": "^7.48.0",
     "@paddle/paddle-js": "^1.5.1",
-    "@revenuecat/purchases-ui-js": "3.9.2",
+    "@revenuecat/purchases-ui-js": "3.10.0",
     "@storybook/addon-essentials": "^8.6.15",
     "@storybook/addon-interactions": "^8.6.15",
     "@storybook/addon-links": "^8.6.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1
       "@revenuecat/purchases-ui-js":
-        specifier: 3.9.2
-        version: 3.9.2(svelte@5.46.4)
+        specifier: 3.10.0
+        version: 3.10.0(svelte@5.46.4)
       "@storybook/addon-essentials":
         specifier: ^8.6.15
         version: 8.6.15(@types/react@19.0.10)(storybook@8.6.15(prettier@3.4.2))
@@ -722,10 +722,10 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
 
-  "@revenuecat/purchases-ui-js@3.9.2":
+  "@revenuecat/purchases-ui-js@3.10.0":
     resolution:
       {
-        integrity: sha512-tlkAwAW4MjrLH1e5Jtb2ktPEmb21uJCRXaM7U77s/oOCxAFE6YeqdfYKqwn2DCJ+RPk7QA3fYpdKGdc4VJ6EAg==,
+        integrity: sha512-X4Cd9I1uqao/FgnJrEjH3qa7b4Shsq+4tWNKogjwZnJVpBOY/QHGIJ1+epa+S0sOTNv6G2+0QTGQGSK6TdcyTw==,
       }
     engines: { node: ^22.18 || ^24.11 }
     peerDependencies:
@@ -6155,7 +6155,7 @@ snapshots:
 
   "@pkgr/core@0.1.1": {}
 
-  "@revenuecat/purchases-ui-js@3.9.2(svelte@5.46.4)":
+  "@revenuecat/purchases-ui-js@3.10.0(svelte@5.46.4)":
     dependencies:
       qrcode: 1.5.4
       svelte: 5.46.4

--- a/src/entities/present-paywall-params.ts
+++ b/src/entities/present-paywall-params.ts
@@ -1,5 +1,10 @@
 import type { Offering } from "./offerings";
-import type { CustomVariables } from "@revenuecat/purchases-ui-js";
+import type {
+  CompleteWorkflowNavigateArgs,
+  CustomVariables,
+} from "@revenuecat/purchases-ui-js";
+
+export type { CompleteWorkflowNavigateArgs };
 
 /**
  * Parameters for the {@link Purchases.presentPaywall} method.
@@ -34,6 +39,16 @@ export interface PresentPaywallParams {
    * Callback to be called when the paywall tries to navigate to an external URL.
    */
   readonly onNavigateToUrl?: (url: string) => void;
+
+  /**
+   * Called when the paywall uses a complete_workflow button (exit URL).
+   * If omitted, the SDK opens the URL: new tab for `external_browser`, same tab for
+   * `in_app_browser` / `deep_link`.
+   * @internal
+   */
+  readonly onCompleteWorkflowNavigate?: (
+    args: CompleteWorkflowNavigateArgs,
+  ) => void | Promise<void>;
 
   /**
    * Callback to be called when the paywall tries to navigate back.

--- a/src/helpers/complete-workflow-navigate-url.ts
+++ b/src/helpers/complete-workflow-navigate-url.ts
@@ -1,0 +1,38 @@
+import type { CompleteWorkflowNavigateArgs } from "@revenuecat/purchases-ui-js";
+
+const BLOCKED_PROTOCOLS = new Set(["javascript:", "data:", "vbscript:"]);
+
+function blockedProtocol(protocol: string): boolean {
+  return BLOCKED_PROTOCOLS.has(protocol.toLowerCase());
+}
+
+/**
+ * Returns whether a URL string is safe for default complete-workflow navigation
+ * using `window.open` or `location.assign`.
+ */
+export function isAllowedCompleteWorkflowNavigateUrl(
+  rawUrl: string,
+  method: CompleteWorkflowNavigateArgs["method"],
+): boolean {
+  const trimmed = rawUrl.trim();
+  if (trimmed.length === 0) {
+    return false;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return false;
+  }
+
+  if (blockedProtocol(parsed.protocol)) {
+    return false;
+  }
+
+  if (method === "deep_link") {
+    return true;
+  }
+
+  return parsed.protocol === "http:" || parsed.protocol === "https:";
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,7 +61,10 @@ import {
   type PurchaseResult,
 } from "./entities/purchase-result";
 import { mount, unmount } from "svelte";
-import { type PresentPaywallParams } from "./entities/present-paywall-params";
+import {
+  type CompleteWorkflowNavigateArgs,
+  type PresentPaywallParams,
+} from "./entities/present-paywall-params";
 import type { WalletButtonRender } from "@revenuecat/purchases-ui-js";
 import { Paywall, type PaywallData } from "@revenuecat/purchases-ui-js";
 import { PaywallDefaultContainerZIndex } from "./ui/theme/constants";
@@ -109,6 +112,7 @@ import type {
 } from "./entities/present-express-purchase-button-params";
 import { ExpressPurchaseButtonWrapper } from "./ui/express-purchase-button/express-purchase-button-wrapper.svelte";
 import { getWindow, getDocument } from "./helpers/browser-globals";
+import { isAllowedCompleteWorkflowNavigateUrl } from "./helpers/complete-workflow-navigate-url";
 import { StripeService } from "./stripe/stripe-service";
 
 export { ProductType } from "./entities/offerings";
@@ -642,6 +646,29 @@ export class Purchases {
       win.open(url, "_blank")?.focus();
     };
 
+    const onCompleteWorkflowNavigate = async (
+      args: CompleteWorkflowNavigateArgs,
+    ) => {
+      if (paywallParams.onCompleteWorkflowNavigate) {
+        await paywallParams.onCompleteWorkflowNavigate(args);
+        return;
+      }
+
+      if (!isAllowedCompleteWorkflowNavigateUrl(args.url, args.method)) {
+        Logger.warnLog(
+          "Blocked complete-workflow navigation to a disallowed URL.",
+        );
+        return;
+      }
+
+      const win = getWindow();
+      if (args.method === "external_browser") {
+        win.open(args.url, "_blank", "noopener,noreferrer")?.focus();
+      } else {
+        win.location.assign(args.url);
+      }
+    };
+
     const onRestorePurchasesClicked = () => {
       // DO NOTHING
     };
@@ -739,6 +766,8 @@ export class Purchases {
           paywallData: offering.paywallComponents!,
           selectedLocale: finalLocale,
           onNavigateToUrlClicked: navigateToUrl,
+          appUserId: this._appUserId,
+          onCompleteWorkflowNavigate,
           onVisitCustomerCenterClicked: onVisitCustomerCenterClicked,
           uiConfig: offering.uiConfig!,
           onBackClicked: () => {

--- a/src/tests/helpers/complete-workflow-navigate-url.test.ts
+++ b/src/tests/helpers/complete-workflow-navigate-url.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+import { isAllowedCompleteWorkflowNavigateUrl } from "../../helpers/complete-workflow-navigate-url";
+
+describe("isAllowedCompleteWorkflowNavigateUrl", () => {
+  test("allows http(s) for external_browser", () => {
+    expect(
+      isAllowedCompleteWorkflowNavigateUrl(
+        "https://example.com/path",
+        "external_browser",
+      ),
+    ).toBe(true);
+    expect(
+      isAllowedCompleteWorkflowNavigateUrl("http://a.test", "external_browser"),
+    ).toBe(true);
+  });
+
+  test("allows http(s) for in_app_browser", () => {
+    expect(
+      isAllowedCompleteWorkflowNavigateUrl(
+        "https://example.com/",
+        "in_app_browser",
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects non-http(s) schemes for external_browser and in_app_browser", () => {
+    expect(
+      isAllowedCompleteWorkflowNavigateUrl("myapp://home", "external_browser"),
+    ).toBe(false);
+    expect(
+      isAllowedCompleteWorkflowNavigateUrl("myapp://home", "in_app_browser"),
+    ).toBe(false);
+  });
+
+  test("allows custom schemes for deep_link when not dangerous", () => {
+    expect(
+      isAllowedCompleteWorkflowNavigateUrl("myapp://home", "deep_link"),
+    ).toBe(true);
+    expect(
+      isAllowedCompleteWorkflowNavigateUrl("https://x.test", "deep_link"),
+    ).toBe(true);
+  });
+
+  test("rejects dangerous schemes for all methods", () => {
+    for (const method of [
+      "deep_link",
+      "external_browser",
+      "in_app_browser",
+    ] as const) {
+      expect(
+        isAllowedCompleteWorkflowNavigateUrl("javascript:alert(1)", method),
+      ).toBe(false);
+      expect(
+        isAllowedCompleteWorkflowNavigateUrl("data:text/html,hi", method),
+      ).toBe(false);
+      expect(
+        isAllowedCompleteWorkflowNavigateUrl("vbscript:evil", method),
+      ).toBe(false);
+    }
+  });
+
+  test("rejects empty and invalid URLs", () => {
+    expect(isAllowedCompleteWorkflowNavigateUrl("", "external_browser")).toBe(
+      false,
+    );
+    expect(
+      isAllowedCompleteWorkflowNavigateUrl("   ", "external_browser"),
+    ).toBe(false);
+    expect(
+      isAllowedCompleteWorkflowNavigateUrl("not a url", "external_browser"),
+    ).toBe(false);
+  });
+});

--- a/src/tests/present-paywall.events.test.ts
+++ b/src/tests/present-paywall.events.test.ts
@@ -4,6 +4,9 @@ import { configurePurchases } from "./base.purchases_test";
 import { createMonthlyPackageMock } from "./mocks/offering-mock-provider";
 import { ErrorCode, PurchasesError } from "../main";
 import type { Offering } from "../entities/offerings";
+import type { CompleteWorkflowNavigateArgs } from "../entities/present-paywall-params";
+import * as browserGlobals from "../helpers/browser-globals";
+import { Logger } from "../helpers/logger";
 
 vi.mock("svelte", () => ({
   mount: vi.fn(),
@@ -13,6 +16,9 @@ vi.mock("svelte", () => ({
 type PaywallMountProps = {
   onPurchaseClicked: (selectedPackageId: string) => void;
   onBackClicked: () => void;
+  onCompleteWorkflowNavigate: (
+    args: CompleteWorkflowNavigateArgs,
+  ) => void | Promise<void>;
 };
 
 const createOfferingWithPaywall = (): Offering => {
@@ -193,5 +199,125 @@ describe("Purchases.presentPaywall() paywall events", () => {
         ["paywall_impression", "paywall_close", "paywall_cancel"],
       );
     });
+  });
+});
+
+describe("Purchases.presentPaywall() complete workflow navigation", () => {
+  let paywallProps: PaywallMountProps | undefined;
+  let assignMock: ReturnType<typeof vi.fn>;
+  let openMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    paywallProps = undefined;
+    assignMock = vi.fn();
+    openMock = vi.fn().mockReturnValue({ focus: vi.fn() });
+    vi.spyOn(browserGlobals, "getWindow").mockReturnValue({
+      open: openMock,
+      location: { assign: assignMock },
+      matchMedia: vi.fn().mockReturnValue({ matches: false }),
+    } as unknown as Window);
+
+    vi.mocked(mount).mockImplementation((_component, options) => {
+      paywallProps = options.props as PaywallMountProps;
+      (options.target as Element).innerHTML =
+        "<div data-testid='paywall-root'></div>";
+      return {} as ReturnType<typeof mount>;
+    });
+  });
+
+  afterEach(() => {
+    vi.mocked(browserGlobals.getWindow).mockRestore();
+    vi.clearAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  test("default external_browser opens a new tab for https URLs", async () => {
+    const purchases = configurePurchases();
+    const offering = createOfferingWithPaywall();
+
+    void purchases.presentPaywall({ offering });
+
+    expect(paywallProps).toBeDefined();
+    await paywallProps!.onCompleteWorkflowNavigate({
+      url: "https://example.com/exit",
+      method: "external_browser",
+    });
+
+    expect(openMock).toHaveBeenCalledWith(
+      "https://example.com/exit",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  test("default in_app_browser navigates in the same tab", async () => {
+    const purchases = configurePurchases();
+    const offering = createOfferingWithPaywall();
+
+    void purchases.presentPaywall({ offering });
+
+    await paywallProps!.onCompleteWorkflowNavigate({
+      url: "https://example.com/in-app",
+      method: "in_app_browser",
+    });
+
+    expect(assignMock).toHaveBeenCalledWith("https://example.com/in-app");
+    expect(openMock).not.toHaveBeenCalled();
+  });
+
+  test("default deep_link allows non-http(s) schemes", async () => {
+    const purchases = configurePurchases();
+    const offering = createOfferingWithPaywall();
+
+    void purchases.presentPaywall({ offering });
+
+    await paywallProps!.onCompleteWorkflowNavigate({
+      url: "myapp://complete",
+      method: "deep_link",
+    });
+
+    expect(assignMock).toHaveBeenCalledWith("myapp://complete");
+    expect(openMock).not.toHaveBeenCalled();
+  });
+
+  test("custom onCompleteWorkflowNavigate runs instead of default navigation", async () => {
+    const custom = vi.fn().mockResolvedValue(undefined);
+    const purchases = configurePurchases();
+    const offering = createOfferingWithPaywall();
+
+    void purchases.presentPaywall({
+      offering,
+      onCompleteWorkflowNavigate: custom,
+    });
+
+    await paywallProps!.onCompleteWorkflowNavigate({
+      url: "https://example.com",
+      method: "external_browser",
+    });
+
+    expect(custom).toHaveBeenCalledWith({
+      url: "https://example.com",
+      method: "external_browser",
+    });
+    expect(openMock).not.toHaveBeenCalled();
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  test("default navigation blocks disallowed URLs", async () => {
+    const purchases = configurePurchases();
+    const offering = createOfferingWithPaywall();
+    const warnSpy = vi.spyOn(Logger, "warnLog").mockImplementation(() => {});
+
+    void purchases.presentPaywall({ offering });
+
+    await paywallProps!.onCompleteWorkflowNavigate({
+      url: "javascript:void(0)",
+      method: "in_app_browser",
+    });
+
+    expect(warnSpy).toHaveBeenCalled();
+    expect(openMock).not.toHaveBeenCalled();
+    expect(assignMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### TL;DR

Upgraded `@revenuecat/purchases-ui-js` to version 3.10.0 and added support for complete workflow navigation handling in paywalls.

### What changed?

- Upgraded `@revenuecat/purchases-ui-js` from version 3.9.2 to 3.10.0
- Added `onCompleteWorkflowNavigate` callback parameter to `PresentPaywallParams` interface for handling complete workflow button navigation with configurable methods (deep_link, external_browser, in_app_browser)
- Implemented default navigation behavior in the paywall presentation logic that opens external URLs in new tabs for external browser method and navigates in the same tab for other methods
- Added `appUserId` to the paywall component props

### How to test?

1. Present a paywall that includes a complete workflow button (exit URL)
2. Test the default behavior without providing `onCompleteWorkflowNavigate` callback
3. Test custom navigation behavior by providing the `onCompleteWorkflowNavigate` callback
4. Verify different navigation methods work correctly (external_browser opens new tab, others navigate in same tab)

### Why make this change?

This change provides developers with more control over how users are navigated when completing workflows in paywalls, allowing for custom handling of exit URLs while maintaining sensible defaults for different navigation methods.
