### PR TITLE
Guard against accidental version bumps outside release branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,9 @@ jobs:
       - revenuecat/setup-git-credentials
       - install-dependencies
       - run:
+          name: Check version consistency
+          command: pnpm run check-version-consistency
+      - run:
           name: Install dependencies webbilling-demo
           working_directory: examples/webbilling-demo
           command: pnpm install

--- a/Dangerfile
+++ b/Dangerfile
@@ -22,8 +22,9 @@ unless head_branch.to_s.start_with?('release/')
 
     fail(
       "`#{path}` contains a version change, but this PR is not targeting a `release/*` branch. " \
-      "Versions are managed by Fastlane — please revert the change and run `bundle exec fastlane bump` " \
-      "to cut a release. See `fastlane/Fastfile` for the release flow."
+      "Versions are managed by Fastlane — please revert the change and either run `bundle exec fastlane bump` " \
+      "locally, or trigger the `manual-trigger-bump` pipeline in CircleCI with the `action` parameter set to " \
+      "`bump`. See `fastlane/Fastfile` and `.circleci/config.yml` for the release flow."
     )
   end
 end

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,1 +1,29 @@
 danger.import_dangerfile(github: 'RevenueCat/Dangerfile')
+
+# Block accidental version bumps outside release/* branches.
+# The proper flow is `bundle exec fastlane bump`, which updates .version,
+# package.json, and src/helpers/constants.ts atomically. Manual edits have
+# caused drift in the past.
+head_branch = github.branch_for_head
+unless head_branch.to_s.start_with?('release/')
+  version_file_checks = {
+    'package.json' => /^[-+]\s*"version":\s*"[^"]+"/,
+    'src/helpers/constants.ts' => /^[-+].*VERSION\s*=\s*"[^"]+"/,
+    '.version' => /./
+  }
+
+  touched = (git.modified_files + git.added_files).uniq
+  version_file_checks.each do |path, version_line_pattern|
+    next unless touched.include?(path)
+
+    diff = git.diff_for_file(path)
+    next if diff.nil?
+    next unless diff.patch.to_s.lines.any? { |line| line =~ version_line_pattern }
+
+    fail(
+      "`#{path}` contains a version change, but this PR is not targeting a `release/*` branch. " \
+      "Versions are managed by Fastlane — please revert the change and run `bundle exec fastlane bump` " \
+      "to cut a release. See `fastlane/Fastfile` for the release flow."
+    )
+  end
+end

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "extract-api": "api-extractor run --local --verbose",
+    "check-version-consistency": "node scripts/check-version-consistency.mjs",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/scripts/check-version-consistency.mjs
+++ b/scripts/check-version-consistency.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import process from "node:process";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const versionFile = readFileSync(resolve(repoRoot, ".version"), "utf8").trim();
+
+const pkg = JSON.parse(readFileSync(resolve(repoRoot, "package.json"), "utf8"));
+const packageJsonVersion = pkg.version;
+
+const constantsSrc = readFileSync(
+  resolve(repoRoot, "src/helpers/constants.ts"),
+  "utf8",
+);
+const constantsMatch = constantsSrc.match(/VERSION\s*=\s*"([^"]+)"/);
+if (!constantsMatch) {
+  console.error('Could not find `VERSION = "..."` in src/helpers/constants.ts');
+  process.exit(1);
+}
+const constantsVersion = constantsMatch[1];
+
+const versions = {
+  ".version": versionFile,
+  "package.json": packageJsonVersion,
+  "src/helpers/constants.ts": constantsVersion,
+};
+
+const unique = new Set(Object.values(versions));
+if (unique.size > 1) {
+  console.error("Version mismatch across source-of-truth files:");
+  for (const [file, value] of Object.entries(versions)) {
+    console.error(`  ${file}: ${value}`);
+  }
+  console.error(
+    "\nThese files must stay in lockstep. Run `bundle exec fastlane bump` " +
+      "to cut a release rather than editing them by hand.",
+  );
+  process.exit(1);
+}
+
+console.log(`Version consistency OK: ${[...unique][0]}`);

--- a/scripts/check-version-consistency.mjs
+++ b/scripts/check-version-consistency.mjs
@@ -35,8 +35,10 @@ if (unique.size > 1) {
     console.error(`  ${file}: ${value}`);
   }
   console.error(
-    "\nThese files must stay in lockstep. Run `bundle exec fastlane bump` " +
-      "to cut a release rather than editing them by hand.",
+    "\nThese files must stay in lockstep. To cut a release, run " +
+      "`bundle exec fastlane bump` locally, or trigger the " +
+      "`manual-trigger-bump` pipeline in CircleCI with the `action` " +
+      "parameter set to `bump` — don't edit these files by hand.",
   );
   process.exit(1);
 }


### PR DESCRIPTION
## Summary

Adds two complementary guardrails so contributors can't accidentally modify the version manually, and so drift between the three version sources (`.version`, `package.json`, `src/helpers/constants.ts`) is caught in CI:

- **Danger rule** (local `Dangerfile`) — fails PRs that touch the `version` line in `package.json`, `.version`, or `src/helpers/constants.ts` when the head branch is **not** `release/*`. Error message points contributors to `bundle exec fastlane bump`.
- **CI consistency check** — new step in the existing `test` job (`pnpm run check-version-consistency`) runs `scripts/check-version-consistency.mjs`, which reads the three files and fails if they disagree. Runs regardless of branch, so it also catches drift on release branches.

The Fastlane `bump` lane already updates all three files atomically via the `files_with_version_number` map in `fastlane/Fastfile`, so no changes are needed on the release side.

### Why

Contributors have occasionally edited `package.json`'s `version` directly in feature PRs (historical examples around PRs #824 / #835), thinking that's how releases are cut. That causes drift from `.version`, which is Fastlane's source of truth.

## Test plan

- [ ] CI: `danger` job passes on this PR (no version lines touched).
- [ ] CI: `test` job's new "Check version consistency" step passes on this PR.
- [ ] Manual sanity: push a scratch commit that bumps only `package.json` version → both Danger and the CI step should fail with the instructive messages. Revert before merging.
- [ ] On a `release/*` branch, the Danger rule should skip (allow the bump) while the CI consistency step still passes as long as the three files match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)