### PR TITLE
Migrated to using stripe pure

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -2002,7 +2002,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@revenuecat/purchases-js!FlagsConfig#storeLoadTime:member",
-              "docComment": "/**\n * Determines when the store module (e.g. Stripe) is loaded. - `\"configuration\"`: Preloaded when the SDK is configured (default). - `\"purchase_start\"`: Loaded on demand when a purchase is started.\n *\n * @defaultValue\n *\n * \"configuration\"\n */\n",
+              "docComment": "/**\n * Determines when the store module (e.g. Stripe) is loaded. - `\"configuration\"`: Preloaded when the SDK is configured (default). - `\"purchase_start\"`: Loaded on demand when a purchase is started.\n *\n * @deprecated\n *\n * we always load stripe only when needed\n *\n * @defaultValue\n *\n * \"configuration\"\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -8965,7 +8965,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "@revenuecat/purchases-js!StoreLoadTime:type",
-          "docComment": "/**\n * Determines when the store module (e.g. Stripe) is loaded. - `\"configuration\"`: The store module is preloaded when the SDK is configured. - `\"purchase_start\"`: The store module is loaded on demand when a purchase is started.\n *\n * @public\n */\n",
+          "docComment": "/**\n * Determines when the store module (e.g. Stripe) is loaded. - `\"configuration\"`: The store module is preloaded when the SDK is configured. - `\"purchase_start\"`: The store module is loaded on demand when a purchase is started.\n *\n * @deprecated\n *\n * we always load stripe only when needed\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -148,6 +148,7 @@ export enum ErrorCode {
 export interface FlagsConfig {
     autoCollectUTMAsMetadata?: boolean;
     collectAnalyticsEvents?: boolean;
+    // @deprecated
     storeLoadTime?: StoreLoadTime;
 }
 
