### PR TITLE
Expose express purchase button API

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -1933,7 +1933,7 @@
         {
           "kind": "Interface",
           "canonicalReference": "@revenuecat/purchases-js!ExpressPurchaseButtonUpdater:interface",
-          "docComment": "/**\n * Callback to be called when the express purchase button is ready to be updated.\n *\n * @experimental\n */\n",
+          "docComment": "/**\n * Callback to be called when the express purchase button is ready to be updated.\n *\n * @experimental @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -3671,121 +3671,31 @@
           ]
         },
         {
-          "kind": "Interface",
-          "canonicalReference": "@revenuecat/purchases-js!PaywallListener:interface",
+          "kind": "TypeAlias",
+          "canonicalReference": "@revenuecat/purchases-js!PaywallListener:type",
           "docComment": "/**\n * Listener for paywall purchase lifecycle events.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare interface PaywallListener "
+              "text": "export declare type PaywallListener = "
+            },
+            {
+              "kind": "Reference",
+              "text": "PurchaseListener",
+              "canonicalReference": "@revenuecat/purchases-js!PurchaseListener:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
             }
           ],
           "fileUrlPath": "dist/Purchases.es.d.ts",
           "releaseTag": "Public",
           "name": "PaywallListener",
-          "preserveMemberOrder": false,
-          "members": [
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!PaywallListener#onPurchaseCancelled:member",
-              "docComment": "/**\n * Called when the user cancels the purchase flow.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "onPurchaseCancelled?: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "() => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "onPurchaseCancelled",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!PaywallListener#onPurchaseError:member",
-              "docComment": "/**\n * Callback called when an error that won't close the paywall occurs. For example, a retryable error during the purchase process.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "onPurchaseError?: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "(error: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "Error",
-                  "canonicalReference": "!Error:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ") => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "onPurchaseError",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 4
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!PaywallListener#onPurchaseStarted:member",
-              "docComment": "/**\n * Called when a purchase flow is about to start for the given package.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "onPurchaseStarted?: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "(rcPackage: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "Package",
-                  "canonicalReference": "@revenuecat/purchases-js!Package:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ") => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "onPurchaseStarted",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 4
-              }
-            }
-          ],
-          "extendsTokenRanges": []
+          "typeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 2
+          }
         },
         {
           "kind": "Interface",
@@ -4226,7 +4136,7 @@
         {
           "kind": "Interface",
           "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams:interface",
-          "docComment": "/**\n * Parameters for the {@link Purchases.presentExpressPurchaseButton} method.\n *\n * @experimental\n */\n",
+          "docComment": "/**\n * Parameters for the {@link Purchases.presentExpressPurchaseButton} method.\n *\n * @example\n * ```ts\n * const offerings = await purchases.getOfferings();\n * const pkg = offerings.current?.availablePackages[0];\n * const htmlTarget = document.getElementById(\"express-purchase-button\");\n * const fallbackButton = document.getElementById(\"checkout-button\");\n *\n * if (pkg && htmlTarget) {\n *   let expressButtonUpdater: ExpressPurchaseButtonUpdater | undefined;\n *\n *   void purchases.presentExpressPurchaseButton({\n *     rcPackage: pkg,\n *     htmlTarget,\n *     onButtonReady: (updater, walletsAvailable) => {\n *       expressButtonUpdater = updater;\n *       htmlTarget.hidden = !walletsAvailable;\n *\n *       if (fallbackButton) {\n *         fallbackButton.hidden = walletsAvailable;\n *       }\n *     },\n *   });\n *\n *   // If the customer selects a different package later, update the button\n *   // instead of rendering a new one.\n *   function onSelectedPackageChanged(nextPackage: Package) {\n *     expressButtonUpdater?.updatePurchase(nextPackage);\n *   }\n * }\n * ```\n *\n * @experimental @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -4295,11 +4205,11 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#htmlTarget:member",
-              "docComment": "/**\n * The HTML element where the billing view should be added. If undefined, a new div will be created at the root of the page and appended to the body.\n */\n",
+              "docComment": "/**\n * The HTML element where the express purchase button should be rendered.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "htmlTarget?: "
+                  "text": "htmlTarget: "
                 },
                 {
                   "kind": "Reference",
@@ -4312,7 +4222,7 @@
                 }
               ],
               "isReadonly": false,
