### PR TITLE
test(e2e): add Paddle cancel/close coverage for inline and overlay (WST-713)

### DIFF
--- a/examples/webbilling-demo/src/tests/paddle/cancel-flow.test.ts
+++ b/examples/webbilling-demo/src/tests/paddle/cancel-flow.test.ts
@@ -1,0 +1,114 @@
+import { expect } from "@playwright/test";
+import { PADDLE_TEST_API_KEY } from "../helpers/fixtures";
+import { integrationTest } from "../helpers/integration-test";
+import {
+  getPackageCards,
+  skipPaddleTestsIfDisabled,
+  startPurchaseFlow,
+} from "../helpers/test-helpers";
+import {
+  confirmPaddleCheckoutFormVisible,
+  confirmPaddleInlineCheckoutVisible,
+  forcePaddleCheckoutMode,
+  getPaddleOverlayCloseButton,
+  getPaddleOverlayFrame,
+  getPaddleReturnButton,
+  navigateToPaddleLandingUrl,
+  PADDLE_TEST_TIMEOUT_MS,
+  PADDLE_UI_STEP_TIMEOUT_MS,
+} from "./test-helpers";
+
+// Cancel/close flows never complete a payment, so unlike the happy-path
+// purchases they are safe to run from CI datacenter IPs.
+integrationTest.describe("Paddle cancel flow", () => {
+  integrationTest.describe.configure({
+    timeout: PADDLE_TEST_TIMEOUT_MS,
+  });
+
+  integrationTest.skip(
+    ({ browserName }) => !!process.env.CI && browserName !== "chromium",
+    "Paddle tests run only in Chromium on CI",
+  );
+
+  skipPaddleTestsIfDisabled(integrationTest);
+
+  integrationTest.skip(
+    !PADDLE_TEST_API_KEY,
+    "Paddle E2E tests require VITE_RC_PADDLE_E2E_API_KEY.",
+  );
+
+  integrationTest.afterEach(async () => {
+    // Sleep between tests to stay clear of Paddle sandbox rate limits.
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  });
+
+  integrationTest(
+    "Returns to the paywall when closing the inline checkout",
+    async ({ page, userId, email }) => {
+      page = await navigateToPaddleLandingUrl(page, userId, { email });
+      await forcePaddleCheckoutMode(page, "inline");
+
+      await expect(page.getByText("Paddle demo")).toBeVisible({
+        timeout: PADDLE_UI_STEP_TIMEOUT_MS,
+      });
+
+      const packageCards = await getPackageCards(page);
+      expect(packageCards.length).toBeGreaterThan(0);
+
+      await startPurchaseFlow(packageCards[0]);
+      await confirmPaddleInlineCheckoutVisible(page);
+
+      const returnButton = getPaddleReturnButton(page);
+      await expect(returnButton).toBeVisible({
+        timeout: PADDLE_UI_STEP_TIMEOUT_MS,
+      });
+      await returnButton.click();
+
+      // The purchase promise rejects with a user-cancelled error and the demo
+      // stays on the paywall with the checkout UI fully unmounted.
+      await expect(
+        page.getByTestId("paddle-inline-checkout-container"),
+      ).not.toBeVisible({ timeout: PADDLE_UI_STEP_TIMEOUT_MS });
+
+      const packageCardsAfterCancel = await getPackageCards(page);
+      expect(packageCardsAfterCancel.length).toBeGreaterThan(0);
+      expect(page.url()).not.toContain("/success/");
+    },
+  );
+
+  integrationTest(
+    "Returns to the paywall when closing the overlay checkout",
+    async ({ page, userId, email }) => {
+      page = await navigateToPaddleLandingUrl(page, userId, { email });
+      await forcePaddleCheckoutMode(page, "overlay");
+
+      await expect(page.getByText("Paddle demo")).toBeVisible({
+        timeout: PADDLE_UI_STEP_TIMEOUT_MS,
+      });
+
+      const packageCards = await getPackageCards(page);
+      expect(packageCards.length).toBeGreaterThan(0);
+
+      await startPurchaseFlow(packageCards[0]);
+
+      const overlayFrame = getPaddleOverlayFrame(page);
+      await confirmPaddleCheckoutFormVisible(overlayFrame);
+
+      // Closing via Paddle's own control fires a user-initiated
+      // checkout.closed event, which the SDK maps to a user-cancelled error.
+      const closeButton = getPaddleOverlayCloseButton(overlayFrame);
+      await expect(closeButton).toBeVisible({
+        timeout: PADDLE_UI_STEP_TIMEOUT_MS,
+      });
+      await closeButton.click();
+
+      await expect(page.locator("iframe[src*='paddle.com']")).not.toBeVisible({
+        timeout: PADDLE_UI_STEP_TIMEOUT_MS,
+      });
+
+      const packageCardsAfterCancel = await getPackageCards(page);
+      expect(packageCardsAfterCancel.length).toBeGreaterThan(0);
+      expect(page.url()).not.toContain("/success/");
+    },
+  );
+});

