### PR TITLE
[WEB-4282] Hide "Total excluding tax" when no tax

### DIFF
--- a/src/tests/ui/purchases-ui.test.ts
+++ b/src/tests/ui/purchases-ui.test.ts
@@ -32,24 +32,36 @@ const createCheckoutPricingResponse = (
     durationMode?: "time_window" | null;
     timeWindow?: string | null;
   },
-): CheckoutPricingResponse => ({
-  ...structuredClone(checkoutPricingResponse),
-  original_amount_in_micros:
-    checkoutPricingResponse.total_excluding_tax_in_micros,
-  applied_discounts: discountCode
-    ? [
-        {
-          identifier: "discount-id",
-          display_name: "SAVE10",
-          discounted_amount_in_micros: 1000000,
-          percentage: 10,
-          discount_code: discountCode,
-          duration_mode: options?.durationMode ?? null,
-          time_window: options?.timeWindow ?? null,
-        },
-      ]
-    : [],
-});
+): CheckoutPricingResponse => {
+  const subtotalInMicros =
+    checkoutPricingResponse.total_excluding_tax_in_micros;
+  const discountedAmountInMicros = 1000000;
+  const discountedSubtotalInMicros = discountCode
+    ? subtotalInMicros - discountedAmountInMicros
+    : subtotalInMicros;
+
+  return {
+    ...structuredClone(checkoutPricingResponse),
+    original_amount_in_micros: subtotalInMicros,
+    total_excluding_tax_in_micros: discountedSubtotalInMicros,
+    total_amount_in_micros: discountedSubtotalInMicros,
+    tax_amount_in_micros: 0,
+    tax_breakdown: [],
+    applied_discounts: discountCode
+      ? [
+          {
+            identifier: "discount-id",
+            display_name: "SAVE10",
+            discounted_amount_in_micros: discountedAmountInMicros,
+            percentage: 10,
+            discount_code: discountCode,
+            duration_mode: options?.durationMode ?? null,
+            time_window: options?.timeWindow ?? null,
+          },
+        ]
+      : [],
+  };
+};
 
 const purchaseOperationHelperMock: PurchaseOperationHelper = {
   prepareCheckout: async () => Promise.resolve(checkoutPrepareResponse),
@@ -342,6 +354,7 @@ describe("PurchasesUI", () => {
         screen.getByRole("button", { name: "Remove promo code SAVE10" }),
       ).toBeTruthy();
       expect(screen.getByText("-$1.00")).toBeTruthy();
+      expect(screen.queryByText("Total excluding tax")).not.toBeInTheDocument();
     });
   });
 

--- a/src/ui/molecules/pricing-table.svelte
+++ b/src/ui/molecules/pricing-table.svelte
@@ -262,33 +262,31 @@
       {/if}
     {/if}
 