@@ -557,7 +558,7 @@ export enum ReservedCustomerAttribute {
 // @public
 export type Store = "app_store" | "mac_app_store" | "play_store" | "amazon" | "stripe" | "rc_billing" | "promotional" | "paddle" | "test_store" | "galaxy" | "unknown";
 
-// @public
+// @public @deprecated
 export type StoreLoadTime = "configuration" | "purchase_start";
 
 // @public

--- a/src/entities/flags-config.ts
+++ b/src/entities/flags-config.ts
@@ -5,6 +5,7 @@ export const supportedRCSources = ["app", "embedded"];
  * - `"configuration"`: The store module is preloaded when the SDK is configured.
  * - `"purchase_start"`: The store module is loaded on demand when a purchase is started.
  * @public
+ * @deprecated we always load stripe only when needed
  */
 export type StoreLoadTime = "configuration" | "purchase_start";
 
@@ -53,6 +54,7 @@ export interface FlagsConfig {
    * - `"configuration"`: Preloaded when the SDK is configured (default).
    * - `"purchase_start"`: Loaded on demand when a purchase is started.
    * @defaultValue "configuration"
+   * @deprecated we always load stripe only when needed
    */
   storeLoadTime?: StoreLoadTime;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -118,9 +118,8 @@ import type {
   PresentExpressPurchaseButtonParams,
 } from "./entities/present-express-purchase-button-params";
 import { ExpressPurchaseButtonWrapper } from "./ui/express-purchase-button/express-purchase-button-wrapper.svelte";
-import { getWindow, getDocument } from "./helpers/browser-globals";
+import { getDocument, getWindow } from "./helpers/browser-globals";
 import { isAllowedCompleteWorkflowNavigateUrl } from "./helpers/complete-workflow-navigate-url";
-import { StripeService } from "./stripe/stripe-service";
 
 type UIComponentInteractionFields = UIComponentInteractionData & {
   componentURL?: string;
@@ -390,12 +389,6 @@ export class Purchases {
     const finalFlags = flags ?? defaultFlagsConfig;
 
     Purchases.validateConfig(config);
-    if (
-      finalFlags.storeLoadTime === "configuration" &&
-      (isWebBillingApiKey(apiKey) || isStripeApiKey(apiKey))
-    ) {
-      StripeService.preloadStripeModule();
-    }
     Purchases.instance = new Purchases(
       apiKey,
       appUserId,

--- a/src/stripe/stripe-service.ts
+++ b/src/stripe/stripe-service.ts
@@ -5,9 +5,11 @@ import type {
   Stripe,
   StripeElementLocale,
   StripeElements,
-  StripeError,
   StripeEmbeddedCheckout,
+  StripeError,
 } from "@stripe/stripe-js";
+import { loadStripe } from "@stripe/stripe-js/pure";
+
 import type { BrandingInfoResponse } from "../networking/responses/branding-response";
 import { Theme } from "../ui/theme/theme";
 import { DEFAULT_TEXT_STYLES } from "../ui/theme/text";
@@ -41,32 +43,6 @@ export type TaxCustomerDetails = {
 };
 
 export class StripeService {
-  /* eslint-disable @typescript-eslint/consistent-type-imports */
-  private static stripeModulePromise: Promise<
-    typeof import("@stripe/stripe-js")
-  > | null = null;
-  /* eslint-enable @typescript-eslint/consistent-type-imports */
-
-  static preloadStripeModule(): void {
-    if (!StripeService.stripeModulePromise) {
-      StripeService.stripeModulePromise = import("@stripe/stripe-js");
-    }
-  }
-
-  private static async getLoadStripe() {
-    if (!StripeService.stripeModulePromise) {
-      StripeService.stripeModulePromise = import("@stripe/stripe-js");
-    }
-    const { loadStripe } = await StripeService.stripeModulePromise.catch(() => {
-      throw new StripeServiceError(
-        StripeServiceErrorCode.ErrorLoadingStripe,
-        undefined,
-        "Failed to load Stripe library",
-      );
-    });
-    return loadStripe;
-  }
-
   private static FORM_VALIDATED_CARD_ERROR_CODES = [
     "card_declined",
     "expired_card",
@@ -107,8 +83,6 @@ export class StripeService {
     stripeAccountId: string,
     publishableApiKey: string,
   ): Promise<{ stripe: Stripe }> {
-    const loadStripe = await StripeService.getLoadStripe();
-
     const stripe = await loadStripe(publishableApiKey, {
       stripeAccount: stripeAccountId,
     }).catch((error) => {

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -26,7 +26,6 @@ import { waitFor } from "@testing-library/svelte";
 import { http, HttpResponse } from "msw";
 import { expectPromiseToError } from "./test-helpers";
 import { StatusCodes } from "http-status-codes";
-import { StripeService } from "../stripe/stripe-service";
 
 describe("Purchases.configure() legacy", () => {
   test("throws error if given invalid api key", () => {
@@ -291,46 +290,6 @@ describe("Purchases.configure()", () => {
         apiKey: testApiKey,
       } as PurchasesConfig),
     ).toThrowError(PurchasesError);
-  });
-
-  test("preloads Stripe module for web billing api key with default storeLoadTime", () => {
-    const spy = vi.spyOn(StripeService, "preloadStripeModule");
-    Purchases.configure({
-      apiKey: testApiKey,
-      appUserId: testUserId,
-    });
-    expect(spy).toHaveBeenCalled();
-    spy.mockRestore();
-  });
-
-  test("does not preload Stripe module for paddle api key", () => {
-    const spy = vi.spyOn(StripeService, "preloadStripeModule");
-    Purchases.configure({
-      apiKey: "pdl_valid_key",
-      appUserId: testUserId,
-    });
-    expect(spy).not.toHaveBeenCalled();
-    spy.mockRestore();
-  });
-
-  test("preloads Stripe module for stripe api key with default storeLoadTime", () => {
-    const spy = vi.spyOn(StripeService, "preloadStripeModule");
-    Purchases.configure({
-      apiKey: "strp_valid_key",
-      appUserId: testUserId,
-    });
-    expect(spy).toHaveBeenCalled();
-    spy.mockRestore();
-  });
-
-  test("does not preload Stripe module for simulated store api key", () => {
-    const spy = vi.spyOn(StripeService, "preloadStripeModule");
-    Purchases.configure({
-      apiKey: "test_valid_key",
-      appUserId: testUserId,
-    });
-    expect(spy).not.toHaveBeenCalled();
-    spy.mockRestore();
   });
 });
 

--- a/src/tests/stripe/stripe-service.test.ts
+++ b/src/tests/stripe/stripe-service.test.ts
@@ -10,7 +10,7 @@ import type {
   StripeElements,
   StripeError,
 } from "@stripe/stripe-js";
-import { loadStripe } from "@stripe/stripe-js";
+import { loadStripe } from "@stripe/stripe-js/pure";
 import type { StripeElementsConfiguration } from "../../networking/responses/stripe-elements";
 import type { BrandingInfoResponse } from "../../networking/responses/branding-response";
 import { Translator } from "../../ui/localization/translator";

--- a/src/tests/stripe/stripe-service.test.ts
+++ b/src/tests/stripe/stripe-service.test.ts
@@ -17,7 +17,7 @@ import { Translator } from "../../ui/localization/translator";
 import { product, trialProduct } from "../../stories/fixtures";
 import type { PriceBreakdown } from "../../ui/ui-types";
 
-vi.mock("@stripe/stripe-js", () => ({
+vi.mock("@stripe/stripe-js/pure", () => ({
   loadStripe: vi.fn(),
 }));
 


### PR DESCRIPTION
## Motivation / Description
We can migrate directly to Stripe pure instead of over-complicating with the config flag.
This PR does that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Deprecations**
  * Deprecated the `storeLoadTime` configuration option. The SDK now manages Stripe module loading automatically, loading it on-demand when needed.

* **Breaking Changes**
  * Removed the `StripeService.preloadStripeModule()` public method. Manual Stripe module preloading during SDK configuration is no longer available.

* **Documentation**
  * Updated API documentation to reflect deprecations and API changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RevenueCat/purchases-js/pull/882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->