--- a/examples/webbilling-demo/src/tests/paddle/test-helpers.ts
+++ b/examples/webbilling-demo/src/tests/paddle/test-helpers.ts
@@ -102,6 +102,14 @@ export const getPaddleReturnButton = (page: Page) =>
 export const getPaddleOverlayFrame = (page: Page) =>
   page.frameLocator("iframe.paddle-frame, iframe[name='paddle_frame']");
 
+// Paddle renders its own close affordance inside the overlay frame.
+// TODO(WST-713): verify the exact control headed against the sandbox.
+export const getPaddleOverlayCloseButton = (checkoutFrame: FrameLocator) =>
+  checkoutFrame
+    .getByRole("button", { name: /close/i })
+    .or(checkoutFrame.locator("[aria-label*='close' i]"))
+    .first();
+
 export async function confirmPaddleInlineCheckoutVisible(page: Page) {
   await expect(
     page.getByTestId("paddle-inline-checkout-container"),

--- a/examples/webbilling-demo/src/tests/paddle/test-helpers.ts
+++ b/examples/webbilling-demo/src/tests/paddle/test-helpers.ts
@@ -102,13 +102,10 @@ export const getPaddleReturnButton = (page: Page) =>
 export const getPaddleOverlayFrame = (page: Page) =>
   page.frameLocator("iframe.paddle-frame, iframe[name='paddle_frame']");
 
-// Paddle renders its own close affordance inside the overlay frame.
-// TODO(WST-713): verify the exact control headed against the sandbox.
+// Paddle's overlay close affordance, verified against the sandbox: a
+// "Return to {seller name}" button rendered inside the overlay frame.
 export const getPaddleOverlayCloseButton = (checkoutFrame: FrameLocator) =>
-  checkoutFrame
-    .getByRole("button", { name: /close/i })
-    .or(checkoutFrame.locator("[aria-label*='close' i]"))
-    .first();
+  checkoutFrame.getByRole("button", { name: /^return to/i }).first();
 
 export async function confirmPaddleInlineCheckoutVisible(page: Page) {
   await expect(


### PR DESCRIPTION
## Summary
Stacked on #918. The WST-564 failure/edge-path requirement — fully CI-safe since no payment is ever completed.

- **Inline cancel**: forced-inline checkout → click the RC return button (`data-testid=paddle-return-button`) → checkout unmounts, demo stays on the paywall, no `/success` navigation. Covers `handleInlineClose` → `Paddle.Checkout.close()`.
- **Overlay cancel**: forced-overlay checkout → click Paddle's own close control — a **'Return to {seller}'** button inside the overlay frame (selector verified against the sandbox) → user-initiated `checkout.closed` → SDK maps it to a user-cancelled error, paywall interactive again. Covers the user-initiated-close branch in `paddle-service.ts`.

Part of [WST-564](https://linear.app/revenuecat/issue/WST-564/add-paddle-e2e-coverage-in-purchases-js-webbilling-demo) (subtask [WST-713](https://linear.app/revenuecat/issue/WST-713/paddle-e2e-pr-d-cancelclose-coverage-inline-overlay)).

## Test plan
- [x] `tsc --noEmit`, eslint, prettier clean
- [x] Verified locally against the sandbox: both cancel flows green on 3 consecutive runs (~3–5s each)
- [x] CI green (these tests always run on CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in the demo app; no production billing or SDK behavior is modified.
> 
> **Overview**
> Adds **CI-safe Paddle E2E coverage** for checkout cancel/close paths (no completed payments), extending the webbilling-demo Paddle suite.
> 
> A new `cancel-flow.test.ts` suite exercises **inline** mode (forced via `forcePaddleCheckoutMode`) by opening checkout, clicking the demo **`paddle-return-button`**, and asserting the inline container unmounts, package cards remain, and the URL never hits `/success/`. It also covers **overlay** mode by opening checkout in the Paddle iframe, clicking Paddle’s **“Return to …”** close control via a new helper, and asserting the overlay iframe disappears with the same paywall expectations. Shared setup matches other Paddle tests (Chromium-only on CI, API key gate, post-test rate-limit sleep).
> 
> `test-helpers.ts` adds **`getPaddleOverlayCloseButton`** (`getByRole("button", { name: /^return to/i })` inside the overlay frame) for the overlay cancel scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 441db18b1f4988105af8dcdcab3b52eef174737a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->