### PR TITLE
Bump @revenuecat/purchases-ui-js to 4.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@babel/runtime": "^7.26.10",
     "@eslint/js": "^9.16.0",
     "@microsoft/api-extractor": "^7.48.0",
-    "@revenuecat/purchases-ui-js": "^4.7.3",
+    "@revenuecat/purchases-ui-js": "^4.7.4",
     "@paddle/paddle-js": "^1.6.4",
     "@storybook/addon-essentials": "^8.6.15",
     "@storybook/addon-interactions": "^8.6.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^1.6.4
         version: 1.6.4
       "@revenuecat/purchases-ui-js":
-        specifier: ^4.7.3
-        version: 4.7.3(svelte@5.46.4)
+        specifier: ^4.7.4
+        version: 4.7.4(svelte@5.46.4)
       "@storybook/addon-essentials":
         specifier: ^8.6.15
         version: 8.6.15(@types/react@19.0.10)(storybook@8.6.15(prettier@3.4.2))
@@ -722,10 +722,10 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
 
-  "@revenuecat/purchases-ui-js@4.7.3":
+  "@revenuecat/purchases-ui-js@4.7.4":
     resolution:
       {
-        integrity: sha512-iRzZc1/9KPoVG/LuBGVh9W+R3ixtdT0dnXkdq9ay+ABPcKLUMnja+dyqvRMY9ReBis0fKo5F1HqLztqjbpSnQQ==,
+        integrity: sha512-Ra8VhN5KihaQ1avy27LzG6dGUjhVx2oVOOfJQVKf81oIOgKbiA0NLwrMJ/9XvHrvwzEdLOGC45zeN4oPlsDixw==,
       }
     engines: { node: ^22.18 || ^24.11 }
     peerDependencies:
@@ -6155,7 +6155,7 @@ snapshots:
 
   "@pkgr/core@0.1.1": {}
 
-  "@revenuecat/purchases-ui-js@4.7.3(svelte@5.46.4)":
+  "@revenuecat/purchases-ui-js@4.7.4(svelte@5.46.4)":
     dependencies:
       qrcode: 1.5.4
       svelte: 5.46.4


### PR DESCRIPTION
Upgrade @revenuecat/purchases-ui-js from 4.7.3 to 4.7.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level dev dependency bump with no application source changes; risk is limited to Storybook/UI tooling behavior in 4.7.4.
> 
> **Overview**
> Bumps the **`@revenuecat/purchases-ui-js`** dev dependency from **4.7.3** to **4.7.4** in `package.json` and refreshes **`pnpm-lock.yaml`** (specifier, resolved version, and integrity hash).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e48a8a1ba1be694041ca71f6cfab93e3f585ad8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->