### PR TITLE
[WEB-2682] Re-enable fixme e2e tests

### DIFF
--- a/examples/webbilling-demo/src/tests/purchase-flow.test.ts
+++ b/examples/webbilling-demo/src/tests/purchase-flow.test.ts
@@ -223,20 +223,17 @@ test.describe("Purchase error paths", () => {
     await confirmStripeEmailError(page, "Your email address is invalid.");
   });
 
-  integrationTest.fixme(
-    "Email deliverability errors",
-    async ({ page, userId }) => {
-      page = await navigateToLandingUrl(page, userId);
-      const email = `${userId}@revenueci.comm`;
+  integrationTest("Email deliverability errors", async ({ page, userId }) => {
+    page = await navigateToLandingUrl(page, userId);
+    const email = `${userId}@revenueci.comm`;
 
-      const packageCards = await getPackageCards(page);
-      await startPurchaseFlow(packageCards[1]);
-      await enterEmail(page, email);
-      await enterCreditCardDetails(page, "4242 4242 4242 4242");
-      await clickPayButton(page);
-      await confirmPaymentError(page, "Please provide a valid email address.");
-    },
-  );
+    const packageCards = await getPackageCards(page);
+    await startPurchaseFlow(packageCards[1]);
+    await enterEmail(page, email);
+    await enterCreditCardDetails(page, "4242 4242 4242 4242");
+    await clickPayButton(page);
+    await confirmPaymentError(page, "Please provide a valid email address.");
+  });
 
   integrationTest("Handled card declined errors", async ({ page, userId }) => {
     page = await navigateToLandingUrl(page, userId);

--- a/examples/webbilling-demo/src/tests/tax-calculation.test.ts
+++ b/examples/webbilling-demo/src/tests/tax-calculation.test.ts
@@ -525,7 +525,7 @@ const mockTaxCalculationRequest = async (
 });
 
 integrationTest.describe("Tax calculation setup errors", () => {
-  integrationTest.fixme("Stripe tax not active", async ({ page, userId }) => {
+  integrationTest("Stripe tax not active", async ({ page, userId }) => {
     await page.route(TAX_ROUTE_PATH, async (route) => {
       await route.fulfill(STRIPE_TAX_NOT_ACTIVE_RESPONSE);
 
@@ -536,31 +536,25 @@ integrationTest.describe("Tax calculation setup errors", () => {
     });
   });
 
-  integrationTest.fixme(
-    "Invalid tax origin address",
-    async ({ page, userId }) => {
-      await page.route(TAX_ROUTE_PATH, async (route) => {
-        await route.fulfill(INVALID_TAX_ORIGIN_RESPONSE);
-      });
+  integrationTest("Invalid tax origin address", async ({ page, userId }) => {
+    await page.route(TAX_ROUTE_PATH, async (route) => {
+      await route.fulfill(INVALID_TAX_ORIGIN_RESPONSE);
+    });
 
-      page = await navigateToTaxesLandingUrl(page, userId);
-      const packageCards = await getPackageCards(page);
-      await startPurchaseFlow(packageCards[0]);
-      await confirmPaymentError(page, /Invalid tax origin address/);
-    },
-  );
+    page = await navigateToTaxesLandingUrl(page, userId);
+    const packageCards = await getPackageCards(page);
+    await startPurchaseFlow(packageCards[0]);
+    await confirmPaymentError(page, /Invalid tax origin address/);
+  });
 
-  integrationTest.fixme(
-    "Missing Stripe permission",
-    async ({ page, userId }) => {
-      await page.route(TAX_ROUTE_PATH, async (route) => {
-        await route.fulfill(MISSING_STRIPE_PERMISSION_RESPONSE);
-      });
+  integrationTest("Missing Stripe permission", async ({ page, userId }) => {
+    await page.route(TAX_ROUTE_PATH, async (route) => {
+      await route.fulfill(MISSING_STRIPE_PERMISSION_RESPONSE);
+    });
 
-      page = await navigateToTaxesLandingUrl(page, userId);
-      const packageCards = await getPackageCards(page);
-      await startPurchaseFlow(packageCards[0]);
-      await confirmPaymentError(page, "Missing Stripe permission");
-    },
-  );
+    page = await navigateToTaxesLandingUrl(page, userId);
+    const packageCards = await getPackageCards(page);
+    await startPurchaseFlow(packageCards[0]);
+    await confirmPaymentError(page, "Missing Stripe permission");
+  });
 });


### PR DESCRIPTION
## Motivation / Description

These were marked fixme like a year ago, with a note adding to re-enable after addressing flakiness in CI. I've rerun this build 10-20 times and haven't seen any of _these_ tests flake. So opting to just re-enable and if they're problematic we can revisit.

## Changes introduced

## Linear ticket (if any)

## Additional comments
