### PR TITLE
Danger: block manual edits to generated error codes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  revenuecat: revenuecat/sdks-common-config@3.21.0
+  revenuecat: revenuecat/sdks-common-config@3.21.1
   aws-cli: circleci/aws-cli@4.1.3
   node: circleci/node@7.2.1
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -28,3 +28,5 @@ unless head_branch.to_s.start_with?('release/')
     )
   end
 end
+
+fail_on_generated_edits(["src/generated/"])


### PR DESCRIPTION
- Adds a Danger check to prevent modification of autogenerated files from [purchases-error-codes](https://github.com/RevenueCat/purchases-error-codes). Calls a function defined in [RevenueCat/Dangerfile](https://github.com/RevenueCat/Dangerfile/pull/16)
- Bumps the [shared orb](https://github.com/RevenueCat/sdks-circleci-orb/pull/68) to get the proper labels on the generated PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and Danger policy only; no runtime SDK or auth/data behavior changes.
> 
> **Overview**
> Adds a **Danger** guard that fails PRs that touch files under `src/generated/` (e.g. autogenerated `error-codes.ts` from purchases-error-codes), using the shared `fail_on_generated_edits` helper from **RevenueCat/Dangerfile**.
> 
> Bumps the **sdks-common-config** CircleCI orb from `3.21.0` to `3.21.1` so automated `update_error_codes` PRs get the correct labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 680579ec4d0058c1cdde34aeb443db5f400a7e93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->