### PR TITLE
feat: send paywall session id on web checkout (WEB-4389)

### DIFF
--- a/src/entities/present-express-purchase-button-params.ts
+++ b/src/entities/present-express-purchase-button-params.ts
@@ -76,4 +76,12 @@ export interface PresentExpressPurchaseButtonParams {
    * @default "black"
    */
   walletButtonTheme?: WalletButtonTheme;
+
+  /**
+   * The paywall session ID (one per presentPaywall() call) when this button is
+   * rendered inside a paywall. Used to mark the resulting transaction as an
+   * RC Paywall purchase in reporting.
+   * @internal
+   */
+  paywallSessionId?: string;
 }

--- a/src/entities/purchase-params.ts
+++ b/src/entities/purchase-params.ts
@@ -100,6 +100,14 @@ export interface PurchaseParams {
   paywallId?: string;
 
   /**
+   * The paywall session ID (one per presentPaywall() call) from which this
+   * purchase originated, if applicable. Used to mark the transaction as an
+   * RC Paywall purchase in reporting.
+   * @internal
+   */
+  paywallSessionId?: string;
+
+  /**
    * The locale to use for the purchase flow. If not specified, English will be used
    */
   selectedLocale?: string;

--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -124,6 +124,7 @@ interface CheckoutStartParams {
   presentedOfferingContext: PresentedOfferingContext;
   workflowPurchaseContext?: WorkflowPurchaseContext;
   paywallId?: string;
+  paywallSessionId?: string;
 
   // Customer data
   customerEmail?: string;
@@ -248,6 +249,7 @@ export class PurchaseOperationHelper {
     presentedOfferingContext,
     workflowPurchaseContext,
     paywallId,
+    paywallSessionId,
     customerEmail,
     metadata,
     locale,
@@ -266,6 +268,7 @@ export class PurchaseOperationHelper {
           traceId,
           presentedStepId,
           paywallId,
+          paywallSessionId,
           customerEmail,
           metadata,
           locale,

--- a/src/main.ts
+++ b/src/main.ts
@@ -737,6 +737,7 @@ export class Purchases {
         defaultLocale:
           offering.paywallComponents?.default_locale || englishLocale,
         paywallId: offering.paywallComponents?.id,
+        paywallSessionId,
       });
 
       return { ...purchaseResult, selectedPackage: pkg };
@@ -987,6 +988,7 @@ export class Purchases {
         paywallParams.customerEmail,
         onError("Error presenting express purchase button"),
         listener,
+        paywallSessionId,
       );
 
       certainHTMLTarget.innerHTML = "";
@@ -1175,6 +1177,7 @@ export class Purchases {
       defaultLocale = englishLocale,
       onButtonReady = () => {},
       walletButtonTheme,
+      paywallSessionId,
     } = params;
 
     if (htmlTarget === undefined) {
@@ -1252,6 +1255,7 @@ export class Purchases {
         onError,
         listener: params.listener,
         walletButtonTheme,
+        paywallSessionId,
       });
     });
   }