-    {#if showDetailsControls}
-      {#if showTaxBreakdown}
-        <div class="rcb-pricing-table-row">
-          <div class="rcb-pricing-table-header">
-            <Typography size="body-small">
-              {$translator.translate(LocalizationKeys.PricingTotalExcludingTax)}
-            </Typography>
-          </div>
-          <div class="rcb-pricing-table-value">
-            <Typography size="body-small">
-              {#if isTaxCalculationPending}
-                <Skeleton>
-                  {$translator.formatPrice(
-                    priceBreakdown.totalExcludingTaxInMicros,
-                    priceBreakdown.currency,
-                  )}
-                </Skeleton>
-              {:else}
+    {#if showTaxBreakdown}
+      <div class="rcb-pricing-table-row">
+        <div class="rcb-pricing-table-header">
+          <Typography size="body-small">
+            {$translator.translate(LocalizationKeys.PricingTotalExcludingTax)}
+          </Typography>
+        </div>
+        <div class="rcb-pricing-table-value">
+          <Typography size="body-small">
+            {#if isTaxCalculationPending}
+              <Skeleton>
                 {$translator.formatPrice(
                   priceBreakdown.totalExcludingTaxInMicros,
                   priceBreakdown.currency,
                 )}
-              {/if}
-            </Typography>
-          </div>
+              </Skeleton>
+            {:else}
+              {$translator.formatPrice(
+                priceBreakdown.totalExcludingTaxInMicros,
+                priceBreakdown.currency,
+              )}
+            {/if}
+          </Typography>
         </div>
-      {/if}
+      </div>
 
       {#if priceBreakdown.taxCalculationStatus === "loading"}
         <div class="rcb-pricing-table-row" data-testid="tax-loading-skeleton">
@@ -338,9 +336,7 @@
         {/each}
       {/if}
 
-      {#if showTaxBreakdown}
-        <div class="rcb-pricing-table-separator"></div>
-      {/if}
+      <div class="rcb-pricing-table-separator"></div>
     {/if}
 
     {#if trialEndDate}

--- a/src/ui/molecules/pricing-table.svelte
+++ b/src/ui/molecules/pricing-table.svelte
@@ -335,7 +335,8 @@
           </div>
         {/each}
       {/if}
-
+    {/if}
+    {#if showTaxBreakdown || appliedDiscountCode}
       <div class="rcb-pricing-table-separator"></div>
     {/if}
 

--- a/src/ui/molecules/pricing-table.svelte
+++ b/src/ui/molecules/pricing-table.svelte
@@ -67,12 +67,20 @@
     priceBreakdown.appliedDiscounts?.[0] ?? null,
   );
 
+  const isTaxCalculationPending = $derived(
+    priceBreakdown.taxCalculationStatus === "loading" ||
+      priceBreakdown.taxCalculationStatus === "pending",
+  );
+
+  const showTaxBreakdown = $derived(
+    priceBreakdown.taxCalculationStatus !== "unavailable" &&
+      priceBreakdown.taxCalculationStatus !== "disabled" &&
+      (isTaxCalculationPending ||
+        (priceBreakdown.taxBreakdown?.length ?? 0) > 0),
+  );
+
   const showDetailsControls = $derived(
-    showDiscountCodeField ||
-      (priceBreakdown.taxCalculationStatus !== "unavailable" &&
-        priceBreakdown.taxCalculationStatus !== "disabled" &&
-        priceBreakdown.taxBreakdown &&
-        priceBreakdown.taxBreakdown.length > 0),
+    showDiscountCodeField || showTaxBreakdown,
   );
 
   const subtotalAmount = $derived(
@@ -227,7 +235,9 @@
             </Typography>
           </div>
         </div>
-        <div class="rcb-pricing-table-row">
+        <div
+          class="rcb-pricing-table-row rcb-pricing-table-row-applied-discount"
+        >
           <DiscountInput
             {showDiscountCodeField}
             {discountCode}
@@ -253,21 +263,32 @@
     {/if}
 
     {#if showDetailsControls}
-      <div class="rcb-pricing-table-row">
-        <div class="rcb-pricing-table-header">
-          <Typography size="body-small">
-            {$translator.translate(LocalizationKeys.PricingTotalExcludingTax)}
-          </Typography>
+      {#if showTaxBreakdown}
+        <div class="rcb-pricing-table-row">
+          <div class="rcb-pricing-table-header">
+            <Typography size="body-small">
+              {$translator.translate(LocalizationKeys.PricingTotalExcludingTax)}
+            </Typography>
+          </div>
+          <div class="rcb-pricing-table-value">
+            <Typography size="body-small">
+              {#if isTaxCalculationPending}
+                <Skeleton>
+                  {$translator.formatPrice(
+                    priceBreakdown.totalExcludingTaxInMicros,
+                    priceBreakdown.currency,
+                  )}
+                </Skeleton>
+              {:else}
+                {$translator.formatPrice(
+                  priceBreakdown.totalExcludingTaxInMicros,
+                  priceBreakdown.currency,
+                )}
+              {/if}
+            </Typography>
+          </div>
         </div>
-        <div class="rcb-pricing-table-value">
-          <Typography size="body-small">
-            {$translator.formatPrice(
-              priceBreakdown.totalExcludingTaxInMicros,
-              priceBreakdown.currency,
-            )}
-          </Typography>
-        </div>
-      </div>
+      {/if}
 
       {#if priceBreakdown.taxCalculationStatus === "loading"}
         <div class="rcb-pricing-table-row" data-testid="tax-loading-skeleton">
@@ -317,7 +338,9 @@
         {/each}
       {/if}
 
-      <div class="rcb-pricing-table-separator"></div>
+      {#if showTaxBreakdown}
+        <div class="rcb-pricing-table-separator"></div>
+      {/if}
     {/if}
 
     {#if trialEndDate}
@@ -377,6 +400,10 @@
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
+  }
+
+  .rcb-pricing-table-row-applied-discount {
+    align-items: flex-end;
   }
 
   .rcb-pricing-table-separator {

--- a/src/ui/molecules/pricing-table.svelte
+++ b/src/ui/molecules/pricing-table.svelte
@@ -271,7 +271,7 @@
         </div>
         <div class="rcb-pricing-table-value">
           <Typography size="body-small">
-            {#if isTaxCalculationPending}
+            {#if priceBreakdown.taxCalculationStatus === "loading"}
               <Skeleton>
                 {$translator.formatPrice(
                   priceBreakdown.totalExcludingTaxInMicros,


### PR DESCRIPTION
## Motivation / Description

Storybooks show the changes pretty clearly!

- We currently show "Total excluding tax" in all cases when a discount box is shown - we shouldn't do this
- Also show loading indicator for the "Total excluding tax" value when appropriate
- Aligned the discounted amount with the "X% off" and not centered between that and the discount code box.

## Changes introduced

## Linear ticket (if any)

## Additional comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows a loading state while tax calculations are pending and displays tax breakdown earlier when appropriate.

* **Bug Fixes**
  * Hides the "Total excluding tax" after applying a discount code and ensures checkout pricing refreshes and displays correctly with discounts.
  * Ensures details controls appear when a discount code field or tax breakdown is present.

* **Style**
  * Improved alignment and layout for applied-discount rows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RevenueCat/purchases-js/pull/886?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->