### PR TITLE
Add express checkout theme support

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@eslint/js": "^9.16.0",
     "@microsoft/api-extractor": "^7.48.0",
     "@paddle/paddle-js": "^1.5.1",
-    "@revenuecat/purchases-ui-js": "3.12.0",
+    "@revenuecat/purchases-ui-js": "3.12.1",
     "@storybook/addon-essentials": "^8.6.15",
     "@storybook/addon-interactions": "^8.6.15",
     "@storybook/addon-links": "^8.6.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -725,7 +725,7 @@ packages:
   "@revenuecat/purchases-ui-js@3.12.1":
     resolution:
       {
-        integrity: sha512-Un96Z0tS1A7Ie01Fj8vGBfUikoIMl/kzwdCK+F2IG+KgihBOo52MuDE9w0rasgYyWv1nkiXOWUiIRknKa9Z6og==,
+        integrity: sha512-87Z+tKSTsVbujdELcxebfhmNf5NbIleXFxlqxdcVQLAo/RaLWn2TcM0YOQQ7M5aOWLKt/44I2CcUQT56KcYETQ==,
       }
     engines: { node: ^22.18 || ^24.11 }
     peerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1
       "@revenuecat/purchases-ui-js":
-        specifier: 3.12.0
-        version: 3.12.0(svelte@5.46.4)
+        specifier: 3.12.1
+        version: 3.12.1(svelte@5.46.4)
       "@storybook/addon-essentials":
         specifier: ^8.6.15
         version: 8.6.15(@types/react@19.0.10)(storybook@8.6.15(prettier@3.4.2))
@@ -722,7 +722,7 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
 
-  "@revenuecat/purchases-ui-js@3.12.0":
+  "@revenuecat/purchases-ui-js@3.12.1":
     resolution:
       {
         integrity: sha512-Un96Z0tS1A7Ie01Fj8vGBfUikoIMl/kzwdCK+F2IG+KgihBOo52MuDE9w0rasgYyWv1nkiXOWUiIRknKa9Z6og==,
@@ -6155,7 +6155,7 @@ snapshots:
 
   "@pkgr/core@0.1.1": {}
 
-  "@revenuecat/purchases-ui-js@3.12.0(svelte@5.46.4)":
+  "@revenuecat/purchases-ui-js@3.12.1(svelte@5.46.4)":
     dependencies:
       qrcode: 1.5.4
       svelte: 5.46.4

--- a/src/entities/present-express-purchase-button-params.ts
+++ b/src/entities/present-express-purchase-button-params.ts
@@ -1,7 +1,7 @@
-import type { Package, PurchaseMetadata, PurchaseOption } from "./offerings";
+import type { WalletButtonStyleType } from "@revenuecat/purchases-ui-js";
 import type { CustomTranslations } from "../ui/localization/translator";
+import type { Package, PurchaseMetadata, PurchaseOption } from "./offerings";
 import type { PaywallListener } from "./paywall-listener";
-
 /**
  * Callback to be called when the express purchase button is ready to be updated.
  * @internal
@@ -70,4 +70,10 @@ export interface PresentExpressPurchaseButtonParams {
    * Optional listener for purchase lifecycle events.
    */
   listener?: PaywallListener;
+  /*
+   * @internal
+   * Style for the wallet button appearance. Matches Apple Pay button styles:
+   * 'black', 'white', or 'white-outline'.
+   */
+  walletButtonStyle?: WalletButtonStyleType;
 }

--- a/src/entities/present-express-purchase-button-params.ts
+++ b/src/entities/present-express-purchase-button-params.ts
@@ -1,4 +1,4 @@
-import type { WalletButtonStyleType } from "@revenuecat/purchases-ui-js";
+import type { WalletButtonTheme } from "@revenuecat/purchases-ui-js";
 import type { CustomTranslations } from "../ui/localization/translator";
 import type { Package, PurchaseMetadata, PurchaseOption } from "./offerings";
 import type { PaywallListener } from "./paywall-listener";
@@ -70,10 +70,10 @@ export interface PresentExpressPurchaseButtonParams {
    * Optional listener for purchase lifecycle events.
    */
   listener?: PaywallListener;
-  /*
-   * @internal
-   * Style for the wallet button appearance. Matches Apple Pay button styles:
-   * 'black', 'white', or 'white-outline'.
+  /**
+   * Theme for the Stripe wallet button appearance.
+   * Matches Apple Pay button styles: 'black', 'white', or 'white-outline'
+   * @default "black"
    */
-  walletButtonStyle?: WalletButtonStyleType;
+  walletButtonTheme?: WalletButtonTheme;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1211,7 +1211,7 @@ export class Purchases {
       selectedLocale = englishLocale,
       defaultLocale = englishLocale,
       onButtonReady = () => {},
-      walletButtonStyle,
+      walletButtonTheme,
     } = params;
 
     if (htmlTarget === undefined) {
@@ -1288,7 +1288,7 @@ export class Purchases {
         onFinished,
         onError,
         listener: params.listener,
-        walletButtonStyle,
+        walletButtonTheme,
       });
     });
   }
