### PR TITLE
Bump purchases-ui-js to 3.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@eslint/js": "^9.16.0",
     "@microsoft/api-extractor": "^7.48.0",
     "@paddle/paddle-js": "^1.5.1",
-    "@revenuecat/purchases-ui-js": "3.11.0",
+    "@revenuecat/purchases-ui-js": "3.11.1",
     "@storybook/addon-essentials": "^8.6.15",
     "@storybook/addon-interactions": "^8.6.15",
     "@storybook/addon-links": "^8.6.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1
       "@revenuecat/purchases-ui-js":
-        specifier: 3.11.0
-        version: 3.11.0(svelte@5.46.4)
+        specifier: 3.11.1
+        version: 3.11.1(svelte@5.46.4)
       "@storybook/addon-essentials":
         specifier: ^8.6.15
         version: 8.6.15(@types/react@19.0.10)(storybook@8.6.15(prettier@3.4.2))
@@ -722,10 +722,10 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
 
-  "@revenuecat/purchases-ui-js@3.11.0":
+  "@revenuecat/purchases-ui-js@3.11.1":
     resolution:
       {
-        integrity: sha512-Pjf31WjWoQDZ8d3oPFfgUhPeIzCZE+gsQtXvmzl14ZTCsKE8Y+dt/U+KRrsWm5hg+HBhUF0PElvzkzYkYbKS2Q==,
+        integrity: sha512-kOA3u6L63/3RitF3MhZBcvR+pExJCatJStOTVhVX3uqPqvX1+C3iPhC1qr+hrruuZUJZsA775i0PXD48kFiC4g==,
       }
     engines: { node: ^22.18 || ^24.11 }
     peerDependencies:
@@ -6155,7 +6155,7 @@ snapshots:
 
   "@pkgr/core@0.1.1": {}
 
-  "@revenuecat/purchases-ui-js@3.11.0(svelte@5.46.4)":
+  "@revenuecat/purchases-ui-js@3.11.1(svelte@5.46.4)":
     dependencies:
       qrcode: 1.5.4
       svelte: 5.46.4


### PR DESCRIPTION
### TL;DR

Upgraded `@revenuecat/purchases-ui-js` from version 3.11.0 to 3.11.1

### What changed?

Updated the `@revenuecat/purchases-ui-js` dependency to version 3.11.1, which includes the corresponding changes to the package lock file with the new integrity hash.

### How to test?

Run the existing test suite to ensure all functionality continues to work as expected with the updated dependency. Verify that any RevenueCat purchases UI components still render and behave correctly.

### Why make this change?

This patch version update likely includes bug fixes or minor improvements to the RevenueCat purchases UI library that should be incorporated to maintain compatibility and benefit from any fixes.