### PR TITLE
feat(paddle): map branding to inline checkout theme (WST-567 PR 4)

### DIFF
--- a/src/paddle/paddle-service.ts
+++ b/src/paddle/paddle-service.ts
@@ -3,7 +3,6 @@ import type {
   DisplayMode,
   Paddle,
   PaddleEventData,
-  Theme,
   Variant,
   Version,
 } from "@paddle/paddle-js";
@@ -105,7 +104,7 @@ export function buildPaddleCheckoutOptions({
   theme = "light",
 }: BuildPaddleCheckoutOptionsParams): CheckoutOpenOptions {
   const commonSettings = {
-    theme: theme as Theme,
+    theme,
     variant: "one-page" as Variant,
     locale,
     allowLogout: false,

--- a/src/paddle/paddle-service.ts
+++ b/src/paddle/paddle-service.ts
@@ -50,6 +50,9 @@ interface PaddlePurchaseParams {
  */
 export type PaddleCheckoutDisplayMode = "overlay" | "inline";
 
+/** Paddle checkout color theme. Mapped from the merchant's branding. */
+export type PaddleCheckoutTheme = "light" | "dark";
+
 /**
  * Order totals surfaced by Paddle's checkout events (`checkout.loaded` /
  * `checkout.updated`). Amounts are in major currency units (e.g. 9.99). Lets
@@ -85,6 +88,7 @@ interface BuildPaddleCheckoutOptionsParams {
   locale: string;
   customerEmail?: string;
   displayMode?: PaddleCheckoutDisplayMode;
+  theme?: PaddleCheckoutTheme;
 }
 
 /**
@@ -98,9 +102,10 @@ export function buildPaddleCheckoutOptions({
   locale,
   customerEmail,
   displayMode = "overlay",
+  theme = "light",
 }: BuildPaddleCheckoutOptionsParams): CheckoutOpenOptions {
   const commonSettings = {
-    theme: "light" as Theme,
+    theme: theme as Theme,
     variant: "one-page" as Variant,
     locale,
     allowLogout: false,
@@ -137,6 +142,7 @@ interface PaddlePurchase {
   params: PaddlePurchaseParams;
   onClose: () => void;
   displayMode?: PaddleCheckoutDisplayMode;
+  theme?: PaddleCheckoutTheme;
   /**
    * Invoked with the order totals whenever Paddle reports them
    * (`checkout.loaded` and `checkout.updated`). Used by the inline UI to render
@@ -291,6 +297,7 @@ export class PaddleService {
     onClose,
     params,
     displayMode = "overlay",
+    theme = "light",
     onCheckoutTotals,
     onCheckoutCompleted,
   }: PaddlePurchase): Promise<OperationSessionSuccessfulResult> {
@@ -373,6 +380,7 @@ export class PaddleService {
         locale,
         customerEmail,
         displayMode,
+        theme,
       });
 
       try {

--- a/src/tests/paddle/paddle-service.test.ts
+++ b/src/tests/paddle/paddle-service.test.ts
@@ -140,6 +140,17 @@ describe("buildPaddleCheckoutOptions", () => {
     });
   });
 
+  test("defaults to the light theme and respects an explicit theme", () => {
+    expect(
+      buildPaddleCheckoutOptions({ transactionId, locale: "en" }).settings,
+    ).toEqual(expect.objectContaining({ theme: "light" }));
+
+    expect(
+      buildPaddleCheckoutOptions({ transactionId, locale: "en", theme: "dark" })
+        .settings,
+    ).toEqual(expect.objectContaining({ theme: "dark" }));
+  });
+
   test("includes customer email when provided and omits it otherwise", () => {
     const withEmail = buildPaddleCheckoutOptions({
       transactionId,

--- a/src/tests/theme/utils.test.ts
+++ b/src/tests/theme/utils.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, test } from "vitest";
-import { applyAlpha } from "../../ui/theme/utils";
+import { applyAlpha, isHexColorLight } from "../../ui/theme/utils";
+
+describe("isHexColorLight", () => {
+  test("returns true for light colors", () => {
+    expect(isHexColorLight("#ffffff")).toBe(true);
+    expect(isHexColorLight("#EFF3FA")).toBe(true);
+  });
+
+  test("returns false for dark colors", () => {
+    expect(isHexColorLight("#000000")).toBe(false);
+    expect(isHexColorLight("#1a1a2e")).toBe(false);
+  });
+
+  test("falls back to light for unparseable colors", () => {
+    expect(isHexColorLight("transparent")).toBe(true);
+    expect(isHexColorLight("")).toBe(true);
+  });
+});
 describe("overlayColor", () => {
   test("applies black overlay for a light color", () => {
     expect(applyAlpha("#FFFFFF", 0.1)).toBe("#E6E6E6"); // 10% black overlay on white

--- a/src/tests/ui/paddle-purchases-ui.test.ts
+++ b/src/tests/ui/paddle-purchases-ui.test.ts
@@ -20,6 +20,7 @@ import {
   PurchaseFlowErrorCode,
 } from "../../helpers/purchase-operation-helper";
 import type { ComponentProps } from "svelte";
+import type { BrandingAppearance } from "../../entities/branding";
 
 const eventsTrackerMock = createEventsTrackerMock();
 
@@ -539,6 +540,56 @@ describe("PaddlePurchasesUI", () => {
       await waitFor(() => {
         expect(purchaseSpy).toHaveBeenCalledWith(
           expect.objectContaining({ displayMode: "inline" }),
+        );
+      });
+    });
+
+    const brandingWithPageBg = (color: string) => ({
+      ...brandingInfo,
+      appearance: {
+        ...(brandingInfo.appearance ?? ({} as BrandingAppearance)),
+        color_page_bg: color,
+      },
+    });
+
+    test("passes a light theme when the page background is light", async () => {
+      const paddleServiceMock = createPaddleServiceMock();
+      const purchaseSpy = vi.spyOn(paddleServiceMock, "purchase");
+
+      render(PaddlePurchasesUI, {
+        props: {
+          ...baseProps,
+          useInlineCheckout: true,
+          brandingInfo: brandingWithPageBg("#ffffff"),
+          paddleService: paddleServiceMock,
+        },
+        context: defaultContext,
+      });
+
+      await waitFor(() => {
+        expect(purchaseSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ theme: "light" }),
+        );
+      });
+    });
+
+    test("passes a dark theme when the page background is dark", async () => {
+      const paddleServiceMock = createPaddleServiceMock();
+      const purchaseSpy = vi.spyOn(paddleServiceMock, "purchase");
+
+      render(PaddlePurchasesUI, {
+        props: {
+          ...baseProps,
+          useInlineCheckout: true,
+          brandingInfo: brandingWithPageBg("#101010"),
+          paddleService: paddleServiceMock,
+        },
+        context: defaultContext,
+      });
+
+      await waitFor(() => {
+        expect(purchaseSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ theme: "dark" }),
         );
       });
     });

--- a/src/ui/paddle-purchases-ui.svelte
+++ b/src/ui/paddle-purchases-ui.svelte
@@ -26,6 +26,7 @@
   import PaddlePurchasesUiInner from "./paddle-purchases-ui-inner.svelte";
   import PaddleInlineCheckoutPage from "./paddle-inline-checkout-page.svelte";
   import type { BrandingAppearance } from "../entities/branding";
+  import { isHexColorLight } from "./theme/utils";
 
   interface Props {
     brandingInfo: BrandingInfoResponse | null;
@@ -109,6 +110,15 @@
   const onCheckoutTotals = (totals: PaddleCheckoutTotals) => {
     paddleTotals = totals;
   };
+
+  // Paddle's inline checkout only exposes a light/dark theme (deeper colors are
+  // configured in the Paddle dashboard). Pick the variant that matches the
+  // merchant's page background so the embedded checkout blends with our UI.
+  const paddleCheckoutTheme = isHexColorLight(
+    brandingInfo?.appearance?.color_page_bg ?? "#ffffff",
+  )
+    ? "light"
+    : "dark";
 
   $effect(() => {
     if (currentPage === "success" && operationResult && skipSuccessPage) {
@@ -215,6 +225,7 @@
         },
         ...(useInlineCheckout && {
           displayMode: "inline" as const,
+          theme: paddleCheckoutTheme,
           onCheckoutTotals,
           onCheckoutCompleted,
         }),

--- a/src/ui/theme/utils.ts
+++ b/src/ui/theme/utils.ts
@@ -74,6 +74,20 @@ const isLightColor = ({
 
 export const DEFAULT_LUMINANCE_THRESHOLD = 0.37;
 
+/**
+ * Returns whether a hex color (e.g. "#ffffff" or "#fff") reads as light.
+ * Unparseable colors fall back to `true` (light), matching the default
+ * white-ish backgrounds used across the checkout UI.
+ */
+export const isHexColorLight = (
+  hexColor: string,
+  luminanceThreshold: number = DEFAULT_LUMINANCE_THRESHOLD,
+): boolean => {
+  const rgb = hexToRGB(hexColor);
+  if (!rgb) return true;
+  return isLightColor({ ...rgb, luminanceThreshold });
+};
+
 const rgbToTextColors = (
   rgb: RGB,
   luminanceThreshold: number = DEFAULT_LUMINANCE_THRESHOLD,

--- a/src/ui/theme/utils.ts
+++ b/src/ui/theme/utils.ts
@@ -75,7 +75,8 @@ const isLightColor = ({
 export const DEFAULT_LUMINANCE_THRESHOLD = 0.37;
 
 /**
- * Returns whether a hex color (e.g. "#ffffff" or "#fff") reads as light.
+ * Returns whether a 6-digit hex color (e.g. "#ffffff") reads as light.
+ * Shorthand (#fff) is not expanded — branding colors are always 6-digit.
  * Unparseable colors fall back to `true` (light), matching the default
  * white-ish backgrounds used across the checkout UI.
  */


### PR DESCRIPTION
## Summary

Fourth PR in the stack switching Paddle from overlay to **inline** checkout (**WST-567**). Builds on #898.

Maps the merchant's RevenueCat branding onto Paddle's inline checkout so the embedded checkout visually matches the surrounding branded UI.

> ⚠️ Stacked on **#898 → #897 → #896**. Merge in order. This PR's diff is against `paddle-inline/03-inline-state-machine`.

## What changed

- **`src/ui/theme/utils.ts`** — exported `isHexColorLight(hex)`, reusing the existing private `hexToRGB` + WCAG luminance logic and `DEFAULT_LUMINANCE_THRESHOLD`.
- **`src/paddle/paddle-service.ts`** — added a `theme` option (`"light" | "dark"`, default `"light"`) to `buildPaddleCheckoutOptions()` / `purchase()`.
- **`src/ui/paddle-purchases-ui.svelte`** — derives the Paddle theme from the branding page background (`color_page_bg`, default `#ffffff` → light) and passes it through when inline.

## Scope rationale

Paddle's inline checkout only exposes **`theme`** and **`frameStyle`** in code — deeper colors/typography are configured in the Paddle dashboard, not via Paddle.js. So:

- **theme** → mapped from branding (this PR).
- **frameStyle** → kept `transparent` so the iframe inherits our page background; no per-brand value needed.
- **locale** → already forwarded via `selectedLocale` → `purchase()`.
- **success / error parity** → already rendered by the shared `PaddlePurchasesUiInner` (PR 2/3).
- **responsive height** → Paddle auto-resizes the iframe; `frameInitialHeight` is just the starting value.

Note: the existing `hexToRGB` doesn't expand 3-digit shorthand hex; real branding colors are 6-digit, so `isHexColorLight` is exercised/tested with 6-digit values.

## Safety

All inline behavior stays behind `useInlineCheckout` (default `false`); overlay is unchanged (still `theme: "light"`, no theme passed from the UI).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `svelte-check` 0 errors
- [x] `vitest run` full suite green (+ tests: `isHexColorLight` light/dark/fallback; `buildPaddleCheckoutOptions` theme default + override; inline UI passes light/dark theme based on page background)
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
