### PR TITLE
feat(paddle): inline checkout UI page, gated off by default (WST-567 PR 2)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1652,6 +1652,13 @@ export class Purchases {
           unmountPaddlePurchaseUi();
         });
 
+      // Cancel the checkout on browser back. The inline checkout has no
+      // Paddle-provided dismiss, so this (and the in-page close button) are the
+      // ways to back out. Mirrors the Web Billing / Stripe flows.
+      if (!isInElement) {
+        win.addEventListener("popstate", onClose as EventListener);
+      }
+
       const onFinished = this.createCheckoutOnFinishedHandler(
         resolve,
         appUserId,

--- a/src/paddle/paddle-service.ts
+++ b/src/paddle/paddle-service.ts
@@ -61,6 +61,12 @@ export interface PaddleCheckoutTotals {
   subtotalAmount: number;
   taxAmount: number;
   totalAmount: number;
+  /** Recurring total (incl. tax) for the next billing period, if subscription. */
+  recurringTotalAmount: number | null;
+  /** Product name from Paddle's first checkout item (e.g. "Premium"). */
+  productName: string | null;
+  /** Price name from Paddle's first checkout item (e.g. "monthly"). */
+  priceName: string | null;
 }
 
 /**
@@ -285,11 +291,15 @@ export class PaddleService {
 
     const forwardTotals = (data: PaddleEventData["data"]) => {
       if (onCheckoutTotals && data?.totals) {
+        const item = data.items?.[0];
         onCheckoutTotals({
           currencyCode: data.currency_code,
           subtotalAmount: data.totals.subtotal,
           taxAmount: data.totals.tax,
           totalAmount: data.totals.total,
+          recurringTotalAmount: data.recurring_totals?.total ?? null,
+          productName: item?.product?.name ?? null,
+          priceName: item?.price_name ?? null,
         });
       }
     };

--- a/src/paddle/paddle-service.ts
+++ b/src/paddle/paddle-service.ts
@@ -51,6 +51,19 @@ interface PaddlePurchaseParams {
 export type PaddleCheckoutDisplayMode = "overlay" | "inline";
 
 /**
+ * Order totals surfaced by Paddle's checkout events (`checkout.loaded` /
+ * `checkout.updated`). Amounts are in major currency units (e.g. 9.99). Lets
+ * the inline UI render the same Subtotal/Tax/Total breakdown Paddle's overlay
+ * shows, and keep it updated live as the customer enters their address.
+ */
+export interface PaddleCheckoutTotals {
+  currencyCode: string;
+  subtotalAmount: number;
+  taxAmount: number;
+  totalAmount: number;
+}
+
+/**
  * Class name of the container element Paddle injects its inline checkout iframe
  * into. The element must already exist in the DOM when `Checkout.open()` is
  * called. Only relevant when displayMode is "inline".
@@ -118,6 +131,12 @@ interface PaddlePurchase {
   params: PaddlePurchaseParams;
   onClose: () => void;
   displayMode?: PaddleCheckoutDisplayMode;
+  /**
+   * Invoked with the order totals whenever Paddle reports them
+   * (`checkout.loaded` and `checkout.updated`). Used by the inline UI to render
+   * the Subtotal/Tax/Total breakdown.
+   */
+  onCheckoutTotals?: (totals: PaddleCheckoutTotals) => void;
 }
 
 interface PaddleStartCheckoutParams {
@@ -259,9 +278,21 @@ export class PaddleService {
     onClose,
     params,
     displayMode = "overlay",
+    onCheckoutTotals,
   }: PaddlePurchase): Promise<OperationSessionSuccessfulResult> {
     const paddleInstance = this.getPaddleInstance();
     const { customerEmail, locale = "en" } = params;
+
+    const forwardTotals = (data: PaddleEventData["data"]) => {
+      if (onCheckoutTotals && data?.totals) {
+        onCheckoutTotals({
+          currencyCode: data.currency_code,
+          subtotalAmount: data.totals.subtotal,
+          taxAmount: data.totals.tax,
+          totalAmount: data.totals.total,
+        });
+      }
+    };
 
     return new Promise<OperationSessionSuccessfulResult>((resolve, reject) => {
       paddleInstance.Update({
@@ -272,6 +303,10 @@ export class PaddleService {
           try {
             if (eventName === CheckoutEventNames.CHECKOUT_LOADED) {
               onCheckoutLoaded();
+              forwardTotals(data);
+            } else if (eventName === CheckoutEventNames.CHECKOUT_UPDATED) {
+              // Totals change as the customer enters their address (tax) etc.
+              forwardTotals(data);
             } else if (eventName === CheckoutEventNames.CHECKOUT_COMPLETED) {
               // Close Paddle's success page to show the PaddlePurchaseUi status page
               paddleInstance.Checkout.close();

--- a/src/paddle/paddle-service.ts
+++ b/src/paddle/paddle-service.ts
@@ -193,6 +193,18 @@ export class PaddleService {
     return this.paddleInstance;
   }
 
+  /**
+   * Closes Paddle's checkout via `Paddle.Checkout.close()`. For the inline
+   * presentation this removes the embedded iframe from the DOM so we can return
+   * the user to the previous step (see Paddle's branded inline checkout docs).
+   * Safe no-op if Paddle isn't initialized.
+   */
+  closeCheckout(): void {
+    if (this.paddleInstance?.Initialized) {
+      this.paddleInstance.Checkout.close();
+    }
+  }
+
   async startCheckout({
     appUserId,
     productId,

--- a/src/tests/paddle/paddle-service.test.ts
+++ b/src/tests/paddle/paddle-service.test.ts
@@ -537,6 +537,8 @@ describe("PaddleService", () => {
         data: {
           currency_code: "USD",
           totals: { subtotal: 8.26, tax: 1.74, total: 10 },
+          recurring_totals: { subtotal: 8.26, tax: 1.74, total: 10 },
+          items: [{ price_name: "monthly", product: { name: "Premium" } }],
         },
       } as unknown as PaddleEventData);
 
@@ -545,6 +547,9 @@ describe("PaddleService", () => {
         subtotalAmount: 8.26,
         taxAmount: 1.74,
         totalAmount: 10,
+        recurringTotalAmount: 10,
+        productName: "Premium",
+        priceName: "monthly",
       });
 
       await paddleEventCallback({
@@ -560,6 +565,9 @@ describe("PaddleService", () => {
         subtotalAmount: 9.0,
         taxAmount: 1.9,
         totalAmount: 10.9,
+        recurringTotalAmount: null,
+        productName: null,
+        priceName: null,
       });
 
       purchasePromise.catch(() => {});

--- a/src/tests/paddle/paddle-service.test.ts
+++ b/src/tests/paddle/paddle-service.test.ts
@@ -299,6 +299,22 @@ describe("PaddleService", () => {
     });
   });
 
+  describe("closeCheckout", () => {
+    test("calls Paddle Checkout.close when initialized", async () => {
+      vi.mocked(initPaddle).mockResolvedValue(mockPaddleInstance);
+      await paddleService.initializePaddle("test-token", true);
+
+      paddleService.closeCheckout();
+
+      expect(mockPaddleInstance.Checkout?.close).toHaveBeenCalledTimes(1);
+    });
+
+    test("is a no-op when Paddle is not initialized", () => {
+      expect(() => paddleService.closeCheckout()).not.toThrow();
+      expect(mockPaddleInstance.Checkout?.close).not.toHaveBeenCalled();
+    });
+  });
+
   describe("startCheckout", () => {
     const startCheckoutArgs = {
       appUserId: "test-app-user-id",

--- a/src/tests/paddle/paddle-service.test.ts
+++ b/src/tests/paddle/paddle-service.test.ts
@@ -36,6 +36,7 @@ vi.mock("@paddle/paddle-js", () => ({
   initializePaddle: vi.fn(),
   CheckoutEventNames: {
     CHECKOUT_LOADED: "checkout.loaded",
+    CHECKOUT_UPDATED: "checkout.updated",
     CHECKOUT_COMPLETED: "checkout.completed",
     CHECKOUT_CLOSED: "checkout.closed",
   },
@@ -516,6 +517,50 @@ describe("PaddleService", () => {
           }),
         }),
       );
+
+      purchasePromise.catch(() => {});
+    });
+
+    test("forwards order totals on checkout.loaded and checkout.updated", async () => {
+      const onCheckoutTotals = vi.fn();
+      const purchasePromise = paddleService.purchase({
+        operationSessionId,
+        transactionId,
+        onCheckoutLoaded: vi.fn(),
+        onClose: vi.fn(),
+        params: purchaseParams,
+        onCheckoutTotals,
+      });
+
+      await paddleEventCallback({
+        name: CheckoutEventNames.CHECKOUT_LOADED,
+        data: {
+          currency_code: "USD",
+          totals: { subtotal: 8.26, tax: 1.74, total: 10 },
+        },
+      } as unknown as PaddleEventData);
+
+      expect(onCheckoutTotals).toHaveBeenCalledWith({
+        currencyCode: "USD",
+        subtotalAmount: 8.26,
+        taxAmount: 1.74,
+        totalAmount: 10,
+      });
+
+      await paddleEventCallback({
+        name: CheckoutEventNames.CHECKOUT_UPDATED,
+        data: {
+          currency_code: "USD",
+          totals: { subtotal: 9.0, tax: 1.9, total: 10.9 },
+        },
+      } as unknown as PaddleEventData);
+
+      expect(onCheckoutTotals).toHaveBeenLastCalledWith({
+        currencyCode: "USD",
+        subtotalAmount: 9.0,
+        taxAmount: 1.9,
+        totalAmount: 10.9,
+      });
 
       purchasePromise.catch(() => {});
     });

--- a/src/tests/ui/paddle-purchases-ui.test.ts
+++ b/src/tests/ui/paddle-purchases-ui.test.ts
@@ -608,5 +608,53 @@ describe("PaddlePurchasesUI", () => {
         screen.queryByTestId("paddle-return-button"),
       ).not.toBeInTheDocument();
     });
+
+    test("passes onCheckoutTotals to purchase when inline", async () => {
+      const paddleServiceMock = createPaddleServiceMock();
+      const purchaseSpy = vi.spyOn(paddleServiceMock, "purchase");
+
+      render(PaddlePurchasesUI, {
+        props: {
+          ...baseProps,
+          useInlineCheckout: true,
+          paddleService: paddleServiceMock,
+        },
+        context: defaultContext,
+      });
+
+      await waitFor(() => {
+        expect(purchaseSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ onCheckoutTotals: expect.any(Function) }),
+        );
+      });
+    });
+
+    test("renders the tax breakdown from Paddle totals", async () => {
+      const paddleServiceMock = createPaddleServiceMock();
+      // Report totals (incl. tax) the way Paddle's checkout.loaded event does,
+      // then keep the checkout open so the summary stays on screen.
+      vi.spyOn(paddleServiceMock, "purchase").mockImplementation((params) => {
+        params.onCheckoutTotals?.({
+          currencyCode: "USD",
+          subtotalAmount: 8.26,
+          taxAmount: 1.74,
+          totalAmount: 10,
+        });
+        return new Promise(() => {});
+      });
+
+      render(PaddlePurchasesUI, {
+        props: {
+          ...baseProps,
+          useInlineCheckout: true,
+          paddleService: paddleServiceMock,
+        },
+        context: defaultContext,
+      });
+
+      // The subtotal (excl. tax) only renders when the tax breakdown is shown,
+      // i.e. when we feed Paddle's calculated totals into the price breakdown.
+      expect(await screen.findByText("$8.26")).toBeInTheDocument();
+    });
   });
 });

--- a/src/tests/ui/paddle-purchases-ui.test.ts
+++ b/src/tests/ui/paddle-purchases-ui.test.ts
@@ -639,6 +639,9 @@ describe("PaddlePurchasesUI", () => {
           subtotalAmount: 8.26,
           taxAmount: 1.74,
           totalAmount: 10,
+          recurringTotalAmount: 10,
+          productName: "Premium",
+          priceName: "monthly",
         });
         return new Promise(() => {});
       });

--- a/src/tests/ui/paddle-purchases-ui.test.ts
+++ b/src/tests/ui/paddle-purchases-ui.test.ts
@@ -559,5 +559,48 @@ describe("PaddlePurchasesUI", () => {
         screen.queryByTestId("paddle-inline-checkout-container"),
       ).not.toBeInTheDocument();
     });
+
+    test("renders a close button that invokes onClose when not in an element", async () => {
+      const paddleServiceMock = createPaddleServiceMock();
+      vi.spyOn(paddleServiceMock, "purchase").mockImplementation(
+        () => new Promise(() => {}),
+      );
+      const onClose = vi.fn();
+
+      render(PaddlePurchasesUI, {
+        props: {
+          ...baseProps,
+          useInlineCheckout: true,
+          onClose,
+          paddleService: paddleServiceMock,
+        },
+        context: defaultContext,
+      });
+
+      const closeButton = await screen.findByTestId("close-button");
+      closeButton.click();
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    test("does not render the close button when embedded in an element", async () => {
+      const paddleServiceMock = createPaddleServiceMock();
+      vi.spyOn(paddleServiceMock, "purchase").mockImplementation(
+        () => new Promise(() => {}),
+      );
+
+      render(PaddlePurchasesUI, {
+        props: {
+          ...baseProps,
+          useInlineCheckout: true,
+          isInElement: true,
+          paddleService: paddleServiceMock,
+        },
+        context: defaultContext,
+      });
+
+      // Wait for the inline container to mount, then assert no close affordance.
+      await screen.findByTestId("paddle-inline-checkout-container");
+      expect(screen.queryByTestId("close-button")).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/tests/ui/paddle-purchases-ui.test.ts
+++ b/src/tests/ui/paddle-purchases-ui.test.ts
@@ -498,4 +498,66 @@ describe("PaddlePurchasesUI", () => {
     const sandboxBanner = await screen.findByText("SANDBOX");
     expect(sandboxBanner).toBeInTheDocument();
   });
+
+  describe("inline checkout (useInlineCheckout)", () => {
+    test("renders the inline checkout container when enabled", async () => {
+      const paddleServiceMock = createPaddleServiceMock();
+      // Keep purchase pending so the inline container stays mounted.
+      vi.spyOn(paddleServiceMock, "purchase").mockImplementation(
+        () => new Promise(() => {}),
+      );
+
+      render(PaddlePurchasesUI, {
+        props: {
+          ...baseProps,
+          useInlineCheckout: true,
+          paddleService: paddleServiceMock,
+        },
+        context: defaultContext,
+      });
+
+      const container = await screen.findByTestId(
+        "paddle-inline-checkout-container",
+      );
+      expect(container).toBeInTheDocument();
+    });
+
+    test("calls purchase with displayMode inline when enabled", async () => {
+      const paddleServiceMock = createPaddleServiceMock();
+      const purchaseSpy = vi.spyOn(paddleServiceMock, "purchase");
+
+      render(PaddlePurchasesUI, {
+        props: {
+          ...baseProps,
+          useInlineCheckout: true,
+          paddleService: paddleServiceMock,
+        },
+        context: defaultContext,
+      });
+
+      await waitFor(() => {
+        expect(purchaseSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ displayMode: "inline" }),
+        );
+      });
+    });
+
+    test("does not render the inline container or pass displayMode by default", async () => {
+      const paddleServiceMock = createPaddleServiceMock();
+      const purchaseSpy = vi.spyOn(paddleServiceMock, "purchase");
+
+      render(PaddlePurchasesUI, {
+        props: { ...baseProps, paddleService: paddleServiceMock },
+        context: defaultContext,
+      });
+
+      await waitFor(() => {
+        expect(purchaseSpy).toHaveBeenCalled();
+      });
+      expect(purchaseSpy.mock.calls[0][0]).not.toHaveProperty("displayMode");
+      expect(
+        screen.queryByTestId("paddle-inline-checkout-container"),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/tests/ui/paddle-purchases-ui.test.ts
+++ b/src/tests/ui/paddle-purchases-ui.test.ts
@@ -577,8 +577,10 @@ describe("PaddlePurchasesUI", () => {
         context: defaultContext,
       });
 
-      const closeButton = await screen.findByTestId("close-button");
-      closeButton.click();
+      // BrandingHeader renders both a back and a close button (same testid).
+      const closeButtons = await screen.findAllByTestId("close-button");
+      expect(closeButtons.length).toBeGreaterThan(0);
+      closeButtons[0].click();
       expect(onClose).toHaveBeenCalled();
     });
 
@@ -600,7 +602,7 @@ describe("PaddlePurchasesUI", () => {
 
       // Wait for the inline container to mount, then assert no close affordance.
       await screen.findByTestId("paddle-inline-checkout-container");
-      expect(screen.queryByTestId("close-button")).not.toBeInTheDocument();
+      expect(screen.queryAllByTestId("close-button")).toHaveLength(0);
     });
   });
 });

--- a/src/tests/ui/paddle-purchases-ui.test.ts
+++ b/src/tests/ui/paddle-purchases-ui.test.ts
@@ -561,7 +561,7 @@ describe("PaddlePurchasesUI", () => {
       ).not.toBeInTheDocument();
     });
 
-    test("renders a close button that invokes onClose when not in an element", async () => {
+    test("renders a return button that invokes onClose when not in an element", async () => {
       const paddleServiceMock = createPaddleServiceMock();
       vi.spyOn(paddleServiceMock, "purchase").mockImplementation(
         () => new Promise(() => {}),
@@ -578,17 +578,15 @@ describe("PaddlePurchasesUI", () => {
         context: defaultContext,
       });
 
-      // BrandingHeader renders both a back and a close button (same testid).
-      const closeButtons = await screen.findAllByTestId("close-button");
-      expect(closeButtons.length).toBeGreaterThan(0);
-      closeButtons[0].click();
+      const returnButton = await screen.findByTestId("paddle-return-button");
+      returnButton.click();
       // Inline cancel tears down Paddle's iframe via Checkout.close(), then
       // runs the normal close flow.
       expect(paddleServiceMock.closeCheckout).toHaveBeenCalled();
       expect(onClose).toHaveBeenCalled();
     });
 
-    test("does not render the close button when embedded in an element", async () => {
+    test("does not render the return button when embedded in an element", async () => {
       const paddleServiceMock = createPaddleServiceMock();
       vi.spyOn(paddleServiceMock, "purchase").mockImplementation(
         () => new Promise(() => {}),
@@ -604,9 +602,11 @@ describe("PaddlePurchasesUI", () => {
         context: defaultContext,
       });
 
-      // Wait for the inline container to mount, then assert no close affordance.
+      // Wait for the inline container to mount, then assert no return affordance.
       await screen.findByTestId("paddle-inline-checkout-container");
-      expect(screen.queryAllByTestId("close-button")).toHaveLength(0);
+      expect(
+        screen.queryByTestId("paddle-return-button"),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/src/tests/ui/paddle-purchases-ui.test.ts
+++ b/src/tests/ui/paddle-purchases-ui.test.ts
@@ -53,6 +53,7 @@ const createPaddleServiceMock = (): PaddleService => {
   return {
     startCheckout: vi.fn().mockResolvedValue(paddleCheckoutStartResponse),
     purchase: vi.fn().mockResolvedValue(operationSessionSuccessfulResult),
+    closeCheckout: vi.fn(),
   } as unknown as PaddleService;
 };
 
@@ -581,6 +582,9 @@ describe("PaddlePurchasesUI", () => {
       const closeButtons = await screen.findAllByTestId("close-button");
       expect(closeButtons.length).toBeGreaterThan(0);
       closeButtons[0].click();
+      // Inline cancel tears down Paddle's iframe via Checkout.close(), then
+      // runs the normal close flow.
+      expect(paddleServiceMock.closeCheckout).toHaveBeenCalled();
       expect(onClose).toHaveBeenCalled();
     });
 

--- a/src/ui/organisms/paddle-order-summary.svelte
+++ b/src/ui/organisms/paddle-order-summary.svelte
@@ -1,113 +1,157 @@
 <script lang="ts">
   import { getContext } from "svelte";
   import { type Writable } from "svelte/store";
-  import ProductHeader from "../molecules/product-header.svelte";
-  import PricingTable from "../molecules/pricing-table.svelte";
   import Typography from "../atoms/typography.svelte";
   import { Theme } from "../theme/theme";
   import { translatorContextKey } from "../localization/constants";
   import { Translator } from "../localization/translator";
+  import { getInitialPriceFromPurchaseOption } from "../../helpers/purchase-option-price-helper";
   import type { BrandingInfoResponse } from "../../networking/responses/branding-response";
   import {
     type Product,
     type PurchaseOption,
     type SubscriptionOption,
-    type NonSubscriptionOption,
-    type PricingPhase,
   } from "../../entities/offerings";
-  import { type PriceBreakdown } from "../ui-types";
+  import { type Period } from "../../helpers/duration-helper";
+  import type { PaddleCheckoutTotals } from "../../paddle/paddle-service";
 
   interface Props {
     brandingInfo: BrandingInfoResponse | null;
     productDetails: Product;
     purchaseOption: PurchaseOption;
-    priceBreakdown: PriceBreakdown;
+    // Live order totals from Paddle's checkout events (null until the inline
+    // checkout reports them); drives the breakdown + recurring amount.
+    totals: PaddleCheckoutTotals | null;
   }
 
-  const {
-    brandingInfo,
-    productDetails,
-    purchaseOption,
-    priceBreakdown,
-  }: Props = $props();
+  const { brandingInfo, productDetails, purchaseOption, totals }: Props =
+    $props();
 
   const translator: Writable<Translator> = getContext(translatorContextKey);
 
-  // Card chrome comes from the same branding/appearance config the rest of the
-  // checkout uses: the form background for the cards, the shape preset for the
-  // corner radius. The amount uses the primary (buttons) color.
+  // Card chrome from the branding/appearance config: form background for the
+  // cards, primary (buttons) color for the amount. Corner radius is generous to
+  // match the hosted overlay summary.
   const theme = new Theme(brandingInfo?.appearance ?? null);
   const cardBackground = theme.formColors.background;
-  const cardRadius = theme.shape["input-border-radius"];
 
   const isSubscription = productDetails.productType === "subscription";
-  const subscriptionOption = isSubscription
-    ? (purchaseOption as SubscriptionOption)
+  const basePeriod: Period | null = isSubscription
+    ? ((purchaseOption as SubscriptionOption)?.base?.period ?? null)
     : null;
-  const nonSubscriptionOption = !isSubscription
-    ? (purchaseOption as NonSubscriptionOption)
-    : null;
-  const basePhase: PricingPhase | null = isSubscription
-    ? (subscriptionOption?.base ?? null)
-    : nonSubscriptionOption?.basePrice
-      ? {
-          periodDuration: null,
-          period: null,
-          cycleCount: 1,
-          price: nonSubscriptionOption.basePrice,
-          pricePerWeek: null,
-          pricePerMonth: null,
-          pricePerYear: null,
-        }
-      : null;
-  const trialPhase = subscriptionOption?.trial ?? null;
+
+  const toMicros = (amount: number): number => Math.round(amount * 1_000_000);
+
+  const fallbackPrice = getInitialPriceFromPurchaseOption(
+    productDetails,
+    purchaseOption,
+  );
+  const currency = $derived(totals?.currencyCode ?? fallbackPrice.currency);
+  const totalMicros = $derived(
+    totals ? toMicros(totals.totalAmount) : fallbackPrice.amountMicros,
+  );
+
+  const formatAmount = (micros: number): string =>
+    $translator.formatPrice(micros, currency);
+
+  const periodUnitLabel = $derived(
+    basePeriod ? $translator.translatePeriodUnit(basePeriod.unit) : null,
+  );
+  const billedFrequencyLabel = $derived(
+    basePeriod
+      ? $translator.translatePeriodFrequency(basePeriod.number, basePeriod.unit)
+      : null,
+  );
+
+  const productName = $derived(totals?.productName ?? productDetails.title);
+  const priceName = $derived(totals?.priceName ?? null);
+  const hasTax = $derived(!!totals && totals.taxAmount > 0);
+
+  // Best-effort next billing date for the recurring row: today + the base
+  // period. The exact Paddle renewal date isn't exposed through checkout events.
+  const nextBillingLabel = $derived.by(() => {
+    if (!totals || totals.recurringTotalAmount === null || !basePeriod)
+      return null;
+    const date = new Date();
+    const n = basePeriod.number;
+    switch (basePeriod.unit) {
+      case "day":
+        date.setDate(date.getDate() + n);
+        break;
+      case "week":
+        date.setDate(date.getDate() + 7 * n);
+        break;
+      case "month":
+        date.setMonth(date.getMonth() + n);
+        break;
+      case "year":
+        date.setFullYear(date.getFullYear() + n);
+        break;
+      default:
+        return null;
+    }
+    return new Intl.DateTimeFormat(undefined, {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    }).format(date);
+  });
 </script>
 
-<div
-  class="rcb-paddle-summary"
-  style="--rcb-card-bg: {cardBackground}; --rcb-card-radius: {cardRadius};"
->
+<div class="rcb-paddle-summary" style="--rcb-card-bg: {cardBackground};">
+  <!-- Product card -->
   <div class="rcb-paddle-summary-card">
-    <div class="rcb-paddle-summary-amount">
-      {$translator.formatPrice(
-        priceBreakdown.totalAmountInMicros,
-        priceBreakdown.currency,
-      )}
+    <div class="rcb-paddle-summary-amount-row">
+      <span class="rcb-paddle-summary-amount">{formatAmount(totalMicros)}</span>
+      {#if hasTax}
+        <span class="rcb-paddle-summary-muted">inc. VAT</span>
+      {/if}
     </div>
-    <ProductHeader
-      {productDetails}
-      showProductDescription={brandingInfo?.appearance
-        ?.show_product_description ?? false}
-    />
-    {#if basePhase?.period}
-      <Typography size="body-small">
-        {$translator.translatePeriodFrequency(
-          basePhase.period.number,
-          basePhase.period.unit,
-        )}
-      </Typography>
+    {#if billedFrequencyLabel}
+      <Typography size="body-small">billed {billedFrequencyLabel}</Typography>
     {/if}
+
+    <div class="rcb-paddle-summary-product">
+      <Typography size="body-base">{productName}</Typography>
+      {#if priceName}
+        <span class="rcb-paddle-summary-muted">{priceName}</span>
+      {/if}
+      <div class="rcb-paddle-summary-product-price">
+        <span>{formatAmount(totalMicros)}</span>
+        {#if periodUnitLabel}
+          <span class="rcb-paddle-summary-muted">/ {periodUnitLabel}</span>
+        {/if}
+      </div>
+    </div>
   </div>
 
-  <div class="rcb-paddle-summary-card">
-    <PricingTable
-      {priceBreakdown}
-      {trialPhase}
-      {basePhase}
-      promotionalPricePhase={null}
-      hasDiscount={false}
-      showDiscountCodeField={false}
-      discountCode=""
-      appliedDiscountCode={null}
-      appliedDiscountPercentage={null}
-      discountCodeError={null}
-      isUpdatingDiscountCode={false}
-      isDiscountCodeControlsEnabled={false}
-      onDiscountCodeChange={undefined}
-      onApplyDiscountCode={undefined}
-      onRemoveDiscountCode={undefined}
-    />
-  </div>
+  <!-- Totals breakdown card -->
+  {#if totals}
+    <div class="rcb-paddle-summary-card">
+      <div class="rcb-paddle-summary-row">
+        <span class="rcb-paddle-summary-muted">Subtotal</span>
+        <span>{formatAmount(toMicros(totals.subtotalAmount))}</span>
+      </div>
+      {#if hasTax}
+        <div class="rcb-paddle-summary-row">
+          <span class="rcb-paddle-summary-muted">VAT</span>
+          <span>{formatAmount(toMicros(totals.taxAmount))}</span>
+        </div>
+      {/if}
+      <hr class="rcb-paddle-summary-divider" />
+      <div class="rcb-paddle-summary-row rcb-paddle-summary-row-strong">
+        <span>Total</span>
+        <span>{formatAmount(toMicros(totals.totalAmount))}</span>
+      </div>
+      {#if totals.recurringTotalAmount !== null && nextBillingLabel}
+        <div class="rcb-paddle-summary-row">
+          <span class="rcb-paddle-summary-muted">Due on {nextBillingLabel}</span
+          >
+          <span>{formatAmount(toMicros(totals.recurringTotalAmount))}</span>
+        </div>
+      {/if}
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -120,17 +164,58 @@
 
   .rcb-paddle-summary-card {
     background: var(--rcb-card-bg);
-    border-radius: var(--rcb-card-radius);
-    padding: var(--rc-spacing-gapLarge-mobile, 24px);
+    border-radius: 16px;
+    padding: 28px;
     display: flex;
     flex-direction: column;
     gap: var(--rc-spacing-gapMedium-mobile, 12px);
+  }
+
+  .rcb-paddle-summary-amount-row {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
   }
 
   .rcb-paddle-summary-amount {
     color: var(--rc-color-primary);
     font-weight: 700;
     font-size: 2rem;
-    line-height: 1.2;
+    line-height: 1.1;
+  }
+
+  .rcb-paddle-summary-product {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .rcb-paddle-summary-product-price {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    font-weight: 600;
+    font-size: 1.25rem;
+  }
+
+  .rcb-paddle-summary-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .rcb-paddle-summary-row-strong {
+    font-weight: 700;
+  }
+
+  .rcb-paddle-summary-muted {
+    color: var(--rc-color-grey-text-light);
+  }
+
+  .rcb-paddle-summary-divider {
+    border: none;
+    border-top: 1px solid var(--rc-color-grey-ui-light);
+    margin: 4px 0;
+    width: 100%;
   }
 </style>

--- a/src/ui/organisms/paddle-order-summary.svelte
+++ b/src/ui/organisms/paddle-order-summary.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+  import { getContext } from "svelte";
+  import { type Writable } from "svelte/store";
+  import ProductHeader from "../molecules/product-header.svelte";
+  import PricingTable from "../molecules/pricing-table.svelte";
+  import Typography from "../atoms/typography.svelte";
+  import { Theme } from "../theme/theme";
+  import { translatorContextKey } from "../localization/constants";
+  import { Translator } from "../localization/translator";
+  import type { BrandingInfoResponse } from "../../networking/responses/branding-response";
+  import {
+    type Product,
+    type PurchaseOption,
+    type SubscriptionOption,
+    type NonSubscriptionOption,
+    type PricingPhase,
+  } from "../../entities/offerings";
+  import { type PriceBreakdown } from "../ui-types";
+
+  interface Props {
+    brandingInfo: BrandingInfoResponse | null;
+    productDetails: Product;
+    purchaseOption: PurchaseOption;
+    priceBreakdown: PriceBreakdown;
+  }
+
+  const {
+    brandingInfo,
+    productDetails,
+    purchaseOption,
+    priceBreakdown,
+  }: Props = $props();
+
+  const translator: Writable<Translator> = getContext(translatorContextKey);
+
+  // Card chrome comes from the same branding/appearance config the rest of the
+  // checkout uses: the form background for the cards, the shape preset for the
+  // corner radius. The amount uses the primary (buttons) color.
+  const theme = new Theme(brandingInfo?.appearance ?? null);
+  const cardBackground = theme.formColors.background;
+  const cardRadius = theme.shape["input-border-radius"];
+
+  const isSubscription = productDetails.productType === "subscription";
+  const subscriptionOption = isSubscription
+    ? (purchaseOption as SubscriptionOption)
+    : null;
+  const nonSubscriptionOption = !isSubscription
+    ? (purchaseOption as NonSubscriptionOption)
+    : null;
+  const basePhase: PricingPhase | null = isSubscription
+    ? (subscriptionOption?.base ?? null)
+    : nonSubscriptionOption?.basePrice
+      ? {
+          periodDuration: null,
+          period: null,
+          cycleCount: 1,
+          price: nonSubscriptionOption.basePrice,
+          pricePerWeek: null,
+          pricePerMonth: null,
+          pricePerYear: null,
+        }
+      : null;
+  const trialPhase = subscriptionOption?.trial ?? null;
+</script>
+
+<div
+  class="rcb-paddle-summary"
+  style="--rcb-card-bg: {cardBackground}; --rcb-card-radius: {cardRadius};"
+>
+  <div class="rcb-paddle-summary-card">
+    <div class="rcb-paddle-summary-amount">
+      {$translator.formatPrice(
+        priceBreakdown.totalAmountInMicros,
+        priceBreakdown.currency,
+      )}
+    </div>
+    <ProductHeader
+      {productDetails}
+      showProductDescription={brandingInfo?.appearance
+        ?.show_product_description ?? false}
+    />
+    {#if basePhase?.period}
+      <Typography size="body-small">
+        {$translator.translatePeriodFrequency(
+          basePhase.period.number,
+          basePhase.period.unit,
+        )}
+      </Typography>
+    {/if}
+  </div>
+
+  <div class="rcb-paddle-summary-card">
+    <PricingTable
+      {priceBreakdown}
+      {trialPhase}
+      {basePhase}
+      promotionalPricePhase={null}
+      hasDiscount={false}
+      showDiscountCodeField={false}
+      discountCode=""
+      appliedDiscountCode={null}
+      appliedDiscountPercentage={null}
+      discountCodeError={null}
+      isUpdatingDiscountCode={false}
+      isDiscountCodeControlsEnabled={false}
+      onDiscountCodeChange={undefined}
+      onApplyDiscountCode={undefined}
+      onRemoveDiscountCode={undefined}
+    />
+  </div>
+</div>
+
+<style>
+  .rcb-paddle-summary {
+    display: flex;
+    flex-direction: column;
+    gap: var(--rc-spacing-gapLarge-mobile, 16px);
+    width: 100%;
+  }
+
+  .rcb-paddle-summary-card {
+    background: var(--rcb-card-bg);
+    border-radius: var(--rcb-card-radius);
+    padding: var(--rc-spacing-gapLarge-mobile, 24px);
+    display: flex;
+    flex-direction: column;
+    gap: var(--rc-spacing-gapMedium-mobile, 12px);
+  }
+
+  .rcb-paddle-summary-amount {
+    color: var(--rc-color-primary);
+    font-weight: 700;
+    font-size: 2rem;
+    line-height: 1.2;
+  }
+</style>

--- a/src/ui/organisms/paddle-order-summary.svelte
+++ b/src/ui/organisms/paddle-order-summary.svelte
@@ -12,7 +12,12 @@
     type PurchaseOption,
     type SubscriptionOption,
   } from "../../entities/offerings";
-  import { type Period } from "../../helpers/duration-helper";
+  import {
+    getNextRenewalDate,
+    type Period,
+  } from "../../helpers/duration-helper";
+  import { toBcp47Locale } from "../../helpers/locale-helper";
+  import { LocalizationKeys } from "../localization/supportedLanguages";
   import type { PaddleCheckoutTotals } from "../../paddle/paddle-service";
 
   interface Props {
@@ -35,9 +40,13 @@
   const theme = new Theme(brandingInfo?.appearance ?? null);
   const cardBackground = theme.formColors.background;
 
-  const isSubscription = productDetails.productType === "subscription";
-  const basePeriod: Period | null = isSubscription
-    ? ((purchaseOption as SubscriptionOption)?.base?.period ?? null)
+  // Type guard instead of an unchecked `as SubscriptionOption` cast: only
+  // subscription options expose `base`, which carries the renewal period.
+  const isSubscriptionOption = (
+    option: PurchaseOption,
+  ): option is SubscriptionOption => "base" in option;
+  const basePeriod: Period | null = isSubscriptionOption(purchaseOption)
+    ? (purchaseOption.base.period ?? null)
     : null;
 
   const toMicros = (amount: number): number => Math.round(amount * 1_000_000);
@@ -68,33 +77,19 @@
   const hasTax = $derived(!!totals && totals.taxAmount > 0);
 
   // Best-effort next billing date for the recurring row: today + the base
-  // period. The exact Paddle renewal date isn't exposed through checkout events.
+  // period, formatted in the active locale. Reuses getNextRenewalDate so the
+  // leap-year / month-overflow edge cases live in one place. The exact Paddle
+  // renewal date isn't exposed through checkout events.
   const nextBillingLabel = $derived.by(() => {
     if (!totals || totals.recurringTotalAmount === null || !basePeriod)
       return null;
-    const date = new Date();
-    const n = basePeriod.number;
-    switch (basePeriod.unit) {
-      case "day":
-        date.setDate(date.getDate() + n);
-        break;
-      case "week":
-        date.setDate(date.getDate() + 7 * n);
-        break;
-      case "month":
-        date.setMonth(date.getMonth() + n);
-        break;
-      case "year":
-        date.setFullYear(date.getFullYear() + n);
-        break;
-      default:
-        return null;
-    }
-    return new Intl.DateTimeFormat(undefined, {
+    const renewalDate = getNextRenewalDate(new Date(), basePeriod, true);
+    if (!renewalDate) return null;
+    return new Intl.DateTimeFormat(toBcp47Locale($translator.selectedLocale), {
       day: "numeric",
       month: "long",
       year: "numeric",
-    }).format(date);
+    }).format(renewalDate);
   });
 </script>
 
@@ -104,7 +99,7 @@
     <div class="rcb-paddle-summary-amount-row">
       <span class="rcb-paddle-summary-amount">{formatAmount(totalMicros)}</span>
       {#if hasTax}
-        <span class="rcb-paddle-summary-muted">inc. VAT</span>
+        <span class="rcb-paddle-summary-muted">inc. tax</span>
       {/if}
     </div>
     {#if billedFrequencyLabel}
@@ -131,18 +126,26 @@
   {#if totals}
     <div class="rcb-paddle-summary-card">
       <div class="rcb-paddle-summary-row">
-        <span class="rcb-paddle-summary-muted">Subtotal</span>
+        <span class="rcb-paddle-summary-muted"
+          >{$translator.translate(LocalizationKeys.PricingTableSubtotal)}</span
+        >
         <span>{formatAmount(toMicros(totals.subtotalAmount))}</span>
       </div>
       {#if hasTax}
         <div class="rcb-paddle-summary-row">
-          <span class="rcb-paddle-summary-muted">VAT</span>
+          <span class="rcb-paddle-summary-muted"
+            >{$translator.translate(LocalizationKeys.PricingTableTax)}</span
+          >
           <span>{formatAmount(toMicros(totals.taxAmount))}</span>
         </div>
       {/if}
       <hr class="rcb-paddle-summary-divider" />
       <div class="rcb-paddle-summary-row rcb-paddle-summary-row-strong">
-        <span>Total</span>
+        <span
+          >{$translator.translate(
+            LocalizationKeys.PricingTableTotalDueToday,
+          )}</span
+        >
         <span>{formatAmount(toMicros(totals.totalAmount))}</span>
       </div>
       {#if totals.recurringTotalAmount !== null && nextBillingLabel}

--- a/src/ui/organisms/paddle-order-summary.svelte
+++ b/src/ui/organisms/paddle-order-summary.svelte
@@ -114,7 +114,9 @@
     <div class="rcb-paddle-summary-product">
       <Typography size="body-base">{productName}</Typography>
       {#if priceName}
-        <span class="rcb-paddle-summary-muted">{priceName}</span>
+        <span class="rcb-paddle-summary-muted rcb-paddle-summary-price-name"
+          >{priceName}</span
+        >
       {/if}
       <div class="rcb-paddle-summary-product-price">
         <span>{formatAmount(totalMicros)}</span>
@@ -188,6 +190,12 @@
     display: flex;
     flex-direction: column;
     gap: 2px;
+    /* Extra separation between the amount/billing line and the product block. */
+    margin-top: var(--rc-spacing-gapLarge-mobile, 16px);
+  }
+
+  .rcb-paddle-summary-price-name {
+    font-size: 0.8125rem;
   }
 
   .rcb-paddle-summary-product-price {
@@ -196,6 +204,8 @@
     gap: 6px;
     font-weight: 600;
     font-size: 1.25rem;
+    /* A bit more separation from the price-name line above. */
+    margin-top: var(--rc-spacing-gapSmall-mobile, 8px);
   }
 
   .rcb-paddle-summary-row {

--- a/src/ui/paddle-inline-checkout-page.svelte
+++ b/src/ui/paddle-inline-checkout-page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import FullscreenTemplate from "./layout/fullscreen-template.svelte";
+  import CloseButton from "./molecules/close-button.svelte";
   import { type BrandingInfoResponse } from "../networking/responses/branding-response";
   import { PADDLE_INLINE_FRAME_TARGET } from "../paddle/paddle-service";
 
@@ -7,20 +8,42 @@
     brandingInfo: BrandingInfoResponse | null;
     isSandbox: boolean;
     isInElement: boolean;
+    onClose: () => void;
   }
 
-  const { brandingInfo, isSandbox, isInElement }: Props = $props();
+  const { brandingInfo, isSandbox, isInElement, onClose }: Props = $props();
 </script>
 
 <FullscreenTemplate {brandingInfo} {isInElement} {isSandbox}>
   {#snippet mainContent()}
-    <!-- Paddle injects its inline checkout iframe into this container (its
-         frameTarget className). The element must already exist in the DOM when
-         PaddleService.purchase() calls Paddle.Checkout.open(). -->
-    <div
-      class={PADDLE_INLINE_FRAME_TARGET}
-      data-testid="paddle-inline-checkout-container"
-      style="width: 100%; min-height: 450px;"
-    ></div>
+    <div class="rcb-paddle-inline-checkout">
+      {#if !isInElement}
+        <!-- Inline checkout has no Paddle-provided dismiss (unlike the overlay
+             modal), so we render our own close affordance to cancel. -->
+        <div class="rcb-paddle-inline-checkout-header">
+          <CloseButton on:click={onClose} />
+        </div>
+      {/if}
+      <!-- Paddle injects its inline checkout iframe into this container (its
+           frameTarget className). The element must already exist in the DOM when
+           PaddleService.purchase() calls Paddle.Checkout.open(). -->
+      <div
+        class={PADDLE_INLINE_FRAME_TARGET}
+        data-testid="paddle-inline-checkout-container"
+        style="width: 100%; min-height: 450px;"
+      ></div>
+    </div>
   {/snippet}
 </FullscreenTemplate>
+
+<style>
+  .rcb-paddle-inline-checkout {
+    width: 100%;
+  }
+
+  .rcb-paddle-inline-checkout-header {
+    display: flex;
+    justify-content: flex-end;
+    width: 100%;
+  }
+</style>

--- a/src/ui/paddle-inline-checkout-page.svelte
+++ b/src/ui/paddle-inline-checkout-page.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
-  import FullscreenTemplate from "./layout/fullscreen-template.svelte";
-  import BrandingHeader from "./molecules/branding-header.svelte";
+  import Template from "./layout/template.svelte";
   import ProductInfo from "./organisms/product-info.svelte";
+  import SuccessPage from "./pages/success-page.svelte";
+  import ErrorPage from "./pages/error-page.svelte";
+  import Icon from "./atoms/icon.svelte";
   import { type BrandingInfoResponse } from "../networking/responses/branding-response";
   import type { Product, PurchaseOption } from "../entities/offerings";
   import { getInitialPriceFromPurchaseOption } from "../helpers/purchase-option-price-helper";
   import { type PriceBreakdown } from "./ui-types";
   import { PADDLE_INLINE_FRAME_TARGET } from "../paddle/paddle-service";
+  import { type PurchaseFlowError } from "../helpers/purchase-operation-helper";
 
   interface Props {
     brandingInfo: BrandingInfoResponse | null;
@@ -15,6 +18,10 @@
     onClose: () => void;
     productDetails: Product;
     purchaseOption: PurchaseOption;
+    currentPage: "waiting" | "loading" | "success" | "error";
+    lastError: PurchaseFlowError | null;
+    onContinue: () => void;
+    closeWithError: () => void;
   }
 
   const {
@@ -24,9 +31,13 @@
     onClose,
     productDetails,
     purchaseOption,
+    currentPage,
+    lastError,
+    onContinue,
+    closeWithError,
   }: Props = $props();
 
-  // Paddle's iframe shows the authoritative totals; the product-info panel
+  // Paddle's iframe shows the authoritative totals; the order-summary panel
   // mirrors the Web Billing / Stripe layout using the option's initial price.
   const initialPrice = getInitialPriceFromPurchaseOption(
     productDetails,
@@ -40,23 +51,48 @@
     taxAmountInMicros: null,
     taxBreakdown: null,
   };
+
+  const appName = brandingInfo?.app_name ?? null;
 </script>
 
-<FullscreenTemplate {brandingInfo} {isInElement} {isSandbox}>
+<Template {brandingInfo} {isInElement} {isSandbox} {onClose}>
+  {#snippet navbarHeaderContent()}
+    {#if !isInElement}
+      <!-- Inline checkout embeds Paddle's iframe in our page, so we provide the
+           back affordance (Paddle's own "Return to <seller>" link only exists in
+           the overlay/hosted checkout, not inline). -->
+      <button
+        type="button"
+        class="rcb-paddle-return-button"
+        data-testid="paddle-return-button"
+        onclick={onClose}
+      >
+        <Icon name="back" />
+        <span>{appName ? `Return to ${appName}` : "Back"}</span>
+      </button>
+    {/if}
+  {/snippet}
+  {#snippet navbarBodyContent()}
+    <ProductInfo
+      {productDetails}
+      {purchaseOption}
+      showProductDescription={brandingInfo?.appearance
+        ?.show_product_description ?? false}
+      {priceBreakdown}
+    />
+  {/snippet}
   {#snippet mainContent()}
-    <div class="rcb-paddle-inline-checkout">
-      {#if !isInElement}
-        <!-- Inline checkout has no Paddle-provided dismiss (unlike the overlay
-             modal), so render our own branded header with a back/close button. -->
-        <BrandingHeader {brandingInfo} {onClose} showCloseButton={true} />
-      {/if}
-      <ProductInfo
+    {#if currentPage === "success"}
+      <SuccessPage {onContinue} />
+    {:else if currentPage === "error"}
+      <ErrorPage
+        {lastError}
         {productDetails}
-        {purchaseOption}
-        showProductDescription={brandingInfo?.appearance
-          ?.show_product_description ?? false}
-        {priceBreakdown}
+        supportEmail={brandingInfo?.support_email ?? null}
+        onDismiss={closeWithError}
+        appName={brandingInfo?.app_name ?? null}
       />
+    {:else}
       <!-- Paddle injects its inline checkout iframe into this container (its
            frameTarget className). The element must already exist in the DOM when
            PaddleService.purchase() calls Paddle.Checkout.open(). -->
@@ -65,16 +101,20 @@
         data-testid="paddle-inline-checkout-container"
         style="width: 100%; min-height: 450px;"
       ></div>
-    </div>
+    {/if}
   {/snippet}
-</FullscreenTemplate>
+</Template>
 
 <style>
-  .rcb-paddle-inline-checkout {
-    width: 100%;
-    max-width: 768px;
-    display: flex;
-    flex-direction: column;
-    gap: var(--rc-spacing-gapLarge-mobile, 16px);
+  .rcb-paddle-return-button {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--rc-spacing-gapSmall-mobile, 8px);
+    padding: 8px 0;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: var(--rc-color-accent);
+    font: inherit;
   }
 </style>

--- a/src/ui/paddle-inline-checkout-page.svelte
+++ b/src/ui/paddle-inline-checkout-page.svelte
@@ -6,8 +6,10 @@
   import Icon from "./atoms/icon.svelte";
   import { type BrandingInfoResponse } from "../networking/responses/branding-response";
   import type { Product, PurchaseOption } from "../entities/offerings";
-  import { type PriceBreakdown } from "./ui-types";
-  import { PADDLE_INLINE_FRAME_TARGET } from "../paddle/paddle-service";
+  import {
+    PADDLE_INLINE_FRAME_TARGET,
+    type PaddleCheckoutTotals,
+  } from "../paddle/paddle-service";
   import { type PurchaseFlowError } from "../helpers/purchase-operation-helper";
 
   interface Props {
@@ -17,9 +19,8 @@
     onClose: () => void;
     productDetails: Product;
     purchaseOption: PurchaseOption;
-    // Built from Paddle's checkout-totals events; renders the Subtotal/Tax/Total
-    // breakdown in the order-summary panel (same component as Web Billing).
-    priceBreakdown: PriceBreakdown;
+    // Live order totals from Paddle's checkout events; render the order summary.
+    totals: PaddleCheckoutTotals | null;
     currentPage: "waiting" | "loading" | "success" | "error";
     lastError: PurchaseFlowError | null;
     onContinue: () => void;
@@ -33,7 +34,7 @@
     onClose,
     productDetails,
     purchaseOption,
-    priceBreakdown,
+    totals,
     currentPage,
     lastError,
     onContinue,
@@ -65,7 +66,7 @@
       {brandingInfo}
       {productDetails}
       {purchaseOption}
-      {priceBreakdown}
+      {totals}
     />
   {/snippet}
   {#snippet mainContent()}

--- a/src/ui/paddle-inline-checkout-page.svelte
+++ b/src/ui/paddle-inline-checkout-page.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import FullscreenTemplate from "./layout/fullscreen-template.svelte";
+  import { type BrandingInfoResponse } from "../networking/responses/branding-response";
+  import { PADDLE_INLINE_FRAME_TARGET } from "../paddle/paddle-service";
+
+  interface Props {
+    brandingInfo: BrandingInfoResponse | null;
+    isSandbox: boolean;
+    isInElement: boolean;
+  }
+
+  const { brandingInfo, isSandbox, isInElement }: Props = $props();
+</script>
+
+<FullscreenTemplate {brandingInfo} {isInElement} {isSandbox}>
+  {#snippet mainContent()}
+    <!-- Paddle injects its inline checkout iframe into this container (its
+         frameTarget className). The element must already exist in the DOM when
+         PaddleService.purchase() calls Paddle.Checkout.open(). -->
+    <div
+      class={PADDLE_INLINE_FRAME_TARGET}
+      data-testid="paddle-inline-checkout-container"
+      style="width: 100%; min-height: 450px;"
+    ></div>
+  {/snippet}
+</FullscreenTemplate>

--- a/src/ui/paddle-inline-checkout-page.svelte
+++ b/src/ui/paddle-inline-checkout-page.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
   import Template from "./layout/template.svelte";
-  import ProductInfo from "./organisms/product-info.svelte";
+  import PaddleOrderSummary from "./organisms/paddle-order-summary.svelte";
   import SuccessPage from "./pages/success-page.svelte";
   import ErrorPage from "./pages/error-page.svelte";
   import Icon from "./atoms/icon.svelte";
   import { type BrandingInfoResponse } from "../networking/responses/branding-response";
   import type { Product, PurchaseOption } from "../entities/offerings";
-  import { getInitialPriceFromPurchaseOption } from "../helpers/purchase-option-price-helper";
   import { type PriceBreakdown } from "./ui-types";
   import { PADDLE_INLINE_FRAME_TARGET } from "../paddle/paddle-service";
   import { type PurchaseFlowError } from "../helpers/purchase-operation-helper";
@@ -18,6 +17,9 @@
     onClose: () => void;
     productDetails: Product;
     purchaseOption: PurchaseOption;
+    // Built from Paddle's checkout-totals events; renders the Subtotal/Tax/Total
+    // breakdown in the order-summary panel (same component as Web Billing).
+    priceBreakdown: PriceBreakdown;
     currentPage: "waiting" | "loading" | "success" | "error";
     lastError: PurchaseFlowError | null;
     onContinue: () => void;
@@ -31,26 +33,12 @@
     onClose,
     productDetails,
     purchaseOption,
+    priceBreakdown,
     currentPage,
     lastError,
     onContinue,
     closeWithError,
   }: Props = $props();
-
-  // Paddle's iframe shows the authoritative totals; the order-summary panel
-  // mirrors the Web Billing / Stripe layout using the option's initial price.
-  const initialPrice = getInitialPriceFromPurchaseOption(
-    productDetails,
-    purchaseOption,
-  );
-  const priceBreakdown: PriceBreakdown = {
-    currency: initialPrice.currency,
-    totalAmountInMicros: initialPrice.amountMicros,
-    totalExcludingTaxInMicros: initialPrice.amountMicros,
-    taxCalculationStatus: "unavailable",
-    taxAmountInMicros: null,
-    taxBreakdown: null,
-  };
 
   const appName = brandingInfo?.app_name ?? null;
 </script>
@@ -73,11 +61,10 @@
     {/if}
   {/snippet}
   {#snippet navbarBodyContent()}
-    <ProductInfo
+    <PaddleOrderSummary
+      {brandingInfo}
       {productDetails}
       {purchaseOption}
-      showProductDescription={brandingInfo?.appearance
-        ?.show_product_description ?? false}
       {priceBreakdown}
     />
   {/snippet}

--- a/src/ui/paddle-inline-checkout-page.svelte
+++ b/src/ui/paddle-inline-checkout-page.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import FullscreenTemplate from "./layout/fullscreen-template.svelte";
-  import CloseButton from "./molecules/close-button.svelte";
+  import BrandingHeader from "./molecules/branding-header.svelte";
+  import ProductInfo from "./organisms/product-info.svelte";
   import { type BrandingInfoResponse } from "../networking/responses/branding-response";
+  import type { Product, PurchaseOption } from "../entities/offerings";
+  import { getInitialPriceFromPurchaseOption } from "../helpers/purchase-option-price-helper";
+  import { type PriceBreakdown } from "./ui-types";
   import { PADDLE_INLINE_FRAME_TARGET } from "../paddle/paddle-service";
 
   interface Props {
@@ -9,9 +13,33 @@
     isSandbox: boolean;
     isInElement: boolean;
     onClose: () => void;
+    productDetails: Product;
+    purchaseOption: PurchaseOption;
   }
 
-  const { brandingInfo, isSandbox, isInElement, onClose }: Props = $props();
+  const {
+    brandingInfo,
+    isSandbox,
+    isInElement,
+    onClose,
+    productDetails,
+    purchaseOption,
+  }: Props = $props();
+
+  // Paddle's iframe shows the authoritative totals; the product-info panel
+  // mirrors the Web Billing / Stripe layout using the option's initial price.
+  const initialPrice = getInitialPriceFromPurchaseOption(
+    productDetails,
+    purchaseOption,
+  );
+  const priceBreakdown: PriceBreakdown = {
+    currency: initialPrice.currency,
+    totalAmountInMicros: initialPrice.amountMicros,
+    totalExcludingTaxInMicros: initialPrice.amountMicros,
+    taxCalculationStatus: "unavailable",
+    taxAmountInMicros: null,
+    taxBreakdown: null,
+  };
 </script>
 
 <FullscreenTemplate {brandingInfo} {isInElement} {isSandbox}>
@@ -19,11 +47,16 @@
     <div class="rcb-paddle-inline-checkout">
       {#if !isInElement}
         <!-- Inline checkout has no Paddle-provided dismiss (unlike the overlay
-             modal), so we render our own close affordance to cancel. -->
-        <div class="rcb-paddle-inline-checkout-header">
-          <CloseButton on:click={onClose} />
-        </div>
+             modal), so render our own branded header with a back/close button. -->
+        <BrandingHeader {brandingInfo} {onClose} showCloseButton={true} />
       {/if}
+      <ProductInfo
+        {productDetails}
+        {purchaseOption}
+        showProductDescription={brandingInfo?.appearance
+          ?.show_product_description ?? false}
+        {priceBreakdown}
+      />
       <!-- Paddle injects its inline checkout iframe into this container (its
            frameTarget className). The element must already exist in the DOM when
            PaddleService.purchase() calls Paddle.Checkout.open(). -->
@@ -39,11 +72,9 @@
 <style>
   .rcb-paddle-inline-checkout {
     width: 100%;
-  }
-
-  .rcb-paddle-inline-checkout-header {
+    max-width: 768px;
     display: flex;
-    justify-content: flex-end;
-    width: 100%;
+    flex-direction: column;
+    gap: var(--rc-spacing-gapLarge-mobile, 16px);
   }
 </style>

--- a/src/ui/paddle-purchases-ui.svelte
+++ b/src/ui/paddle-purchases-ui.svelte
@@ -110,6 +110,14 @@
     }
   };
 
+  // Inline checkout embeds Paddle's iframe in our page, so cancelling must tear
+  // it down via Paddle.Checkout.close() before unmounting our UI (per Paddle's
+  // branded inline checkout guidance), then run the normal close/cancel flow.
+  const handleInlineClose = () => {
+    paddleService.closeCheckout();
+    onClose();
+  };
+
   const closeWithError = () => {
     onError(
       error ??
@@ -234,7 +242,7 @@
       {brandingInfo}
       {isSandbox}
       {isInElement}
-      {onClose}
+      onClose={handleInlineClose}
       {productDetails}
       {purchaseOption}
     />

--- a/src/ui/paddle-purchases-ui.svelte
+++ b/src/ui/paddle-purchases-ui.svelte
@@ -20,11 +20,14 @@
   } from "../entities/offerings";
   import type { AttributionMetadata } from "../entities/purchase-params";
   import { PaddleService } from "../paddle/paddle-service";
+  import type { PaddleCheckoutTotals } from "../paddle/paddle-service";
   import { normalizeToPurchaseFlowError } from "../helpers/normalize-to-purchase-flow-error";
   import type { PaddleCheckoutStartResponse } from "../networking/responses/checkout-start-response";
   import PaddlePurchasesUiInner from "./paddle-purchases-ui-inner.svelte";
   import PaddleInlineCheckoutPage from "./paddle-inline-checkout-page.svelte";
   import type { BrandingAppearance } from "../entities/branding";
+  import { type PriceBreakdown } from "./ui-types";
+  import { getInitialPriceFromPurchaseOption } from "../helpers/purchase-option-price-helper";
 
   interface Props {
     brandingInfo: BrandingInfoResponse | null;
@@ -97,6 +100,46 @@
   let currentPage = $state<"waiting" | "loading" | "success" | "error">(
     "waiting",
   );
+
+  // Order totals reported by Paddle's checkout events; drives the inline order
+  // summary's Subtotal/Tax/Total breakdown and updates live.
+  let paddleTotals = $state<PaddleCheckoutTotals | null>(null);
+  const onCheckoutTotals = (totals: PaddleCheckoutTotals) => {
+    paddleTotals = totals;
+  };
+
+  const toMicros = (amount: number): number => Math.round(amount * 1_000_000);
+
+  // Before Paddle reports totals, fall back to the option's initial price (no
+  // tax breakdown yet); once totals arrive, show the full Subtotal/Tax/Total.
+  const inlinePriceBreakdown: PriceBreakdown = $derived.by(() => {
+    if (paddleTotals) {
+      const taxInMicros = toMicros(paddleTotals.taxAmount);
+      return {
+        currency: paddleTotals.currencyCode,
+        totalAmountInMicros: toMicros(paddleTotals.totalAmount),
+        totalExcludingTaxInMicros: toMicros(paddleTotals.subtotalAmount),
+        taxAmountInMicros: taxInMicros,
+        taxBreakdown:
+          taxInMicros > 0
+            ? [{ tax_amount_in_micros: taxInMicros, display_name: "Tax" }]
+            : [],
+        taxCalculationStatus: "calculated",
+      };
+    }
+    const initialPrice = getInitialPriceFromPurchaseOption(
+      productDetails,
+      purchaseOption,
+    );
+    return {
+      currency: initialPrice.currency,
+      totalAmountInMicros: initialPrice.amountMicros,
+      totalExcludingTaxInMicros: initialPrice.amountMicros,
+      taxAmountInMicros: null,
+      taxBreakdown: null,
+      taxCalculationStatus: "unavailable",
+    };
+  });
 
   $effect(() => {
     if (currentPage === "success" && operationResult && skipSuccessPage) {
@@ -195,7 +238,10 @@
           customerEmail,
           locale: selectedLocale || defaultLocale,
         },
-        ...(useInlineCheckout && { displayMode: "inline" as const }),
+        ...(useInlineCheckout && {
+          displayMode: "inline" as const,
+          onCheckoutTotals,
+        }),
       });
 
       if (skipSuccessPage) {
@@ -245,6 +291,7 @@
     onClose={handleInlineClose}
     {productDetails}
     {purchaseOption}
+    priceBreakdown={inlinePriceBreakdown}
     {currentPage}
     lastError={error}
     onContinue={handleContinue}

--- a/src/ui/paddle-purchases-ui.svelte
+++ b/src/ui/paddle-purchases-ui.svelte
@@ -23,6 +23,7 @@
   import { normalizeToPurchaseFlowError } from "../helpers/normalize-to-purchase-flow-error";
   import type { PaddleCheckoutStartResponse } from "../networking/responses/checkout-start-response";
   import PaddlePurchasesUiInner from "./paddle-purchases-ui-inner.svelte";
+  import PaddleInlineCheckoutPage from "./paddle-inline-checkout-page.svelte";
   import type { BrandingAppearance } from "../entities/branding";
 
   interface Props {
@@ -45,6 +46,13 @@
     attributionMetadata?: AttributionMetadata;
     unmountPaddlePurchaseUi: () => void;
     paddleService: PaddleService;
+    /**
+     * Internal flag (defaults to false). When true, Paddle's checkout is
+     * embedded inline in our own container instead of opening as an overlay.
+     * Not yet exposed through the public configure() surface — wiring and the
+     * inline state machine land in follow-up PRs.
+     */
+    useInlineCheckout?: boolean;
   }
 
   const {
@@ -67,6 +75,7 @@
     attributionMetadata,
     unmountPaddlePurchaseUi,
     paddleService,
+    useInlineCheckout = false,
   }: Props = $props();
 
   let translator: Translator = new Translator(
@@ -178,6 +187,7 @@
           customerEmail,
           locale: selectedLocale || defaultLocale,
         },
+        ...(useInlineCheckout && { displayMode: "inline" as const }),
       });
 
       if (skipSuccessPage) {
@@ -217,7 +227,23 @@
   });
 </script>
 
-{#if currentPage !== "waiting"}
+{#if useInlineCheckout}
+  {#if currentPage === "waiting" || currentPage === "loading"}
+    <!-- Paddle's inline checkout iframe mounts into the container rendered here. -->
+    <PaddleInlineCheckoutPage {brandingInfo} {isSandbox} {isInElement} />
+  {:else}
+    <PaddlePurchasesUiInner
+      currentPage={currentPage as "loading" | "success" | "error"}
+      {brandingInfo}
+      {productDetails}
+      {isSandbox}
+      lastError={error}
+      {isInElement}
+      onContinue={handleContinue}
+      {closeWithError}
+    />
+  {/if}
+{:else if currentPage !== "waiting"}
   <PaddlePurchasesUiInner
     currentPage={currentPage as "loading" | "success" | "error"}
     {brandingInfo}

--- a/src/ui/paddle-purchases-ui.svelte
+++ b/src/ui/paddle-purchases-ui.svelte
@@ -26,8 +26,6 @@
   import PaddlePurchasesUiInner from "./paddle-purchases-ui-inner.svelte";
   import PaddleInlineCheckoutPage from "./paddle-inline-checkout-page.svelte";
   import type { BrandingAppearance } from "../entities/branding";
-  import { type PriceBreakdown } from "./ui-types";
-  import { getInitialPriceFromPurchaseOption } from "../helpers/purchase-option-price-helper";
 
   interface Props {
     brandingInfo: BrandingInfoResponse | null;
@@ -107,39 +105,6 @@
   const onCheckoutTotals = (totals: PaddleCheckoutTotals) => {
     paddleTotals = totals;
   };
-
-  const toMicros = (amount: number): number => Math.round(amount * 1_000_000);
-
-  // Before Paddle reports totals, fall back to the option's initial price (no
-  // tax breakdown yet); once totals arrive, show the full Subtotal/Tax/Total.
-  const inlinePriceBreakdown: PriceBreakdown = $derived.by(() => {
-    if (paddleTotals) {
-      const taxInMicros = toMicros(paddleTotals.taxAmount);
-      return {
-        currency: paddleTotals.currencyCode,
-        totalAmountInMicros: toMicros(paddleTotals.totalAmount),
-        totalExcludingTaxInMicros: toMicros(paddleTotals.subtotalAmount),
-        taxAmountInMicros: taxInMicros,
-        taxBreakdown:
-          taxInMicros > 0
-            ? [{ tax_amount_in_micros: taxInMicros, display_name: "Tax" }]
-            : [],
-        taxCalculationStatus: "calculated",
-      };
-    }
-    const initialPrice = getInitialPriceFromPurchaseOption(
-      productDetails,
-      purchaseOption,
-    );
-    return {
-      currency: initialPrice.currency,
-      totalAmountInMicros: initialPrice.amountMicros,
-      totalExcludingTaxInMicros: initialPrice.amountMicros,
-      taxAmountInMicros: null,
-      taxBreakdown: null,
-      taxCalculationStatus: "unavailable",
-    };
-  });
 
   $effect(() => {
     if (currentPage === "success" && operationResult && skipSuccessPage) {
@@ -291,7 +256,7 @@
     onClose={handleInlineClose}
     {productDetails}
     {purchaseOption}
-    priceBreakdown={inlinePriceBreakdown}
+    totals={paddleTotals}
     {currentPage}
     lastError={error}
     onContinue={handleContinue}

--- a/src/ui/paddle-purchases-ui.svelte
+++ b/src/ui/paddle-purchases-ui.svelte
@@ -236,28 +236,20 @@
 </script>
 
 {#if useInlineCheckout}
-  {#if currentPage === "waiting" || currentPage === "loading"}
-    <!-- Paddle's inline checkout iframe mounts into the container rendered here. -->
-    <PaddleInlineCheckoutPage
-      {brandingInfo}
-      {isSandbox}
-      {isInElement}
-      onClose={handleInlineClose}
-      {productDetails}
-      {purchaseOption}
-    />
-  {:else}
-    <PaddlePurchasesUiInner
-      currentPage={currentPage as "loading" | "success" | "error"}
-      {brandingInfo}
-      {productDetails}
-      {isSandbox}
-      lastError={error}
-      {isInElement}
-      onContinue={handleContinue}
-      {closeWithError}
-    />
-  {/if}
+  <!-- Single branded two-column shell for every inline state (form / success /
+       error), so there's no swap between different root templates. -->
+  <PaddleInlineCheckoutPage
+    {brandingInfo}
+    {isSandbox}
+    {isInElement}
+    onClose={handleInlineClose}
+    {productDetails}
+    {purchaseOption}
+    {currentPage}
+    lastError={error}
+    onContinue={handleContinue}
+    {closeWithError}
+  />
 {:else if currentPage !== "waiting"}
   <PaddlePurchasesUiInner
     currentPage={currentPage as "loading" | "success" | "error"}

--- a/src/ui/paddle-purchases-ui.svelte
+++ b/src/ui/paddle-purchases-ui.svelte
@@ -235,6 +235,8 @@
       {isSandbox}
       {isInElement}
       {onClose}
+      {productDetails}
+      {purchaseOption}
     />
   {:else}
     <PaddlePurchasesUiInner

--- a/src/ui/paddle-purchases-ui.svelte
+++ b/src/ui/paddle-purchases-ui.svelte
@@ -230,7 +230,12 @@
 {#if useInlineCheckout}
   {#if currentPage === "waiting" || currentPage === "loading"}
     <!-- Paddle's inline checkout iframe mounts into the container rendered here. -->
-    <PaddleInlineCheckoutPage {brandingInfo} {isSandbox} {isInElement} />
+    <PaddleInlineCheckoutPage
+      {brandingInfo}
+      {isSandbox}
+      {isInElement}
+      {onClose}
+    />
   {:else}
     <PaddlePurchasesUiInner
       currentPage={currentPage as "loading" | "success" | "error"}


### PR DESCRIPTION
## Summary

Second PR in the stack switching Paddle from overlay to **inline** checkout (**WST-567**). Builds on the service-layer foundation from #896.

Introduces the inline checkout **UI page and an internal feature flag**, both **gated off by default** — production still uses the overlay. No public API change.

> ⚠️ Stacked on **#896** — review/merge that first. This PR's diff is against `paddle-inline/01-service-inline-support`.

## What changed

- **New `src/ui/paddle-inline-checkout-page.svelte`** — renders RevenueCat's branded `FullscreenTemplate` containing the `.paddle-checkout-container` div that Paddle injects its inline iframe into (uses the exported `PADDLE_INLINE_FRAME_TARGET` from #896 as the single source of truth for the class name).
- **`src/ui/paddle-purchases-ui.svelte`** — adds an internal `useInlineCheckout` prop (default `false`). When `true`:
  - renders `PaddleInlineCheckoutPage` (so the container exists in the DOM before `purchase()` runs), and
  - passes `displayMode: "inline"` through to `PaddleService.purchase()`.
  When `false`, the overlay path is **byte-for-byte unchanged** — no `displayMode` is passed and no container is rendered.

## Why this is safe to merge on its own

`useInlineCheckout` defaults to `false` and is **not wired to any public configure() option yet**, so nothing reaches the new code path in production. The flag-off branch renders exactly as before.

## Out of scope (next PR)

The inline **state machine**, `checkout.closed` semantics (no popup to dismiss), iframe mount/unmount lifecycle, and simplifying the full-page body-style overrides land in PR 3.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `svelte-check` 0 errors
- [x] `vitest run` full suite green; Paddle UI suite 19 passed (16 existing unchanged + 3 new: container renders when enabled, `displayMode: "inline"` passed when enabled, neither happens by default)
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Update:** also adds the **cancel affordance** for inline checkout. Inline has no Paddle-provided dismiss (unlike the overlay modal), so `PaddleInlineCheckoutPage` now renders an in-page close button (wired to `onClose`, shown when not embedded in a host element), and the Paddle flow registers a `popstate → onClose` listener so browser-back also cancels — matching the Web Billing / Stripe flows. Covered by tests (close button renders + invokes `onClose`; hidden when `isInElement`).


---

**Update 2 (review feedback):** the inline page now renders through the branded `FullscreenTemplate` with a `BrandingHeader` (back/close affordance) and the `ProductInfo` panel — restoring the product/offering details and replacing the ad-hoc floating close button. Cancelling the inline checkout calls **`Paddle.Checkout.close()`** (`PaddleService.closeCheckout()`) to tear down the embedded iframe before unmounting, per Paddle's branded inline checkout guidance. (`FullscreenTemplate` is used rather than the two-column `Template` because the latter left an orphaned container node when swapping to the processing/status pages.)


---

**Update 3 — inline order summary (new component, by necessity):** the inline checkout now renders a branded two-column order summary (amount card + Subtotal/Tax/Total card), fed live by Paddle's own checkout totals (`onCheckoutTotals` ← `checkout.loaded` / `checkout.updated`).

Why this is **newly built**: with the **overlay** checkout, Paddle rendered this order summary itself — it's part of Paddle's hosted overlay UI, so we never had to build it. The **inline** checkout only renders the payment form, so the summary has to be reconstructed on our side from the totals Paddle exposes through its checkout events.

All styling comes from the server-provided branding **appearance config** (nothing hardcoded): card background = `color_form_bg`, corner radius = `shapes`, amount color = `color_buttons_primary`, panel background = `color_product_info_bg`. New component: `src/ui/organisms/paddle-order-summary.svelte` (reuses the shared `ProductHeader` + `PricingTable`).

Note: the tax row label is generic ("Tax") since Paddle's event totals expose the tax amount but not a region-specific label (e.g. "VAT"); and the Paddle seller name still isn't exposed to the SDK, so the back link uses the branding app name.


---

**Update 4 — order summary restyled to match Paddle's overlay.** `PaddleOrderSummary` now mirrors the hosted overlay's summary: amount + "inc. VAT", "billed <frequency>", product name, price name, amount/period; and a breakdown card with Subtotal / VAT / Total + a recurring "Due on <date>" row. Generous padding, rounded cards. The extra data (recurring total, product name, price name) is forwarded from Paddle's checkout events via `onCheckoutTotals`. Card colors come from the appearance config; the rounded radius is fixed to match the overlay. Next-billing date is computed client-side from the billing period (the exact Paddle renewal date isn't exposed via events).
