### PR TITLE
Add update-error-codes workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  revenuecat: revenuecat/sdks-common-config@3.16.0
+  revenuecat: revenuecat/sdks-common-config@3.21.0
   aws-cli: circleci/aws-cli@4.1.3
   node: circleci/node@7.2.1
 
@@ -25,7 +25,7 @@ aliases:
 parameters:
   action:
     type: enum
-    enum: [ default, bump ]
+    enum: [ default, bump, update_error_codes ]
     default: default
   version:
     type: string
@@ -246,8 +246,11 @@ jobs:
 workflows:
   danger:
     when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      and:
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - not:
+            equal: [ update_error_codes, << pipeline.parameters.action >> ]
     jobs:
       - revenuecat/danger
 
@@ -265,10 +268,32 @@ workflows:
     jobs:
       - revenuecat/automatic-bump
 
+  update-error-codes:
+    when:
+      equal: [ update_error_codes, << pipeline.parameters.action >> ]
+    jobs:
+      - revenuecat/update-error-codes:
+          platform: js
+          output: src/generated/error-codes.ts
+          commit_paths: "src/generated/error-codes.ts,api-report"
+          update_api_steps:
+            - install-dependencies
+            - revenuecat/install-gem-unix-dependencies:
+                cache-version: v1
+            - run:
+                name: Build
+                command: pnpm run build
+            - run:
+                name: Extract API
+                command: pnpm run extract-api
+
   test-deploy:
     when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      and:
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - not:
+            equal: [ update_error_codes, << pipeline.parameters.action >> ]
     jobs:
       - test
       - test-e2e

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 894bb1b3dd9472b488d01754118f387a2d5957b6
+  revision: d911a06677d2926dd61beb80400b5b5e69fbc1df
   branch: main
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)


### PR DESCRIPTION
Adds the `update-error-codes` workflow (gated on `action=update_error_codes`) that runs `revenuecat/update-error-codes@3.21.0`: copies the generated `src/generated/error-codes.ts` from purchases-error-codes, rebuilds the API report, and opens/updates the PR. Bumps the orb to 3.21.0.

Merge after the orb is published and the plugin pin is bumped (`bundle update fastlane-plugin-revenuecat_internal`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and dependency pin changes only; no runtime SDK logic is modified in this diff.
> 
> **Overview**
> Adds a **manual/parameterized CI path** to refresh SDK error codes from the shared `purchases-error-codes` source and keep the public API report in sync.
> 
> **CircleCI:** Bumps `revenuecat/sdks-common-config` to **3.21.0**, extends the `action` pipeline parameter with `update_error_codes`, and introduces an **`update-error-codes` workflow** that runs `revenuecat/update-error-codes` for the JS platform—writing `src/generated/error-codes.ts`, then building and running `extract-api` so `api-report` is updated in the same commit. **`danger`** and **`test-deploy`** are gated so they **do not run** when `action=update_error_codes` (alongside the existing scheduled-pipeline exclusion for `danger`).
> 
> **Ruby:** `Gemfile.lock` pins a newer revision of `fastlane-plugin-revenuecat_internal` to align with the orb workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a51a0aa0665fcaa3c653dd9ec0d688f37334b268. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->