### PR TITLE
Update sdks-common-config orb to 3.21.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  revenuecat: revenuecat/sdks-common-config@3.21.1
+  revenuecat: revenuecat/sdks-common-config@3.21.2
   aws-cli: circleci/aws-cli@4.1.3
   node: circleci/node@7.2.1
 


### PR DESCRIPTION
### Motivation
Pull in [sdks-circleci-orb#69](https://github.com/RevenueCat/sdks-circleci-orb/pull/69), which fixes the `merge-release-pr` job failing after a successful merge.

### Description
Bump the CircleCI orb to `3.21.2`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single orb version bump in CI config only; no application or release job definition changes in-repo.
> 
> **Overview**
> Bumps the shared **`revenuecat/sdks-common-config`** CircleCI orb from **3.21.1** to **3.21.2** in `.circleci/config.yml`.
> 
> This pulls in a fix for **`revenuecat/merge-release-pr`** (used at the end of the release workflow after `docs-deploy`) so the job no longer fails after a successful merge. No other pipeline jobs or workflow wiring change in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ab0142fe29aaf31660419cab152d23851e57e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->