-              "isOptional": true,
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "htmlTarget",
               "propertyTypeTokenRange": {
@@ -4331,8 +4241,8 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "PaywallListener",
-                  "canonicalReference": "@revenuecat/purchases-js!PaywallListener:interface"
+                  "text": "PurchaseListener",
+                  "canonicalReference": "@revenuecat/purchases-js!PurchaseListener:interface"
                 },
                 {
                   "kind": "Content",
@@ -4502,7 +4412,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#walletButtonTheme:member",
-              "docComment": "/**\n * Theme for the Stripe wallet button appearance. Matches Apple Pay button styles: 'black', 'white', or 'white-outline'  @default \"black\"\n */\n",
+              "docComment": "/**\n * Theme for the Stripe wallet button appearance. Matches Apple Pay button styles: 'black', 'white', or 'white-outline' Defaults to \"black\".\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -4694,7 +4604,7 @@
                 {
                   "kind": "Reference",
                   "text": "PaywallListener",
-                  "canonicalReference": "@revenuecat/purchases-js!PaywallListener:interface"
+                  "canonicalReference": "@revenuecat/purchases-js!PaywallListener:type"
                 },
                 {
                   "kind": "Content",
@@ -5920,6 +5830,123 @@
               "name": "Subscription"
             }
           ]
