### PR TITLE
Bump sdks-common-config orb to 4.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  revenuecat: revenuecat/sdks-common-config@4.0.0
+  revenuecat: revenuecat/sdks-common-config@4.1.0
   aws-cli: circleci/aws-cli@4.1.3
   node: circleci/node@7.2.1
 


### PR DESCRIPTION
Bump common config orb to 4.1.0 to include error codes reminder

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single orb version pin in CI config with no runtime or application changes; risk is limited to possible shared-pipeline behavior differences in the orb.
> 
> **Overview**
> Updates the CircleCI **`revenuecat/sdks-common-config`** orb from **4.0.0** to **4.1.0** so this repo picks up shared SDK CI behavior from the newer orb release (including the **error codes reminder** called out in the PR).
> 
> No job definitions, workflows, or application code change—only the orb version pin in `.circleci/config.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebdfa54aae211e730e8637bee719bc6ef5b419b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->