@@ -1317,7 +1317,7 @@ export class Purchases {
 
     return (
       element: HTMLElement,
-      { selectedPackageId, onReady, walletButtonStyle },
+      { selectedPackageId, onReady, walletButtonTheme },
     ) => {
       const pkg = offering.packagesById[selectedPackageId];
       if (!pkg) {
@@ -1334,7 +1334,7 @@ export class Purchases {
           onReady?.(walletsAvailable);
         },
         listener,
-        walletButtonStyle,
+        walletButtonTheme,
       })
         .then((purchaseResult) => {
           onSuccess({ ...purchaseResult, selectedPackage: pkg });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1211,6 +1211,7 @@ export class Purchases {
       selectedLocale = englishLocale,
       defaultLocale = englishLocale,
       onButtonReady = () => {},
+      walletButtonStyle,
     } = params;
 
     if (htmlTarget === undefined) {
@@ -1287,6 +1288,7 @@ export class Purchases {
         onFinished,
         onError,
         listener: params.listener,
+        walletButtonStyle,
       });
     });
   }
@@ -1313,7 +1315,10 @@ export class Purchases {
       return undefined;
     }
 
-    return (element: HTMLElement, { selectedPackageId, onReady }) => {
+    return (
+      element: HTMLElement,
+      { selectedPackageId, onReady, walletButtonStyle },
+    ) => {
       const pkg = offering.packagesById[selectedPackageId];
       if (!pkg) {
         return {};
@@ -1329,6 +1334,7 @@ export class Purchases {
           onReady?.(walletsAvailable);
         },
         listener,
+        walletButtonStyle,
       })
         .then((purchaseResult) => {
           onSuccess({ ...purchaseResult, selectedPackage: pkg });
@@ -1339,12 +1345,7 @@ export class Purchases {
         destroy() {
           element.innerHTML = "";
         },
-        update({
-          selectedPackageId,
-        }: {
-          selectedPackageId: string;
-          onReady?: () => void;
-        }) {
+        update({ selectedPackageId }) {
           if (buttonUpdater) {
             const pkg = offering.packagesById[selectedPackageId];
             if (!pkg) {

--- a/src/ui/express-purchase-button/express-purchase-button-props.ts
+++ b/src/ui/express-purchase-button/express-purchase-button-props.ts
@@ -1,21 +1,22 @@
+import type { WalletButtonStyleType } from "@revenuecat/purchases-ui-js";
+import type { IEventsTracker } from "../../behavioural-events/events-tracker";
 import type {
   Package,
   PurchaseMetadata,
   PurchaseOption,
 } from "../../entities/offerings";
-import type { BrandingInfoResponse } from "../../networking/responses/branding-response";
-import type { Purchases } from "../../main";
-import type { IEventsTracker } from "../../behavioural-events/events-tracker";
+import type { PaywallListener } from "../../entities/paywall-listener";
 import type {
   OperationSessionSuccessfulResult,
   PurchaseFlowError,
   PurchaseOperationHelper,
 } from "../../helpers/purchase-operation-helper";
+import type { Purchases } from "../../main";
+import type { BrandingInfoResponse } from "../../networking/responses/branding-response";
 import type {
   CustomTranslations,
   Translator,
 } from "../localization/translator";
-import type { PaywallListener } from "../../entities/paywall-listener";
 
 export interface ExpressPurchaseButtonProps {
   customerEmail: string | undefined;
@@ -33,4 +34,5 @@ export interface ExpressPurchaseButtonProps {
   onError: (error: PurchaseFlowError) => void;
   onReady?: (walletsAvailable: boolean) => void;
   listener?: PaywallListener;
+  walletButtonStyle?: WalletButtonStyleType;
 }

--- a/src/ui/express-purchase-button/express-purchase-button-props.ts
+++ b/src/ui/express-purchase-button/express-purchase-button-props.ts
@@ -1,4 +1,4 @@
-import type { WalletButtonStyleType } from "@revenuecat/purchases-ui-js";
+import type { WalletButtonTheme } from "@revenuecat/purchases-ui-js";
 import type { IEventsTracker } from "../../behavioural-events/events-tracker";
 import type {
   Package,
@@ -34,5 +34,5 @@ export interface ExpressPurchaseButtonProps {
   onError: (error: PurchaseFlowError) => void;
   onReady?: (walletsAvailable: boolean) => void;
   listener?: PaywallListener;
-  walletButtonStyle?: WalletButtonStyleType;
+  walletButtonTheme?: WalletButtonTheme;
 }

--- a/src/ui/express-purchase-button/express-purchase-button.svelte
+++ b/src/ui/express-purchase-button/express-purchase-button.svelte
@@ -53,6 +53,7 @@
     onError,
     onReady,
     listener,
+    walletButtonStyle,
   }: ExpressPurchaseButtonProps = $props();
 
   const mode: SDKEventPurchaseMode = "express_purchase_button";
@@ -121,6 +122,7 @@
             purchaseOption,
             translator,
             brandingInfo,
+            walletButtonStyle,
           );
         stripe = stripeInstance;
         elements = elementsInstance;
@@ -133,6 +135,7 @@
           rcPackage,
           purchaseOption,
           translator,
+          walletButtonStyle,
         );
         expressCheckoutOptions = expOptions;
       }
@@ -311,6 +314,7 @@
         rcPackage,
         purchaseOption,
         translator,
+        walletButtonStyle,
       );
 
       return { applePay: options.applePay } as ClickResolveDetails;

--- a/src/ui/express-purchase-button/express-purchase-button.svelte
+++ b/src/ui/express-purchase-button/express-purchase-button.svelte
@@ -53,7 +53,7 @@
     onError,
     onReady,
     listener,
-    walletButtonStyle,
+    walletButtonTheme,
   }: ExpressPurchaseButtonProps = $props();
 
   const mode: SDKEventPurchaseMode = "express_purchase_button";
@@ -122,7 +122,7 @@
             purchaseOption,
             translator,
             brandingInfo,
-            walletButtonStyle,
+            walletButtonTheme,
           );
         stripe = stripeInstance;
         elements = elementsInstance;
@@ -135,7 +135,7 @@
           rcPackage,
           purchaseOption,
           translator,
-          walletButtonStyle,
+          walletButtonTheme,
         );
         expressCheckoutOptions = expOptions;
       }
@@ -314,7 +314,7 @@
         rcPackage,
         purchaseOption,
         translator,
-        walletButtonStyle,
+        walletButtonTheme,
       );
 
       return { applePay: options.applePay } as ClickResolveDetails;