+        },
+        {
+          "kind": "Interface",
+          "canonicalReference": "@revenuecat/purchases-js!PurchaseListener:interface",
+          "docComment": "/**\n * Listener for purchase lifecycle events.\n *\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare interface PurchaseListener "
+            }
+          ],
+          "fileUrlPath": "dist/Purchases.es.d.ts",
+          "releaseTag": "Public",
+          "name": "PurchaseListener",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PurchaseListener#onPurchaseCancelled:member",
+              "docComment": "/**\n * Called when the user cancels the purchase flow.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onPurchaseCancelled?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "onPurchaseCancelled",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PurchaseListener#onPurchaseError:member",
+              "docComment": "/**\n * Callback called when an error that won't close the paywall occurs. For example, a retryable error during the purchase process.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onPurchaseError?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(error: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Error",
+                  "canonicalReference": "!Error:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ") => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "onPurchaseError",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PurchaseListener#onPurchaseStarted:member",
+              "docComment": "/**\n * Called when a purchase flow is about to start for the given package.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onPurchaseStarted?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(rcPackage: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Package",
+                  "canonicalReference": "@revenuecat/purchases-js!Package:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ") => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "onPurchaseStarted",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              }
+            }
+          ],
+          "extendsTokenRanges": []
         },
         {
           "kind": "TypeAlias",

--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -1932,6 +1932,69 @@
         },
         {
           "kind": "Interface",
+          "canonicalReference": "@revenuecat/purchases-js!ExpressPurchaseButtonUpdater:interface",
+          "docComment": "/**\n * Callback to be called when the express purchase button is ready to be updated.\n *\n * @experimental\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare interface ExpressPurchaseButtonUpdater "
+            }
+          ],
+          "fileUrlPath": "dist/Purchases.es.d.ts",
+          "releaseTag": "Public",
+          "name": "ExpressPurchaseButtonUpdater",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!ExpressPurchaseButtonUpdater#updatePurchase:member",
+              "docComment": "/**\n * Updates the purchase option of the express purchase button.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "updatePurchase: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(pkg: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Package",
+                  "canonicalReference": "@revenuecat/purchases-js!Package:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", purchaseOption?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PurchaseOption",
+                  "canonicalReference": "@revenuecat/purchases-js!PurchaseOption:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ") => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "updatePurchase",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 6
+              }
+            }
+          ],
+          "extendsTokenRanges": []
+        },
+        {
+          "kind": "Interface",
           "canonicalReference": "@revenuecat/purchases-js!FlagsConfig:interface",
           "docComment": "/**\n * Flags used to enable or disable certain features in the sdk.\n *\n * @public\n */\n",
           "excerptTokens": [
@@ -4155,6 +4218,313 @@
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 3
+              }
+            }
+          ],
+          "extendsTokenRanges": []
+        },
+        {
+          "kind": "Interface",
+          "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams:interface",
+          "docComment": "/**\n * Parameters for the {@link Purchases.presentExpressPurchaseButton} method.\n *\n * @experimental\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare interface PresentExpressPurchaseButtonParams "
+            }
+          ],
+          "fileUrlPath": "dist/Purchases.es.d.ts",
+          "releaseTag": "Public",
+          "name": "PresentExpressPurchaseButtonParams",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#customerEmail:member",
+              "docComment": "/**\n * The email of the user. If undefined, RevenueCat will ask the customer for their email.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "customerEmail?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "customerEmail",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#defaultLocale:member",
+              "docComment": "/**\n * The default locale to use if the selectedLocale is not available. Defaults to english.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "defaultLocale?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "defaultLocale",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#htmlTarget:member",
+              "docComment": "/**\n * The HTML element where the billing view should be added. If undefined, a new div will be created at the root of the page and appended to the body.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "htmlTarget?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "HTMLElement",
+                  "canonicalReference": "!HTMLElement:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "htmlTarget",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#listener:member",
+              "docComment": "/**\n * Optional listener for purchase lifecycle events.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "listener?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PaywallListener",
+                  "canonicalReference": "@revenuecat/purchases-js!PaywallListener:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "listener",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#metadata:member",
+              "docComment": "/**\n * The purchase metadata to be passed to the backend. Any information provided here will be propagated to the payment gateway and to the RC transaction as metadata.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "metadata?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PurchaseMetadata",
+                  "canonicalReference": "@revenuecat/purchases-js!PurchaseMetadata:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "metadata",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#onButtonReady:member",
+              "docComment": "/**\n * Callback to be called when the express purchase button is ready to be clicked.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onButtonReady?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(updater: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "ExpressPurchaseButtonUpdater",
+                  "canonicalReference": "@revenuecat/purchases-js!ExpressPurchaseButtonUpdater:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", walletsAvailable: boolean) => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "onButtonReady",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#purchaseOption:member",
+              "docComment": "/**\n * The option to be used for this purchase. If not specified or null the default one will be used.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "purchaseOption?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PurchaseOption",
+                  "canonicalReference": "@revenuecat/purchases-js!PurchaseOption:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | null"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "purchaseOption",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#rcPackage:member",
+              "docComment": "/**\n * The package you want to purchase. Obtained from {@link Purchases.getOfferings}.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "rcPackage: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Package",
+                  "canonicalReference": "@revenuecat/purchases-js!Package:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "rcPackage",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#selectedLocale:member",
+              "docComment": "/**\n * The locale to use for the purchase flow. If not specified, English will be used\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "selectedLocale?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "selectedLocale",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#walletButtonTheme:member",
+              "docComment": "/**\n * Theme for the Stripe wallet button appearance. Matches Apple Pay button styles: 'black', 'white', or 'white-outline'  @default \"black\"\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "walletButtonTheme?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "WalletButtonTheme",
+                  "canonicalReference": "@revenuecat/purchases-ui-js!WalletButtonTheme:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "walletButtonTheme",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
               }
             }
           ],
