### PR TITLE
fix: use createEmbeddedCheckoutPage for Stripe embedded checkout

### DIFF
--- a/examples/webbilling-demo/src/tests/stripe-checkout/config-guard.test.ts
+++ b/examples/webbilling-demo/src/tests/stripe-checkout/config-guard.test.ts
@@ -6,9 +6,9 @@ import { skipStripeTestsIfDisabled } from "../helpers/test-helpers";
 integrationTest.describe("Stripe Checkout E2E configuration", () => {
   skipStripeTestsIfDisabled(integrationTest);
 
-  // A missing key makes the whole Stripe Checkout suite (including the
-  // cross-version matrix) skip while CI still reports green - hiding the gap.
-  // Fail loudly on CI instead so a dropped secret cannot pass unnoticed.
+  // A missing key skips the whole Stripe Checkout suite (including the
+  // cross-version matrix) while CI still reports green, so fail loudly here
+  // instead and surface the dropped secret.
   integrationTest(
     "Stripe Checkout E2E key is set on CI so the suite cannot silently skip",
     () => {
@@ -18,7 +18,7 @@ integrationTest.describe("Stripe Checkout E2E configuration", () => {
       );
       expect(
         STRIPE_CHECKOUT_TEST_API_KEY,
-        "E2E_RC_STRIPE_CHECKOUT_E2E_API_KEY is not set; the Stripe Checkout E2E suite would skip. Configure the secret in CircleCI.",
+        "VITE_RC_STRIPE_CHECKOUT_E2E_API_KEY is not set; the Stripe Checkout E2E suite would skip. Configure the secret in CircleCI.",
       ).toBeTruthy();
     },
   );

--- a/examples/webbilling-demo/src/tests/stripe-checkout/config-guard.test.ts
+++ b/examples/webbilling-demo/src/tests/stripe-checkout/config-guard.test.ts
@@ -1,0 +1,25 @@
+import { expect } from "@playwright/test";
+import { STRIPE_CHECKOUT_TEST_API_KEY } from "../helpers/fixtures";
+import { integrationTest } from "../helpers/integration-test";
+import { skipStripeTestsIfDisabled } from "../helpers/test-helpers";
+
+integrationTest.describe("Stripe Checkout E2E configuration", () => {
+  skipStripeTestsIfDisabled(integrationTest);
+
+  // A missing key makes the whole Stripe Checkout suite (including the
+  // cross-version matrix) skip while CI still reports green - hiding the gap.
+  // Fail loudly on CI instead so a dropped secret cannot pass unnoticed.
+  integrationTest(
+    "Stripe Checkout E2E key is set on CI so the suite cannot silently skip",
+    () => {
+      integrationTest.skip(
+        !process.env.CI,
+        "Only enforced on CI, where the secret must be configured.",
+      );
+      expect(
+        STRIPE_CHECKOUT_TEST_API_KEY,
+        "E2E_RC_STRIPE_CHECKOUT_E2E_API_KEY is not set; the Stripe Checkout E2E suite would skip. Configure the secret in CircleCI.",
+      ).toBeTruthy();
+    },
+  );
+});

--- a/examples/webbilling-demo/src/tests/stripe-checkout/cross-version.test.ts
+++ b/examples/webbilling-demo/src/tests/stripe-checkout/cross-version.test.ts
@@ -21,23 +21,12 @@ import {
 // (initEmbeddedCheckout -> createEmbeddedCheckoutPage in dahlia).
 const STRIPE_JS_TRAINS = ["basil", "clover", "dahlia"] as const;
 
-async function preloadStripeJsTrain(page: Page, train: string): Promise<void> {
-  await page.addInitScript((trainName) => {
-    const script = document.createElement("script");
-    script.src = `https://js.stripe.com/${trainName}/stripe.js`;
-    (document.head ?? document.documentElement).appendChild(script);
-  }, train);
-}
-
-async function loadedStripeJsTrains(page: Page): Promise<string[]> {
-  return page.$$eval(
-    'script[src*="js.stripe.com"][src*="/stripe.js"]',
-    (scripts) =>
-      scripts.map(
-        (script) =>
-          new URL((script as HTMLScriptElement).src).pathname.split("/")[1],
-      ),
-  );
+async function activeStripeTrain(page: Page): Promise<string | undefined> {
+  return page.evaluate(() => {
+    const stripe = (window as unknown as { Stripe?: { version?: unknown } })
+      .Stripe;
+    return stripe?.version === undefined ? undefined : String(stripe.version);
+  });
 }
 
 integrationTest.describe("Stripe Checkout cross-version compatibility", () => {
@@ -68,7 +57,6 @@ integrationTest.describe("Stripe Checkout cross-version compatibility", () => {
       async ({ page, userId, email }) => {
         const fullName = `E2E ${userId.replace(/_/g, " ")}`;
 
-        await preloadStripeJsTrain(page, train);
         page = await navigateToStripeCheckoutLandingUrl(page, userId, {
           email,
         });
@@ -77,15 +65,22 @@ integrationTest.describe("Stripe Checkout cross-version compatibility", () => {
           timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
         });
 
+        // Self-load this train so it is the active Stripe.js before checkout,
+        // mimicking a merchant that loads Stripe.js itself. addScriptTag awaits
+        // the load, so window.Stripe is set when it resolves.
+        await page.addScriptTag({
+          url: `https://js.stripe.com/${train}/stripe.js`,
+        });
+        expect(await activeStripeTrain(page)).toBe(train);
+
         const packageCards = await getPackageCards(page);
         expect(packageCards.length).toBeGreaterThan(0);
 
         await startPurchaseFlow(packageCards[0]);
         await confirmStripeCheckoutVisible(page);
 
-        // The SDK reuses the page's train rather than injecting its own; a
-        // second train would mean it bypassed the merchant's Stripe.js.
-        expect([...new Set(await loadedStripeJsTrains(page))]).toEqual([train]);
+        // The SDK ran against the merchant's train, not its own bundled one.
+        expect(await activeStripeTrain(page)).toBe(train);
 
         await completeStripeCheckoutEmbeddedForm(page, email, fullName, false);
         await confirmPaymentComplete(page, STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS);

--- a/examples/webbilling-demo/src/tests/stripe-checkout/cross-version.test.ts
+++ b/examples/webbilling-demo/src/tests/stripe-checkout/cross-version.test.ts
@@ -1,0 +1,113 @@
+import { expect, type Page } from "@playwright/test";
+import { STRIPE_CHECKOUT_TEST_API_KEY } from "../helpers/fixtures";
+import { integrationTest } from "../helpers/integration-test";
+import {
+  confirmPaymentComplete,
+  getPackageCards,
+  skipStripeTestsIfDisabled,
+  startPurchaseFlow,
+} from "../helpers/test-helpers";
+import {
+  completeStripeCheckoutEmbeddedForm,
+  confirmStripeCheckoutVisible,
+  navigateToStripeCheckoutLandingUrl,
+  STRIPE_CHECKOUT_TEST_TIMEOUT_MS,
+  STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
+} from "./test-helpers";
+
+// Stripe.js ships as named release trains, and the embedded-checkout method was
+// renamed across them (initEmbeddedCheckout -> createEmbeddedCheckoutPage in
+// dahlia). A merchant self-loads one train, Stripe.js is a single global per
+// page, and our loader reuses whatever is already there - so the SDK runs
+// against whatever train the merchant loaded. Pin each train, then run a real
+// checkout to prove the SDK works across all of them.
+const STRIPE_JS_TRAINS = ["basil", "clover", "dahlia"] as const;
+
+async function preloadStripeJsTrain(page: Page, train: string): Promise<void> {
+  await page.addInitScript((trainName) => {
+    const script = document.createElement("script");
+    script.src = `https://js.stripe.com/${trainName}/stripe.js`;
+    (document.head ?? document.documentElement).appendChild(script);
+  }, train);
+}
+
+async function loadedStripeJsTrains(page: Page): Promise<string[]> {
+  return page.$$eval(
+    'script[src*="js.stripe.com"][src*="/stripe.js"]',
+    (scripts) =>
+      scripts.map(
+        (script) =>
+          new URL((script as HTMLScriptElement).src).pathname.split("/")[1],
+      ),
+  );
+}
+
+integrationTest.describe("Stripe Checkout cross-version compatibility", () => {
+  integrationTest.describe.configure({
+    timeout: STRIPE_CHECKOUT_TEST_TIMEOUT_MS,
+  });
+
+  integrationTest.skip(
+    ({ browserName }) => !!process.env.CI && browserName !== "chromium",
+    "Stripe Checkout tests run only in Chromium on CI",
+  );
+
+  skipStripeTestsIfDisabled(integrationTest);
+
+  integrationTest.skip(
+    !STRIPE_CHECKOUT_TEST_API_KEY,
+    "Stripe Checkout E2E tests require VITE_RC_STRIPE_CHECKOUT_E2E_API_KEY.",
+  );
+
+  integrationTest.afterEach(async () => {
+    // Sleep between tests to avoid hitting the rate limit of the Stripe Checkout API.
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  });
+
+  for (const train of STRIPE_JS_TRAINS) {
+    integrationTest(
+      `completes embedded checkout when the page self-loads Stripe.js ${train}`,
+      async ({ page, userId, email }) => {
+        const fullName = `E2E ${userId.replace(/_/g, " ")}`;
+
+        await preloadStripeJsTrain(page, train);
+        page = await navigateToStripeCheckoutLandingUrl(page, userId, {
+          email,
+        });
+
+        await expect(page.getByText("Stripe Checkout demo")).toBeVisible({
+          timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
+        });
+
+        const packageCards = await getPackageCards(page);
+        expect(packageCards.length).toBeGreaterThan(0);
+
+        await startPurchaseFlow(packageCards[0]);
+        await confirmStripeCheckoutVisible(page);
+
+        // The SDK must reuse the train the page already loaded, not inject its
+        // own - a second train would be the method-name mismatch we guard for.
+        expect([...new Set(await loadedStripeJsTrains(page))]).toEqual([train]);
+
+        await completeStripeCheckoutEmbeddedForm(page, email, fullName, false);
+        await confirmPaymentComplete(page, STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS);
+
+        const continueButton = page.getByRole("button", { name: /continue/i });
+        await expect(continueButton).toBeVisible({
+          timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
+        });
+
+        await Promise.all([
+          page.waitForURL(/\/success\//, {
+            timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
+          }),
+          continueButton.click(),
+        ]);
+
+        await expect(
+          page.getByText("Enjoy your premium experience."),
+        ).toBeVisible({ timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS });
+      },
+    );
+  }
+});

--- a/examples/webbilling-demo/src/tests/stripe-checkout/cross-version.test.ts
+++ b/examples/webbilling-demo/src/tests/stripe-checkout/cross-version.test.ts
@@ -15,12 +15,10 @@ import {
   STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
 } from "./test-helpers";
 
-// Stripe.js ships as named release trains, and the embedded-checkout method was
-// renamed across them (initEmbeddedCheckout -> createEmbeddedCheckoutPage in
-// dahlia). A merchant self-loads one train, Stripe.js is a single global per
-// page, and our loader reuses whatever is already there - so the SDK runs
-// against whatever train the merchant loaded. Pin each train, then run a real
-// checkout to prove the SDK works across all of them.
+// Stripe.js is a single global per page and our loader reuses whatever train a
+// merchant self-loaded, so the SDK must work against any of them - even though
+// the embedded-checkout method was renamed across trains
+// (initEmbeddedCheckout -> createEmbeddedCheckoutPage in dahlia).
 const STRIPE_JS_TRAINS = ["basil", "clover", "dahlia"] as const;
 
 async function preloadStripeJsTrain(page: Page, train: string): Promise<void> {
@@ -85,8 +83,8 @@ integrationTest.describe("Stripe Checkout cross-version compatibility", () => {
         await startPurchaseFlow(packageCards[0]);
         await confirmStripeCheckoutVisible(page);
 
-        // The SDK must reuse the train the page already loaded, not inject its
-        // own - a second train would be the method-name mismatch we guard for.
+        // The SDK reuses the page's train rather than injecting its own; a
+        // second train would mean it bypassed the merchant's Stripe.js.
         expect([...new Set(await loadedStripeJsTrains(page))]).toEqual([train]);
 
         await completeStripeCheckoutEmbeddedForm(page, email, fullName, false);

--- a/src/stripe/stripe-service.ts
+++ b/src/stripe/stripe-service.ts
@@ -211,16 +211,14 @@ export class StripeService {
     let embeddedCheckout: StripeEmbeddedCheckout;
 
     try {
-      // Stripe.js is a single global per page, so a merchant's own (newer)
-      // copy can be the instance we get. It renamed initEmbeddedCheckout ->
-      // createEmbeddedCheckoutPage, so detect whichever the loaded version has.
-      const createEmbeddedCheckout =
-        (
-          stripe as Stripe & {
-            createEmbeddedCheckoutPage?: Stripe["initEmbeddedCheckout"];
-          }
-        ).createEmbeddedCheckoutPage ?? stripe.initEmbeddedCheckout;
-      embeddedCheckout = await createEmbeddedCheckout.call(stripe, {
+      // createEmbeddedCheckoutPage works on every Stripe.js release train and is
+      // the only name that works on dahlia (initEmbeddedCheckout throws there).
+      // It is not in the basil-era types yet, so cast to reach it.
+      embeddedCheckout = await (
+        stripe as Stripe & {
+          createEmbeddedCheckoutPage: Stripe["initEmbeddedCheckout"];
+        }
+      ).createEmbeddedCheckoutPage({
         fetchClientSecret: () =>
           Promise.resolve(StripeBillingParams.client_secret),
         onComplete,

--- a/src/stripe/stripe-service.ts
+++ b/src/stripe/stripe-service.ts
@@ -211,7 +211,16 @@ export class StripeService {
     let embeddedCheckout: StripeEmbeddedCheckout;
 
     try {
-      embeddedCheckout = await stripe.initEmbeddedCheckout({
+      // Stripe renamed initEmbeddedCheckout -> createEmbeddedCheckoutPage in its
+      // dahlia release. Stripe.js is a single global per page, so a merchant's
+      // own newer Stripe.js can be the instance we get - use whichever exists.
+      const createEmbeddedCheckout =
+        (
+          stripe as Stripe & {
+            createEmbeddedCheckoutPage?: Stripe["initEmbeddedCheckout"];
+          }
+        ).createEmbeddedCheckoutPage ?? stripe.initEmbeddedCheckout;
+      embeddedCheckout = await createEmbeddedCheckout.call(stripe, {
         fetchClientSecret: () =>
           Promise.resolve(StripeBillingParams.client_secret),
         onComplete,

--- a/src/stripe/stripe-service.ts
+++ b/src/stripe/stripe-service.ts
@@ -211,9 +211,9 @@ export class StripeService {
     let embeddedCheckout: StripeEmbeddedCheckout;
 
     try {
-      // Stripe renamed initEmbeddedCheckout -> createEmbeddedCheckoutPage in its
-      // dahlia release. Stripe.js is a single global per page, so a merchant's
-      // own newer Stripe.js can be the instance we get - use whichever exists.
+      // Stripe.js is a single global per page, so a merchant's own (newer)
+      // copy can be the instance we get. It renamed initEmbeddedCheckout ->
+      // createEmbeddedCheckoutPage, so detect whichever the loaded version has.
       const createEmbeddedCheckout =
         (
           stripe as Stripe & {

--- a/src/tests/stripe/stripe-service.test.ts
+++ b/src/tests/stripe/stripe-service.test.ts
@@ -185,52 +185,13 @@ describe("StripeService", () => {
       });
     });
 
-    test("initializes embedded checkout with client secret and onComplete callback", async () => {
-      const mockEmbeddedCheckout = {} as StripeEmbeddedCheckout;
-      const initEmbeddedCheckout = vi
-        .fn()
-        .mockResolvedValue(mockEmbeddedCheckout);
-      const mockStripe: Partial<Stripe> = {
-        initEmbeddedCheckout,
-      };
-      const onComplete = vi.fn();
-
-      vi.mocked(loadStripe).mockResolvedValue(mockStripe as Stripe);
-
-      const result = await StripeService.initializeStripeCheckout(
-        "acct_123",
-        "pk_test_123",
-        stripeBillingParams,
-        onComplete,
-      );
-
-      expect(loadStripe).toHaveBeenCalledWith("pk_test_123", {
-        stripeAccount: "acct_123",
-      });
-      expect(initEmbeddedCheckout).toHaveBeenCalledWith({
-        fetchClientSecret: expect.any(Function),
-        onComplete,
-      });
-
-      const fetchClientSecret = initEmbeddedCheckout.mock.calls[0]?.[0]
-        ?.fetchClientSecret as () => Promise<string>;
-      await expect(fetchClientSecret()).resolves.toBe("cs_test_123");
-
-      expect(result).toEqual({
-        stripe: mockStripe,
-        embeddedCheckout: mockEmbeddedCheckout,
-      });
-    });
-
-    test("uses createEmbeddedCheckoutPage when the loaded Stripe.js exposes it (dahlia)", async () => {
+    test("initializes embedded checkout via createEmbeddedCheckoutPage", async () => {
       const mockEmbeddedCheckout = {} as StripeEmbeddedCheckout;
       const createEmbeddedCheckoutPage = vi
         .fn()
         .mockResolvedValue(mockEmbeddedCheckout);
-      const initEmbeddedCheckout = vi.fn();
       const mockStripe = {
         createEmbeddedCheckoutPage,
-        initEmbeddedCheckout,
       } as unknown as Stripe;
       const onComplete = vi.fn();
 
@@ -243,24 +204,34 @@ describe("StripeService", () => {
         onComplete,
       );
 
+      expect(loadStripe).toHaveBeenCalledWith("pk_test_123", {
+        stripeAccount: "acct_123",
+      });
       expect(createEmbeddedCheckoutPage).toHaveBeenCalledWith({
         fetchClientSecret: expect.any(Function),
         onComplete,
       });
-      expect(initEmbeddedCheckout).not.toHaveBeenCalled();
-      expect(result.embeddedCheckout).toBe(mockEmbeddedCheckout);
+
+      const fetchClientSecret = createEmbeddedCheckoutPage.mock.calls[0]?.[0]
+        ?.fetchClientSecret as () => Promise<string>;
+      await expect(fetchClientSecret()).resolves.toBe("cs_test_123");
+
+      expect(result).toEqual({
+        stripe: mockStripe,
+        embeddedCheckout: mockEmbeddedCheckout,
+      });
     });
 
     test("throws mapped initialization error when embedded checkout initialization fails", async () => {
-      const mockStripe: Partial<Stripe> = {
-        initEmbeddedCheckout: vi.fn().mockRejectedValue({
+      const mockStripe = {
+        createEmbeddedCheckoutPage: vi.fn().mockRejectedValue({
           type: "api_connection_error",
           code: "failed_to_load",
           message: "Failed to load",
         } as StripeError),
-      };
+      } as unknown as Stripe;
 
-      vi.mocked(loadStripe).mockResolvedValue(mockStripe as Stripe);
+      vi.mocked(loadStripe).mockResolvedValue(mockStripe);
 
       await expect(
         StripeService.initializeStripeCheckout(

--- a/src/tests/stripe/stripe-service.test.ts
+++ b/src/tests/stripe/stripe-service.test.ts
@@ -222,6 +222,35 @@ describe("StripeService", () => {
       });
     });
 
+    test("uses createEmbeddedCheckoutPage when the loaded Stripe.js exposes it (dahlia)", async () => {
+      const mockEmbeddedCheckout = {} as StripeEmbeddedCheckout;
+      const createEmbeddedCheckoutPage = vi
+        .fn()
+        .mockResolvedValue(mockEmbeddedCheckout);
+      const initEmbeddedCheckout = vi.fn();
+      const mockStripe = {
+        createEmbeddedCheckoutPage,
+        initEmbeddedCheckout,
+      } as unknown as Stripe;
+      const onComplete = vi.fn();
+
+      vi.mocked(loadStripe).mockResolvedValue(mockStripe);
+
+      const result = await StripeService.initializeStripeCheckout(
+        "acct_123",
+        "pk_test_123",
+        stripeBillingParams,
+        onComplete,
+      );
+
+      expect(createEmbeddedCheckoutPage).toHaveBeenCalledWith({
+        fetchClientSecret: expect.any(Function),
+        onComplete,
+      });
+      expect(initEmbeddedCheckout).not.toHaveBeenCalled();
+      expect(result.embeddedCheckout).toBe(mockEmbeddedCheckout);
+    });
+
     test("throws mapped initialization error when embedded checkout initialization fails", async () => {
       const mockStripe: Partial<Stripe> = {
         initEmbeddedCheckout: vi.fn().mockRejectedValue({


### PR DESCRIPTION
## What

The Web SDK now calls `stripe.createEmbeddedCheckoutPage()` for embedded checkout instead of the removed `stripe.initEmbeddedCheckout()`.

## Why

Stripe removed `stripe.initEmbeddedCheckout()` in its dahlia release - calling it throws `IntegrationError`. Stripe.js is a single `window.Stripe` per page and the SDK's loader reuses whatever `js.stripe.com` script a merchant has already loaded, so a merchant whose page runs dahlia got a broken checkout (silent on live keys - Stripe's version-mismatch warning fires only for test keys).

`createEmbeddedCheckoutPage()` is present and works on every current Stripe.js release train (acacia through dahlia), so calling it directly fixes checkout on all of them. The basil-era types do not declare the method yet, so the call needs one cast in `stripe-service.ts`.

## Cross-version E2E

Adds `examples/webbilling-demo/src/tests/stripe-checkout/cross-version.test.ts`: for each train (basil / clover / dahlia) it self-loads that Stripe.js, runs a real embedded checkout, and asserts the SDK ran against the merchant's train. Verified locally against a Stripe sandbox - all three complete. It is skipped on CI because the stripe E2E suite is disabled there (`VITE_SKIP_STRIPE_TESTS=true`), so it serves as a local/manual check.

A small guard (`config-guard.test.ts`) fails loudly if the stripe E2E key is missing while the suite is enabled, so a dropped secret cannot pass as green.

## Scope

SDK-only. The backend already returns the embedded-session `client_secret`, so no backend or schema change.

## Test plan

- `pnpm test`, `tsc --noEmit`, `pnpm svelte-check` clean
- Cross-version matrix passes locally (real sandbox checkout on basil, clover, dahlia)

---
Linear: https://linear.app/revenuecat/issue/WST-695/purchases-js-feature-detect-stripe-embedded-checkout-method
Part of https://linear.app/revenuecat/issue/WST-694/purchases-js-stripejs-decouple-checkout-from-the-pages-stripejs
