### PR TITLE
Bump purchases-ui-js to 4.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@eslint/js": "^9.16.0",
     "@microsoft/api-extractor": "^7.48.0",
     "@paddle/paddle-js": "^1.5.1",
-    "@revenuecat/purchases-ui-js": "^4.3.0",
+    "@revenuecat/purchases-ui-js": "^4.5.1",
     "@storybook/addon-essentials": "^8.6.15",
     "@storybook/addon-interactions": "^8.6.15",
     "@storybook/addon-links": "^8.6.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1
       "@revenuecat/purchases-ui-js":
-        specifier: ^4.3.0
-        version: 4.3.0(svelte@5.46.4)
+        specifier: ^4.5.1
+        version: 4.5.1(svelte@5.46.4)
       "@storybook/addon-essentials":
         specifier: ^8.6.15
         version: 8.6.15(@types/react@19.0.10)(storybook@8.6.15(prettier@3.4.2))
@@ -722,10 +722,10 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
 
-  "@revenuecat/purchases-ui-js@4.3.0":
+  "@revenuecat/purchases-ui-js@4.5.1":
     resolution:
       {
-        integrity: sha512-mQWWWl0/aSnCphj+PmoVzJ6PFiYo7rg4Cjw2yk7EigGBDjXUvsD3oxDOw8rFZVgydrrNvnHjEJVoAeb5IWE6Rg==,
+        integrity: sha512-oBqoO03ifA1+37/WgSaR7qAu2UejaVW/+Cjtj+YuWeBDSz0zDFNho1R3e50FMWZrxVR6/lJU+faLRWwvSSlF5g==,
       }
     engines: { node: ^22.18 || ^24.11 }
     peerDependencies:
@@ -6155,7 +6155,7 @@ snapshots:
 
   "@pkgr/core@0.1.1": {}
 
-  "@revenuecat/purchases-ui-js@4.3.0(svelte@5.46.4)":
+  "@revenuecat/purchases-ui-js@4.5.1(svelte@5.46.4)":
     dependencies:
       qrcode: 1.5.4
       svelte: 5.46.4


### PR DESCRIPTION
### TL;DR

Bumps `@revenuecat/purchases-ui-js` from `4.3.0` to `4.5.1`.

### What changed?

The `@revenuecat/purchases-ui-js` dependency has been upgraded to `4.5.1`.

### 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency to a newer version.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RevenueCat/purchases-js/pull/872)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->