### PR TITLE
feat(paddle): make inline checkout the default — cutover (WST-567 PR 5)

### DIFF
--- a/src/tests/ui/paddle-purchases-ui.test.ts
+++ b/src/tests/ui/paddle-purchases-ui.test.ts
@@ -123,22 +123,27 @@ describe("PaddlePurchasesUI", () => {
     });
 
     await waitFor(() => {
-      expect(purchaseSpy).toHaveBeenCalledWith({
-        operationSessionId: "test-operation-session-id",
-        transactionId: "test-transaction-id",
-        onCheckoutLoaded: expect.any(Function),
-        onClose: expect.any(Function),
-        params: {
-          rcPackage: rcPackage,
-          purchaseOption: subscriptionOption,
-          appUserId: "test-app-user-id",
-          presentedOfferingIdentifier:
-            rcPackage.webBillingProduct.presentedOfferingContext
-              .offeringIdentifier,
-          customerEmail: undefined,
-          locale: "en",
-        },
-      });
+      // Inline is the default presentation after the cutover.
+      expect(purchaseSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operationSessionId: "test-operation-session-id",
+          transactionId: "test-transaction-id",
+          onCheckoutLoaded: expect.any(Function),
+          onClose: expect.any(Function),
+          onCheckoutCompleted: expect.any(Function),
+          displayMode: "inline",
+          params: {
+            rcPackage: rcPackage,
+            purchaseOption: subscriptionOption,
+            appUserId: "test-app-user-id",
+            presentedOfferingIdentifier:
+              rcPackage.webBillingProduct.presentedOfferingContext
+                .offeringIdentifier,
+            customerEmail: undefined,
+            locale: "en",
+          },
+        }),
+      );
     });
   });
 
@@ -166,7 +171,7 @@ describe("PaddlePurchasesUI", () => {
     });
   });
 
-  test("transitions to loading page when checkout is loaded", async () => {
+  test("transitions to loading page when checkout is loaded (overlay)", async () => {
     const paddleServiceMock = createPaddleServiceMock();
     let onCheckoutLoadedCallback: (() => void) | undefined;
 
@@ -182,7 +187,13 @@ describe("PaddlePurchasesUI", () => {
     );
 
     render(PaddlePurchasesUI, {
-      props: { ...baseProps, paddleService: paddleServiceMock },
+      // Overlay shows the processing spinner while open; inline shows the
+      // checkout container instead, so this behavior is overlay-specific.
+      props: {
+        ...baseProps,
+        useInlineCheckout: false,
+        paddleService: paddleServiceMock,
+      },
       context: defaultContext,
     });
 
@@ -621,12 +632,16 @@ describe("PaddlePurchasesUI", () => {
       ).not.toBeInTheDocument();
     });
 
-    test("does not render the inline container or pass displayMode by default", async () => {
+    test("falls back to overlay (no inline container, no displayMode) when disabled", async () => {
       const paddleServiceMock = createPaddleServiceMock();
       const purchaseSpy = vi.spyOn(paddleServiceMock, "purchase");
 
       render(PaddlePurchasesUI, {
-        props: { ...baseProps, paddleService: paddleServiceMock },
+        props: {
+          ...baseProps,
+          useInlineCheckout: false,
+          paddleService: paddleServiceMock,
+        },
         context: defaultContext,
       });
 

--- a/src/ui/paddle-purchases-ui.svelte
+++ b/src/ui/paddle-purchases-ui.svelte
@@ -49,10 +49,10 @@
     unmountPaddlePurchaseUi: () => void;
     paddleService: PaddleService;
     /**
-     * Internal flag (defaults to false). When true, Paddle's checkout is
-     * embedded inline in our own container instead of opening as an overlay.
-     * Not yet exposed through the public configure() surface — wiring and the
-     * inline state machine land in follow-up PRs.
+     * Controls how Paddle's checkout is presented. Defaults to `true`
+     * (inline — embedded in our own container). Set to `false` to fall back to
+     * the legacy overlay (modal popup) presentation; this fallback is kept for
+     * one release and is expected to be removed once inline has soaked.
      */
     useInlineCheckout?: boolean;
   }
@@ -77,7 +77,7 @@
     attributionMetadata,
     unmountPaddlePurchaseUi,
     paddleService,
-    useInlineCheckout = false,
+    useInlineCheckout = true,
   }: Props = $props();
 
   let translator: Translator = new Translator(


### PR DESCRIPTION
## Summary

Final functional PR in the stack switching Paddle from overlay to **inline** checkout (**WST-567**) — the **production cutover**. Builds on #899.

Flips `PaddlePurchasesUi`'s `useInlineCheckout` default to `true`. Since `main.ts` mounts the component without passing the flag, this single default change makes all Paddle purchases render **inline** (embedded in our branded UI) instead of the legacy overlay popup.

> ⚠️ This PR **changes production behavior**. Stacked on **#899 → #898 → #897 → #896**; merge in order.

## What changed

- **`src/ui/paddle-purchases-ui.svelte`** — `useInlineCheckout` now defaults to `true`. Overlay stays reachable via `useInlineCheckout={false}` as a one-release fallback (dead-code removal is a follow-up).
- **`src/tests/ui/paddle-purchases-ui.test.ts`** — the default-path test now asserts inline; overlay-specific tests (loading spinner, "no displayMode") pass `useInlineCheckout={false}` explicitly, preserving overlay regression coverage.

## Live validation

Re-ran the full flow against the Paddle sandbox via the demo app with **no flag passed** (i.e. exercising the new default through the real PR 1–5 code path, not the spike):

- ✅ Paddle iframe mounts inside `.paddle-checkout-container`
- ✅ checkout URL: `display_mode=inline&variant=one-page`
- ✅ renders embedded in our branded page (not an overlay popup)

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` full suite green; Paddle UI suite 22 passed
- [x] `npm run build` succeeds
- [x] Manual: sandbox purchase renders inline end-to-end

## Follow-ups (not in this stack)

- Remove the overlay fallback code once inline has soaked.
- PR 6 — Paddle upsells (depends on backend support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
