### PR TITLE
Add /pure entrypoint that resolves @stripe/stripe-js to its /pure variant

### DIFF
--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,3 +1,7 @@
+## RevenueCat SDK
+### ✨ New Features
+* Add `@revenuecat/purchases-js/pure` entrypoint that resolves `@stripe/stripe-js` to its `/pure` variant, so Stripe.js is not auto-loaded at SDK initialization. Intended for consumers bundling with Rollup's `output.inlineDynamicImports: true`.
+
 ## RevenueCatUI SDK
 ### 🐞 Bugfixes
 * Paywalls | Update purchases-ui-js to support visibility from custom variables w/tests (#870) via Rosie Watson (@RosieWatson)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ Login @ [app.revenuecat.com](https://app.revenuecat.com)
 
 See the [RevenueCat docs](https://www.revenuecat.com/docs/web/web-billing) and the [SDK Reference](https://revenuecat.github.io/purchases-js-docs).
 
+## The `/pure` entrypoint
+
+A secondary entrypoint, `@revenuecat/purchases-js/pure`, is also published. It exposes the exact same public API as the default entrypoint, but internally resolves `@stripe/stripe-js` to its [`/pure`](https://docs.stripe.com/sdks/stripejs-versioning#stripejs-pure-loader) variant. This means Stripe.js is not auto-loaded when the SDK module is evaluated — the `<script>` tag is only inserted into the page when a purchase actually begins.
+
+Use this entrypoint when bundling `@revenuecat/purchases-js` inside a library that sets Rollup's `output.inlineDynamicImports: true`, which would otherwise flatten the SDK's internal dynamic `import("@stripe/stripe-js")` into a static import and trigger Stripe.js to load at SDK initialization. For all other consumers, the default entrypoint is the right choice.
+
+```ts
+import { Purchases } from "@revenuecat/purchases-js/pure";
+```
+
 # Development
 
 ## Install the library in a local project

--- a/examples/webbilling-demo/src/App.tsx
+++ b/examples/webbilling-demo/src/App.tsx
@@ -14,6 +14,7 @@ import {
   loadPurchases,
   loadPurchasesWithDelayedStore,
 } from "./util/PurchasesLoader";
+import { loadPurchasesPure } from "./util/PurchasesLoaderPure";
 import RCPaywallPage from "./pages/rc_paywall";
 import DelayedStoreLoadPage from "./pages/delayed_store_load";
 import RCPaywallNoOfferingPassedPage from "./pages/rc_paywall_no_offering_passed";
@@ -22,6 +23,7 @@ import RedemptionLinksTester from "./pages/redemption_links_tester";
 import RCPaywallLauncherPage from "./pages/rc_paywall_launcher";
 import ExpressPurchaseButtonsPackageSelector from "./pages/express_purchase_buttons";
 import RCPaywallSettingsPage from "./pages/rc_paywall_settings";
+import PurePage from "./pages/pure";
 
 const router = createBrowserRouter([
   {
@@ -102,6 +104,15 @@ const router = createBrowserRouter([
     element: (
       <WithoutEntitlement>
         <DelayedStoreLoadPage />
+      </WithoutEntitlement>
+    ),
+  },
+  {
+    path: "/pure/:app_user_id",
+    loader: loadPurchasesPure,
+    element: (
+      <WithoutEntitlement>
+        <PurePage />
       </WithoutEntitlement>
     ),
   },

--- a/examples/webbilling-demo/src/pages/login/index.tsx
+++ b/examples/webbilling-demo/src/pages/login/index.tsx
@@ -29,6 +29,11 @@ const LoginPage: React.FC = () => {
     }
   };
 
+  const navigateToPureEntrypoint = (appUserId?: string) => {
+    const id = appUserId || Purchases.generateRevenueCatAnonymousAppUserId();
+    navigate(`/pure/${encodeURIComponent(id)}`);
+  };
+
   return (
     <div className="login">
       <h1>Hello! What's your user ID?</h1>
@@ -92,6 +97,10 @@ const LoginPage: React.FC = () => {
                 appUserId || Purchases.generateRevenueCatAnonymousAppUserId(),
               );
             }}
+          />
+          <Button
+            caption="Try /pure entrypoint"
+            onClick={() => navigateToPureEntrypoint(appUserId)}
           />
         </div>
       </form>

--- a/examples/webbilling-demo/src/pages/pure/index.tsx
+++ b/examples/webbilling-demo/src/pages/pure/index.tsx
@@ -1,0 +1,97 @@
+import type { Package } from "@revenuecat/purchases-js/pure";
+import { PurchasesError } from "@revenuecat/purchases-js/pure";
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { usePurchasesPureLoaderData } from "../../util/PurchasesLoaderPure";
+import Button from "../../components/Button";
+import LogoutButton from "../../components/LogoutButton";
+
+const PurePage: React.FC = () => {
+  const navigate = useNavigate();
+  const { purchases, offering } = usePurchasesPureLoaderData();
+
+  if (!offering) {
+    console.error("No offering found");
+    return <>No offering found!</>;
+  }
+  const packages: Package[] = offering?.availablePackages || [];
+
+  const onPackageCardClicked = async (pkg: Package) => {
+    if (!pkg.webBillingProduct) return;
+    const option = pkg.webBillingProduct.defaultSubscriptionOption;
+    try {
+      const { customerInfo } = await purchases.purchase({
+        rcPackage: pkg,
+        purchaseOption: option,
+        selectedLocale: navigator.language,
+      });
+      console.log(
+        `CustomerInfo after purchase: ${JSON.stringify(customerInfo)}`,
+      );
+      navigate(`/success/${purchases.getAppUserId()}`);
+    } catch (e) {
+      if (e instanceof PurchasesError) {
+        console.log(`Error performing purchase: ${e}`);
+      } else {
+        console.error(`Unknown error: ${e}`);
+      }
+    }
+  };
+
+  return (
+    <>
+      <LogoutButton />
+      <div className="rc-paywall">
+        <div
+          className="payment-method-badge"
+          style={{
+            backgroundColor: "#f7f8f9",
+            padding: "8px 16px",
+            borderRadius: "4px",
+            display: "inline-block",
+            fontSize: "14px",
+            fontWeight: "500",
+          }}
+        >
+          Pure entrypoint demo
+        </div>
+
+        <h1>Pure entrypoint test</h1>
+        <p style={{ maxWidth: "600px" }}>
+          This page imports the SDK from{" "}
+          <code>@revenuecat/purchases-js/pure</code>. Open DevTools → Network
+          and filter by <code>js.stripe.com</code>. Stripe.js should{" "}
+          <strong>not</strong> load until you click a package below to start a
+          purchase.
+        </p>
+
+        <div className="packages">
+          {packages.map((pkg) =>
+            pkg.webBillingProduct !== null ? (
+              <div
+                key={pkg.identifier}
+                role="button"
+                className="card"
+                onClick={() => onPackageCardClicked(pkg)}
+              >
+                <div className="cardContent">
+                  <div>
+                    <div className="productName">
+                      {pkg.webBillingProduct.title}
+                    </div>
+                    <div className="packageCTA">
+                      <Button caption="Choose plan" />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ) : null,
+          )}
+        </div>
+        <div className="notice">Demo only. No payment will be processed.</div>
+      </div>
+    </>
+  );
+};
+
+export default PurePage;

--- a/examples/webbilling-demo/src/util/PurchasesLoaderPure.ts
+++ b/examples/webbilling-demo/src/util/PurchasesLoaderPure.ts
@@ -1,0 +1,142 @@
+import type { CustomerInfo, Offering } from "@revenuecat/purchases-js/pure";
+import {
+  type FlagsConfig,
+  type HttpConfig,
+  type LogHandler,
+  type StoreLoadTime,
+  LogLevel,
+  Purchases,
+} from "@revenuecat/purchases-js/pure";
+import type { LoaderFunction } from "react-router-dom";
+import { redirect, useLoaderData } from "react-router-dom";
+
+declare global {
+  interface Window {
+    __RC_API_KEY__?: string;
+  }
+}
+
+const apiKey = window.__RC_API_KEY__ || import.meta.env.VITE_RC_API_KEY;
+const canary = import.meta.env.VITE_RC_CANARY;
+const proxyURL = import.meta.env.VITE_RC_PROXY_URL as string | undefined;
+const eventsURL = import.meta.env.VITE_RC_EVENTS_URL as string | undefined;
+
+type IPurchasesPureLoaderData = {
+  purchases: Purchases;
+  customerInfo: CustomerInfo;
+  offering: Offering;
+};
+
+const loadPurchasesPure: LoaderFunction<IPurchasesPureLoaderData> = async ({
+  params,
+  request,
+}) => {
+  const appUserId = params["app_user_id"];
+  const searchParams = new URL(request.url).searchParams;
+  const currency = searchParams.get("currency");
+  const offeringId = searchParams.get("offeringId");
+  const discountCode = searchParams.get("discountCode") || undefined;
+  const rcSource = searchParams.get("rcSource") || undefined;
+  const optOutOfAutoUTM =
+    searchParams.get("optOutOfAutoUTM") === "true" || false;
+  const useCustomLogger = searchParams.get("useCustomLogger") === "true";
+  const storeLoadTime =
+    (searchParams.get("storeLoadTime") as StoreLoadTime) || undefined;
+
+  if (!appUserId) {
+    throw redirect("/");
+  }
+  const additionalHeaders: Record<string, string> = {};
+  if (canary) {
+    additionalHeaders["X-RC-Canary"] = canary;
+  }
+
+  const httpConfig: HttpConfig = { additionalHeaders, proxyURL };
+  if (eventsURL) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    httpConfig.eventsURL = eventsURL;
+  }
+
+  const flagsConfig: FlagsConfig = {
+    autoCollectUTMAsMetadata: !optOutOfAutoUTM,
+    ...(storeLoadTime ? { storeLoadTime } : {}),
+  };
+  if (rcSource) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    flagsConfig.rcSource = rcSource;
+  }
+
+  if (useCustomLogger) {
+    const healthLogHandler: LogHandler = (level, message) => {
+      const healthIcon = "🏥";
+      const logMessage = `${healthIcon} ${message}`;
+
+      switch (level) {
+        case LogLevel.Error:
+          console.error(logMessage);
+          break;
+        case LogLevel.Warn:
+          console.warn(logMessage);
+          break;
+        case LogLevel.Info:
+          console.info(logMessage);
+          break;
+        case LogLevel.Debug:
+          console.debug(logMessage);
+          break;
+        case LogLevel.Verbose:
+          console.debug(logMessage);
+          break;
+      }
+    };
+
+    Purchases.setLogHandler(healthLogHandler);
+  } else {
+    Purchases.setLogHandler(null);
+  }
+
+  Purchases.setLogLevel(LogLevel.Verbose);
+  try {
+    if (!Purchases.isConfigured()) {
+      Purchases.configure({
+        apiKey,
+        appUserId,
+        httpConfig,
+        flags: flagsConfig,
+      });
+    } else {
+      await Purchases.getSharedInstance().changeUser(appUserId);
+    }
+    const purchases = Purchases.getSharedInstance();
+    const [customerInfo, offerings] = await Promise.all([
+      purchases.getCustomerInfo(),
+      purchases.getOfferings({
+        currency: currency || undefined,
+        offeringIdentifier: offeringId || undefined,
+
+        // @ts-expect-error - discountCode is experimental
+        discountCode: discountCode || undefined,
+      }),
+    ]);
+
+    const offering = offeringId
+      ? offerings.all[offeringId] || null
+      : offerings.current || null;
+
+    return {
+      purchases,
+      customerInfo,
+      offering,
+    };
+  } catch (error) {
+    console.error(error);
+    throw redirect("/");
+  }
+};
+
+const usePurchasesPureLoaderData: () => IPurchasesPureLoaderData = () =>
+  useLoaderData() as IPurchasesPureLoaderData;
+
+export { loadPurchasesPure, usePurchasesPureLoaderData };

--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
       "import": "./dist/Purchases.es.js",
       "require": "./dist/Purchases.umd.js"
     },
+    "./pure": {
+      "types": "./dist/Purchases.es.d.ts",
+      "import": "./dist/Purchases-pure.es.js",
+      "require": "./dist/Purchases-pure.umd.js"
+    },
     "./styles": {
       "import": "./dist/style.css",
       "require": "./dist/style.css"
@@ -37,8 +42,8 @@
   ],
   "scripts": {
     "watch": "vite build --watch",
-    "build": "tsc && vite build",
-    "build:dev": "tsc && vite build --mode development",
+    "build": "tsc && vite build && BUILD_VARIANT=pure vite build",
+    "build:dev": "tsc && vite build --mode development && BUILD_VARIANT=pure vite build --mode development",
     "build:dev-watch": "tsc && vite build --mode development --watch",
     "preview": "vite preview",
     "lint": "prettier --check . && eslint src/",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,6 @@
 import { fileURLToPath } from "url";
 import { dirname, resolve } from "path";
+import process from "node:process";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
@@ -7,18 +8,33 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const isPureBuild = process.env.BUILD_VARIANT === "pure";
+
 export default defineConfig({
   build: {
+    emptyOutDir: !isPureBuild,
     lib: {
       entry: resolve(__dirname, "src/main.ts"),
       name: "Purchases",
-      fileName: (format) => `Purchases.${format}.js`,
+      fileName: (format) =>
+        isPureBuild ? `Purchases-pure.${format}.js` : `Purchases.${format}.js`,
     },
   },
+  resolve: isPureBuild
+    ? {
+        alias: {
+          "@stripe/stripe-js": "@stripe/stripe-js/pure",
+        },
+      }
+    : undefined,
   plugins: [
-    dts({
-      rollupTypes: true,
-    }),
+    ...(isPureBuild
+      ? []
+      : [
+          dts({
+            rollupTypes: true,
+          }),
+        ]),
     svelte({ compilerOptions: { css: "injected" } }),
   ],
 });


### PR DESCRIPTION
## Summary

- Adds a secondary entrypoint, `@revenuecat/purchases-js/pure`, that exposes the same public API as the default but resolves `@stripe/stripe-js` to the [`/pure`](https://docs.stripe.com/sdks/stripejs-versioning#stripejs-pure-loader) variant at bundle time. The pure variant does not auto-inject the Stripe.js `<script>` tag on import — it's inserted only when a purchase begins.
- Motivation: when a downstream library bundles `purchases-js` with Rollup's `output.inlineDynamicImports: true` (required by some hybrid SDK distributions), our internal dynamic `import("@stripe/stripe-js")` is flattened to a static one, which causes Stripe.js to load at SDK initialization. The `/pure` entrypoint sidesteps that.
- Implemented via a build-time alias gated by `BUILD_VARIANT=pure`; no source changes in `src/`. Types are identical and shared between both entrypoints.
- Adds a `/pure` test page and "Try /pure entrypoint" button to the example app for manual verification.

## Usage

```ts
import { Purchases } from "@revenuecat/purchases-js/pure";
```

Same public API as the default entrypoint. Recommended only for consumers affected by `inlineDynamicImports`-style bundling.

## Test plan

- [x] `pnpm build` produces both `dist/Purchases.{es,umd}.js` and `dist/Purchases-pure.{es,umd}.js`
- [x] Default Stripe chunk contains the auto-load init (`Promise.resolve().then(E())`); pure chunk does not, and contains the pure-only `setLoadParameters` API
- [x] `pnpm typecheck`, `pnpm test` (591 tests), `prettier --check .`, `eslint src/` all pass
- [x] Example app builds and includes both Stripe loader chunks
- [ ] Manual smoke test in example app: `cd examples/webbilling-demo && pnpm dev`, visit `/pure/<id>`, confirm `js.stripe.com` is not requested until clicking a package
- [ ] Manual smoke test in a downstream Rollup project with `output.inlineDynamicImports: true`: import from `/pure`, confirm no Stripe.js request on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)