### PR TITLE
chore: bump @stripe/stripe-js to v9 (dahlia)

### DIFF
--- a/examples/webbilling-demo/src/tests/stripe-checkout/config-guard.test.ts
+++ b/examples/webbilling-demo/src/tests/stripe-checkout/config-guard.test.ts
@@ -6,9 +6,9 @@ import { skipStripeTestsIfDisabled } from "../helpers/test-helpers";
 integrationTest.describe("Stripe Checkout E2E configuration", () => {
   skipStripeTestsIfDisabled(integrationTest);
 
-  // A missing key makes the whole Stripe Checkout suite (including the
-  // cross-version matrix) skip while CI still reports green - hiding the gap.
-  // Fail loudly on CI instead so a dropped secret cannot pass unnoticed.
+  // A missing key skips the whole Stripe Checkout suite (including the
+  // cross-version matrix) while CI still reports green, so fail loudly here
+  // instead and surface the dropped secret.
   integrationTest(
     "Stripe Checkout E2E key is set on CI so the suite cannot silently skip",
     () => {
@@ -18,7 +18,7 @@ integrationTest.describe("Stripe Checkout E2E configuration", () => {
       );
       expect(
         STRIPE_CHECKOUT_TEST_API_KEY,
-        "E2E_RC_STRIPE_CHECKOUT_E2E_API_KEY is not set; the Stripe Checkout E2E suite would skip. Configure the secret in CircleCI.",
+        "VITE_RC_STRIPE_CHECKOUT_E2E_API_KEY is not set; the Stripe Checkout E2E suite would skip. Configure the secret in CircleCI.",
       ).toBeTruthy();
     },
   );

--- a/examples/webbilling-demo/src/tests/stripe-checkout/config-guard.test.ts
+++ b/examples/webbilling-demo/src/tests/stripe-checkout/config-guard.test.ts
@@ -1,0 +1,25 @@
+import { expect } from "@playwright/test";
+import { STRIPE_CHECKOUT_TEST_API_KEY } from "../helpers/fixtures";
+import { integrationTest } from "../helpers/integration-test";
+import { skipStripeTestsIfDisabled } from "../helpers/test-helpers";
+
+integrationTest.describe("Stripe Checkout E2E configuration", () => {
+  skipStripeTestsIfDisabled(integrationTest);
+
+  // A missing key makes the whole Stripe Checkout suite (including the
+  // cross-version matrix) skip while CI still reports green - hiding the gap.
+  // Fail loudly on CI instead so a dropped secret cannot pass unnoticed.
+  integrationTest(
+    "Stripe Checkout E2E key is set on CI so the suite cannot silently skip",
+    () => {
+      integrationTest.skip(
+        !process.env.CI,
+        "Only enforced on CI, where the secret must be configured.",
+      );
+      expect(
+        STRIPE_CHECKOUT_TEST_API_KEY,
+        "E2E_RC_STRIPE_CHECKOUT_E2E_API_KEY is not set; the Stripe Checkout E2E suite would skip. Configure the secret in CircleCI.",
+      ).toBeTruthy();
+    },
+  );
+});

--- a/examples/webbilling-demo/src/tests/stripe-checkout/cross-version.test.ts
+++ b/examples/webbilling-demo/src/tests/stripe-checkout/cross-version.test.ts
@@ -21,23 +21,12 @@ import {
 // (initEmbeddedCheckout -> createEmbeddedCheckoutPage in dahlia).
 const STRIPE_JS_TRAINS = ["basil", "clover", "dahlia"] as const;
 
-async function preloadStripeJsTrain(page: Page, train: string): Promise<void> {
-  await page.addInitScript((trainName) => {
-    const script = document.createElement("script");
-    script.src = `https://js.stripe.com/${trainName}/stripe.js`;
-    (document.head ?? document.documentElement).appendChild(script);
-  }, train);
-}
-
-async function loadedStripeJsTrains(page: Page): Promise<string[]> {
-  return page.$$eval(
-    'script[src*="js.stripe.com"][src*="/stripe.js"]',
-    (scripts) =>
-      scripts.map(
-        (script) =>
-          new URL((script as HTMLScriptElement).src).pathname.split("/")[1],
-      ),
-  );
+async function activeStripeTrain(page: Page): Promise<string | undefined> {
+  return page.evaluate(() => {
+    const stripe = (window as unknown as { Stripe?: { version?: unknown } })
+      .Stripe;
+    return stripe?.version === undefined ? undefined : String(stripe.version);
+  });
 }
 
 integrationTest.describe("Stripe Checkout cross-version compatibility", () => {
@@ -68,7 +57,6 @@ integrationTest.describe("Stripe Checkout cross-version compatibility", () => {
       async ({ page, userId, email }) => {
         const fullName = `E2E ${userId.replace(/_/g, " ")}`;
 
-        await preloadStripeJsTrain(page, train);
         page = await navigateToStripeCheckoutLandingUrl(page, userId, {
           email,
         });
@@ -77,15 +65,22 @@ integrationTest.describe("Stripe Checkout cross-version compatibility", () => {
           timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
         });
 
+        // Self-load this train so it is the active Stripe.js before checkout,
+        // mimicking a merchant that loads Stripe.js itself. addScriptTag awaits
+        // the load, so window.Stripe is set when it resolves.
+        await page.addScriptTag({
+          url: `https://js.stripe.com/${train}/stripe.js`,
+        });
+        expect(await activeStripeTrain(page)).toBe(train);
+
         const packageCards = await getPackageCards(page);
         expect(packageCards.length).toBeGreaterThan(0);
 
         await startPurchaseFlow(packageCards[0]);
         await confirmStripeCheckoutVisible(page);
 
-        // The SDK reuses the page's train rather than injecting its own; a
-        // second train would mean it bypassed the merchant's Stripe.js.
-        expect([...new Set(await loadedStripeJsTrains(page))]).toEqual([train]);
+        // The SDK ran against the merchant's train, not its own bundled one.
+        expect(await activeStripeTrain(page)).toBe(train);
 
         await completeStripeCheckoutEmbeddedForm(page, email, fullName, false);
         await confirmPaymentComplete(page, STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS);

--- a/examples/webbilling-demo/src/tests/stripe-checkout/cross-version.test.ts
+++ b/examples/webbilling-demo/src/tests/stripe-checkout/cross-version.test.ts
@@ -1,0 +1,113 @@
+import { expect, type Page } from "@playwright/test";
+import { STRIPE_CHECKOUT_TEST_API_KEY } from "../helpers/fixtures";
+import { integrationTest } from "../helpers/integration-test";
+import {
+  confirmPaymentComplete,
+  getPackageCards,
+  skipStripeTestsIfDisabled,
+  startPurchaseFlow,
+} from "../helpers/test-helpers";
+import {
+  completeStripeCheckoutEmbeddedForm,
+  confirmStripeCheckoutVisible,
+  navigateToStripeCheckoutLandingUrl,
+  STRIPE_CHECKOUT_TEST_TIMEOUT_MS,
+  STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
+} from "./test-helpers";
+
+// Stripe.js ships as named release trains, and the embedded-checkout method was
+// renamed across them (initEmbeddedCheckout -> createEmbeddedCheckoutPage in
+// dahlia). A merchant self-loads one train, Stripe.js is a single global per
+// page, and our loader reuses whatever is already there - so the SDK runs
+// against whatever train the merchant loaded. Pin each train, then run a real
+// checkout to prove the SDK works across all of them.
+const STRIPE_JS_TRAINS = ["basil", "clover", "dahlia"] as const;
+
+async function preloadStripeJsTrain(page: Page, train: string): Promise<void> {
+  await page.addInitScript((trainName) => {
+    const script = document.createElement("script");
+    script.src = `https://js.stripe.com/${trainName}/stripe.js`;
+    (document.head ?? document.documentElement).appendChild(script);
+  }, train);
+}
+
+async function loadedStripeJsTrains(page: Page): Promise<string[]> {
+  return page.$$eval(
+    'script[src*="js.stripe.com"][src*="/stripe.js"]',
+    (scripts) =>
+      scripts.map(
+        (script) =>
+          new URL((script as HTMLScriptElement).src).pathname.split("/")[1],
+      ),
+  );
+}
+
+integrationTest.describe("Stripe Checkout cross-version compatibility", () => {
+  integrationTest.describe.configure({
+    timeout: STRIPE_CHECKOUT_TEST_TIMEOUT_MS,
+  });
+
+  integrationTest.skip(
+    ({ browserName }) => !!process.env.CI && browserName !== "chromium",
+    "Stripe Checkout tests run only in Chromium on CI",
+  );
+
+  skipStripeTestsIfDisabled(integrationTest);
+
+  integrationTest.skip(
+    !STRIPE_CHECKOUT_TEST_API_KEY,
+    "Stripe Checkout E2E tests require VITE_RC_STRIPE_CHECKOUT_E2E_API_KEY.",
+  );
+
+  integrationTest.afterEach(async () => {
+    // Sleep between tests to avoid hitting the rate limit of the Stripe Checkout API.
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  });
+
+  for (const train of STRIPE_JS_TRAINS) {
+    integrationTest(
+      `completes embedded checkout when the page self-loads Stripe.js ${train}`,
+      async ({ page, userId, email }) => {
+        const fullName = `E2E ${userId.replace(/_/g, " ")}`;
+
+        await preloadStripeJsTrain(page, train);
+        page = await navigateToStripeCheckoutLandingUrl(page, userId, {
+          email,
+        });
+
+        await expect(page.getByText("Stripe Checkout demo")).toBeVisible({
+          timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
+        });
+
+        const packageCards = await getPackageCards(page);
+        expect(packageCards.length).toBeGreaterThan(0);
+
+        await startPurchaseFlow(packageCards[0]);
+        await confirmStripeCheckoutVisible(page);
+
+        // The SDK must reuse the train the page already loaded, not inject its
+        // own - a second train would be the method-name mismatch we guard for.
+        expect([...new Set(await loadedStripeJsTrains(page))]).toEqual([train]);
+
+        await completeStripeCheckoutEmbeddedForm(page, email, fullName, false);
+        await confirmPaymentComplete(page, STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS);
+
+        const continueButton = page.getByRole("button", { name: /continue/i });
+        await expect(continueButton).toBeVisible({
+          timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
+        });
+
+        await Promise.all([
+          page.waitForURL(/\/success\//, {
+            timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
+          }),
+          continueButton.click(),
+        ]);
+
+        await expect(
+          page.getByText("Enjoy your premium experience."),
+        ).toBeVisible({ timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS });
+      },
+    );
+  }
+});

--- a/examples/webbilling-demo/src/tests/stripe-checkout/cross-version.test.ts
+++ b/examples/webbilling-demo/src/tests/stripe-checkout/cross-version.test.ts
@@ -2,14 +2,13 @@ import { expect, type Page } from "@playwright/test";
 import { STRIPE_CHECKOUT_TEST_API_KEY } from "../helpers/fixtures";
 import { integrationTest } from "../helpers/integration-test";
 import {
-  confirmPaymentComplete,
   getPackageCards,
   skipStripeTestsIfDisabled,
   startPurchaseFlow,
 } from "../helpers/test-helpers";
 import {
-  completeStripeCheckoutEmbeddedForm,
   confirmStripeCheckoutVisible,
+  getStripeEmbeddedCheckoutFrame,
   navigateToStripeCheckoutLandingUrl,
   STRIPE_CHECKOUT_TEST_TIMEOUT_MS,
   STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
@@ -19,6 +18,12 @@ import {
 // merchant self-loaded, so the SDK must work against any of them - even though
 // the embedded-checkout method was renamed across trains
 // (initEmbeddedCheckout -> createEmbeddedCheckoutPage in dahlia).
+//
+// This matrix asserts the only train-sensitive part: the SDK's call mounts
+// Stripe's checkout form against the merchant's self-loaded train. Completing
+// the payment is left to purchase-flow.test.ts (local only) - completion runs
+// server-side at Stripe, behaves identically across trains, and Stripe blocks
+// it from CI datacenter IPs.
 const STRIPE_JS_TRAINS = ["basil", "clover", "dahlia"] as const;
 
 async function activeStripeTrain(page: Page): Promise<string | undefined> {
@@ -53,10 +58,8 @@ integrationTest.describe("Stripe Checkout cross-version compatibility", () => {
 
   for (const train of STRIPE_JS_TRAINS) {
     integrationTest(
-      `completes embedded checkout when the page self-loads Stripe.js ${train}`,
+      `mounts embedded checkout against self-loaded Stripe.js ${train}`,
       async ({ page, userId, email }) => {
-        const fullName = `E2E ${userId.replace(/_/g, " ")}`;
-
         page = await navigateToStripeCheckoutLandingUrl(page, userId, {
           email,
         });
@@ -77,29 +80,21 @@ integrationTest.describe("Stripe Checkout cross-version compatibility", () => {
         expect(packageCards.length).toBeGreaterThan(0);
 
         await startPurchaseFlow(packageCards[0]);
+
+        // The SDK called createEmbeddedCheckoutPage and Stripe mounted its form.
+        // A method missing on this train would throw IntegrationError here, so
+        // the iframe and its card field would never render.
         await confirmStripeCheckoutVisible(page);
-
-        // The SDK ran against the merchant's train, not its own bundled one.
-        expect(await activeStripeTrain(page)).toBe(train);
-
-        await completeStripeCheckoutEmbeddedForm(page, email, fullName, false);
-        await confirmPaymentComplete(page, STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS);
-
-        const continueButton = page.getByRole("button", { name: /continue/i });
-        await expect(continueButton).toBeVisible({
-          timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
-        });
-
-        await Promise.all([
-          page.waitForURL(/\/success\//, {
-            timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
-          }),
-          continueButton.click(),
-        ]);
-
+        const checkoutFrame = getStripeEmbeddedCheckoutFrame(page);
         await expect(
-          page.getByText("Enjoy your premium experience."),
+          checkoutFrame
+            .getByLabel(/card number/i)
+            .or(checkoutFrame.getByPlaceholder(/1234 1234/i))
+            .first(),
         ).toBeVisible({ timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS });
+
+        // ...and it ran against the merchant's train, not the SDK's bundled one.
+        expect(await activeStripeTrain(page)).toBe(train);
       },
     );
   }

--- a/examples/webbilling-demo/src/tests/stripe-checkout/cross-version.test.ts
+++ b/examples/webbilling-demo/src/tests/stripe-checkout/cross-version.test.ts
@@ -23,7 +23,7 @@ import {
 // Stripe's checkout form against the merchant's self-loaded train. Completing
 // the payment is left to purchase-flow.test.ts (local only) - completion runs
 // server-side at Stripe, behaves identically across trains, and Stripe blocks
-// it from CI datacenter IPs.
+// it from CI datacenter IPs (https://docs.stripe.com/automated-testing).
 const STRIPE_JS_TRAINS = ["basil", "clover", "dahlia"] as const;
 
 async function activeStripeTrain(page: Page): Promise<string | undefined> {

--- a/examples/webbilling-demo/src/tests/stripe-checkout/cross-version.test.ts
+++ b/examples/webbilling-demo/src/tests/stripe-checkout/cross-version.test.ts
@@ -15,12 +15,10 @@ import {
   STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
 } from "./test-helpers";
 
-// Stripe.js ships as named release trains, and the embedded-checkout method was
-// renamed across them (initEmbeddedCheckout -> createEmbeddedCheckoutPage in
-// dahlia). A merchant self-loads one train, Stripe.js is a single global per
-// page, and our loader reuses whatever is already there - so the SDK runs
-// against whatever train the merchant loaded. Pin each train, then run a real
-// checkout to prove the SDK works across all of them.
+// Stripe.js is a single global per page and our loader reuses whatever train a
+// merchant self-loaded, so the SDK must work against any of them - even though
+// the embedded-checkout method was renamed across trains
+// (initEmbeddedCheckout -> createEmbeddedCheckoutPage in dahlia).
 const STRIPE_JS_TRAINS = ["basil", "clover", "dahlia"] as const;
 
 async function preloadStripeJsTrain(page: Page, train: string): Promise<void> {
@@ -85,8 +83,8 @@ integrationTest.describe("Stripe Checkout cross-version compatibility", () => {
         await startPurchaseFlow(packageCards[0]);
         await confirmStripeCheckoutVisible(page);
 
-        // The SDK must reuse the train the page already loaded, not inject its
-        // own - a second train would be the method-name mismatch we guard for.
+        // The SDK reuses the page's train rather than injecting its own; a
+        // second train would mean it bypassed the merchant's Stripe.js.
         expect([...new Set(await loadedStripeJsTrains(page))]).toEqual([train]);
 
         await completeStripeCheckoutEmbeddedForm(page, email, fullName, false);

--- a/examples/webbilling-demo/src/tests/stripe-checkout/purchase-flow.test.ts
+++ b/examples/webbilling-demo/src/tests/stripe-checkout/purchase-flow.test.ts
@@ -18,9 +18,8 @@ import {
 
 // Stripe blocks the embedded checkout from completing on CI cloud/datacenter
 // IPs - the success callback never fires - so these full-completion tests run
-// locally only. cross-version.test.ts covers per-train mounting in CI.
-// Ref: https://docs.stripe.com/automated-testing - frontends like Stripe
-// Checkout have anti-automation measures that block this from CI.
+// locally only (https://docs.stripe.com/automated-testing).
+// cross-version.test.ts covers per-train mounting in CI.
 const LOCAL_ONLY_COMPLETION =
   "Stripe blocks payment completion from CI datacenter IPs; runs locally.";
 

--- a/examples/webbilling-demo/src/tests/stripe-checkout/purchase-flow.test.ts
+++ b/examples/webbilling-demo/src/tests/stripe-checkout/purchase-flow.test.ts
@@ -19,6 +19,8 @@ import {
 // Stripe blocks the embedded checkout from completing on CI cloud/datacenter
 // IPs - the success callback never fires - so these full-completion tests run
 // locally only. cross-version.test.ts covers per-train mounting in CI.
+// Ref: https://docs.stripe.com/automated-testing - frontends like Stripe
+// Checkout have anti-automation measures that block this from CI.
 const LOCAL_ONLY_COMPLETION =
   "Stripe blocks payment completion from CI datacenter IPs; runs locally.";
 

--- a/examples/webbilling-demo/src/tests/stripe-checkout/purchase-flow.test.ts
+++ b/examples/webbilling-demo/src/tests/stripe-checkout/purchase-flow.test.ts
@@ -16,6 +16,12 @@ import {
   STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
 } from "./test-helpers";
 
+// Stripe blocks the embedded checkout from completing on CI cloud/datacenter
+// IPs - the success callback never fires - so these full-completion tests run
+// locally only. cross-version.test.ts covers per-train mounting in CI.
+const LOCAL_ONLY_COMPLETION =
+  "Stripe blocks payment completion from CI datacenter IPs; runs locally.";
+
 integrationTest.describe("Stripe Checkout flow", () => {
   integrationTest.describe.configure({
     timeout: STRIPE_CHECKOUT_TEST_TIMEOUT_MS,
@@ -41,6 +47,8 @@ integrationTest.describe("Stripe Checkout flow", () => {
   integrationTest(
     "Purchases a product with embedded Stripe Checkout",
     async ({ page, userId, email }) => {
+      integrationTest.skip(!!process.env.CI, LOCAL_ONLY_COMPLETION);
+
       const fullName = `E2E ${userId.replace(/_/g, " ")}`;
 
       page = await navigateToStripeCheckoutLandingUrl(page, userId);
@@ -77,6 +85,8 @@ integrationTest.describe("Stripe Checkout flow", () => {
   integrationTest(
     "Purchases a product with embedded Stripe Checkout passing the email as query parameter",
     async ({ page, userId, email }) => {
+      integrationTest.skip(!!process.env.CI, LOCAL_ONLY_COMPLETION);
+
       const fullName = `E2E ${userId.replace(/_/g, " ")}`;
 
       page = await navigateToStripeCheckoutLandingUrl(page, userId, {
@@ -156,6 +166,7 @@ integrationTest.describe("Stripe Checkout flow", () => {
   integrationTest(
     "Purchases monthly product from RC Paywall with Stripe Checkout",
     async ({ page, userId, email }) => {
+      integrationTest.skip(!!process.env.CI, LOCAL_ONLY_COMPLETION);
       skipPaywallsTestIfDisabled(integrationTest);
 
       const fullName = `E2E ${userId.replace(/_/g, " ")}`;

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@storybook/svelte": "^8.6.15",
     "@storybook/sveltekit": "^8.6.15",
     "@storybook/test": "^8.6.15",
-    "@stripe/stripe-js": "^7.3.1",
+    "@stripe/stripe-js": "^9.7.0",
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/svelte": "^5.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,8 +50,8 @@ importers:
         specifier: ^8.6.15
         version: 8.6.15(storybook@8.6.15(prettier@3.4.2))
       "@stripe/stripe-js":
-        specifier: ^7.3.1
-        version: 7.3.1
+        specifier: ^9.7.0
+        version: 9.7.0
       "@sveltejs/vite-plugin-svelte":
         specifier: ^6.2.1
         version: 6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))
@@ -1254,10 +1254,10 @@ packages:
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
-  "@stripe/stripe-js@7.3.1":
+  "@stripe/stripe-js@9.7.0":
     resolution:
       {
-        integrity: sha512-pTzb864TQWDRQBPLgSPFRoyjSDUqpCkbEgTzpsjiTjGz1Z5SxZNXJek28w1s6Dyry4CyW4/Izj5jHE/J9hCJYQ==,
+        integrity: sha512-r1ElolvWXM4aYnZZVHvKW3EDL8JcwEuIgTuWxlB5lvC+YsvjkQ0gX35x9d8dTDubX395fViLVqkaolVs1PmIQQ==,
       }
     engines: { node: ">=12.16" }
 
@@ -6554,7 +6554,7 @@ snapshots:
     dependencies:
       storybook: 8.6.15(prettier@3.4.2)
 
-  "@stripe/stripe-js@7.3.1": {}
+  "@stripe/stripe-js@9.7.0": {}
 
   "@sveltejs/acorn-typescript@1.0.8(acorn@8.15.0)":
     dependencies:

--- a/src/stripe/stripe-service.ts
+++ b/src/stripe/stripe-service.ts
@@ -211,16 +211,14 @@ export class StripeService {
     let embeddedCheckout: StripeEmbeddedCheckout;
 
     try {
-      // Stripe.js is a single global per page, so a merchant's own (newer)
-      // copy can be the instance we get. It renamed initEmbeddedCheckout ->
-      // createEmbeddedCheckoutPage, so detect whichever the loaded version has.
-      const createEmbeddedCheckout =
-        (
-          stripe as Stripe & {
-            createEmbeddedCheckoutPage?: Stripe["initEmbeddedCheckout"];
-          }
-        ).createEmbeddedCheckoutPage ?? stripe.initEmbeddedCheckout;
-      embeddedCheckout = await createEmbeddedCheckout.call(stripe, {
+      // createEmbeddedCheckoutPage works on every Stripe.js release train and is
+      // the only name that works on dahlia (initEmbeddedCheckout throws there).
+      // It is not in the basil-era types yet, so cast to reach it.
+      embeddedCheckout = await (
+        stripe as Stripe & {
+          createEmbeddedCheckoutPage: Stripe["initEmbeddedCheckout"];
+        }
+      ).createEmbeddedCheckoutPage({
         fetchClientSecret: () =>
           Promise.resolve(StripeBillingParams.client_secret),
         onComplete,

--- a/src/stripe/stripe-service.ts
+++ b/src/stripe/stripe-service.ts
@@ -5,6 +5,7 @@ import type {
   Stripe,
   StripeElementLocale,
   StripeElements,
+  StripeElementsOptionsMode,
   StripeEmbeddedCheckout,
   StripeError,
 } from "@stripe/stripe-js";
@@ -181,7 +182,9 @@ export class StripeService {
             },
           },
         },
-      });
+        // Backend guarantees payment-mode amount/currency; v9 types elements()
+        // options as a discriminated union, so assert the union shape.
+      } as StripeElementsOptionsMode);
     } catch (error) {
       throw this.mapInitializationError(error as StripeError);
     }
@@ -213,12 +216,7 @@ export class StripeService {
     try {
       // createEmbeddedCheckoutPage works on every Stripe.js release train and is
       // the only name that works on dahlia (initEmbeddedCheckout throws there).
-      // It is not in the basil-era types yet, so cast to reach it.
-      embeddedCheckout = await (
-        stripe as Stripe & {
-          createEmbeddedCheckoutPage: Stripe["initEmbeddedCheckout"];
-        }
-      ).createEmbeddedCheckoutPage({
+      embeddedCheckout = await stripe.createEmbeddedCheckoutPage({
         fetchClientSecret: () =>
           Promise.resolve(StripeBillingParams.client_secret),
         onComplete,

--- a/src/stripe/stripe-service.ts
+++ b/src/stripe/stripe-service.ts
@@ -211,7 +211,16 @@ export class StripeService {
     let embeddedCheckout: StripeEmbeddedCheckout;
 
     try {
-      embeddedCheckout = await stripe.initEmbeddedCheckout({
+      // Stripe renamed initEmbeddedCheckout -> createEmbeddedCheckoutPage in its
+      // dahlia release. Stripe.js is a single global per page, so a merchant's
+      // own newer Stripe.js can be the instance we get - use whichever exists.
+      const createEmbeddedCheckout =
+        (
+          stripe as Stripe & {
+            createEmbeddedCheckoutPage?: Stripe["initEmbeddedCheckout"];
+          }
+        ).createEmbeddedCheckoutPage ?? stripe.initEmbeddedCheckout;
+      embeddedCheckout = await createEmbeddedCheckout.call(stripe, {
         fetchClientSecret: () =>
           Promise.resolve(StripeBillingParams.client_secret),
         onComplete,

--- a/src/stripe/stripe-service.ts
+++ b/src/stripe/stripe-service.ts
@@ -211,9 +211,9 @@ export class StripeService {
     let embeddedCheckout: StripeEmbeddedCheckout;
 
     try {
-      // Stripe renamed initEmbeddedCheckout -> createEmbeddedCheckoutPage in its
-      // dahlia release. Stripe.js is a single global per page, so a merchant's
-      // own newer Stripe.js can be the instance we get - use whichever exists.
+      // Stripe.js is a single global per page, so a merchant's own (newer)
+      // copy can be the instance we get. It renamed initEmbeddedCheckout ->
+      // createEmbeddedCheckoutPage, so detect whichever the loaded version has.
       const createEmbeddedCheckout =
         (
           stripe as Stripe & {

--- a/src/tests/stripe/stripe-service.test.ts
+++ b/src/tests/stripe/stripe-service.test.ts
@@ -190,12 +190,12 @@ describe("StripeService", () => {
       const createEmbeddedCheckoutPage = vi
         .fn()
         .mockResolvedValue(mockEmbeddedCheckout);
-      const mockStripe = {
+      const mockStripe: Partial<Stripe> = {
         createEmbeddedCheckoutPage,
-      } as unknown as Stripe;
+      };
       const onComplete = vi.fn();
 
-      vi.mocked(loadStripe).mockResolvedValue(mockStripe);
+      vi.mocked(loadStripe).mockResolvedValue(mockStripe as Stripe);
 
       const result = await StripeService.initializeStripeCheckout(
         "acct_123",
@@ -223,15 +223,15 @@ describe("StripeService", () => {
     });
 
     test("throws mapped initialization error when embedded checkout initialization fails", async () => {
-      const mockStripe = {
+      const mockStripe: Partial<Stripe> = {
         createEmbeddedCheckoutPage: vi.fn().mockRejectedValue({
           type: "api_connection_error",
           code: "failed_to_load",
           message: "Failed to load",
         } as StripeError),
-      } as unknown as Stripe;
+      };
 
-      vi.mocked(loadStripe).mockResolvedValue(mockStripe);
+      vi.mocked(loadStripe).mockResolvedValue(mockStripe as Stripe);
 
       await expect(
         StripeService.initializeStripeCheckout(

--- a/src/tests/stripe/stripe-service.test.ts
+++ b/src/tests/stripe/stripe-service.test.ts
@@ -185,52 +185,13 @@ describe("StripeService", () => {
       });
     });
 
-    test("initializes embedded checkout with client secret and onComplete callback", async () => {
-      const mockEmbeddedCheckout = {} as StripeEmbeddedCheckout;
-      const initEmbeddedCheckout = vi
-        .fn()
-        .mockResolvedValue(mockEmbeddedCheckout);
-      const mockStripe: Partial<Stripe> = {
-        initEmbeddedCheckout,
-      };
-      const onComplete = vi.fn();
-
-      vi.mocked(loadStripe).mockResolvedValue(mockStripe as Stripe);
-
-      const result = await StripeService.initializeStripeCheckout(
-        "acct_123",
-        "pk_test_123",
-        stripeBillingParams,
-        onComplete,
-      );
-
-      expect(loadStripe).toHaveBeenCalledWith("pk_test_123", {
-        stripeAccount: "acct_123",
-      });
-      expect(initEmbeddedCheckout).toHaveBeenCalledWith({
-        fetchClientSecret: expect.any(Function),
-        onComplete,
-      });
-
-      const fetchClientSecret = initEmbeddedCheckout.mock.calls[0]?.[0]
-        ?.fetchClientSecret as () => Promise<string>;
-      await expect(fetchClientSecret()).resolves.toBe("cs_test_123");
-
-      expect(result).toEqual({
-        stripe: mockStripe,
-        embeddedCheckout: mockEmbeddedCheckout,
-      });
-    });
-
-    test("uses createEmbeddedCheckoutPage when the loaded Stripe.js exposes it (dahlia)", async () => {
+    test("initializes embedded checkout via createEmbeddedCheckoutPage", async () => {
       const mockEmbeddedCheckout = {} as StripeEmbeddedCheckout;
       const createEmbeddedCheckoutPage = vi
         .fn()
         .mockResolvedValue(mockEmbeddedCheckout);
-      const initEmbeddedCheckout = vi.fn();
       const mockStripe = {
         createEmbeddedCheckoutPage,
-        initEmbeddedCheckout,
       } as unknown as Stripe;
       const onComplete = vi.fn();
 
@@ -243,24 +204,34 @@ describe("StripeService", () => {
         onComplete,
       );
 
+      expect(loadStripe).toHaveBeenCalledWith("pk_test_123", {
+        stripeAccount: "acct_123",
+      });
       expect(createEmbeddedCheckoutPage).toHaveBeenCalledWith({
         fetchClientSecret: expect.any(Function),
         onComplete,
       });
-      expect(initEmbeddedCheckout).not.toHaveBeenCalled();
-      expect(result.embeddedCheckout).toBe(mockEmbeddedCheckout);
+
+      const fetchClientSecret = createEmbeddedCheckoutPage.mock.calls[0]?.[0]
+        ?.fetchClientSecret as () => Promise<string>;
+      await expect(fetchClientSecret()).resolves.toBe("cs_test_123");
+
+      expect(result).toEqual({
+        stripe: mockStripe,
+        embeddedCheckout: mockEmbeddedCheckout,
+      });
     });
 
     test("throws mapped initialization error when embedded checkout initialization fails", async () => {
-      const mockStripe: Partial<Stripe> = {
-        initEmbeddedCheckout: vi.fn().mockRejectedValue({
+      const mockStripe = {
+        createEmbeddedCheckoutPage: vi.fn().mockRejectedValue({
           type: "api_connection_error",
           code: "failed_to_load",
           message: "Failed to load",
         } as StripeError),
-      };
+      } as unknown as Stripe;
 
-      vi.mocked(loadStripe).mockResolvedValue(mockStripe as Stripe);
+      vi.mocked(loadStripe).mockResolvedValue(mockStripe);
 
       await expect(
         StripeService.initializeStripeCheckout(

--- a/src/tests/stripe/stripe-service.test.ts
+++ b/src/tests/stripe/stripe-service.test.ts
@@ -222,6 +222,35 @@ describe("StripeService", () => {
       });
     });
 
+    test("uses createEmbeddedCheckoutPage when the loaded Stripe.js exposes it (dahlia)", async () => {
+      const mockEmbeddedCheckout = {} as StripeEmbeddedCheckout;
+      const createEmbeddedCheckoutPage = vi
+        .fn()
+        .mockResolvedValue(mockEmbeddedCheckout);
+      const initEmbeddedCheckout = vi.fn();
+      const mockStripe = {
+        createEmbeddedCheckoutPage,
+        initEmbeddedCheckout,
+      } as unknown as Stripe;
+      const onComplete = vi.fn();
+
+      vi.mocked(loadStripe).mockResolvedValue(mockStripe);
+
+      const result = await StripeService.initializeStripeCheckout(
+        "acct_123",
+        "pk_test_123",
+        stripeBillingParams,
+        onComplete,
+      );
+
+      expect(createEmbeddedCheckoutPage).toHaveBeenCalledWith({
+        fetchClientSecret: expect.any(Function),
+        onComplete,
+      });
+      expect(initEmbeddedCheckout).not.toHaveBeenCalled();
+      expect(result.embeddedCheckout).toBe(mockEmbeddedCheckout);
+    });
+
     test("throws mapped initialization error when embedded checkout initialization fails", async () => {
       const mockStripe: Partial<Stripe> = {
         initEmbeddedCheckout: vi.fn().mockRejectedValue({


### PR DESCRIPTION
## What

Bumps `@stripe/stripe-js` from v7 (basil) to v9 (dahlia) and adapts to its type changes. Ships standalone on `main` - it carries the embedded-checkout `createEmbeddedCheckoutPage` switch, superseding #906.

## Changes

- `@stripe/stripe-js` `^7.3.1` -> `^9.7.0` (dahlia).
- Embedded checkout calls `createEmbeddedCheckoutPage` - the method that works on every current train (acacia through dahlia) and the only one that works on dahlia. v9 declares it, so the call needs no cast.
- `stripe.elements()` options became a discriminated union in v9 (payment mode requires `amount` + `currency`); the wire type models them flatly, so assert the union shape at the call site - the backend guarantees the correlation.

## Safe by omission

The SDK uses none of the APIs removed across the clover/dahlia trains (no `redirectToCheckout`, `createSource`/`retrieveSource`, Clover elements, or deprecated PaymentIntent/SetupIntent/Sources confirm methods). The only renamed surface is the embedded-checkout method, handled above.

## Test plan

- `pnpm test`, `tsc --noEmit`, `pnpm run test:typecheck`, `pnpm svelte-check`, `pnpm build` clean
- Cross-version matrix (`cross-version.test.ts`) runs in CI: per train (basil/clover/dahlia) it self-loads that Stripe.js and asserts the SDK mounts Stripe's embedded checkout against the merchant's train (`window.Stripe.version`). That covers the train-sensitive surface the rename touches.
- Full payment-completion checkout E2E is local-only: Stripe blocks the hosted checkout from completing on CI datacenter IPs (https://docs.stripe.com/automated-testing), and completion is server-side / identical across trains. A config guard fails the build loudly if the suite would silently skip on a missing key.

---
Linear: https://linear.app/revenuecat/issue/WST-696/purchases-js-bump-stripestripe-js-to-v9-dahlia
Part of https://linear.app/revenuecat/issue/WST-694/purchases-js-stripejs-decouple-checkout-from-the-pages-stripejs
