### PR TITLE
Show correctly discounted price in footer

### DIFF
--- a/examples/webbilling-demo/src/pages/paywall/index.tsx
+++ b/examples/webbilling-demo/src/pages/paywall/index.tsx
@@ -184,6 +184,8 @@ const PaywallPage: React.FC = () => {
   const displayName = searchParams.get("$displayName");
   const nickname = searchParams.get("nickname");
   const skipSuccessPage = searchParams.get("skipSuccessPage") === "true";
+  const showDiscountCodeField =
+    searchParams.get("showDiscountCodeField") === "true";
   const attributesSetRef = useRef(false);
 
   useEffect(() => {
@@ -247,6 +249,7 @@ const PaywallPage: React.FC = () => {
         await purchases.purchase({
           rcPackage: pkg,
           purchaseOption: option,
+          showDiscountCodeField,
           selectedLocale: lang || navigator.language,
           customerEmail: email || undefined,
           skipSuccessPage: skipSuccessPage,

--- a/examples/webbilling-demo/src/pages/rc_paywall/index.tsx
+++ b/examples/webbilling-demo/src/pages/rc_paywall/index.tsx
@@ -13,6 +13,8 @@ const RCPaywallPage: React.FC = () => {
   const lang = searchParams.get("lang");
   const email = searchParams.get("email");
   const hideBackButtons = searchParams.get("hideBackButtons") === "true";
+  const showDiscountCodeField =
+    searchParams.get("showDiscountCodeField") === "true";
   const {
     openSettings,
     settings: { customVariables },
@@ -30,6 +32,7 @@ const RCPaywallPage: React.FC = () => {
       .presentPaywall({
         offering: offering,
         htmlTarget: document.getElementById("paywall") || undefined,
+        showDiscountCodeField,
         selectedLocale: lang || undefined,
         hideBackButtons: hideBackButtons,
         customVariables,

--- a/examples/webbilling-demo/src/tests/helpers/fixtures.ts
+++ b/examples/webbilling-demo/src/tests/helpers/fixtures.ts
@@ -30,6 +30,7 @@ type CheckoutPricingResponse = {
     duration_mode?: "time_window" | null;
     time_window?: string | null;
   }>;
+  selected_purchase_option?: Record<string, unknown> | null;
   failed_reason?: string;
   interrupt_checkout?: boolean;
 };

--- a/src/entities/offerings.ts
+++ b/src/entities/offerings.ts
@@ -745,6 +745,25 @@ export const toProduct = (
   }
 };
 
+export const toPurchaseOptionForProductType = (
+  productType: ProductType,
+  purchaseOptionResponse:
+    | SubscriptionOptionResponse
+    | NonSubscriptionOptionResponse,
+): PurchaseOption | null => {
+  if (productType === ProductType.Subscription) {
+    if ("base" in purchaseOptionResponse) {
+      return toSubscriptionOption(purchaseOptionResponse);
+    }
+    return null;
+  }
+
+  if ("base_price" in purchaseOptionResponse) {
+    return toNonSubscriptionOption(purchaseOptionResponse);
+  }
+  return null;
+};
+
 const toNonSubscriptionProduct = (
   productDetailsData: ProductResponse,
   presentedOfferingContext: PresentedOfferingContext,

--- a/src/helpers/checkout-session-purchase-option-helper.ts
+++ b/src/helpers/checkout-session-purchase-option-helper.ts
@@ -1,0 +1,23 @@
+import type { Product, PurchaseOption } from "../entities/offerings";
+import { toPurchaseOptionForProductType } from "../entities/offerings";
+import type { CheckoutPricingResponse } from "../networking/responses/checkout-pricing-response";
+
+export function getActiveCheckoutPurchaseOption(
+  productDetails: Product,
+  fallbackPurchaseOption: PurchaseOption,
+  checkoutPricingResponse?: CheckoutPricingResponse | null,
+): PurchaseOption {
+  const selectedPurchaseOption =
+    checkoutPricingResponse?.selected_purchase_option;
+
+  if (!selectedPurchaseOption) {
+    return fallbackPurchaseOption;
+  }
+
+  return (
+    toPurchaseOptionForProductType(
+      productDetails.productType,
+      selectedPurchaseOption,
+    ) ?? fallbackPurchaseOption
+  );
+}

--- a/src/networking/responses/checkout-pricing-response.ts
+++ b/src/networking/responses/checkout-pricing-response.ts
@@ -1,5 +1,9 @@
 import type { StripeElementsConfiguration } from "./stripe-elements";
 import type { PriceBreakdown, TaxCalculationStatus } from "../../ui/ui-types";
+import type {
+  NonSubscriptionOptionResponse,
+  SubscriptionOptionResponse,
+} from "./products-response";
 
 export interface TaxBreakdown {
   tax_amount_in_micros: number;
@@ -15,6 +19,15 @@ export interface CheckoutAppliedDiscountResponse {
   duration_mode?: "time_window" | null;
   time_window?: string | null;
 }
+
+export type CheckoutPurchaseOptionResponse =
+  | NonSubscriptionOptionResponse
+  | SubscriptionOptionResponse;
+
+export type CheckoutPurchaseOptionsResponse = Record<
+  string,
+  CheckoutPurchaseOptionResponse
+>;
 
 export enum CheckoutPricingFailedReason {
   tax_collection_disabled = "tax_collection_disabled",
@@ -43,6 +56,7 @@ export interface CheckoutPricingResponse {
   interrupt_checkout?: boolean;
   original_amount_in_micros?: number;
   applied_discounts?: CheckoutAppliedDiscountResponse[];
+  selected_purchase_option?: CheckoutPurchaseOptionResponse | null;
 }
 
 export function createPriceBreakdownFromCheckoutPricingResponse(

--- a/src/stories/fixtures.ts
+++ b/src/stories/fixtures.ts
@@ -584,6 +584,21 @@ export const checkoutPricingResponse: CheckoutPricingResponse = {
       amount: 999 + 40,
     },
   },
+  selected_purchase_option: {
+    id: "option_id_1",
+    price_id: "price_1",
+    base: {
+      period_duration: "P1M",
+      cycle_count: 0,
+      price: {
+        amount_micros: 9990000,
+        currency: "USD",
+      },
+    },
+    trial: null,
+    intro_price: null,
+    discount: null,
+  },
 };
 
 export const checkoutCompleteResponse: CheckoutCompleteResponse = {

--- a/src/stories/pages/payment-entry-page.stories.svelte
+++ b/src/stories/pages/payment-entry-page.stories.svelte
@@ -154,6 +154,26 @@
   args={{
     ...defaultArgs,
     currentPage: "payment-entry",
+    defaultPriceBreakdown: {
+      currency: "USD",
+      originalAmountInMicros: 9900000,
+      totalAmountInMicros: 8900000,
+      totalExcludingTaxInMicros: 8900000,
+      taxCalculationStatus: "unavailable",
+      taxAmountInMicros: 0,
+      taxBreakdown: null,
+      appliedDiscounts: [
+        {
+          identifier: "discount-id",
+          displayName: "SAVE10",
+          discountedAmountInMicros: 1000000,
+          percentage: 10,
+          discountCode: "SAVE10",
+          durationMode: null,
+          timeWindow: null,
+        },
+      ],
+    },
     productDetails: {
       ...product,
       subscriptionOptions: {

--- a/src/tests/entities/offerings.test.ts
+++ b/src/tests/entities/offerings.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  ProductType,
+  toPurchaseOptionForProductType,
+} from "../../entities/offerings";
+import type {
+  NonSubscriptionOptionResponse,
+  SubscriptionOptionResponse,
+} from "../../networking/responses/products-response";
+
+const subscriptionOptionResponse: SubscriptionOptionResponse = {
+  id: "sub_option",
+  price_id: "sub_price",
+  base: {
+    cycle_count: 1,
+    period_duration: "P1M",
+    price: {
+      amount_micros: 9990000,
+      currency: "USD",
+    },
+  },
+  trial: null,
+  intro_price: null,
+  discount: null,
+};
+
+const nonSubscriptionOptionResponse: NonSubscriptionOptionResponse = {
+  id: "nonsub_option",
+  price_id: "nonsub_price",
+  base_price: {
+    amount_micros: 4990000,
+    currency: "USD",
+  },
+  discount: null,
+};
+
+describe("toPurchaseOptionForProductType", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("returns a subscription option when a subscription option is used for a subscription product", () => {
+    const result = toPurchaseOptionForProductType(
+      ProductType.Subscription,
+      subscriptionOptionResponse,
+    );
+
+    expect(result).toMatchObject({
+      id: "sub_option",
+      priceId: "sub_price",
+      base: {
+        cycleCount: 1,
+        periodDuration: "P1M",
+        price: expect.objectContaining({
+          amountMicros: 9990000,
+          currency: "USD",
+        }),
+      },
+    });
+  });
+
+  test("returns null when a subscription option is missing its base phase", () => {
+    const result = toPurchaseOptionForProductType(ProductType.Subscription, {
+      ...subscriptionOptionResponse,
+      base: null,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("returns null when a non-subscription option is used for a subscription product", () => {
+    const result = toPurchaseOptionForProductType(
+      ProductType.Subscription,
+      nonSubscriptionOptionResponse,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("returns null when a subscription option is used for a non-subscription product", () => {
+    const result = toPurchaseOptionForProductType(
+      ProductType.NonConsumable,
+      subscriptionOptionResponse,
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/tests/helpers/checkout-session-purchase-option-helper.test.ts
+++ b/src/tests/helpers/checkout-session-purchase-option-helper.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "vitest";
+import { ProductType } from "../../entities/offerings";
+import { getActiveCheckoutPurchaseOption } from "../../helpers/checkout-session-purchase-option-helper";
+import { product, subscriptionOption } from "../../stories/fixtures";
+import type { CheckoutPricingResponse } from "../../networking/responses/checkout-pricing-response";
+import {
+  StripeElementsMode,
+  StripeElementsSetupFutureUsage,
+} from "../../networking/responses/stripe-elements";
+
+const createCheckoutSessionState = (
+  overrides: Partial<CheckoutPricingResponse> = {},
+): CheckoutPricingResponse => ({
+  operation_session_id: "op_session",
+  currency: "USD",
+  total_amount_in_micros: 2990000,
+  tax_amount_in_micros: 0,
+  total_excluding_tax_in_micros: 2990000,
+  tax_inclusive: false,
+  tax_breakdown: [],
+  gateway_params: {
+    elements_configuration: {
+      amount: 299,
+      currency: "usd",
+      mode: StripeElementsMode.Payment,
+      payment_method_types: ["card"],
+      setup_future_usage: StripeElementsSetupFutureUsage.OffSession,
+    },
+  },
+  selected_purchase_option: {
+    id: "session_option",
+    price_id: "session_price",
+    base: {
+      cycle_count: 1,
+      period_duration: "P1M",
+      price: {
+        amount_micros: 2990000,
+        currency: "USD",
+      },
+    },
+    trial: {
+      cycle_count: 1,
+      period_duration: "P1W",
+      price: null,
+    },
+    intro_price: null,
+    discount: null,
+  },
+  ...overrides,
+});
+
+describe("getActiveCheckoutPurchaseOption", () => {
+  test("falls back to the /products purchase option before session purchase options exist", () => {
+    const activePurchaseOption = getActiveCheckoutPurchaseOption(
+      product,
+      subscriptionOption,
+      null,
+    );
+
+    expect(activePurchaseOption).toBe(subscriptionOption);
+  });
+
+  test("returns the operation-session purchase option when session selection data exists", () => {
+    const activePurchaseOption = getActiveCheckoutPurchaseOption(
+      product,
+      subscriptionOption,
+      createCheckoutSessionState(),
+    );
+
+    expect(activePurchaseOption.id).toBe("session_option");
+    expect(activePurchaseOption).toMatchObject({
+      id: "session_option",
+      trial: expect.objectContaining({
+        periodDuration: "P1W",
+      }),
+    });
+  });
+
+  test("falls back when the session selection cannot be resolved", () => {
+    const activePurchaseOption = getActiveCheckoutPurchaseOption(
+      {
+        ...product,
+        productType: ProductType.Subscription,
+      },
+      subscriptionOption,
+      createCheckoutSessionState({
+        selected_purchase_option: null,
+      }),
+    );
+
+    expect(activePurchaseOption).toBe(subscriptionOption);
+  });
+});

--- a/src/tests/ui/pages/payment-entry-page.test.ts
+++ b/src/tests/ui/pages/payment-entry-page.test.ts
@@ -6,6 +6,7 @@ import {
   checkoutPricingResponse,
   checkoutStartResponse,
   rcPackage,
+  subscriptionOption,
   stripeElementsConfiguration,
 } from "../../../stories/fixtures";
 import { checkoutPrepareResponse } from "../../test-responses";
@@ -442,5 +443,51 @@ describe("PurchasesUI", () => {
         error_code: null,
       },
     });
+  });
+
+  test("updates the initial price breakdown when the purchase option changes before session pricing exists", async () => {
+    const onPriceBreakdownUpdated = vi.fn();
+    const updatedPurchaseOption = {
+      ...structuredClone(subscriptionOption),
+      base: {
+        ...structuredClone(subscriptionOption).base,
+        price: {
+          ...structuredClone(subscriptionOption).base.price!,
+          amountMicros: 1230000,
+          currency: "EUR",
+        },
+      },
+    };
+
+    const component = render(PaymentEntryPage, {
+      props: {
+        ...basicProps,
+        brandingInfo: {
+          ...brandingInfo,
+          gateway_tax_collection_enabled: false,
+        },
+        onPriceBreakdownUpdated,
+      },
+      context: defaultContext,
+    });
+
+    await component.rerender({
+      ...basicProps,
+      brandingInfo: {
+        ...brandingInfo,
+        gateway_tax_collection_enabled: false,
+      },
+      purchaseOption: updatedPurchaseOption,
+      onPriceBreakdownUpdated,
+    });
+
+    expect(onPriceBreakdownUpdated).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        currency: "EUR",
+        originalAmountInMicros: 1230000,
+        totalExcludingTaxInMicros: 1230000,
+        totalAmountInMicros: 1230000,
+      }),
+    );
   });
 });

--- a/src/tests/ui/purchases-ui.test.ts
+++ b/src/tests/ui/purchases-ui.test.ts
@@ -23,6 +23,7 @@ import {
   checkoutPrepareResponse,
 } from "../test-responses";
 import type { CheckoutCompleteResponse } from "../../networking/responses/checkout-complete-response";
+import type { SubscriptionOptionResponse } from "../../networking/responses/products-response";
 
 const eventsTrackerMock = createEventsTrackerMock();
 
@@ -31,6 +32,7 @@ const createCheckoutPricingResponse = (
   options?: {
     durationMode?: "time_window" | null;
     timeWindow?: string | null;
+    selectedPurchaseOption?: SubscriptionOptionResponse | null;
   },
 ): CheckoutPricingResponse => {
   const subtotalInMicros =
@@ -47,6 +49,7 @@ const createCheckoutPricingResponse = (
     total_amount_in_micros: discountedSubtotalInMicros,
     tax_amount_in_micros: 0,
     tax_breakdown: [],
+    selected_purchase_option: options?.selectedPurchaseOption,
     applied_discounts: discountCode
       ? [
           {
@@ -62,6 +65,74 @@ const createCheckoutPricingResponse = (
       : [],
   };
 };
+
+const createSessionSubscriptionOptionResponse = (
+  fields: Partial<SubscriptionOptionResponse> = {},
+): SubscriptionOptionResponse => ({
+  id: "session_option",
+  price_id: "session_price",
+  base: {
+    cycle_count: 1,
+    period_duration: "P1M",
+    price: {
+      amount_micros: 2990000,
+      currency: "USD",
+    },
+  },
+  trial: null,
+  intro_price: null,
+  discount: null,
+  ...fields,
+});
+
+const sessionTrialPurchaseOption = createSessionSubscriptionOptionResponse({
+  id: "session_trial_option",
+  price_id: "session_trial_price",
+  trial: {
+    cycle_count: 1,
+    period_duration: "P1W",
+    price: null,
+  },
+});
+
+const sessionIntroBasePurchaseOption = createSessionSubscriptionOptionResponse({
+  id: "base_option",
+  price_id: "session_base_price",
+  intro_price: {
+    cycle_count: 1,
+    period_duration: "P2W",
+    price: {
+      amount_micros: 4990000,
+      currency: "USD",
+    },
+  },
+});
+
+const sessionForeverFreePurchaseOption =
+  createSessionSubscriptionOptionResponse({
+    id: "discnt_foreverfree",
+    price_id: "session_foreverfree_price",
+    base: {
+      cycle_count: 1,
+      period_duration: "P1Y",
+      price: {
+        amount_micros: 100000000,
+        currency: "USD",
+      },
+    },
+    trial: null,
+    intro_price: null,
+    discount: {
+      name: "foreverfree",
+      currency: "USD",
+      amount_micros: 0,
+      duration_mode: "forever",
+      time_window: null,
+      discount_type: "percentage",
+      percentage: 100,
+      fixed_amount_micros: null,
+    },
+  });
 
 const purchaseOperationHelperMock: PurchaseOperationHelper = {
   prepareCheckout: async () => Promise.resolve(checkoutPrepareResponse),
@@ -110,7 +181,11 @@ describe("PurchasesUI", () => {
 
     const calculateTaxSpy = vi
       .spyOn(purchaseOperationHelperMock, "checkoutRefreshPricing")
-      .mockResolvedValue(checkoutPricingResponse);
+      .mockResolvedValue(
+        createCheckoutPricingResponse(null, {
+          selectedPurchaseOption: sessionTrialPurchaseOption,
+        }),
+      );
 
     render(PurchasesUI, {
       props: {
@@ -125,6 +200,12 @@ describe("PurchasesUI", () => {
     await new Promise(process.nextTick);
 
     expect(calculateTaxSpy).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByText("Try free for 1 week")).toBeInTheDocument();
+      expect(
+        screen.getByText(/After your trial ends, you will be charged/i),
+      ).toBeInTheDocument();
+    });
   });
 
   test("does not perform tax calculation when gateway_tax_collection_enabled is false", async () => {
@@ -296,6 +377,57 @@ describe("PurchasesUI", () => {
     });
   });
 
+  test("does not render stale trial copy when session purchase option removes the trial", async () => {
+    vi.spyOn(purchaseOperationHelperMock, "checkoutStart").mockResolvedValue(
+      checkoutStartResponse,
+    );
+    vi.spyOn(
+      purchaseOperationHelperMock,
+      "checkoutRefreshPricing",
+    ).mockResolvedValue(
+      createCheckoutPricingResponse("FOREVERFREE", {
+        selectedPurchaseOption: sessionForeverFreePurchaseOption,
+      }),
+    );
+
+    render(PurchasesUI, {
+      props: {
+        ...basicProps,
+        brandingInfo: {
+          ...brandingInfo,
+          gateway_tax_collection_enabled: true,
+        },
+        showDiscountCodeField: true,
+        discountCode: "FOREVERFREE",
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/After trial ends, on/i)).toBeNull();
+      expect(screen.queryByText(/After your trial ends/i)).toBeNull();
+      expect(screen.queryByRole("button", { name: /start trial/i })).toBeNull();
+      expect(
+        screen.getByRole("button", { name: "Remove promo code FOREVERFREE" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test("falls back to /products purchase option data before session purchase options exist", async () => {
+    render(PurchasesUI, {
+      props: {
+        ...basicProps,
+        brandingInfo,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Try free for 1 week")).toBeNull();
+      expect(
+        screen.getByText(/By subscribing, you agree to allow/i),
+      ).toBeInTheDocument();
+    });
+  });
+
   test("shows the error page if incoming pricing refresh hits a fatal interrupt", async () => {
     const interruptError = new PurchaseFlowError(
       PurchaseFlowErrorCode.StripeMissingRequiredPermission,
@@ -325,7 +457,11 @@ describe("PurchasesUI", () => {
     const onDiscountCodeChanged = vi.fn();
     const checkoutRefreshPricingSpy = vi
       .spyOn(purchaseOperationHelperMock, "checkoutRefreshPricing")
-      .mockResolvedValue(createCheckoutPricingResponse("SAVE10"));
+      .mockResolvedValue(
+        createCheckoutPricingResponse("SAVE10", {
+          selectedPurchaseOption: sessionTrialPurchaseOption,
+        }),
+      );
 
     render(PurchasesUI, {
       props: {
@@ -355,6 +491,7 @@ describe("PurchasesUI", () => {
       ).toBeTruthy();
       expect(screen.getByText("-$1.00")).toBeTruthy();
       expect(screen.queryByText("Total excluding tax")).not.toBeInTheDocument();
+      expect(screen.getByText("Try free for 1 week")).toBeInTheDocument();
     });
   });
 
@@ -395,8 +532,16 @@ describe("PurchasesUI", () => {
     const onDiscountCodeChanged = vi.fn();
     const checkoutRefreshPricingSpy = vi
       .spyOn(purchaseOperationHelperMock, "checkoutRefreshPricing")
-      .mockResolvedValueOnce(createCheckoutPricingResponse("SAVE10"))
-      .mockResolvedValueOnce(createCheckoutPricingResponse(null));
+      .mockResolvedValueOnce(
+        createCheckoutPricingResponse("SAVE10", {
+          selectedPurchaseOption: sessionTrialPurchaseOption,
+        }),
+      )
+      .mockResolvedValueOnce(
+        createCheckoutPricingResponse(null, {
+          selectedPurchaseOption: sessionIntroBasePurchaseOption,
+        }),
+      );
 
     render(PurchasesUI, {
       props: {
@@ -411,6 +556,7 @@ describe("PurchasesUI", () => {
         screen.getByRole("button", { name: "Remove promo code SAVE10" }),
       ).toBeTruthy();
       expect(screen.getByText("-$1.00")).toBeTruthy();
+      expect(screen.getByText("Try free for 1 week")).toBeInTheDocument();
     });
 
     const removeButton = await screen.findByRole("button", {
@@ -425,6 +571,46 @@ describe("PurchasesUI", () => {
       expect(onDiscountCodeChanged).toHaveBeenCalledWith(null);
       expect(screen.getByLabelText("Promo code")).toBeTruthy();
       expect(screen.queryByText("-$1.00")).toBeNull();
+      expect(screen.queryByText("Try free for 1 week")).toBeNull();
+      expect(screen.getByText(/First 2 weeks for/i)).toBeInTheDocument();
+    });
+  });
+
+  test("keeps the current active purchase option unchanged when applying an invalid discount code fails", async () => {
+    vi.spyOn(purchaseOperationHelperMock, "checkoutRefreshPricing")
+      .mockResolvedValueOnce(
+        createCheckoutPricingResponse(null, {
+          selectedPurchaseOption: sessionTrialPurchaseOption,
+        }),
+      )
+      .mockRejectedValueOnce(new Error("Invalid promo code."));
+
+    render(PurchasesUI, {
+      props: {
+        ...basicProps,
+        brandingInfo: {
+          ...brandingInfo,
+          gateway_tax_collection_enabled: true,
+        },
+        showDiscountCodeField: true,
+      },
+    });
+
+    const discountCodeInput = screen.getByLabelText("Promo code");
+    await waitFor(() => {
+      expect(discountCodeInput).not.toBeDisabled();
+      expect(screen.getByText("Try free for 1 week")).toBeInTheDocument();
+    });
+
+    await fireEvent.input(discountCodeInput, {
+      target: { value: "BADCODE" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Code can't be applied.")).toBeInTheDocument();
+      expect(screen.getByText("Try free for 1 week")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("BADCODE")).toBeInTheDocument();
     });
   });
 });

--- a/src/ui/molecules/payment-button.svelte
+++ b/src/ui/molecules/payment-button.svelte
@@ -18,7 +18,7 @@
     selectedPaymentMethod?: string;
   };
 
-  const { disabled, subscriptionOption, priceBreakdown }: Props = $props();
+  let { disabled, subscriptionOption, priceBreakdown }: Props = $props();
 
   const translator: Writable<Translator> = getContext(translatorContextKey);
 

--- a/src/ui/molecules/pricing-table.svelte
+++ b/src/ui/molecules/pricing-table.svelte
@@ -29,7 +29,7 @@
     onRemoveDiscountCode: (() => void | Promise<void>) | undefined;
   }
 
-  const {
+  let {
     priceBreakdown,
     trialPhase,
     basePhase,

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -4,6 +4,7 @@
     ProductType,
     type Product,
     type PurchaseOption,
+    type SubscriptionOption,
   } from "../../entities/offerings";
   import { type BrandingInfoResponse } from "../../networking/responses/branding-response";
   import IconError from "../atoms/icons/icon-error.svelte";
@@ -70,6 +71,10 @@
     onContinue: () => void;
     onError: (error: PurchaseFlowError) => void;
     onPriceBreakdownUpdated: (priceBreakdown: PriceBreakdown) => void;
+    onSessionPricingUpdated?: (
+      pricingResponse: CheckoutPricingResponse,
+      priceBreakdown: PriceBreakdown,
+    ) => void;
     onProcessingStateChange?: (isProcessing: boolean) => void;
   }
 
@@ -79,7 +84,7 @@
 <script lang="ts">
   import { defaultPurchaseMode } from "../../behavioural-events/event";
 
-  const {
+  let {
     gatewayParams,
     managementUrl,
     productDetails,
@@ -93,17 +98,18 @@
     onContinue,
     onError,
     onPriceBreakdownUpdated,
+    onSessionPricingUpdated = undefined,
     onProcessingStateChange = undefined,
   }: Props = $props();
 
   const eventsTracker = getContext(eventsTrackerContextKey) as IEventsTracker;
   const translator = getContext<Writable<Translator>>(translatorContextKey);
-  const subscriptionOption =
-    productDetails.subscriptionOptions?.[purchaseOption.id];
+  const subscriptionOption = $derived(
+    "base" in purchaseOption ? (purchaseOption as SubscriptionOption) : null,
+  );
 
-  const initialPrice = getInitialPriceFromPurchaseOption(
-    productDetails,
-    purchaseOption,
+  const initialPrice = $derived(
+    getInitialPriceFromPurchaseOption(productDetails, purchaseOption),
   );
 
   let taxCalculationStatus: TaxCalculationStatus = $state<TaxCalculationStatus>(
@@ -214,19 +220,36 @@
     onPriceBreakdownUpdated(priceBreakdown);
   });
 
+  function applyLocalPriceBreakdown(nextPriceBreakdown: PriceBreakdown) {
+    taxCalculationStatus = nextPriceBreakdown.taxCalculationStatus;
+    originalAmountInMicros =
+      nextPriceBreakdown.originalAmountInMicros ?? initialPrice.amountMicros;
+    taxAmountInMicros = nextPriceBreakdown.taxAmountInMicros;
+    taxBreakdown = nextPriceBreakdown.taxBreakdown;
+    totalExcludingTaxInMicros = nextPriceBreakdown.totalExcludingTaxInMicros;
+    totalAmountInMicros = nextPriceBreakdown.totalAmountInMicros;
+    appliedDiscounts = nextPriceBreakdown.appliedDiscounts ?? [];
+  }
+
+  $effect(() => {
+    if (defaultPriceBreakdown) {
+      return;
+    }
+
+    originalAmountInMicros = initialPrice.amountMicros;
+    taxAmountInMicros = null;
+    taxBreakdown = null;
+    totalExcludingTaxInMicros = initialPrice.amountMicros;
+    totalAmountInMicros = initialPrice.amountMicros;
+    appliedDiscounts = [];
+  });
+
   $effect(() => {
     if (!defaultPriceBreakdown) {
       return;
     }
 
-    taxCalculationStatus = defaultPriceBreakdown.taxCalculationStatus;
-    originalAmountInMicros =
-      defaultPriceBreakdown.originalAmountInMicros ?? initialPrice.amountMicros;
-    taxAmountInMicros = defaultPriceBreakdown.taxAmountInMicros;
-    taxBreakdown = defaultPriceBreakdown.taxBreakdown;
-    totalExcludingTaxInMicros = defaultPriceBreakdown.totalExcludingTaxInMicros;
-    totalAmountInMicros = defaultPriceBreakdown.totalAmountInMicros;
-    appliedDiscounts = defaultPriceBreakdown.appliedDiscounts ?? [];
+    applyLocalPriceBreakdown(defaultPriceBreakdown);
   });
 
   $effect(() => {
@@ -308,16 +331,14 @@
       nextTaxCalculationStatus,
     );
 
-    taxCalculationStatus = nextPriceBreakdown.taxCalculationStatus;
-    originalAmountInMicros =
-      nextPriceBreakdown.originalAmountInMicros ?? initialPrice.amountMicros;
-    taxAmountInMicros = nextPriceBreakdown.taxAmountInMicros;
-    taxBreakdown = nextPriceBreakdown.taxBreakdown;
-    totalExcludingTaxInMicros = nextPriceBreakdown.totalExcludingTaxInMicros;
-    totalAmountInMicros = nextPriceBreakdown.totalAmountInMicros;
-    appliedDiscounts = nextPriceBreakdown.appliedDiscounts ?? [];
-    elementsConfiguration =
-      pricingResponse.gateway_params.elements_configuration;
+    if (onSessionPricingUpdated) {
+      onSessionPricingUpdated(pricingResponse, nextPriceBreakdown);
+    } else {
+      applyLocalPriceBreakdown(nextPriceBreakdown);
+      elementsConfiguration =
+        pricingResponse.gateway_params.elements_configuration;
+    }
+
     lastTaxCustomerDetails = taxCustomerDetails;
   }
 

--- a/src/ui/purchases-ui-inner.svelte
+++ b/src/ui/purchases-ui-inner.svelte
@@ -15,6 +15,7 @@
   import Template from "./layout/template.svelte";
   import { type GatewayParams } from "../networking/responses/stripe-elements";
   import BrandingHeader from "./molecules/branding-header.svelte";
+  import type { CheckoutPricingResponse } from "../networking/responses/checkout-pricing-response";
 
   interface Props {
     currentPage: CurrentPage;
@@ -42,12 +43,16 @@
     onApplyDiscountCode?: () => void | Promise<void>;
     onRemoveDiscountCode?: () => void | Promise<void>;
     onPaymentProcessingChange?: (isProcessing: boolean) => void;
+    onSessionPricingUpdated?: (
+      pricingResponse: CheckoutPricingResponse,
+      priceBreakdown: PriceBreakdown,
+    ) => void;
     onContinue: () => void;
     onError: (error: PurchaseFlowError) => void;
     onClose?: () => void;
   }
 
-  const {
+  let {
     currentPage,
     brandingInfo,
     productDetails,
@@ -73,6 +78,7 @@
     onApplyDiscountCode = undefined,
     onRemoveDiscountCode = undefined,
     onPaymentProcessingChange = undefined,
+    onSessionPricingUpdated = undefined,
     onContinue,
     onError,
     onClose = undefined,
@@ -160,6 +166,7 @@
         {onContinue}
         {onError}
         {onPriceBreakdownUpdated}
+        {onSessionPricingUpdated}
         onProcessingStateChange={onPaymentProcessingChange}
       />
     {/if}

--- a/src/ui/purchases-ui.svelte
+++ b/src/ui/purchases-ui.svelte
@@ -40,6 +40,7 @@
   } from "../networking/responses/checkout-pricing-response";
   import { validateEmail } from "../helpers/validators";
   import type { PriceBreakdown, TaxCalculationStatus } from "./ui-types";
+  import { getActiveCheckoutPurchaseOption } from "../helpers/checkout-session-purchase-option-helper";
 
   interface Props {
     customerEmail: string | undefined;
@@ -101,19 +102,40 @@
   let email = $state(emailError ? undefined : customerEmail);
 
   let productDetails: Product = $state(rcPackage.webBillingProduct);
-  let purchaseOptionToUse: PurchaseOption = $state(purchaseOption);
+  let latestCheckoutPricingResponse = $state<CheckoutPricingResponse | null>(
+    null,
+  );
+  let purchaseOptionToUse: PurchaseOption = $derived(
+    getActiveCheckoutPurchaseOption(
+      productDetails,
+      purchaseOption,
+      latestCheckoutPricingResponse,
+    ),
+  );
   let lastError: PurchaseFlowError | null = $state(null);
   let draftDiscountCode = $state(discountCode ?? "");
-  let appliedDiscountCode: string | null = $state(null);
   let discountCodeError: string | null = $state(null);
   let isUpdatingDiscountCode = $state(false);
   let isPaymentProcessing = $state(false);
 
   let currentPage: CurrentPage = $state("payment-entry-loading");
   let operationResult: OperationSessionSuccessfulResult | null = $state(null);
-  let gatewayParams: GatewayParams = $state({});
-  let currentPriceBreakdown: PriceBreakdown | undefined = $state(undefined);
+  let initialGatewayParams: GatewayParams = $state({});
   let managementUrl: string | null = $state(null);
+  let currentPriceBreakdown = $state<PriceBreakdown | undefined>(undefined);
+  let appliedDiscountCode: string | null = $derived(
+    latestCheckoutPricingResponse?.applied_discounts?.[0]?.discount_code ??
+      null,
+  );
+  let gatewayParams: GatewayParams = $derived.by(() => ({
+    ...initialGatewayParams,
+    ...(latestCheckoutPricingResponse?.gateway_params?.elements_configuration
+      ? {
+          elements_configuration:
+            latestCheckoutPricingResponse.gateway_params.elements_configuration,
+        }
+      : {}),
+  }));
 
   let originalHtmlHeight: string | null = $state(null);
   let originalHtmlOverflow: string | null = $state(null);
@@ -249,17 +271,17 @@
       PurchaseFlowErrorCode.StripeMissingRequiredPermission,
     ].includes(error.errorCode);
 
-  const applyPricingResponse = (response: CheckoutPricingResponse) => {
-    currentPriceBreakdown = createPriceBreakdownFromCheckoutPricingResponse(
-      response,
-      getTaxCalculationStatusForPricingResponse(response.failed_reason),
-    );
-    gatewayParams = {
-      ...gatewayParams,
-      elements_configuration: response.gateway_params.elements_configuration,
-    };
-    appliedDiscountCode =
-      response.applied_discounts?.[0]?.discount_code ?? null;
+  const applyPricingResponse = (
+    response: CheckoutPricingResponse,
+    nextPriceBreakdown?: PriceBreakdown,
+  ) => {
+    latestCheckoutPricingResponse = response;
+    currentPriceBreakdown =
+      nextPriceBreakdown ??
+      createPriceBreakdownFromCheckoutPricingResponse(
+        response,
+        getTaxCalculationStatusForPricingResponse(response.failed_reason),
+      );
   };
 
   onMount(async () => {
@@ -271,7 +293,7 @@
       );
       lastError = null;
       email = emailToUse;
-      gatewayParams = result.gateway_params;
+      initialGatewayParams = result.gateway_params;
       managementUrl = result.management_url;
 
       if (discountCode) {
@@ -441,6 +463,7 @@
   onApplyDiscountCode={handleApplyDiscountCode}
   onRemoveDiscountCode={handleRemoveDiscountCode}
   onPaymentProcessingChange={handlePaymentProcessingChange}
+  onSessionPricingUpdated={applyPricingResponse}
   onContinue={handleContinue}
   onError={handleError}
   {onClose}


### PR DESCRIPTION
## Motivation / Description

When a discount code is applied to a subscription with a free trial, the footer terms still show the undiscounted base price. This PR fixes that by using the updated purchase_options provided by the operation session endpoint.

## Changes Introduced

* Uses the correct discounted price in the footer.
* Updates the example app to allow us to enable `showDiscountCodeField` via a query param.

## Screenshots

## Before
<img width="967" height="615" alt="Screenshot 2026-06-02 at 11 35 28 AM" src="https://github.com/user-attachments/assets/cc8ae539-1f44-48d6-80ad-7cac3f1ba7a5" />

## After

#### Time window discount

<img width="986" height="483" alt="Screenshot 2026-06-10 at 12 15 40 PM" src="https://github.com/user-attachments/assets/950bfcd5-43e0-49d1-b042-39cacae686cc" />
<img width="983" height="474" alt="Screenshot 2026-06-10 at 12 15 22 PM" src="https://github.com/user-attachments/assets/c897a6d3-3019-4c9c-9f5f-7206564c1a44" />

#### One time discount
<img width="989" height="464" alt="Screenshot 2026-06-10 at 12 15 08 PM" src="https://github.com/user-attachments/assets/6a2441eb-d7a2-4aa4-81b0-62569ab0bdab" />
<img width="989" height="483" alt="Screenshot 2026-06-10 at 12 14 55 PM" src="https://github.com/user-attachments/assets/89257125-3ef9-45cf-9f33-5c4ff13a9cb1" />

#### Forever discount
<img width="984" height="492" alt="Screenshot 2026-06-10 at 12 14 43 PM" src="https://github.com/user-attachments/assets/b372dfe9-eae3-42b1-a5fd-78a0526cf1b3" />
<img width="1017" height="480" alt="Screenshot 2026-06-10 at 12 14 28 PM" src="https://github.com/user-attachments/assets/4d8d2f46-9d2d-4baf-95fc-e8744f5202e7" />



## Linear ticket (if any)

## Additional comments
Completes WEB-4344

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how purchase options and pricing copy are sourced during checkout and discount flows; incorrect fallback could misstate renewal prices or trial terms, though behavior is covered by new unit/UI tests.
> 
> **Overview**
> Fixes checkout footer and related copy showing **undiscounted** subscription terms (e.g. post-trial price) after a promo code is applied.
> 
> Checkout pricing responses now include **`selected_purchase_option`**. The UI resolves the **active purchase option** via `getActiveCheckoutPurchaseOption` (session option when present, otherwise the `/products` option), and **`purchases-ui`** keeps pricing, Stripe elements config, and applied discount code in sync with the latest session refresh instead of stale product catalog data.
> 
> **`payment-entry-page`** derives subscription phases from the passed `purchaseOption` (not `productDetails.subscriptionOptions`) and can bubble session pricing updates to the parent so trial/intro/discount labels update when codes are applied or removed.
> 
> The web billing demo exposes **`showDiscountCodeField`** through a query param on paywall routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca10ed693a7a96083fedfae791d70e20f8e070c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->