### PR TITLE
feat: send paywallSessionId in checkout/start

### DIFF
--- a/src/entities/purchase-params.ts
+++ b/src/entities/purchase-params.ts
@@ -100,6 +100,12 @@ export interface PurchaseParams {
   paywallId?: string;
 
   /**
+   * The paywall session ID from which this purchase originated, if applicable.
+   * @internal
+   */
+  paywallSessionId?: string;
+
+  /**
    * The locale to use for the purchase flow. If not specified, English will be used
    */
   selectedLocale?: string;

--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -124,6 +124,7 @@ interface CheckoutStartParams {
   presentedOfferingContext: PresentedOfferingContext;
   workflowPurchaseContext?: WorkflowPurchaseContext;
   paywallId?: string;
+  paywallSessionId?: string;
 
   // Customer data
   customerEmail?: string;
@@ -248,6 +249,7 @@ export class PurchaseOperationHelper {
     presentedOfferingContext,
     workflowPurchaseContext,
     paywallId,
+    paywallSessionId,
     customerEmail,
     metadata,
     locale,
@@ -266,6 +268,7 @@ export class PurchaseOperationHelper {
           traceId,
           presentedStepId,
           paywallId,
+          paywallSessionId,
           customerEmail,
           metadata,
           locale,

--- a/src/main.ts
+++ b/src/main.ts
@@ -759,6 +759,7 @@ export class Purchases {
         defaultLocale:
           offering.paywallComponents?.default_locale ?? englishLocale,
         paywallId: offering.paywallComponents?.id,
+        paywallSessionId,
       });
 
       return { ...purchaseResult, selectedPackage: pkg };
@@ -1472,6 +1473,7 @@ export class Purchases {
       workflowPurchaseContext,
       attributionMetadata,
       paywallId,
+      paywallSessionId,
       selectedLocale = englishLocale,
       defaultLocale = englishLocale,
       skipSuccessPage = false,
@@ -1558,6 +1560,7 @@ export class Purchases {
           workflowPurchaseContext,
           attributionMetadata,
           paywallId,
+          paywallSessionId,
           onFinished,
           onClose,
           onError,
@@ -1673,6 +1676,7 @@ export class Purchases {
           workflowPurchaseContext,
           attributionMetadata,
           paywallId: params.paywallId,
+          paywallSessionId: params.paywallSessionId,
           onFinished,
           onClose,
           onError,

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -53,6 +53,7 @@ interface CheckoutStartRequestParams {
   presentedOfferingContext: PresentedOfferingContext;
   presentedStepId?: string;
   paywallId?: string;
+  paywallSessionId?: string;
 
   // Customer data
   customerEmail?: string;
@@ -206,6 +207,7 @@ export class Backend {
     traceId,
     presentedStepId,
     paywallId,
+    paywallSessionId,
     customerEmail,
     metadata,
     locale,
@@ -230,6 +232,7 @@ export class Backend {
       locale?: string;
       paywall?: {
         paywall_id: string;
+        paywall_session_id?: string;
       };
       attribution_metadata?: AttributionMetadata;
     };
@@ -276,6 +279,7 @@ export class Backend {
     if (paywallId) {
       requestBody.paywall = {
         paywall_id: paywallId,
+        ...(paywallSessionId ? { paywall_session_id: paywallSessionId } : {}),
       };
     }
 

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -796,6 +796,58 @@ describe("postCheckoutStart request", () => {
     expect(requestBody.paywall).toEqual({ paywall_id: "test-paywall-123" });
   });
 
+  test("includes paywall_session_id in request when provided", async () => {
+    setCheckoutStartResponse(
+      HttpResponse.json(checkoutStartResponse, { status: 200 }),
+    );
+
+    await backend.postCheckoutStart({
+      appUserId: "someAppUserId",
+      productId: "monthly",
+      presentedOfferingContext: {
+        offeringIdentifier: "offering_1",
+        targetingContext: null,
+        placementIdentifier: null,
+      },
+      purchaseOption: { id: "base_option", priceId: "test_price_id" },
+      traceId: "test-trace-id",
+      paywallId: "test-paywall-123",
+      paywallSessionId: "test-paywall-session-456",
+    });
+
+    expect(purchaseMethodAPIMock).toHaveBeenCalledTimes(1);
+    const request = purchaseMethodAPIMock.mock.calls[0][0].request;
+    const requestBody = await request.json();
+    expect(requestBody.paywall).toEqual({
+      paywall_id: "test-paywall-123",
+      paywall_session_id: "test-paywall-session-456",
+    });
+  });
+
+  test("omits paywall_session_id when paywallId not provided", async () => {
+    setCheckoutStartResponse(
+      HttpResponse.json(checkoutStartResponse, { status: 200 }),
+    );
+
+    await backend.postCheckoutStart({
+      appUserId: "someAppUserId",
+      productId: "monthly",
+      presentedOfferingContext: {
+        offeringIdentifier: "offering_1",
+        targetingContext: null,
+        placementIdentifier: null,
+      },
+      purchaseOption: { id: "base_option", priceId: "test_price_id" },
+      traceId: "test-trace-id",
+      paywallSessionId: "test-paywall-session-456",
+    });
+
+    expect(purchaseMethodAPIMock).toHaveBeenCalledTimes(1);
+    const request = purchaseMethodAPIMock.mock.calls[0][0].request;
+    const requestBody = await request.json();
+    expect(requestBody.paywall).toBeUndefined();
+  });
+
   test("omits paywall_id from request when not provided", async () => {
     setCheckoutStartResponse(
       HttpResponse.json(checkoutStartResponse, { status: 200 }),

--- a/src/ui/purchases-ui.svelte
+++ b/src/ui/purchases-ui.svelte
@@ -63,6 +63,7 @@
     workflowPurchaseContext?: WorkflowPurchaseContext;
     attributionMetadata?: AttributionMetadata;
     paywallId?: string;
+    paywallSessionId?: string;
     onFinished: (operationResult: OperationSessionSuccessfulResult) => void;
     onError: (error: PurchaseFlowError) => void;
     onClose: (() => void) | undefined;
@@ -90,6 +91,7 @@
     workflowPurchaseContext,
     attributionMetadata,
     paywallId,
+    paywallSessionId,
     onFinished,
     onError,
     onClose,
@@ -195,6 +197,7 @@
         workflowPurchaseContext,
         attributionMetadata,
         paywallId,
+        paywallSessionId,
         locale: selectedLocale,
       })
       .then((result) => ({ result, emailToUse: nextEmail }))
@@ -215,6 +218,7 @@
             workflowPurchaseContext,
             attributionMetadata,
             paywallId,
+            paywallSessionId,
             locale: selectedLocale,
           })
           .then((result) => ({ result, emailToUse: undefined }));

--- a/src/ui/stripe-checkout-purchases-ui.svelte
+++ b/src/ui/stripe-checkout-purchases-ui.svelte
@@ -47,6 +47,7 @@
     workflowPurchaseContext?: WorkflowPurchaseContext;
     attributionMetadata?: AttributionMetadata;
     paywallId?: string;
+    paywallSessionId?: string;
   }
 
   const {
@@ -68,6 +69,7 @@
     workflowPurchaseContext,
     attributionMetadata,
     paywallId,
+    paywallSessionId,
   }: Props = $props();
   let productDetails: Product = rcPackage.webBillingProduct;
   let translator: Translator = new Translator(
@@ -177,6 +179,7 @@
         workflowPurchaseContext,
         attributionMetadata,
         paywallId,
+        paywallSessionId,
         locale: selectedLocale,
       });
 


### PR DESCRIPTION
Tested the changes locally. Note the paywall_id and paywall_session_id returned for checkout/start
<img width="1721" height="645" alt="image" src="https://github.com/user-attachments/assets/4c551f09-1c82-418f-931d-403ae4d3fbef" />

**The backend change is not yet in review but I'm working on it.**


## Summary
Send `paywallSessionId` to the backend on `POST /rcbilling/v1/checkout/start`. This will allow khepri to populate paywall_session_id on the presented offering context for web paywall txs/

## Changes
- `entities/purchase-params.ts`: add optional `paywallSessionId`.
- `main.ts`: pass generated `paywallSessionId` into the purchase flow and UI components.
- `helpers/purchase-operation-helper.ts` + `networking/backend.ts`: forward `paywallSessionId` and include `paywall_session_id` in the checkout/start body when `paywallId` is set.
- `ui/purchases-ui.svelte`, `ui/stripe-checkout-purchases-ui.svelte`: accept and forward the prop.
- `tests/networking/backend.test.ts`: assert `paywall_session_id` is included when provided and omitted otherwise.

## Test plan
- [ ] `npm run test` (backend networking unit tests for checkout/start body)
- [ ] Manual: load `/rc_paywall/<user>?offeringId=<offering-with-paywall>`, complete a purchase, confirm `paywall.paywall_session_id` is present in the `checkout/start` request body.

Relates to WEB-4389.

Made with [Cursor](https://cursor.com)