@@ -7004,6 +7374,69 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "preload"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@revenuecat/purchases-js!Purchases#presentExpressPurchaseButton:member(1)",
+              "docComment": "/**\n * Renders an Express Purchase button for the supported wallets (Apple Pay/Google Pay). When clicked it uses the wallet UI to execute the purchase instead of the checkout flow that would be shown with `.purchase`.\n *\n * @param params - The parameters object to customise the purchase flow. Check {@link PresentExpressPurchaseButtonParams}\n *\n * @returns Promise<PurchaseResult>\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "presentExpressPurchaseButton(params: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PresentExpressPurchaseButtonParams",
+                  "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PurchaseResult",
+                  "canonicalReference": "@revenuecat/purchases-js!PurchaseResult:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ">"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 7
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "params",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "presentExpressPurchaseButton"
             },
             {
               "kind": "Method",

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -270,11 +270,7 @@ export enum PackageType {
 }
 
 // @public
-export interface PaywallListener {
-    onPurchaseCancelled?: () => void;
-    onPurchaseError?: (error: Error) => void;
-    onPurchaseStarted?: (rcPackage: Package) => void;
-}
+export type PaywallListener = PurchaseListener;
 
 // @public
 export interface PaywallPurchaseResult extends PurchaseResult {
@@ -319,8 +315,8 @@ export interface PresentedOfferingContext {
 export interface PresentExpressPurchaseButtonParams {
     customerEmail?: string;
     defaultLocale?: string;
-    htmlTarget?: HTMLElement;
-    listener?: PaywallListener;
+    htmlTarget: HTMLElement;
+    listener?: PurchaseListener;
     metadata?: PurchaseMetadata;
     onButtonReady?: (updater: ExpressPurchaseButtonUpdater, walletsAvailable: boolean) => void;
     purchaseOption?: PurchaseOption | null;
@@ -401,6 +397,13 @@ export enum ProductType {
     Consumable = "consumable",
     NonConsumable = "non_consumable",
     Subscription = "subscription"
+}
+
+// @public
+export interface PurchaseListener {
+    onPurchaseCancelled?: () => void;
+    onPurchaseError?: (error: Error) => void;
+    onPurchaseStarted?: (rcPackage: Package) => void;
 }
 
 // @public

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -6,6 +6,7 @@
 
 import { CustomVariables } from '@revenuecat/purchases-ui-js';
 import { CustomVariableValue } from '@revenuecat/purchases-ui-js';
+import { WalletButtonTheme } from '@revenuecat/purchases-ui-js';
 
 // @public
 export interface BrandingAppearance {
@@ -142,6 +143,11 @@ export enum ErrorCode {
     UnsupportedError = 24,
     // (undocumented)
     UserCancelledError = 1
+}
+
+// @public
+export interface ExpressPurchaseButtonUpdater {
+    updatePurchase: (pkg: Package, purchaseOption?: PurchaseOption) => void;
 }
 
 // @public
@@ -310,6 +316,20 @@ export interface PresentedOfferingContext {
 }
 
 // @public
+export interface PresentExpressPurchaseButtonParams {
+    customerEmail?: string;
+    defaultLocale?: string;
+    htmlTarget?: HTMLElement;
+    listener?: PaywallListener;
+    metadata?: PurchaseMetadata;
+    onButtonReady?: (updater: ExpressPurchaseButtonUpdater, walletsAvailable: boolean) => void;
+    purchaseOption?: PurchaseOption | null;
+    rcPackage: Package;
+    selectedLocale?: string;
+    walletButtonTheme?: WalletButtonTheme;
+}
+
+// @public
 export interface PresentPaywallParams {
     readonly customerEmail?: string;
     readonly customVariables?: CustomVariables;
@@ -455,6 +475,7 @@ export class Purchases {
     // (undocumented)
     isSandbox(): boolean;
     preload(): Promise<void>;
+    presentExpressPurchaseButton(params: PresentExpressPurchaseButtonParams): Promise<PurchaseResult>;
     presentPaywall(paywallParams: PresentPaywallParams): Promise<PaywallPurchaseResult>;
     purchase(params: PurchaseParams): Promise<PurchaseResult>;
     // @deprecated

--- a/examples/webbilling-demo/src/pages/express_purchase_buttons/index.tsx
+++ b/examples/webbilling-demo/src/pages/express_purchase_buttons/index.tsx
@@ -57,7 +57,6 @@ export const PackageCard: React.FC<IPackageCardProps> = ({
     };
 
     purchases
-      // @ts-expect-error This method is marked as internal for now but it's public.'
       .presentExpressPurchaseButton({
         rcPackage: pkg,
         purchaseOption: pkg.webBillingProduct.defaultPurchaseOption,

--- a/src/entities/paywall-listener.ts
+++ b/src/entities/paywall-listener.ts
@@ -1,23 +1,7 @@
-import type { Package } from "./offerings";
+import type { PurchaseListener } from "./purchase-listener";
 
 /**
  * Listener for paywall purchase lifecycle events.
  * @public
  */
-export interface PaywallListener {
-  /**
-   * Called when a purchase flow is about to start for the given package.
-   */
-  onPurchaseStarted?: (rcPackage: Package) => void;
-
-  /**
-   * Callback called when an error that won't close the paywall occurs.
-   * For example, a retryable error during the purchase process.
-   */
-  onPurchaseError?: (error: Error) => void;
-
-  /**
-   * Called when the user cancels the purchase flow.
-   */
-  onPurchaseCancelled?: () => void;
-}
+export type PaywallListener = PurchaseListener;

--- a/src/entities/present-express-purchase-button-params.ts
+++ b/src/entities/present-express-purchase-button-params.ts
@@ -1,7 +1,8 @@
 import type { WalletButtonTheme } from "@revenuecat/purchases-ui-js";
 import type { CustomTranslations } from "../ui/localization/translator";
 import type { Package, PurchaseMetadata, PurchaseOption } from "./offerings";
-import type { PaywallListener } from "./paywall-listener";
+import type { PurchaseListener } from "./purchase-listener";
+
 /**
  * Callback to be called when the express purchase button is ready to be updated.
  * @experimental
@@ -66,7 +67,7 @@ export interface PresentExpressPurchaseButtonParams {
   /**
    * Optional listener for purchase lifecycle events.
    */
-  listener?: PaywallListener;
+  listener?: PurchaseListener;
   /**
    * Theme for the Stripe wallet button appearance.
    * Matches Apple Pay button styles: 'black', 'white', or 'white-outline'

--- a/src/entities/present-express-purchase-button-params.ts
+++ b/src/entities/present-express-purchase-button-params.ts
@@ -6,6 +6,7 @@ import type { PurchaseListener } from "./purchase-listener";
 /**
  * Callback to be called when the express purchase button is ready to be updated.
  * @experimental
+ * @public
  */
 export interface ExpressPurchaseButtonUpdater {
   /**
@@ -16,7 +17,40 @@ export interface ExpressPurchaseButtonUpdater {
 
 /**
  * Parameters for the {@link Purchases.presentExpressPurchaseButton} method.
+ *
+ * @example
+ * ```ts
+ * const offerings = await purchases.getOfferings();
+ * const pkg = offerings.current?.availablePackages[0];
+ * const htmlTarget = document.getElementById("express-purchase-button");
+ * const fallbackButton = document.getElementById("checkout-button");
+ *
+ * if (pkg && htmlTarget) {
+ *   let expressButtonUpdater: ExpressPurchaseButtonUpdater | undefined;
+ *
+ *   void purchases.presentExpressPurchaseButton({
+ *     rcPackage: pkg,
+ *     htmlTarget,
+ *     onButtonReady: (updater, walletsAvailable) => {
+ *       expressButtonUpdater = updater;
+ *       htmlTarget.hidden = !walletsAvailable;
+ *
+ *       if (fallbackButton) {
+ *         fallbackButton.hidden = walletsAvailable;
+ *       }
+ *     },
+ *   });
+ *
+ *   // If the customer selects a different package later, update the button
+ *   // instead of rendering a new one.
+ *   function onSelectedPackageChanged(nextPackage: Package) {
+ *     expressButtonUpdater?.updatePurchase(nextPackage);
+ *   }
+ * }
+ * ```
+ *
  * @experimental
+ * @public
  */
 export interface PresentExpressPurchaseButtonParams {
   /**
@@ -71,7 +105,7 @@ export interface PresentExpressPurchaseButtonParams {
   /**
    * Theme for the Stripe wallet button appearance.
    * Matches Apple Pay button styles: 'black', 'white', or 'white-outline'
-   * @default "black"
+   * Defaults to "black".
    */
   walletButtonTheme?: WalletButtonTheme;
 }

--- a/src/entities/present-express-purchase-button-params.ts
+++ b/src/entities/present-express-purchase-button-params.ts
@@ -58,13 +58,13 @@ export interface PresentExpressPurchaseButtonParams {
    */
   rcPackage: Package;
   /**
-   * The option to be used for this purchase. If not specified or null the default one will be used.
-   */
-  purchaseOption?: PurchaseOption | null;
-  /**
    * The HTML element where the express purchase button should be rendered.
    */
   htmlTarget: HTMLElement;
+  /**
+   * The option to be used for this purchase. If not specified or null the default one will be used.
+   */
+  purchaseOption?: PurchaseOption | null;
   /**
    * The email of the user. If undefined, RevenueCat will ask the customer for their email.
    */

--- a/src/entities/present-express-purchase-button-params.ts
+++ b/src/entities/present-express-purchase-button-params.ts
@@ -28,9 +28,9 @@ export interface PresentExpressPurchaseButtonParams {
    */
   purchaseOption?: PurchaseOption | null;
   /**
-   * The HTML element where the billing view should be added. If undefined, a new div will be created at the root of the page and appended to the body.
+   * The HTML element where the express purchase button should be rendered.
    */
-  htmlTarget?: HTMLElement;
+  htmlTarget: HTMLElement;
   /**
    * The email of the user. If undefined, RevenueCat will ask the customer for their email.
    */

--- a/src/entities/present-express-purchase-button-params.ts
+++ b/src/entities/present-express-purchase-button-params.ts
@@ -4,7 +4,6 @@ import type { Package, PurchaseMetadata, PurchaseOption } from "./offerings";
 import type { PaywallListener } from "./paywall-listener";
 /**
  * Callback to be called when the express purchase button is ready to be updated.
- * @internal
  * @experimental
  */
 export interface ExpressPurchaseButtonUpdater {
@@ -16,7 +15,6 @@ export interface ExpressPurchaseButtonUpdater {
 
 /**
  * Parameters for the {@link Purchases.presentExpressPurchaseButton} method.
- * @internal
  * @experimental
  */
 export interface PresentExpressPurchaseButtonParams {
@@ -59,7 +57,6 @@ export interface PresentExpressPurchaseButtonParams {
    */
   labelsOverride?: CustomTranslations;
   /**
-   * @internal
    * Callback to be called when the express purchase button is ready to be clicked.
    */
   onButtonReady?: (

--- a/src/entities/purchase-listener.ts
+++ b/src/entities/purchase-listener.ts
@@ -1,0 +1,23 @@
+import type { Package } from "./offerings";
+
+/**
+ * Listener for purchase lifecycle events.
+ * @public
+ */
+export interface PurchaseListener {
+  /**
+   * Called when a purchase flow is about to start for the given package.
+   */
+  onPurchaseStarted?: (rcPackage: Package) => void;
+
+  /**
+   * Callback called when an error that won't close the paywall occurs.
+   * For example, a retryable error during the purchase process.
+   */
+  onPurchaseError?: (error: Error) => void;
+
+  /**
+   * Called when the user cancels the purchase flow.
+   */
+  onPurchaseCancelled?: () => void;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1282,11 +1282,6 @@ export class Purchases {
       walletButtonTheme,
     } = params;
 
-    if (htmlTarget === undefined) {
-      throw new Error(
-        "htmlTarget is required for presentExpressPurchaseButton",
-      );
-    }
     const appUserId = this._appUserId;
 
     if (!isWebBillingApiKey(this._API_KEY)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -210,6 +210,7 @@ export type { VirtualCurrencies } from "./entities/virtual-currencies";
 export type { VirtualCurrency } from "./entities/virtual-currency";
 export type { PresentPaywallParams } from "./entities/present-paywall-params";
 export type { PaywallListener } from "./entities/paywall-listener";
+export type { PurchaseListener } from "./entities/purchase-listener";
 export {
   CustomVariableValue,
   type CustomVariables,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1263,8 +1263,7 @@ export class Purchases {
    * Renders an Express Purchase button for the supported wallets (Apple Pay/Google Pay).
    * When clicked it uses the wallet UI to execute the purchase instead of
    * the checkout flow that would be shown with `.purchase`.
-   * @internal
-   * @param params - The parameters object to customise the purchase flow. Check {@link PurchaseParams}
+   * @param params - The parameters object to customise the purchase flow. Check {@link PresentExpressPurchaseButtonParams}
    * @returns Promise<PurchaseResult>
    */
   @requiresLoadedResources

--- a/src/ui/molecules/stripe-express-checkout-element.svelte
+++ b/src/ui/molecules/stripe-express-checkout-element.svelte
@@ -23,6 +23,7 @@
     ClickResolveDetails,
     StripeExpressCheckoutElementClickEvent,
   } from "@stripe/stripe-js/dist/stripe-js/elements/express-checkout";
+  import { generateUUID } from "../../helpers/uuid-helper";
 
   export interface Props {
     onError: (error: StripeServiceError) => void | Promise<void>;
@@ -61,7 +62,7 @@
   let expressCheckoutElement: StripeExpressCheckoutElement | null = null;
   let hideExpressCheckoutElement = $state(false);
   // Allows having more than one in the page.
-  const expressCheckoutElementId = `express-checkout-element-${new Date().getTime()}`;
+  const expressCheckoutElementId = `express-checkout-element-${generateUUID()}`;
 
   const onCancelCallback = async () => {
     onCancel && onCancel();


### PR DESCRIPTION
## Summary
- Use unique DOM ids for Stripe express checkout elements to avoid collisions when rendering multiple buttons
- Remove internal API docs from `presentExpressPurchaseButton`
- Remove the demo app `@ts-expect-error` now that the method is public

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public purchase API and required `htmlTarget` are breaking/type-surface changes for integrators; wallet checkout DOM id fix reduces multi-button bugs but touches payment UI wiring.
> 
> **Overview**
> **`Purchases.presentExpressPurchaseButton`** and related types (`PresentExpressPurchaseButtonParams`, `ExpressPurchaseButtonUpdater`) are now **public** (still marked experimental), with API Extractor reports and exports updated. Docs now point at `PresentExpressPurchaseButtonParams`, include a usage example for `onButtonReady` / `updatePurchase`, and **`htmlTarget` is required** in the public params (the redundant runtime guard was removed).
> 
> Purchase lifecycle callbacks are unified via a new **`PurchaseListener`** interface; **`PaywallListener`** is now a type alias to it, and express button params use `PurchaseListener` for `listener`.
> 
> Stripe express checkout elements use **`generateUUID()`** for DOM element ids instead of timestamps so multiple buttons on one page do not collide.
> 
> The web billing demo drops the `@ts-expect-error` on the express button call now that the method is public.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99b90d2f0d6b0a991e5dd9a2d7ba5d2d862e4d14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->