--- a/src/ui/express-purchase-button/stripe-helpers.ts
+++ b/src/ui/express-purchase-button/stripe-helpers.ts
@@ -18,7 +18,7 @@ import {
 } from "../../helpers/purchase-operation-helper";
 import { getNullableWindow } from "../../helpers/browser-globals";
 import type { BrandingInfoResponse } from "../../networking/responses/branding-response";
-import type { WalletButtonStyleType } from "@revenuecat/purchases-ui-js";
+import type { WalletButtonTheme } from "@revenuecat/purchases-ui-js";
 
 const getSubscriptionOptionForExpressCheckout = (
   productDetails: Product,
@@ -80,7 +80,7 @@ export const toExpressPurchaseOptions = (
   purchaseOption: PurchaseOption,
   managementUrl: string,
   translator: Translator,
-  walletButtonStyle?: WalletButtonStyleType,
+  walletButtonTheme?: WalletButtonTheme,
 ) => {
   const productDetails: Product = rcPackage.webBillingProduct;
   const { subscriptionOption, priceBreakdown } =
@@ -97,12 +97,12 @@ export const toExpressPurchaseOptions = (
       1,
     );
 
-  if (walletButtonStyle) {
+  if (walletButtonTheme) {
     options.buttonTheme = {
-      applePay: walletButtonStyle,
+      applePay: walletButtonTheme,
       // Google Pay only supports "black" | "white"
       googlePay:
-        walletButtonStyle === "white-outline" ? "white" : walletButtonStyle,
+        walletButtonTheme === "white-outline" ? "white" : walletButtonTheme,
     };
   }
 
@@ -116,7 +116,7 @@ export const updateStripe = (
   rcPackage: Package,
   purchaseOption: PurchaseOption,
   translator: Translator,
-  walletButtonStyle?: WalletButtonStyleType,
+  walletButtonTheme?: WalletButtonTheme,
 ) => {
   if (!gatewayParams.elements_configuration) {
     throw new PurchaseFlowError(PurchaseFlowErrorCode.ErrorSettingUpPurchase);
@@ -132,7 +132,7 @@ export const updateStripe = (
     purchaseOption,
     managementUrl,
     translator,
-    walletButtonStyle,
+    walletButtonTheme,
   );
   return { expOptions: options };
 };
@@ -144,7 +144,7 @@ export const initStripe = async (
   purchaseOption: PurchaseOption,
   translator: Translator,
   brandingInfo: BrandingInfoResponse | null,
-  walletButtonStyle?: WalletButtonStyleType,
+  walletButtonTheme?: WalletButtonTheme,
 ) => {
   if (!gatewayParams.elements_configuration) {
     throw new PurchaseFlowError(PurchaseFlowErrorCode.ErrorSettingUpPurchase);
@@ -205,7 +205,7 @@ export const initStripe = async (
     purchaseOption,
     managementUrl,
     translator,
-    walletButtonStyle,
+    walletButtonTheme,
   );
 
   return { stripeInstance, elementsInstance, expOptions: options };

--- a/src/ui/express-purchase-button/stripe-helpers.ts
+++ b/src/ui/express-purchase-button/stripe-helpers.ts
@@ -18,6 +18,7 @@ import {
 } from "../../helpers/purchase-operation-helper";
 import { getNullableWindow } from "../../helpers/browser-globals";
 import type { BrandingInfoResponse } from "../../networking/responses/branding-response";
+import type { WalletButtonStyleType } from "@revenuecat/purchases-ui-js";
 
 const getSubscriptionOptionForExpressCheckout = (
   productDetails: Product,
@@ -79,20 +80,33 @@ export const toExpressPurchaseOptions = (
   purchaseOption: PurchaseOption,
   managementUrl: string,
   translator: Translator,
+  walletButtonStyle?: WalletButtonStyleType,
 ) => {
   const productDetails: Product = rcPackage.webBillingProduct;
   const { subscriptionOption, priceBreakdown } =
     resolveExpressCheckoutPricingDetails(productDetails, purchaseOption.id);
 
-  return StripeService.buildStripeExpressCheckoutOptionsForSubscription(
-    productDetails,
-    priceBreakdown,
-    subscriptionOption,
-    translator,
-    managementUrl,
-    2,
-    1,
-  );
+  const options =
+    StripeService.buildStripeExpressCheckoutOptionsForSubscription(
+      productDetails,
+      priceBreakdown,
+      subscriptionOption,
+      translator,
+      managementUrl,
+      2,
+      1,
+    );
+
+  if (walletButtonStyle) {
+    options.buttonTheme = {
+      applePay: walletButtonStyle,
+      // Google Pay only supports "black" | "white"
+      googlePay:
+        walletButtonStyle === "white-outline" ? "white" : walletButtonStyle,
+    };
+  }
+
+  return options;
 };
 
 export const updateStripe = (
@@ -102,6 +116,7 @@ export const updateStripe = (
   rcPackage: Package,
   purchaseOption: PurchaseOption,
   translator: Translator,
+  walletButtonStyle?: WalletButtonStyleType,
 ) => {
   if (!gatewayParams.elements_configuration) {
     throw new PurchaseFlowError(PurchaseFlowErrorCode.ErrorSettingUpPurchase);
@@ -117,6 +132,7 @@ export const updateStripe = (
     purchaseOption,
     managementUrl,
     translator,
+    walletButtonStyle,
   );
   return { expOptions: options };
 };
@@ -128,6 +144,7 @@ export const initStripe = async (
   purchaseOption: PurchaseOption,
   translator: Translator,
   brandingInfo: BrandingInfoResponse | null,
+  walletButtonStyle?: WalletButtonStyleType,
 ) => {
   if (!gatewayParams.elements_configuration) {
     throw new PurchaseFlowError(PurchaseFlowErrorCode.ErrorSettingUpPurchase);
@@ -188,6 +205,7 @@ export const initStripe = async (
     purchaseOption,
     managementUrl,
     translator,
+    walletButtonStyle,
   );
 
   return { stripeInstance, elementsInstance, expOptions: options };


### PR DESCRIPTION
## Motivation / Description

Add a way to pass express checkout button theme to button renderer.

Frontend PR: https://github.com/RevenueCat/revenuecat-app/pull/9434
purchases-ui-js PR: https://github.com/RevenueCat/purchases-ui-js/pull/271

## Changes introduced

* Add an optional parameter to express checkout rendering function
* Pass the style parameter to Stripe

## Linear ticket (if any)

Related to: https://linear.app/revenuecat/issue/FUN-2144/express-checkout-button-theme-support

