### PR TITLE
[WEB-4304] fix: Force billing address collection in Express Checkout element

### DIFF
--- a/src/stripe/stripe-service.ts
+++ b/src/stripe/stripe-service.ts
@@ -274,12 +274,11 @@ export class StripeService {
 
   static createExpressCheckoutElement(
     elements: StripeElements,
-    billingAddressRequired: boolean,
     forceEnableWalletMethods: boolean,
     expressCheckoutOptions?: StripeExpressCheckoutConfiguration,
   ) {
     const options = {
-      billingAddressRequired,
+      billingAddressRequired: true,
       emailRequired: true,
       ...(forceEnableWalletMethods
         ? {

--- a/src/ui/express-purchase-button/express-purchase-button.svelte
+++ b/src/ui/express-purchase-button/express-purchase-button.svelte
@@ -362,7 +362,6 @@
       onReady={onExpressCheckoutElementReady}
       {expressCheckoutOptions}
       forceEnableWalletMethods={false}
-      billingAddressRequired={brandingInfo?.gateway_tax_collection_enabled}
       hideCheckoutSeparator={true}
     />
   {/if}

--- a/src/ui/molecules/stripe-elements.svelte
+++ b/src/ui/molecules/stripe-elements.svelte
@@ -35,7 +35,6 @@
     brandingInfo: BrandingInfoResponse | null;
     forceEnableWalletMethods: boolean;
     skipEmail: boolean;
-    billingAddressRequired: boolean;
     onLoadingComplete: () => void;
     onError: (error: StripeServiceError) => void;
     onEmailChange: (complete: boolean, email: string) => void;
@@ -59,7 +58,6 @@
     brandingInfo,
     forceEnableWalletMethods,
     skipEmail,
-    billingAddressRequired,
     onLoadingComplete,
     onError,
     onEmailChange,
@@ -225,7 +223,6 @@
       onSubmit={onExpressCheckoutElementSubmit}
       {expressCheckoutOptions}
       {forceEnableWalletMethods}
-      {billingAddressRequired}
     />
     {#if !skipEmail}
       <LinkAuthenticationElement

--- a/src/ui/molecules/stripe-express-checkout-element.svelte
+++ b/src/ui/molecules/stripe-express-checkout-element.svelte
@@ -39,7 +39,6 @@
     onClick?: (event: StripeExpressCheckoutElementClickEvent) => void;
     onCancel?: () => void;
     elements: StripeElements;
-    billingAddressRequired: boolean;
     forceEnableWalletMethods: boolean;
     expressCheckoutOptions?: StripeExpressCheckoutConfiguration;
     hideCheckoutSeparator?: boolean;
@@ -52,7 +51,6 @@
     onClick,
     onCancel,
     elements,
-    billingAddressRequired,
     forceEnableWalletMethods,
     expressCheckoutOptions,
     hideCheckoutSeparator = false,
@@ -107,7 +105,6 @@
     try {
       expressCheckoutElement = StripeService.createExpressCheckoutElement(
         elements,
-        billingAddressRequired,
         forceEnableWalletMethods,
         expressCheckoutOptions,
       );

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -634,7 +634,6 @@
           {brandingInfo}
           {forceEnableWalletMethods}
           skipEmail={!!customerEmail}
-          billingAddressRequired={taxCalculationStatus !== "disabled"}
           onLoadingComplete={handleStripeLoadingComplete}
           onError={handleStripeElementError}
           onEmailChange={handleEmailChange}


### PR DESCRIPTION
## Motivation / Description

We want to always collect the billing address in the Express Checkout element, regardless of whether tax collection is currently enabled for the merchant. The reasoning:

- Forcing billing address collection has no visible impact on the user-facing UI of the Express Checkout wallets (Apple Pay, Google Pay, etc.).
- It lets us calculate and collect taxes correctly on renewal if tax collection gets enabled for the merchant after the initial checkout, without having to re-prompt the user or fall back to a non-taxable flow.

Previously, `billingAddressRequired` was wired through the component chain and toggled based on `taxCalculationStatus` / `brandingInfo.gateway_tax_collection_enabled`. That meant merchants with tax collection disabled at render time would not get a billing address, even if it later became relevant.

## Changes introduced

- Removed the `billingAddressRequired` prop from the component chain so the Express Checkout element always requests the billing address:
  - `payment-entry-page.svelte`: no longer computes/passes `billingAddressRequired={taxCalculationStatus !== "disabled"}`.
  - `express-purchase-button.svelte`: no longer passes `billingAddressRequired={brandingInfo?.gateway_tax_collection_enabled}`.
  - `stripe-elements.svelte` and `stripe-express-checkout-element.svelte`: drop the prop and stop forwarding it to `StripeService.createExpressCheckoutElement`.

## Linear ticket (if any)

[WEB-4304](https://linear.app/revenuecat/issue/WEB-4304)

## Additional comments

- No user-facing UI change is expected; the Express Checkout wallets do not visibly differ when `billingAddressRequired` is on vs. off.
- Worth a quick manual smoke test with Apple Pay / Google Pay on both tax-enabled and tax-disabled merchants to confirm nothing regresses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized billing-address behavior for express checkout (billing address no longer configurable per-invocation).
* **New Features**
  * Express checkout now reports readiness to improve wallet availability detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RevenueCat/purchases-js/pull/891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->