### PR TITLE
fix: using a regex instead of a fixed string to check the email address issues

### DIFF
--- a/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
+++ b/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
@@ -315,7 +315,10 @@ export async function confirmStripeCardError(page: Page, message: string) {
   await expect(cardError).toBeVisible();
 }
 
-export async function confirmStripeEmailError(page: Page, message: string) {
+export async function confirmStripeEmailError(
+  page: Page,
+  message: string | RegExp,
+) {
   const stripeFrame = getStripeEmailFrame(page);
   const emailError = stripeFrame.getByText(message);
   await expect(emailError).toBeVisible();

--- a/examples/webbilling-demo/src/tests/purchase-flow.test.ts
+++ b/examples/webbilling-demo/src/tests/purchase-flow.test.ts
@@ -220,7 +220,10 @@ test.describe("Purchase error paths", () => {
     const packageCards = await getPackageCards(page);
     await startPurchaseFlow(packageCards[1]);
     await enterEmail(page, "invalid-email");
-    await confirmStripeEmailError(page, "Your email address is invalid.");
+    await confirmStripeEmailError(
+      page,
+      /^Your email address is (?:incomplete|invalid)\.$/,
+    );
   });
 
   integrationTest.fixme(


### PR DESCRIPTION
## Motivation / Description
Stripe changed slightly the error name in the elements form for a wrong email.
This PR adjusts the label we expect to accept both the old and the new one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved email validation error handling tests to accept multiple error formats.

* **Style**
  * Reformatted function parameter layout for improved readability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RevenueCat/purchases-js/pull/878)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->