### PR TITLE
[WEB-3965] Fix offer variables in paywalls

### DIFF
--- a/src/helpers/paywall-offer-helpers.ts
+++ b/src/helpers/paywall-offer-helpers.ts
@@ -7,10 +7,7 @@ import type {
 } from "../entities/offerings";
 import { type Translator } from "../ui/localization/translator";
 import { getNextRenewalDate, type Period } from "./duration-helper";
-import {
-  getDurationInDays,
-  getPeriodVariables,
-} from "./paywall-period-helpers";
+import { getPeriodVariables } from "./paywall-period-helpers";
 import { getPriceVariables } from "./paywall-price-helpers";
 
 type OfferPhase = PricingPhase | DiscountPhase;
@@ -36,49 +33,6 @@ function getOfferPricingPeriod(
   }
 
   return offer.period;
-}
-
-function getTimeWindowBillingCycleCount(
-  product: SubscriptionOption,
-  offerDuration: Period | null,
-): number {
-  const billingPeriod = product.base.period;
-
-  if (billingPeriod === null || offerDuration === null) {
-    return 1;
-  }
-
-  const billingPeriodInDays = getDurationInDays(billingPeriod);
-  const offerDurationInDays = getDurationInDays(offerDuration);
-
-  if (billingPeriodInDays <= 0 || offerDurationInDays <= 0) {
-    return 1;
-  }
-
-  return Math.max(1, Math.floor(offerDurationInDays / billingPeriodInDays));
-}
-
-function getOfferPriceAmountMicros(
-  product: SubscriptionOption,
-  offer: OfferPhase,
-  offerDuration: Period | null,
-): number | null {
-  if (offer.price === null) {
-    return null;
-  }
-
-  if (isForeverOffer(offer)) {
-    return offer.price.amountMicros;
-  }
-
-  if (isTimeWindowOffer(offer)) {
-    return (
-      offer.price.amountMicros *
-      getTimeWindowBillingCycleCount(product, offerDuration)
-    );
-  }
-
-  return offer.price.amountMicros * getOfferCycleCount(offer);
 }
 
 function getOfferDuration(offer: OfferPhase): Period | null {
@@ -125,13 +79,8 @@ export function setOfferVariables(
       offerPricingPeriod,
       translator,
     );
-    const offerPriceAmountMicros = getOfferPriceAmountMicros(
-      product,
-      primaryOffer,
-      offerDuration,
-    );
     variables["product.offer_price"] = translator.formatPrice(
-      offerPriceAmountMicros ?? price.amountMicros,
+      price.amountMicros,
       price.currency,
     );
     variables["product.offer_price_per_day"] = priceVariables.pricePerDay;

--- a/src/helpers/paywall-offer-helpers.ts
+++ b/src/helpers/paywall-offer-helpers.ts
@@ -12,18 +12,37 @@ import { getPriceVariables } from "./paywall-price-helpers";
 
 type OfferPhase = PricingPhase | DiscountPhase;
 
+function getOfferCycleCount(offer: OfferPhase): number {
+  return offer.cycleCount > 0 ? offer.cycleCount : 1;
+}
+
+function isForeverOffer(offer: OfferPhase): boolean {
+  return "durationMode" in offer && offer.durationMode === "forever";
+}
+
+function getOfferPriceAmountMicros(offer: OfferPhase): number | null {
+  if (offer.price === null) {
+    return null;
+  }
+
+  if (isForeverOffer(offer)) {
+    return offer.price.amountMicros;
+  }
+
+  return offer.price.amountMicros * getOfferCycleCount(offer);
+}
+
 function getOfferDuration(offer: OfferPhase): Period | null {
   if (offer.period === null) {
     return null;
   }
 
-  if ("durationMode" in offer && offer.durationMode === "forever") {
+  if (isForeverOffer(offer)) {
     return null;
   }
 
-  const cycleCount = offer.cycleCount > 0 ? offer.cycleCount : 1;
   return {
-    number: offer.period.number * cycleCount,
+    number: offer.period.number * getOfferCycleCount(offer),
     unit: offer.period.unit,
   };
 }
@@ -52,8 +71,9 @@ export function setOfferVariables(
   const offerDuration = getOfferDuration(primaryOffer);
   if (price !== null) {
     const priceVariables = getPriceVariables(price, period, translator);
+    const offerPriceAmountMicros = getOfferPriceAmountMicros(primaryOffer);
     variables["product.offer_price"] = translator.formatPrice(
-      price.amountMicros,
+      offerPriceAmountMicros ?? price.amountMicros,
       price.currency,
     );
     variables["product.offer_price_per_day"] = priceVariables.pricePerDay;

--- a/src/helpers/paywall-offer-helpers.ts
+++ b/src/helpers/paywall-offer-helpers.ts
@@ -1,29 +1,38 @@
 import type { VariableDictionary } from "@revenuecat/purchases-ui-js";
-import type { NonSubscriptionOption } from "../entities/offerings";
-import { type SubscriptionOption } from "../entities/offerings";
+import type {
+  DiscountPhase,
+  NonSubscriptionOption,
+  PricingPhase,
+  SubscriptionOption,
+} from "../entities/offerings";
 import { type Translator } from "../ui/localization/translator";
-import { PeriodUnit, type Period } from "./duration-helper";
+import { getNextRenewalDate, type Period } from "./duration-helper";
 import { getPeriodVariables } from "./paywall-period-helpers";
 import { getPriceVariables } from "./paywall-price-helpers";
 
-function getOfferEndDate(period: Period, translator: Translator): string {
-  const date = new Date();
-  switch (period.unit) {
-    case PeriodUnit.Year:
-      date.setFullYear(date.getFullYear() + period.number);
-      break;
-    case PeriodUnit.Month:
-      date.setMonth(date.getMonth() + period.number);
-      break;
-    case PeriodUnit.Week:
-      date.setDate(date.getDate() + period.number * 7);
-      break;
-    case PeriodUnit.Day:
-      date.setDate(date.getDate() + period.number);
-      break;
+type OfferPhase = PricingPhase | DiscountPhase;
+
+function getOfferDuration(offer: OfferPhase): Period | null {
+  if (offer.period === null) {
+    return null;
   }
 
-  return translator.translateDate(date, { dateStyle: "long" }) ?? "";
+  if ("durationMode" in offer && offer.durationMode === "forever") {
+    return null;
+  }
+
+  const cycleCount = offer.cycleCount > 0 ? offer.cycleCount : 1;
+  return {
+    number: offer.period.number * cycleCount,
+    unit: offer.period.unit,
+  };
+}
+
+function getOfferEndDate(period: Period, translator: Translator): string {
+  const date = getNextRenewalDate(new Date(), period, true);
+  return date
+    ? (translator.translateDate(date, { dateStyle: "long" }) ?? "")
+    : "";
 }
 
 export function setOfferVariables(
@@ -40,7 +49,7 @@ export function setOfferVariables(
   }
 
   const { period, price } = primaryOffer;
-
+  const offerDuration = getOfferDuration(primaryOffer);
   if (price !== null) {
     const priceVariables = getPriceVariables(price, period, translator);
     variables["product.offer_price"] = translator.formatPrice(
@@ -53,8 +62,8 @@ export function setOfferVariables(
     variables["product.offer_price_per_year"] = priceVariables.pricePerYear;
   }
 
-  if (period !== null) {
-    const periodVars = getPeriodVariables(period, translator);
+  if (offerDuration !== null) {
+    const periodVars = getPeriodVariables(offerDuration, translator);
     variables["product.offer_period"] = periodVars.period;
     variables["product.offer_period_abbreviated"] =
       periodVars.periodAbbreviated;
@@ -63,7 +72,10 @@ export function setOfferVariables(
     variables["product.offer_period_in_weeks"] = periodVars.periodInWeeks;
     variables["product.offer_period_in_months"] = periodVars.periodInMonths;
     variables["product.offer_period_in_years"] = periodVars.periodInYears;
-    variables["product.offer_end_date"] = getOfferEndDate(period, translator);
+    variables["product.offer_end_date"] = getOfferEndDate(
+      offerDuration,
+      translator,
+    );
   }
 
   if (secondaryOffer === null) {

--- a/src/helpers/paywall-offer-helpers.ts
+++ b/src/helpers/paywall-offer-helpers.ts
@@ -7,7 +7,10 @@ import type {
 } from "../entities/offerings";
 import { type Translator } from "../ui/localization/translator";
 import { getNextRenewalDate, type Period } from "./duration-helper";
-import { getPeriodVariables } from "./paywall-period-helpers";
+import {
+  getDurationInDays,
+  getPeriodVariables,
+} from "./paywall-period-helpers";
 import { getPriceVariables } from "./paywall-price-helpers";
 
 type OfferPhase = PricingPhase | DiscountPhase;
@@ -20,13 +23,59 @@ function isForeverOffer(offer: OfferPhase): boolean {
   return "durationMode" in offer && offer.durationMode === "forever";
 }
 
-function getOfferPriceAmountMicros(offer: OfferPhase): number | null {
+function isTimeWindowOffer(offer: OfferPhase): offer is DiscountPhase {
+  return "durationMode" in offer && offer.durationMode === "time_window";
+}
+
+function getOfferPricingPeriod(
+  product: SubscriptionOption,
+  offer: OfferPhase,
+): Period | null {
+  if (isTimeWindowOffer(offer)) {
+    return product.base.period;
+  }
+
+  return offer.period;
+}
+
+function getTimeWindowBillingCycleCount(
+  product: SubscriptionOption,
+  offerDuration: Period | null,
+): number {
+  const billingPeriod = product.base.period;
+
+  if (billingPeriod === null || offerDuration === null) {
+    return 1;
+  }
+
+  const billingPeriodInDays = getDurationInDays(billingPeriod);
+  const offerDurationInDays = getDurationInDays(offerDuration);
+
+  if (billingPeriodInDays <= 0 || offerDurationInDays <= 0) {
+    return 1;
+  }
+
+  return Math.max(1, Math.floor(offerDurationInDays / billingPeriodInDays));
+}
+
+function getOfferPriceAmountMicros(
+  product: SubscriptionOption,
+  offer: OfferPhase,
+  offerDuration: Period | null,
+): number | null {
   if (offer.price === null) {
     return null;
   }
 
   if (isForeverOffer(offer)) {
     return offer.price.amountMicros;
+  }
+
+  if (isTimeWindowOffer(offer)) {
+    return (
+      offer.price.amountMicros *
+      getTimeWindowBillingCycleCount(product, offerDuration)
+    );
   }
 
   return offer.price.amountMicros * getOfferCycleCount(offer);
@@ -67,11 +116,20 @@ export function setOfferVariables(
     return;
   }
 
-  const { period, price } = primaryOffer;
   const offerDuration = getOfferDuration(primaryOffer);
+  const offerPricingPeriod = getOfferPricingPeriod(product, primaryOffer);
+  const { price } = primaryOffer;
   if (price !== null) {
-    const priceVariables = getPriceVariables(price, period, translator);
-    const offerPriceAmountMicros = getOfferPriceAmountMicros(primaryOffer);
+    const priceVariables = getPriceVariables(
+      price,
+      offerPricingPeriod,
+      translator,
+    );
+    const offerPriceAmountMicros = getOfferPriceAmountMicros(
+      product,
+      primaryOffer,
+      offerDuration,
+    );
     variables["product.offer_price"] = translator.formatPrice(
       offerPriceAmountMicros ?? price.amountMicros,
       price.currency,

--- a/src/helpers/paywall-period-helpers.ts
+++ b/src/helpers/paywall-period-helpers.ts
@@ -27,7 +27,7 @@ function getDurationInWeeks(period: Period): number {
     case PeriodUnit.Year:
       return period.number * WEEKS_PER_YEAR;
     case PeriodUnit.Month:
-      return period.number * WEEKS_PER_MONTH;
+      return Math.floor(period.number * WEEKS_PER_MONTH);
     case PeriodUnit.Week:
       return period.number;
     case PeriodUnit.Day:

--- a/src/tests/helpers/paywall-variables-helper.test.ts
+++ b/src/tests/helpers/paywall-variables-helper.test.ts
@@ -530,6 +530,58 @@ describe("getPaywallVariables", () => {
       );
     });
 
+    test("Subscription with time window discount shorter than billing cadence discounts the first monthly bill", () => {
+      const monthlyShortWindowDiscount = {
+        timeWindow: "P1W",
+        periodDuration: "P1W",
+        durationMode: "time_window",
+        price: toPrice(5000000, "USD"),
+        name: "Monthly Short Window Discount",
+        period: { number: 1, unit: PeriodUnit.Week },
+        cycleCount: 1,
+        discountType: "percentage",
+        percentage: 50,
+        fixedAmount: null,
+      } satisfies NonNullable<SubscriptionOption["discount"]>;
+
+      const off = toOffering([
+        {
+          packageIdentifier: "$rc_monthly",
+          identifier: "monthly_short_window_discount",
+          title: "Monthly Short Window Discount",
+          basePriceMicros: 10000000,
+          pricePerWeekMicros: 2330000,
+          pricePerMonthMicros: 10000000,
+          pricePerYearMicros: 120000000,
+          currency: "USD",
+          discount: monthlyShortWindowDiscount,
+        },
+      ]);
+
+      const variables = parseOfferingIntoVariables(off, enTranslator);
+
+      expect(variables.$rc_monthly).toEqual(
+        expect.objectContaining({
+          "product.offer_price": "$5.00",
+          "product.offer_price_per_day": "$0.16",
+          "product.offer_price_per_week": "$1.15",
+          "product.offer_price_per_month": "$5.00",
+          "product.offer_price_per_year": "$60.00",
+          "product.offer_period": "week",
+          "product.offer_period_abbreviated": "wk",
+          "product.offer_period_with_unit": "1 week",
+          "product.offer_period_in_days": "7",
+          "product.offer_period_in_weeks": "1",
+          "product.offer_period_in_months": "0",
+          "product.offer_period_in_years": "0",
+          "product.offer_end_date": "November 6, 2025",
+          "product.secondary_offer_price": "",
+          "product.secondary_offer_period": "",
+          "product.secondary_offer_period_abbreviated": "",
+        }),
+      );
+    });
+
     test("Subscription with multi-cycle intro price uses the full promo window for offer duration", () => {
       const off = toOffering([
         {

--- a/src/tests/helpers/paywall-variables-helper.test.ts
+++ b/src/tests/helpers/paywall-variables-helper.test.ts
@@ -457,7 +457,7 @@ describe("getPaywallVariables", () => {
 
       expect(variables.$rc_monthly).toEqual(
         expect.objectContaining({
-          "product.offer_price": "$36.00",
+          "product.offer_price": "$12.00",
           "product.offer_price_per_day": "$0.40",
           "product.offer_price_per_week": "$2.77",
           "product.offer_price_per_month": "$12.00",
@@ -510,7 +510,7 @@ describe("getPaywallVariables", () => {
 
       expect(variables.$rc_weekly).toEqual(
         expect.objectContaining({
-          "product.offer_price": "$600.00",
+          "product.offer_price": "$75.00",
           "product.offer_price_per_day": "$10.71",
           "product.offer_price_per_week": "$75.00",
           "product.offer_price_per_month": "$324.75",
@@ -545,7 +545,7 @@ describe("getPaywallVariables", () => {
 
       expect(variables.$rc_monthly).toEqual(
         expect.objectContaining({
-          "product.offer_price": "$5.97",
+          "product.offer_price": "$1.99",
           "product.offer_price_per_day": "$0.06",
           "product.offer_price_per_week": "$0.45",
           "product.offer_price_per_month": "$1.99",
@@ -558,6 +558,52 @@ describe("getPaywallVariables", () => {
           "product.offer_period_in_months": "3",
           "product.offer_period_in_years": "0",
           "product.offer_end_date": "January 30, 2026",
+          "product.secondary_offer_price": "",
+          "product.secondary_offer_period": "",
+          "product.secondary_offer_period_abbreviated": "",
+        }),
+      );
+    });
+
+    test("Subscription with paid-upfront intro price keeps offer_price as the upfront charge", () => {
+      const introPricePaidUpfront: SubscriptionOption["introPrice"] = {
+        period: { unit: PeriodUnit.Month, number: 6 },
+        periodDuration: "P6M",
+        cycleCount: 1,
+        price: toPrice(6990000, "USD"),
+        pricePerWeek: toPrice(270000, "USD"),
+        pricePerMonth: toPrice(1160000, "USD"),
+        pricePerYear: toPrice(14170000, "USD"),
+      } satisfies PricingPhase;
+
+      const off = toOffering([
+        {
+          packageIdentifier: "$rc_monthly",
+          identifier: "monthly_paid_upfront_intro_price",
+          title: "Monthly Paid Upfront Intro Price",
+          basePriceMicros: 9000000,
+          currency: "USD",
+          introPrice: introPricePaidUpfront,
+        },
+      ]);
+
+      const variables = parseOfferingIntoVariables(off, enTranslator);
+
+      expect(variables.$rc_monthly).toEqual(
+        expect.objectContaining({
+          "product.offer_price": "$6.99",
+          "product.offer_price_per_day": "$0.03",
+          "product.offer_price_per_week": "$0.26",
+          "product.offer_price_per_month": "$1.16",
+          "product.offer_price_per_year": "$13.98",
+          "product.offer_period": "month",
+          "product.offer_period_abbreviated": "mo",
+          "product.offer_period_with_unit": "6 months",
+          "product.offer_period_in_days": "180",
+          "product.offer_period_in_weeks": "25",
+          "product.offer_period_in_months": "6",
+          "product.offer_period_in_years": "0",
+          "product.offer_end_date": "April 30, 2026",
           "product.secondary_offer_price": "",
           "product.secondary_offer_period": "",
           "product.secondary_offer_period_abbreviated": "",

--- a/src/tests/helpers/paywall-variables-helper.test.ts
+++ b/src/tests/helpers/paywall-variables-helper.test.ts
@@ -104,7 +104,7 @@ describe("getPaywallVariables", () => {
           "product.price_per_period": "€9.00/month",
           "product.period_with_unit": "1 month",
           "product.period_in_days": "30",
-          "product.period_in_weeks": "4.33",
+          "product.period_in_weeks": "4",
           "product.period_in_months": "1",
           "product.period_in_years": "0",
           "product.periodly": "monthly",
@@ -200,7 +200,7 @@ describe("getPaywallVariables", () => {
           "product.offer_period_abbreviated": "mo",
           "product.offer_period_in_days": "60",
           "product.offer_period_in_months": "2",
-          "product.offer_period_in_weeks": "8.66",
+          "product.offer_period_in_weeks": "8",
           "product.offer_period_in_years": "0",
           "product.offer_period_with_unit": "2 months",
           "product.offer_end_date": "December 30, 2025",
@@ -216,7 +216,7 @@ describe("getPaywallVariables", () => {
           "product.period_with_unit": "1 month",
           "product.period_in_days": "30",
           "product.period_in_months": "1",
-          "product.period_in_weeks": "4.33",
+          "product.period_in_weeks": "4",
           "product.period_in_years": "0",
           "product.periodly": "monthly",
           "product.period": "month",
@@ -431,7 +431,7 @@ describe("getPaywallVariables", () => {
           "product.offer_period_abbreviated": "mo",
           "product.offer_period_with_unit": "1 month",
           "product.offer_period_in_days": "30",
-          "product.offer_period_in_weeks": "4.33",
+          "product.offer_period_in_weeks": "4",
           "product.offer_period_in_months": "1",
           "product.offer_period_in_years": "0",
           "product.offer_end_date": "November 30, 2025",
@@ -457,7 +457,7 @@ describe("getPaywallVariables", () => {
 
       expect(variables.$rc_monthly).toEqual(
         expect.objectContaining({
-          "product.offer_price": "$12.00",
+          "product.offer_price": "$36.00",
           "product.offer_price_per_day": "$0.40",
           "product.offer_price_per_week": "$2.77",
           "product.offer_price_per_month": "$12.00",
@@ -466,7 +466,7 @@ describe("getPaywallVariables", () => {
           "product.offer_period_abbreviated": "mo",
           "product.offer_period_with_unit": "3 months",
           "product.offer_period_in_days": "90",
-          "product.offer_period_in_weeks": "12.99",
+          "product.offer_period_in_weeks": "12",
           "product.offer_period_in_months": "3",
           "product.offer_period_in_years": "0",
           "product.offer_end_date": "January 30, 2026",
@@ -492,7 +492,7 @@ describe("getPaywallVariables", () => {
 
       expect(variables.$rc_monthly).toEqual(
         expect.objectContaining({
-          "product.offer_price": "$1.99",
+          "product.offer_price": "$5.97",
           "product.offer_price_per_day": "$0.06",
           "product.offer_price_per_week": "$0.45",
           "product.offer_price_per_month": "$1.99",
@@ -501,7 +501,7 @@ describe("getPaywallVariables", () => {
           "product.offer_period_abbreviated": "mo",
           "product.offer_period_with_unit": "3 months",
           "product.offer_period_in_days": "90",
-          "product.offer_period_in_weeks": "12.99",
+          "product.offer_period_in_weeks": "12",
           "product.offer_period_in_months": "3",
           "product.offer_period_in_years": "0",
           "product.offer_end_date": "January 30, 2026",

--- a/src/tests/helpers/paywall-variables-helper.test.ts
+++ b/src/tests/helpers/paywall-variables-helper.test.ts
@@ -477,6 +477,59 @@ describe("getPaywallVariables", () => {
       );
     });
 
+    test("Subscription with time window discount uses base billing cadence for weekly offers", () => {
+      const weeklyTimeWindowDiscount = {
+        timeWindow: "P2M",
+        periodDuration: "P2M",
+        durationMode: "time_window",
+        price: toPrice(75000000, "USD"),
+        name: "Weekly Time Window Discount",
+        period: { number: 1, unit: PeriodUnit.Month },
+        cycleCount: 2,
+        discountType: "percentage",
+        percentage: 25,
+        fixedAmount: null,
+      } satisfies NonNullable<SubscriptionOption["discount"]>;
+
+      const off = toOffering([
+        {
+          packageIdentifier: "$rc_weekly",
+          identifier: "weekly_time_window_discount",
+          title: "Weekly Time Window Discount",
+          period: { unit: PeriodUnit.Week, number: 1 },
+          basePriceMicros: 100000000,
+          pricePerWeekMicros: 100000000,
+          pricePerMonthMicros: 428570000,
+          pricePerYearMicros: 5214280000,
+          currency: "USD",
+          discount: weeklyTimeWindowDiscount,
+        },
+      ]);
+
+      const variables = parseOfferingIntoVariables(off, enTranslator);
+
+      expect(variables.$rc_weekly).toEqual(
+        expect.objectContaining({
+          "product.offer_price": "$600.00",
+          "product.offer_price_per_day": "$10.71",
+          "product.offer_price_per_week": "$75.00",
+          "product.offer_price_per_month": "$324.75",
+          "product.offer_price_per_year": "$3,900.00",
+          "product.offer_period": "month",
+          "product.offer_period_abbreviated": "mo",
+          "product.offer_period_with_unit": "2 months",
+          "product.offer_period_in_days": "60",
+          "product.offer_period_in_weeks": "8",
+          "product.offer_period_in_months": "2",
+          "product.offer_period_in_years": "0",
+          "product.offer_end_date": "December 30, 2025",
+          "product.secondary_offer_price": "",
+          "product.secondary_offer_period": "",
+          "product.secondary_offer_period_abbreviated": "",
+        }),
+      );
+    });
+
     test("Subscription with multi-cycle intro price uses the full promo window for offer duration", () => {
       const off = toOffering([
         {

--- a/src/tests/helpers/paywall-variables-helper.test.ts
+++ b/src/tests/helpers/paywall-variables-helper.test.ts
@@ -20,6 +20,7 @@ import {
   discountPhaseOneTime,
   discountPhaseTimeWindow,
   discountPhaseForever,
+  introPhaseP1M199,
   trialPhaseP2W,
 } from "../fixtures/price-phases";
 const enTranslator = new Translator({}, englishLocale);
@@ -463,12 +464,47 @@ describe("getPaywallVariables", () => {
           "product.offer_price_per_year": "$144.00",
           "product.offer_period": "month",
           "product.offer_period_abbreviated": "mo",
-          "product.offer_period_with_unit": "1 month",
-          "product.offer_period_in_days": "30",
-          "product.offer_period_in_weeks": "4.33",
-          "product.offer_period_in_months": "1",
+          "product.offer_period_with_unit": "3 months",
+          "product.offer_period_in_days": "90",
+          "product.offer_period_in_weeks": "12.99",
+          "product.offer_period_in_months": "3",
           "product.offer_period_in_years": "0",
-          "product.offer_end_date": "November 30, 2025",
+          "product.offer_end_date": "January 30, 2026",
+          "product.secondary_offer_price": "",
+          "product.secondary_offer_period": "",
+          "product.secondary_offer_period_abbreviated": "",
+        }),
+      );
+    });
+
+    test("Subscription with multi-cycle intro price uses the full promo window for offer duration", () => {
+      const off = toOffering([
+        {
+          packageIdentifier: "$rc_monthly",
+          identifier: "monthly_multi_cycle_intro_price",
+          title: "Monthly Multi-Cycle Intro Price",
+          basePriceMicros: 9000000,
+          introPrice: introPhaseP1M199,
+        },
+      ]);
+
+      const variables = parseOfferingIntoVariables(off, enTranslator);
+
+      expect(variables.$rc_monthly).toEqual(
+        expect.objectContaining({
+          "product.offer_price": "$1.99",
+          "product.offer_price_per_day": "$0.06",
+          "product.offer_price_per_week": "$0.45",
+          "product.offer_price_per_month": "$1.99",
+          "product.offer_price_per_year": "$23.88",
+          "product.offer_period": "month",
+          "product.offer_period_abbreviated": "mo",
+          "product.offer_period_with_unit": "3 months",
+          "product.offer_period_in_days": "90",
+          "product.offer_period_in_weeks": "12.99",
+          "product.offer_period_in_months": "3",
+          "product.offer_period_in_years": "0",
+          "product.offer_end_date": "January 30, 2026",
           "product.secondary_offer_price": "",
           "product.secondary_offer_period": "",
           "product.secondary_offer_period_abbreviated": "",
@@ -496,14 +532,14 @@ describe("getPaywallVariables", () => {
           "product.offer_price_per_week": "$3.00",
           "product.offer_price_per_month": "$13.00",
           "product.offer_price_per_year": "$156.00",
-          "product.offer_period": "month",
-          "product.offer_period_abbreviated": "mo",
-          "product.offer_period_with_unit": "1 month",
-          "product.offer_period_in_days": "30",
-          "product.offer_period_in_weeks": "4.33",
-          "product.offer_period_in_months": "1",
-          "product.offer_period_in_years": "0",
-          "product.offer_end_date": "November 30, 2025",
+          "product.offer_period": "",
+          "product.offer_period_abbreviated": "",
+          "product.offer_period_with_unit": "",
+          "product.offer_period_in_days": "",
+          "product.offer_period_in_weeks": "",
+          "product.offer_period_in_months": "",
+          "product.offer_period_in_years": "",
+          "product.offer_end_date": "",
           "product.secondary_offer_price": "",
           "product.secondary_offer_period": "",
           "product.secondary_offer_period_abbreviated": "",


### PR DESCRIPTION
## Motivation / Description

Variables definition for reference: https://www.revenuecat.com/docs/tools/paywalls/creating-paywalls/variables

While developing the Discounts project, which allows applying a fixed percentage discount to a web product for a given period of time, we realised that the variables in paywalls weren't working correctly.

I then noticed that intro offers have the exact same problems.

Specifically this solves the tickets in this bucket: https://linear.app/revenuecat/project/flexible-discounts-282eb1531b65/issues

The changes are:
- Account for offer.cycleCount when determining duration based variables
- Forever discounts now no longer populate offer_period* based variables
- Floor() the durationInWeeks when WEEKS_PER_MONTH is used to avoid decimals when multiplying by 4.33. Opting to leave the 4.33 as-is to not affect existing pricing logic. Opting not to Floor() anything else because assume the `period.number` is whole. I think this matches the dashboard preview equivalent.
- Add tests

Two main questions for the paywalls team are:
- Does this generally match the equivalents displayed in the editor previews?
- `offer_period_abbreviated` shows `/mo` for both a `6 month discount period with a monthly cycle`, and for a `6month period paid up front`. The latter case may be a bit misleading but this seems to follow the var definition. I guess you would construct a string based on this + the `offer_period_in_months`.

I do worry a little bit about duplicating ~complex logic across here, the paywall previews and the backend meaning bugs like e.g this https://github.com/RevenueCat/revenuecat-app/pull/7698. But thats a broader change.

## Testing

I've used this paywall https://app.revenuecat.com/projects/e53bf105/paywalls/pw7013f7d754a84855/builder which logs the values of all relevant variables, with this offering https://app.revenuecat.com/projects/e53bf105/product-catalog/offerings/ofrnga9154231f1, with a set of different products. The variables now all seem to behave as I'd expect.
Unit tests are I think reasonably extensive.

## Linear ticket (if any)

## Additional comments
