### PR TITLE
fix(purchases-js): use default product background for Stripe Billing

### DIFF
--- a/src/tests/ui/stripe-checkout-purchases-ui.test.ts
+++ b/src/tests/ui/stripe-checkout-purchases-ui.test.ts
@@ -295,4 +295,28 @@ describe("StripeCheckoutPurchasesUi", () => {
     });
     expect(screen.queryByText("SANDBOX")).not.toBeInTheDocument();
   });
+
+  test("uses default product background when branding appearance is not customized", async () => {
+    vi.spyOn(purchaseOperationHelperMock, "checkoutStart").mockResolvedValue(
+      createCheckoutStartResponseWithStripeParams("production"),
+    );
+
+    render(StripeCheckoutPurchasesUi, {
+      props: {
+        ...baseProps,
+        brandingInfo: {
+          ...brandingInfo,
+          appearance: null,
+        },
+      },
+    });
+
+    await waitFor(() => {
+      const wrapper = document.querySelector(".stripe-checkout-wrapper");
+      expect(wrapper).toBeInTheDocument();
+      expect(getComputedStyle(wrapper as Element).backgroundColor).toBe(
+        "rgb(239, 243, 250)",
+      );
+    });
+  });
 });

--- a/src/ui/stripe-checkout-purchases-ui-inner.svelte
+++ b/src/ui/stripe-checkout-purchases-ui-inner.svelte
@@ -16,6 +16,7 @@
   import ColLayout from "./layout/col-layout.svelte";
   import type { StripeBillingParams } from "../networking/responses/checkout-start-response";
   import { Theme } from "./theme/theme";
+  import { toProductInfoColors } from "./theme/utils";
   import { brandingContextKey } from "./constants";
 
   interface Props {
@@ -61,7 +62,7 @@
     new Theme(derivedBrandingAppearance).pageStyleVars,
   );
   const productInfoBg = $derived(
-    derivedBrandingAppearance?.color_product_info_bg ?? "#ffffff",
+    toProductInfoColors(derivedBrandingAppearance).background,
   );
 
   const translator: Writable<Translator> = getContext(translatorContextKey);


### PR DESCRIPTION
## Motivation / Description

Fixes Stripe Billing checkout default background handling when `branding.appearance` is null. The Stripe Billing wrapper was falling back to white around embedded Stripe Checkout instead of using the shared default product-info background color, which caused visible whitespace in WPLs using default appearance settings on tall viewports.

This now uses the shared product-info theme defaults, matching the rest of the checkout UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped styling change for Stripe Billing checkout background defaults; no auth, payment, or API behavior changes.
> 
> **Overview**
> When **`branding.appearance` is null**, the Stripe Billing checkout wrapper no longer falls back to **white** (`#ffffff`) for its background. It now uses **`toProductInfoColors`**, the same shared default product-info palette used elsewhere in checkout (e.g. **`rgb(239, 243, 250)`**), so tall viewports don’t show mismatched whitespace around embedded Stripe Checkout.
> 
> A UI test asserts that **`.stripe-checkout-wrapper`** gets that default background when appearance is not customized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c327514c5a9338b649e7620c05147c41db7d514a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->