@@ -1273,6 +1277,7 @@ export class Purchases {
     customerEmail?: string,
     onError?: (error: Error) => void,
     listener?: PaywallListener,
+    paywallSessionId?: string,
   ): WalletButtonRender | undefined {
     if (!isWebBillingApiKey(this._API_KEY)) {
       return undefined;
@@ -1298,6 +1303,7 @@ export class Purchases {
         },
         listener,
         walletButtonTheme,
+        paywallSessionId,
       })
         .then((purchaseResult) => {
           onSuccess({ ...purchaseResult, selectedPackage: pkg });
@@ -1368,6 +1374,7 @@ export class Purchases {
       workflowPurchaseContext,
       attributionMetadata,
       paywallId,
+      paywallSessionId,
       selectedLocale = englishLocale,
       defaultLocale = englishLocale,
       skipSuccessPage = false,
@@ -1454,6 +1461,7 @@ export class Purchases {
           workflowPurchaseContext,
           attributionMetadata,
           paywallId,
+          paywallSessionId,
           onFinished,
           onClose,
           onError,
@@ -1569,6 +1577,7 @@ export class Purchases {
           workflowPurchaseContext,
           attributionMetadata,
           paywallId: params.paywallId,
+          paywallSessionId: params.paywallSessionId,
           onFinished,
           onClose,
           onError,

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -225,7 +225,7 @@ export class Backend {
       locale?: string;
       paywall?: {
         paywall_id?: string;
-        session_id?: string;
+        paywall_session_id?: string;
       };
       attribution_metadata?: AttributionMetadata;
     };
@@ -272,7 +272,7 @@ export class Backend {
     if (paywallId || paywallSessionId) {
       requestBody.paywall = {
         ...(paywallId ? { paywall_id: paywallId } : {}),
-        ...(paywallSessionId ? { session_id: paywallSessionId } : {}),
+        ...(paywallSessionId ? { paywall_session_id: paywallSessionId } : {}),
       };
     }
 

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -46,6 +46,7 @@ interface CheckoutStartRequestParams {
   presentedOfferingContext: PresentedOfferingContext;
   presentedStepId?: string;
   paywallId?: string;
+  paywallSessionId?: string;
 
   // Customer data
   customerEmail?: string;
@@ -199,6 +200,7 @@ export class Backend {
     traceId,
     presentedStepId,
     paywallId,
+    paywallSessionId,
     customerEmail,
     metadata,
     locale,
@@ -222,7 +224,8 @@ export class Backend {
       trace_id: string;
       locale?: string;
       paywall?: {
-        paywall_id: string;
+        paywall_id?: string;
+        session_id?: string;
       };
       attribution_metadata?: AttributionMetadata;
     };
@@ -266,9 +269,10 @@ export class Backend {
       requestBody.presented_step_id = presentedStepId;
     }
 
-    if (paywallId) {
+    if (paywallId || paywallSessionId) {
       requestBody.paywall = {
-        paywall_id: paywallId,
+        ...(paywallId ? { paywall_id: paywallId } : {}),
+        ...(paywallSessionId ? { session_id: paywallSessionId } : {}),
       };
     }
 

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -819,7 +819,7 @@ describe("postCheckoutStart request", () => {
     expect(requestBody.paywall).toBeUndefined();
   });
 
-  test("includes paywall.session_id in request when provided", async () => {
+  test("includes paywall.paywall_session_id in request when provided", async () => {
     setCheckoutStartResponse(
       HttpResponse.json(checkoutStartResponse, { status: 200 }),
     );
@@ -843,11 +843,11 @@ describe("postCheckoutStart request", () => {
     const requestBody = await request.json();
     expect(requestBody.paywall).toEqual({
       paywall_id: "test-paywall-123",
-      session_id: "test-session-456",
+      paywall_session_id: "test-session-456",
     });
   });
 
-  test("includes paywall.session_id even without a paywall_id", async () => {
+  test("includes paywall.paywall_session_id even without a paywall_id", async () => {
     setCheckoutStartResponse(
       HttpResponse.json(checkoutStartResponse, { status: 200 }),
     );
@@ -868,7 +868,9 @@ describe("postCheckoutStart request", () => {
     expect(purchaseMethodAPIMock).toHaveBeenCalledTimes(1);
     const request = purchaseMethodAPIMock.mock.calls[0][0].request;
     const requestBody = await request.json();
-    expect(requestBody.paywall).toEqual({ session_id: "test-session-456" });
+    expect(requestBody.paywall).toEqual({
+      paywall_session_id: "test-session-456",
+    });
   });
 
   test("omits paywall from request when neither id provided", async () => {

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -819,6 +819,81 @@ describe("postCheckoutStart request", () => {
     expect(requestBody.paywall).toBeUndefined();
   });
 
+  test("includes paywall.session_id in request when provided", async () => {
+    setCheckoutStartResponse(
+      HttpResponse.json(checkoutStartResponse, { status: 200 }),
+    );
+
+    await backend.postCheckoutStart({
+      appUserId: "someAppUserId",
+      productId: "monthly",
+      presentedOfferingContext: {
+        offeringIdentifier: "offering_1",
+        targetingContext: null,
+        placementIdentifier: null,
+      },
+      purchaseOption: { id: "base_option", priceId: "test_price_id" },
+      traceId: "test-trace-id",
+      paywallId: "test-paywall-123",
+      paywallSessionId: "test-session-456",
+    });
+
+    expect(purchaseMethodAPIMock).toHaveBeenCalledTimes(1);
+    const request = purchaseMethodAPIMock.mock.calls[0][0].request;
+    const requestBody = await request.json();
+    expect(requestBody.paywall).toEqual({
+      paywall_id: "test-paywall-123",
+      session_id: "test-session-456",
+    });
+  });
+
+  test("includes paywall.session_id even without a paywall_id", async () => {
+    setCheckoutStartResponse(
+      HttpResponse.json(checkoutStartResponse, { status: 200 }),
+    );
+
+    await backend.postCheckoutStart({
+      appUserId: "someAppUserId",
+      productId: "monthly",
+      presentedOfferingContext: {
+        offeringIdentifier: "offering_1",
+        targetingContext: null,
+        placementIdentifier: null,
+      },
+      purchaseOption: { id: "base_option", priceId: "test_price_id" },
+      traceId: "test-trace-id",
+      paywallSessionId: "test-session-456",
+    });
+
+    expect(purchaseMethodAPIMock).toHaveBeenCalledTimes(1);
+    const request = purchaseMethodAPIMock.mock.calls[0][0].request;
+    const requestBody = await request.json();
+    expect(requestBody.paywall).toEqual({ session_id: "test-session-456" });
+  });
+
+  test("omits paywall from request when neither id provided", async () => {
+    setCheckoutStartResponse(
+      HttpResponse.json(checkoutStartResponse, { status: 200 }),
+    );
+
+    await backend.postCheckoutStart({
+      appUserId: "someAppUserId",
+      productId: "monthly",
+      presentedOfferingContext: {
+        offeringIdentifier: "offering_1",
+        targetingContext: null,
+        placementIdentifier: null,
+      },
+      purchaseOption: { id: "base_option", priceId: "test_price_id" },
+      traceId: "test-trace-id",
+    });
+
+    expect(purchaseMethodAPIMock).toHaveBeenCalledTimes(1);
+    const request = purchaseMethodAPIMock.mock.calls[0][0].request;
+    const requestBody = await request.json();
+    expect(requestBody.paywall).toBeUndefined();
+  });
+
   test("includes locale in request when provided", async () => {
     setCheckoutStartResponse(
       HttpResponse.json(checkoutStartResponse, { status: 200 }),

--- a/src/tests/present-paywall.events.test.ts
+++ b/src/tests/present-paywall.events.test.ts
@@ -189,6 +189,37 @@ describe("Purchases.presentPaywall() paywall events", () => {
     ).toEqual(["paywall_impression"]);
   });
 
+  test("threads the same paywall session id into the purchase call", async () => {
+    const purchases = configurePurchases();
+    const offering = createOfferingWithPaywall();
+    const packageId = offering.availablePackages[0]!.identifier;
+    const trackPaywallEventSpy = vi.spyOn(
+      purchases["eventsTracker"],
+      "trackPaywallEvent",
+    );
+    const purchaseSpy = vi
+      .spyOn(purchases, "purchase")
+      .mockRejectedValue(new PurchasesError(ErrorCode.UserCancelledError));
+
+    const paywallPromise = purchases.presentPaywall({ offering });
+    void paywallPromise.catch(() => undefined);
+
+    expect(paywallProps).toBeDefined();
+    paywallProps!.onPurchaseClicked(packageId);
+
+    await vi.waitFor(() => {
+      expect(purchaseSpy).toHaveBeenCalledTimes(1);
+    });
+
+    const impressionEvent = trackPaywallEventSpy.mock.calls
+      .map(([event]) => event)
+      .find((event) => event.type === "paywall_impression");
+    const purchaseParams = purchaseSpy.mock.calls[0]![0];
+
+    expect(purchaseParams.paywallSessionId).toBeDefined();
+    expect(purchaseParams.paywallSessionId).toBe(impressionEvent!.sessionId);
+  });
+
   test("passes presentedOfferingContext to paywall events", async () => {
     const purchases = configurePurchases();
     const offering = createOfferingWithPaywall();

--- a/src/ui/express-purchase-button/express-purchase-button-props.ts
+++ b/src/ui/express-purchase-button/express-purchase-button-props.ts
@@ -35,4 +35,5 @@ export interface ExpressPurchaseButtonProps {
   onReady?: (walletsAvailable: boolean) => void;
   listener?: PaywallListener;
   walletButtonTheme?: WalletButtonTheme;
+  paywallSessionId?: string;
 }

--- a/src/ui/express-purchase-button/express-purchase-button.svelte
+++ b/src/ui/express-purchase-button/express-purchase-button.svelte
@@ -54,6 +54,7 @@
     onReady,
     listener,
     walletButtonTheme,
+    paywallSessionId,
   }: ExpressPurchaseButtonProps = $props();
 
   const mode: SDKEventPurchaseMode = "express_purchase_button";
@@ -297,6 +298,7 @@
           rcPackage.webBillingProduct.presentedOfferingContext,
         customerEmail,
         metadata,
+        paywallSessionId,
         locale: translator.selectedLocale,
       });
 

--- a/src/ui/purchases-ui.svelte
+++ b/src/ui/purchases-ui.svelte
@@ -63,6 +63,7 @@
     workflowPurchaseContext?: WorkflowPurchaseContext;
     attributionMetadata?: AttributionMetadata;
     paywallId?: string;
+    paywallSessionId?: string;
     onFinished: (operationResult: OperationSessionSuccessfulResult) => void;
     onError: (error: PurchaseFlowError) => void;
     onClose: (() => void) | undefined;
@@ -90,6 +91,7 @@
     workflowPurchaseContext,
     attributionMetadata,
     paywallId,
+    paywallSessionId,
     onFinished,
     onError,
     onClose,
@@ -195,6 +197,7 @@
         workflowPurchaseContext,
         attributionMetadata,
         paywallId,
+        paywallSessionId,
         locale: selectedLocale,
       })
       .then((result) => ({ result, emailToUse: nextEmail }))
@@ -215,6 +218,7 @@
             workflowPurchaseContext,
             attributionMetadata,
             paywallId,
+            paywallSessionId,
             locale: selectedLocale,
           })
           .then((result) => ({ result, emailToUse: undefined }));

--- a/src/ui/stripe-checkout-purchases-ui.svelte
+++ b/src/ui/stripe-checkout-purchases-ui.svelte
@@ -47,6 +47,7 @@
     workflowPurchaseContext?: WorkflowPurchaseContext;
     attributionMetadata?: AttributionMetadata;
     paywallId?: string;
+    paywallSessionId?: string;
   }
 
   const {
@@ -68,6 +69,7 @@
     workflowPurchaseContext,
     attributionMetadata,
     paywallId,
+    paywallSessionId,
   }: Props = $props();
   let productDetails: Product = rcPackage.webBillingProduct;
   let translator: Translator = new Translator(
@@ -177,6 +179,7 @@
         workflowPurchaseContext,
         attributionMetadata,
         paywallId,
+        paywallSessionId,
         locale: selectedLocale,
       });
 


### PR DESCRIPTION
## Why

The Looker field **"Is RC Paywall Purchase (Yes / No)"** is derived from `presented_offering_context.paywall_session_id` on the transaction. Web paywalls never sent a paywall session id on purchase, so web paywall purchases always read "No".

[PW-1121](https://linear.app/revenuecat/issue/PW-1121) added the `paywall_impression`/`close`/`cancel` analytics events (and the per-`presentPaywall()` `paywallSessionId`), but never attached that id to the purchase/checkout request. This PR closes that gap.

Linear: [WEB-4389](https://linear.app/revenuecat/issue/WEB-4389/populate-paywall-session-id-on-web-paywall-transactions-fix-is-rc)

## What

Thread the existing `paywallSessionId` from `presentPaywall()` through the purchase flow and send it as `paywall.session_id` on `POST /checkout/start` (matching the native receipts convention):

- New optional `paywallSessionId` on `PurchaseParams` → `CheckoutStartParams` → `postCheckoutStart`.
- `paywall` body object is now built when **either** `paywall_id` or `session_id` is present.
- Covers card checkout (`purchases-ui`, `stripe-checkout-purchases-ui`) **and** the wallet/express button path reached from within a paywall (`getWalletButtonRender` → `presentExpressPurchaseButton` → `ExpressPurchaseButton`).

## Pairs with

khepri PR (persists `paywall_session_id` onto the transaction). The backend side is backward-compatible and should land first; this PR is a no-op for reporting until it does.

## Test plan

- [x] Full suite green locally: **640 passed**.
- [x] `backend.test.ts`: `paywall.session_id` sent with/without `paywall_id`; `paywall` omitted when neither present.
- [x] `present-paywall.events.test.ts`: the same session id used on the impression event reaches the `purchase()` call.