### PR TITLE
[WEB-4178] Fix paywall overlay cleanup when no paywall is attached

### DIFF
--- a/examples/webbilling-demo/src/App.tsx
+++ b/examples/webbilling-demo/src/App.tsx
@@ -18,6 +18,7 @@ import RCPaywallPage from "./pages/rc_paywall";
 import DelayedStoreLoadPage from "./pages/delayed_store_load";
 import RCPaywallNoOfferingPassedPage from "./pages/rc_paywall_no_offering_passed";
 import RCPaywallNoTargetElementPassedPage from "./pages/rc_paywall_no_target_element_passed";
+import RCPaywallNoPaywallAttachedPage from "./pages/rc_paywall_no_paywall_attached";
 import RedemptionLinksTester from "./pages/redemption_links_tester";
 import RCPaywallLauncherPage from "./pages/rc_paywall_launcher";
 import ExpressPurchaseButtonsPackageSelector from "./pages/express_purchase_buttons";
@@ -80,6 +81,15 @@ const router = createBrowserRouter([
     element: (
       <WithoutEntitlement>
         <RCPaywallNoTargetElementPassedPage />
+      </WithoutEntitlement>
+    ),
+  },
+  {
+    path: "/rc_paywall_no_paywall_attached/:app_user_id",
+    loader: loadPurchases,
+    element: (
+      <WithoutEntitlement>
+        <RCPaywallNoPaywallAttachedPage />
       </WithoutEntitlement>
     ),
   },

--- a/examples/webbilling-demo/src/pages/rc_paywall_no_paywall_attached/index.tsx
+++ b/examples/webbilling-demo/src/pages/rc_paywall_no_paywall_attached/index.tsx
@@ -1,0 +1,51 @@
+import { Purchases } from "@revenuecat/purchases-js";
+import React, { useState } from "react";
+import { usePurchasesLoaderData } from "../../util/PurchasesLoader";
+
+const RCPaywallNoPaywallAttachedPage: React.FC = () => {
+  const { offering } = usePurchasesLoaderData();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [clickCount, setClickCount] = useState(0);
+
+  if (!offering) {
+    console.error("No offering found");
+    return <>No offering found!</>;
+  }
+
+  const onShowPaywallClicked = async () => {
+    setErrorMessage(null);
+
+    try {
+      await Purchases.getSharedInstance().presentPaywall({
+        offering,
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Unknown presentPaywall error";
+      console.log(`Error: ${message}`);
+      setErrorMessage(message);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "16px",
+        justifyContent: "center",
+        alignItems: "center",
+        minHeight: "100vh",
+      }}
+    >
+      <h1>No paywall attached repro</h1>
+      <button onClick={onShowPaywallClicked}>Show paywall</button>
+      <button onClick={() => setClickCount((count) => count + 1)}>
+        Background action {clickCount}
+      </button>
+      {errorMessage ? <div role="alert">{errorMessage}</div> : null}
+    </div>
+  );
+};
+
+export default RCPaywallNoPaywallAttachedPage;

--- a/examples/webbilling-demo/src/tests/paywall-overlay-cleanup.test.ts
+++ b/examples/webbilling-demo/src/tests/paywall-overlay-cleanup.test.ts
@@ -1,0 +1,96 @@
+import { expect } from "@playwright/test";
+import { integrationTest } from "./helpers/integration-test";
+import { BASE_URL } from "./helpers/fixtures";
+import { skipPaywallsTestIfDisabled } from "./helpers/test-helpers";
+
+const offeringsResponse = {
+  current_offering_id: "offering_1",
+  offerings: [
+    {
+      identifier: "offering_1",
+      description: "Offering 1",
+      metadata: null,
+      packages: [
+        {
+          identifier: "$rc_monthly",
+          platform_product_identifier: "monthly",
+        },
+      ],
+      paywall_components: null,
+    },
+  ],
+};
+
+const productsResponse = {
+  product_details: [
+    {
+      identifier: "monthly",
+      product_type: "subscription",
+      title: "Monthly test",
+      description: null,
+      default_purchase_option_id: "base_option",
+      purchase_options: {
+        base_option: {
+          id: "base_option",
+          price_id: "test_price_id",
+          base: {
+            period_duration: "P1M",
+            cycle_count: 1,
+            price: {
+              amount_micros: 3000000,
+              currency: "USD",
+            },
+          },
+          trial: null,
+          intro_price: null,
+          discount: null,
+        },
+      },
+    },
+  ],
+};
+
+integrationTest(
+  "removes auto-created paywall overlay when presentPaywall rejects for an offering without a paywall",
+  async ({ page, userId }) => {
+    skipPaywallsTestIfDisabled(integrationTest);
+
+    await page.route("**/v1/subscribers/*/offerings", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        json: offeringsResponse,
+      });
+    });
+
+    await page.route(
+      "**/rcbilling/v1/subscribers/*/products**",
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          json: productsResponse,
+        });
+      },
+    );
+
+    await page.goto(
+      `${BASE_URL}rc_paywall_no_paywall_attached/${encodeURIComponent(userId)}`,
+    );
+
+    await page.getByRole("button", { name: "Show paywall" }).click();
+
+    await expect(page.getByRole("alert")).toHaveText(
+      "This offering doesn't have a paywall attached.",
+    );
+    await expect(page.locator("#rcb-ui-pw-root")).toHaveCount(0);
+
+    const backgroundActionButton = page.getByRole("button", {
+      name: "Background action 0",
+    });
+    await backgroundActionButton.click();
+    await expect(
+      page.getByRole("button", { name: "Background action 1" }),
+    ).toBeVisible();
+  },
+);

--- a/src/main.ts
+++ b/src/main.ts
@@ -488,6 +488,22 @@ export class Purchases {
     const htmlTarget = paywallParams.htmlTarget;
     let wasRootAutoCreated = false;
 
+    const offering = paywallParams.offering
+      ? paywallParams.offering
+      : (await this.getOfferings()).current;
+    if (!offering) {
+      throw new Error("No offering found.");
+    }
+    if (!offering.paywallComponents) {
+      throw new Error("This offering doesn't have a paywall attached.");
+    }
+
+    if (!offering.uiConfig) {
+      throw new Error(
+        "No ui_config found for this offering, please contact support!",
+      );
+    }
+
     const doc = getDocument();
     let resolvedHTMLTarget = htmlTarget ?? doc.getElementById("rcb-ui-pw-root");
 
@@ -523,22 +539,6 @@ export class Purchases {
     }
 
     const certainHTMLTarget = resolvedHTMLTarget as unknown as HTMLElement;
-
-    const offering = paywallParams.offering
-      ? paywallParams.offering
-      : (await this.getOfferings()).current;
-    if (!offering) {
-      throw new Error("No offering found.");
-    }
-    if (!offering.paywallComponents) {
-      throw new Error("This offering doesn't have a paywall attached.");
-    }
-
-    if (!offering.uiConfig) {
-      throw new Error(
-        "No ui_config found for this offering, please contact support!",
-      );
-    }
 
     const calculateLocale = (
       paywallData: PaywallData,


### PR DESCRIPTION
## Summary
- align  with the built SDK behavior by validating the offering before auto-creating the paywall overlay root
- add a demo page in  to reproduce the no-paywall-attached flow
- add a focused Playwright test covering overlay cleanup when  rejects early

## Testing
- pnpm test src/tests/present-paywall.events.test.ts
- pnpm playwright test src/tests/paywall-overlay-cleanup.test.ts --project=chromium