### PR TITLE
Only preload Stripe module for Stripe-based API keys

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -363,7 +363,10 @@ export class Purchases {
     const finalFlags = flags ?? defaultFlagsConfig;
 
     Purchases.validateConfig(config);
-    if (finalFlags.storeLoadTime === "configuration") {
+    if (
+      finalFlags.storeLoadTime === "configuration" &&
+      isWebBillingApiKey(apiKey)
+    ) {
       StripeService.preloadStripeModule();
     }
     Purchases.instance = new Purchases(

--- a/src/main.ts
+++ b/src/main.ts
@@ -365,7 +365,7 @@ export class Purchases {
     Purchases.validateConfig(config);
     if (
       finalFlags.storeLoadTime === "configuration" &&
-      isWebBillingApiKey(apiKey)
+      (isWebBillingApiKey(apiKey) || isStripeApiKey(apiKey))
     ) {
       StripeService.preloadStripeModule();
     }

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -313,13 +313,13 @@ describe("Purchases.configure()", () => {
     spy.mockRestore();
   });
 
-  test("does not preload Stripe module for stripe api key", () => {
+  test("preloads Stripe module for stripe api key with default storeLoadTime", () => {
     const spy = vi.spyOn(StripeService, "preloadStripeModule");
     Purchases.configure({
       apiKey: "strp_valid_key",
       appUserId: testUserId,
     });
-    expect(spy).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalled();
     spy.mockRestore();
   });
 

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -26,6 +26,7 @@ import { waitFor } from "@testing-library/svelte";
 import { http, HttpResponse } from "msw";
 import { expectPromiseToError } from "./test-helpers";
 import { StatusCodes } from "http-status-codes";
+import { StripeService } from "../stripe/stripe-service";
 
 describe("Purchases.configure() legacy", () => {
   test("throws error if given invalid api key", () => {
@@ -290,6 +291,46 @@ describe("Purchases.configure()", () => {
         apiKey: testApiKey,
       } as PurchasesConfig),
     ).toThrowError(PurchasesError);
+  });
+
+  test("preloads Stripe module for web billing api key with default storeLoadTime", () => {
+    const spy = vi.spyOn(StripeService, "preloadStripeModule");
+    Purchases.configure({
+      apiKey: testApiKey,
+      appUserId: testUserId,
+    });
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  test("does not preload Stripe module for paddle api key", () => {
+    const spy = vi.spyOn(StripeService, "preloadStripeModule");
+    Purchases.configure({
+      apiKey: "pdl_valid_key",
+      appUserId: testUserId,
+    });
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  test("does not preload Stripe module for stripe api key", () => {
+    const spy = vi.spyOn(StripeService, "preloadStripeModule");
+    Purchases.configure({
+      apiKey: "strp_valid_key",
+      appUserId: testUserId,
+    });
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  test("does not preload Stripe module for simulated store api key", () => {
+    const spy = vi.spyOn(StripeService, "preloadStripeModule");
+    Purchases.configure({
+      apiKey: "test_valid_key",
+      appUserId: testUserId,
+    });
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary
- Skip Stripe module preloading during configuration for API keys that don't use Stripe (Paddle, simulated store)
- Only preload when the API key is a web billing (`rcb_`) or Stripe billing (`strp_`) key and `storeLoadTime` is `"configuration"`
- Added tests verifying preload behavior for each API key type

🤖 Generated with [Claude Code](https://claude.com/claude-code)