### PR TITLE
test(e2e): add Paddle happy-path purchases for inline and overlay (WST-714)

### DIFF
--- a/examples/webbilling-demo/src/tests/paddle/purchase-flow.test.ts
+++ b/examples/webbilling-demo/src/tests/paddle/purchase-flow.test.ts
@@ -41,9 +41,12 @@ async function confirmSuccessPage(page: Page) {
     continueButton.click(),
   ]);
 
-  await expect(page.getByText("Enjoy your premium experience.")).toBeVisible({
-    timeout: PADDLE_UI_STEP_TIMEOUT_MS,
-  });
+  // Unlike the Stripe E2E projects, the Paddle E2E project's products grant
+  // no entitlement yet, so the entitlement-gated success page content
+  // ("Enjoy your premium experience.") cannot be asserted. Reaching /success/
+  // already proves the purchase completed and the SDK resolved the promise.
+  // Once an entitlement is attached to the paddle_e2e_test offering's
+  // products, assert the success page copy here like the Stripe suite does.
 }
 
 integrationTest.describe("Paddle flow", () => {

--- a/examples/webbilling-demo/src/tests/paddle/purchase-flow.test.ts
+++ b/examples/webbilling-demo/src/tests/paddle/purchase-flow.test.ts
@@ -61,76 +61,61 @@ integrationTest.describe("Paddle flow", () => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
   });
 
-  integrationTest(
-    "Purchases a product with the inline checkout",
-    async ({ page, userId, email }) => {
-      const fullName = `E2E ${userId.replace(/_/g, " ")}`;
+  (["inline", "overlay"] as const).forEach((mode) => {
+    integrationTest(
+      `Purchases a product with the ${mode} checkout`,
+      async ({ page, userId, email }) => {
+        const fullName = `E2E ${userId.replace(/_/g, " ")}`;
 
-      page = await navigateToPaddleLandingUrl(page, userId);
-      await forcePaddleCheckoutMode(page, "inline");
+        page = await navigateToPaddleLandingUrl(page, userId);
+        await forcePaddleCheckoutMode(page, mode);
 
-      await expect(page.getByText("Paddle demo")).toBeVisible({
-        timeout: PADDLE_UI_STEP_TIMEOUT_MS,
-      });
+        await expect(page.getByText("Paddle demo")).toBeVisible({
+          timeout: PADDLE_UI_STEP_TIMEOUT_MS,
+        });
 
-      const packageCards = await getPackageCards(page);
-      expect(packageCards.length).toBeGreaterThan(0);
+        const packageCards = await getPackageCards(page);
+        expect(packageCards.length).toBeGreaterThan(0);
 
-      await startPurchaseFlow(packageCards[0]);
-      await confirmPaddleInlineCheckoutVisible(page);
-      await confirmSandboxBannerVisible(page);
+        await startPurchaseFlow(packageCards[0]);
 
-      // The RC-rendered order summary is fed by Paddle's checkout.updated
-      // totals; assert presence only — exact figures depend on address-entry
-      // timing and would be flaky.
-      await expect(page.locator(".rcb-paddle-summary")).toBeVisible({
-        timeout: PADDLE_UI_STEP_TIMEOUT_MS,
-      });
+        let checkoutFrame;
+        if (mode === "inline") {
+          await confirmPaddleInlineCheckoutVisible(page);
 
-      await completePaddleCheckoutForm(
-        getPaddleInlineCheckoutFrame(page),
-        email,
-        fullName,
-      );
+          // Inline renders RC chrome around Paddle's frame: the sandbox
+          // banner and the order summary fed by Paddle's checkout.updated
+          // totals. Assert presence only — exact figures depend on
+          // address-entry timing and would be flaky.
+          await confirmSandboxBannerVisible(page);
+          await expect(page.locator(".rcb-paddle-summary")).toBeVisible({
+            timeout: PADDLE_UI_STEP_TIMEOUT_MS,
+          });
 
-      // The processing state only shows between checkout.completed and the
-      // backend poll finishing, which can be near-instant — accept either it
-      // or the success page.
-      await expect(
-        page
-          .locator(".rcb-paddle-processing")
-          .or(page.getByText("Payment complete"))
-          .first(),
-      ).toBeVisible({ timeout: PADDLE_UI_STEP_TIMEOUT_MS });
+          checkoutFrame = getPaddleInlineCheckoutFrame(page);
+        } else {
+          checkoutFrame = getPaddleOverlayFrame(page);
+          await confirmPaddleCheckoutFormVisible(checkoutFrame);
+        }
 
-      await confirmSuccessPage(page);
-    },
-  );
+        await completePaddleCheckoutForm(checkoutFrame, email, fullName);
 
-  integrationTest(
-    "Purchases a product with the overlay checkout",
-    async ({ page, userId, email }) => {
-      const fullName = `E2E ${userId.replace(/_/g, " ")}`;
+        if (mode === "inline") {
+          // The processing state only shows between checkout.completed and
+          // the backend poll finishing, which can be near-instant — accept
+          // either it or the success page.
+          await expect(
+            page
+              .locator(".rcb-paddle-processing")
+              .or(page.getByText("Payment complete"))
+              .first(),
+          ).toBeVisible({ timeout: PADDLE_UI_STEP_TIMEOUT_MS });
+        }
 
-      page = await navigateToPaddleLandingUrl(page, userId);
-      await forcePaddleCheckoutMode(page, "overlay");
-
-      await expect(page.getByText("Paddle demo")).toBeVisible({
-        timeout: PADDLE_UI_STEP_TIMEOUT_MS,
-      });
-
-      const packageCards = await getPackageCards(page);
-      expect(packageCards.length).toBeGreaterThan(0);
-
-      await startPurchaseFlow(packageCards[0]);
-
-      const overlayFrame = getPaddleOverlayFrame(page);
-      await confirmPaddleCheckoutFormVisible(overlayFrame);
-      await completePaddleCheckoutForm(overlayFrame, email, fullName);
-
-      await confirmSuccessPage(page);
-    },
-  );
+        await confirmSuccessPage(page);
+      },
+    );
+  });
 
   integrationTest(
     "Shows an error screen when checkout/start returns missing paddle checkout params",

--- a/examples/webbilling-demo/src/tests/paddle/purchase-flow.test.ts
+++ b/examples/webbilling-demo/src/tests/paddle/purchase-flow.test.ts
@@ -1,17 +1,50 @@
-import { expect } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 import { PADDLE_TEST_API_KEY } from "../helpers/fixtures";
 import { integrationTest } from "../helpers/integration-test";
 import {
+  confirmPaymentComplete,
   confirmPaymentError,
   getPackageCards,
   skipPaddleTestsIfDisabled,
   startPurchaseFlow,
 } from "../helpers/test-helpers";
 import {
+  completePaddleCheckoutForm,
+  confirmPaddleCheckoutFormVisible,
+  confirmPaddleInlineCheckoutVisible,
+  confirmSandboxBannerVisible,
+  forcePaddleCheckoutMode,
+  getPaddleInlineCheckoutFrame,
+  getPaddleOverlayFrame,
   navigateToPaddleLandingUrl,
   PADDLE_TEST_TIMEOUT_MS,
   PADDLE_UI_STEP_TIMEOUT_MS,
 } from "./test-helpers";
+
+// TODO(WST-709): completion from CI datacenter IPs is unvalidated for the
+// Paddle sandbox (Stripe blocks it with a CAPTCHA). Skip the full-completion
+// tests on CI until the spike settles the question, mirroring the Stripe
+// Checkout suite's original LOCAL_ONLY_COMPLETION gating.
+const PADDLE_LOCAL_ONLY_COMPLETION =
+  "Paddle sandbox completion from CI IPs is unvalidated (WST-709); run locally.";
+
+async function confirmSuccessPage(page: Page) {
+  await confirmPaymentComplete(page, PADDLE_UI_STEP_TIMEOUT_MS);
+
+  const continueButton = page.getByRole("button", { name: /continue/i });
+  await expect(continueButton).toBeVisible({
+    timeout: PADDLE_UI_STEP_TIMEOUT_MS,
+  });
+
+  await Promise.all([
+    page.waitForURL(/\/success\//, { timeout: PADDLE_UI_STEP_TIMEOUT_MS }),
+    continueButton.click(),
+  ]);
+
+  await expect(page.getByText("Enjoy your premium experience.")).toBeVisible({
+    timeout: PADDLE_UI_STEP_TIMEOUT_MS,
+  });
+}
 
 integrationTest.describe("Paddle flow", () => {
   integrationTest.describe.configure({
@@ -34,6 +67,81 @@ integrationTest.describe("Paddle flow", () => {
     // Sleep between tests to stay clear of Paddle sandbox rate limits.
     await new Promise((resolve) => setTimeout(resolve, 1000));
   });
+
+  integrationTest(
+    "Purchases a product with the inline checkout",
+    async ({ page, userId, email }) => {
+      integrationTest.skip(!!process.env.CI, PADDLE_LOCAL_ONLY_COMPLETION);
+
+      const fullName = `E2E ${userId.replace(/_/g, " ")}`;
+
+      page = await navigateToPaddleLandingUrl(page, userId);
+      await forcePaddleCheckoutMode(page, "inline");
+
+      await expect(page.getByText("Paddle demo")).toBeVisible({
+        timeout: PADDLE_UI_STEP_TIMEOUT_MS,
+      });
+
+      const packageCards = await getPackageCards(page);
+      expect(packageCards.length).toBeGreaterThan(0);
+
+      await startPurchaseFlow(packageCards[0]);
+      await confirmPaddleInlineCheckoutVisible(page);
+      await confirmSandboxBannerVisible(page);
+
+      // The RC-rendered order summary is fed by Paddle's checkout.updated
+      // totals; assert presence only — exact figures depend on address-entry
+      // timing and would be flaky.
+      await expect(page.locator(".rcb-paddle-summary")).toBeVisible({
+        timeout: PADDLE_UI_STEP_TIMEOUT_MS,
+      });
+
+      await completePaddleCheckoutForm(
+        getPaddleInlineCheckoutFrame(page),
+        email,
+        fullName,
+      );
+
+      // The processing state only shows between checkout.completed and the
+      // backend poll finishing, which can be near-instant — accept either it
+      // or the success page.
+      await expect(
+        page
+          .locator(".rcb-paddle-processing")
+          .or(page.getByText("Payment complete"))
+          .first(),
+      ).toBeVisible({ timeout: PADDLE_UI_STEP_TIMEOUT_MS });
+
+      await confirmSuccessPage(page);
+    },
+  );
+
+  integrationTest(
+    "Purchases a product with the overlay checkout",
+    async ({ page, userId, email }) => {
+      integrationTest.skip(!!process.env.CI, PADDLE_LOCAL_ONLY_COMPLETION);
+
+      const fullName = `E2E ${userId.replace(/_/g, " ")}`;
+
+      page = await navigateToPaddleLandingUrl(page, userId);
+      await forcePaddleCheckoutMode(page, "overlay");
+
+      await expect(page.getByText("Paddle demo")).toBeVisible({
+        timeout: PADDLE_UI_STEP_TIMEOUT_MS,
+      });
+
+      const packageCards = await getPackageCards(page);
+      expect(packageCards.length).toBeGreaterThan(0);
+
+      await startPurchaseFlow(packageCards[0]);
+
+      const overlayFrame = getPaddleOverlayFrame(page);
+      await confirmPaddleCheckoutFormVisible(overlayFrame);
+      await completePaddleCheckoutForm(overlayFrame, email, fullName);
+
+      await confirmSuccessPage(page);
+    },
+  );
 
   integrationTest(
     "Shows an error screen when checkout/start returns missing paddle checkout params",

--- a/examples/webbilling-demo/src/tests/paddle/purchase-flow.test.ts
+++ b/examples/webbilling-demo/src/tests/paddle/purchase-flow.test.ts
@@ -41,12 +41,9 @@ async function confirmSuccessPage(page: Page) {
     continueButton.click(),
   ]);
 
-  // Unlike the Stripe E2E projects, the Paddle E2E project's products grant
-  // no entitlement yet, so the entitlement-gated success page content
-  // ("Enjoy your premium experience.") cannot be asserted. Reaching /success/
-  // already proves the purchase completed and the SDK resolved the promise.
-  // Once an entitlement is attached to the paddle_e2e_test offering's
-  // products, assert the success page copy here like the Stripe suite does.
+  await expect(page.getByText("Enjoy your premium experience.")).toBeVisible({
+    timeout: PADDLE_UI_STEP_TIMEOUT_MS,
+  });
 }
 
 integrationTest.describe("Paddle flow", () => {

--- a/examples/webbilling-demo/src/tests/paddle/purchase-flow.test.ts
+++ b/examples/webbilling-demo/src/tests/paddle/purchase-flow.test.ts
@@ -21,13 +21,6 @@ import {
   PADDLE_UI_STEP_TIMEOUT_MS,
 } from "./test-helpers";
 
-// TODO(WST-709): completion from CI datacenter IPs is unvalidated for the
-// Paddle sandbox (Stripe blocks it with a CAPTCHA). Skip the full-completion
-// tests on CI until the spike settles the question, mirroring the Stripe
-// Checkout suite's original LOCAL_ONLY_COMPLETION gating.
-const PADDLE_LOCAL_ONLY_COMPLETION =
-  "Paddle sandbox completion from CI IPs is unvalidated (WST-709); run locally.";
-
 async function confirmSuccessPage(page: Page) {
   await confirmPaymentComplete(page, PADDLE_UI_STEP_TIMEOUT_MS);
 
@@ -71,8 +64,6 @@ integrationTest.describe("Paddle flow", () => {
   integrationTest(
     "Purchases a product with the inline checkout",
     async ({ page, userId, email }) => {
-      integrationTest.skip(!!process.env.CI, PADDLE_LOCAL_ONLY_COMPLETION);
-
       const fullName = `E2E ${userId.replace(/_/g, " ")}`;
 
       page = await navigateToPaddleLandingUrl(page, userId);
@@ -119,8 +110,6 @@ integrationTest.describe("Paddle flow", () => {
   integrationTest(
     "Purchases a product with the overlay checkout",
     async ({ page, userId, email }) => {
-      integrationTest.skip(!!process.env.CI, PADDLE_LOCAL_ONLY_COMPLETION);
-
       const fullName = `E2E ${userId.replace(/_/g, " ")}`;
 
       page = await navigateToPaddleLandingUrl(page, userId);


### PR DESCRIPTION
## Summary
Stacked on #919. Completes the WST-564 happy-path requirement for both presentation modes — **both tests complete real Paddle sandbox purchases**, and they **run on CI** (the WST-709 spike, #923, confirmed Paddle sandbox completes purchases from CircleCI IPs — no Stripe-style CAPTCHA gating needed).

- **Inline**: forced inline → sandbox banner + RC order summary visible (presence only — exact totals depend on `checkout.updated` timing) → form completion in the container-scoped frame → processing-state-or-success race → 'Payment complete' → Continue → `/success/` → entitlement-gated success content ('Enjoy your premium experience.').
- **Overlay**: forced overlay → form completion in Paddle's overlay frame → 'Payment complete' → Continue → `/success/` → entitlement-gated success content.

Part of [WST-564](https://linear.app/revenuecat/issue/WST-564/add-paddle-e2e-coverage-in-purchases-js-webbilling-demo) (subtask [WST-714](https://linear.app/revenuecat/issue/WST-714/paddle-e2e-pr-e-happy-path-purchases-inline-overlay)).

## Test plan
- [x] `tsc --noEmit`, eslint, prettier clean
- [x] Verified locally: both happy paths complete real sandbox purchases (~15–19s each), repeatedly green
- [x] Entitlement-gated success page asserted (entitlement attached to the `paddle_e2e_test` offering's products)
- [x] CI completion validated via spike #923 — happy paths run on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in the webbilling demo; no production billing or app logic is modified.
> 
> **Overview**
> Adds **end-to-end happy-path purchase coverage** for Paddle in the webbilling demo, parameterized for **inline** and **overlay** checkout modes. Each test forces the mode, starts a purchase from the paywall, fills the Paddle checkout in the correct iframe, and asserts through **payment complete → Continue → `/success/`** with entitlement copy (**"Enjoy your premium experience."**).
> 
> A shared **`confirmSuccessPage`** helper centralizes the post-payment navigation and success assertions. **Inline** tests additionally check RC chrome (sandbox banner, `.rcb-paddle-summary`) and tolerate a race between processing UI and success; **overlay** tests target Paddle’s overlay frame. The existing **checkout/start error** scenario is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad6c5c9fc0cbbe7c0ed33cee7ef8e7fd6aca18a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->