### PR TITLE
Migrate update_error_codes to the outputs parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  revenuecat: revenuecat/sdks-common-config@3.21.2
+  revenuecat: revenuecat/sdks-common-config@4.0.0
   aws-cli: circleci/aws-cli@4.1.3
   node: circleci/node@7.2.1
 
@@ -274,7 +274,7 @@ workflows:
     jobs:
       - revenuecat/update-error-codes:
           platform: js
-          output: src/generated/error-codes.ts
+          outputs: "error-codes.ts:src/generated/error-codes.ts"
           commit_paths: "src/generated/error-codes.ts,api-report"
           update_api_steps:
             - install-dependencies


### PR DESCRIPTION
Migrates the `update_error_codes` job to the orb's `outputs` parameter, required by sdks-circleci-orb v4.0.0 (which removes the `output` parameter).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only orb upgrade and parameter rename; no application runtime or release artifact logic changes beyond how generated error codes are wired in the pipeline.
> 
> **Overview**
> Upgrades the **RevenueCat `sdks-common-config` CircleCI orb** from `3.21.2` to **`4.0.0`**, which drops the legacy `output` parameter on `update-error-codes`.
> 
> The **`update_error_codes` workflow** now passes **`outputs`** with a source→destination mapping (`error-codes.ts:src/generated/error-codes.ts`) instead of a single `output` path. Build, commit paths, and API update steps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f925a9f3248fab92b92d691f75aa4c978bff1136. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->