### PR TITLE
[DO NOT MERGE] spike(e2e): validate Paddle CI purchase completion (WST-709)

### DIFF
--- a/examples/webbilling-demo/package.json
+++ b/examples/webbilling-demo/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint \"**/*.{ts,tsx}\" --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "test": "vitest",
-    "test:ci": "(vite &) && sleep 5 && playwright test",
+    "test:ci": "(vite &) && sleep 5 && playwright test src/tests/paddle",
     "test:ui": "(vite &) && sleep 5 && playwright test --ui",
     "test:e2e": "playwright test",
     "test:e2e-ui": "playwright test --ui",

--- a/examples/webbilling-demo/src/tests/paddle/purchase-flow.test.ts
+++ b/examples/webbilling-demo/src/tests/paddle/purchase-flow.test.ts
@@ -21,13 +21,6 @@ import {
   PADDLE_UI_STEP_TIMEOUT_MS,
 } from "./test-helpers";
 
-// TODO(WST-709): completion from CI datacenter IPs is unvalidated for the
-// Paddle sandbox (Stripe blocks it with a CAPTCHA). Skip the full-completion
-// tests on CI until the spike settles the question, mirroring the Stripe
-// Checkout suite's original LOCAL_ONLY_COMPLETION gating.
-const PADDLE_LOCAL_ONLY_COMPLETION =
-  "Paddle sandbox completion from CI IPs is unvalidated (WST-709); run locally.";
-
 async function confirmSuccessPage(page: Page) {
   await confirmPaymentComplete(page, PADDLE_UI_STEP_TIMEOUT_MS);
 
@@ -71,8 +64,6 @@ integrationTest.describe("Paddle flow", () => {
   integrationTest(
     "Purchases a product with the inline checkout",
     async ({ page, userId, email }) => {
-      integrationTest.skip(!!process.env.CI, PADDLE_LOCAL_ONLY_COMPLETION);
-
       const fullName = `E2E ${userId.replace(/_/g, " ")}`;
 
       page = await navigateToPaddleLandingUrl(page, userId);
@@ -119,8 +110,6 @@ integrationTest.describe("Paddle flow", () => {
   integrationTest(
     "Purchases a product with the overlay checkout",
     async ({ page, userId, email }) => {
-      integrationTest.skip(!!process.env.CI, PADDLE_LOCAL_ONLY_COMPLETION);
-
       const fullName = `E2E ${userId.replace(/_/g, " ")}`;
 
       page = await navigateToPaddleLandingUrl(page, userId);


### PR DESCRIPTION
## Summary
Throwaway spike for [WST-709](https://linear.app/revenuecat/issue/WST-709): removes the CI skip from the Paddle happy-path tests and scopes `test:ci` to the Paddle suite only, to get a clean signal on whether Paddle sandbox completes purchases from CircleCI datacenter IPs.

- **If `test-e2e` passes here** → Paddle completes from CI; remove the CI skip in #920 for real and close WST-709.
- **If it fails on the happy paths** → keep the skip, document the finding in WST-709.

**Do not merge** — close after reading the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)