### PR TITLE
WEB-4012 Add checkout back button visibility flag

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -1932,6 +1932,69 @@
         },
         {
           "kind": "Interface",
+          "canonicalReference": "@revenuecat/purchases-js!ExpressPurchaseButtonUpdater:interface",
+          "docComment": "/**\n * Callback to be called when the express purchase button is ready to be updated.\n *\n * @experimental @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare interface ExpressPurchaseButtonUpdater "
+            }
+          ],
+          "fileUrlPath": "dist/Purchases.es.d.ts",
+          "releaseTag": "Public",
+          "name": "ExpressPurchaseButtonUpdater",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!ExpressPurchaseButtonUpdater#updatePurchase:member",
+              "docComment": "/**\n * Updates the purchase option of the express purchase button.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "updatePurchase: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(pkg: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Package",
+                  "canonicalReference": "@revenuecat/purchases-js!Package:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", purchaseOption?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PurchaseOption",
+                  "canonicalReference": "@revenuecat/purchases-js!PurchaseOption:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ") => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "updatePurchase",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 6
+              }
+            }
+          ],
+          "extendsTokenRanges": []
+        },
+        {
+          "kind": "Interface",
           "canonicalReference": "@revenuecat/purchases-js!FlagsConfig:interface",
           "docComment": "/**\n * Flags used to enable or disable certain features in the sdk.\n *\n * @public\n */\n",
           "excerptTokens": [
@@ -1994,6 +2057,33 @@
               "isOptional": true,
               "releaseTag": "Public",
               "name": "collectAnalyticsEvents",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!FlagsConfig#hideBackButton:member",
+              "docComment": "/**\n * If set to true, the checkout back button will be hidden.\n *\n * @defaultValue\n *\n * false\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "hideBackButton?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "hideBackButton",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
@@ -3608,121 +3698,31 @@
           ]
         },
         {
-          "kind": "Interface",
-          "canonicalReference": "@revenuecat/purchases-js!PaywallListener:interface",
+          "kind": "TypeAlias",
+          "canonicalReference": "@revenuecat/purchases-js!PaywallListener:type",
           "docComment": "/**\n * Listener for paywall purchase lifecycle events.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare interface PaywallListener "
+              "text": "export declare type PaywallListener = "
+            },
+            {
+              "kind": "Reference",
+              "text": "PurchaseListener",
+              "canonicalReference": "@revenuecat/purchases-js!PurchaseListener:interface"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
             }
           ],
           "fileUrlPath": "dist/Purchases.es.d.ts",
           "releaseTag": "Public",
           "name": "PaywallListener",
-          "preserveMemberOrder": false,
-          "members": [
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!PaywallListener#onPurchaseCancelled:member",
-              "docComment": "/**\n * Called when the user cancels the purchase flow.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "onPurchaseCancelled?: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "() => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "onPurchaseCancelled",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!PaywallListener#onPurchaseError:member",
-              "docComment": "/**\n * Callback called when an error that won't close the paywall occurs. For example, a retryable error during the purchase process.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "onPurchaseError?: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "(error: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "Error",
-                  "canonicalReference": "!Error:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ") => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "onPurchaseError",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 4
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!PaywallListener#onPurchaseStarted:member",
-              "docComment": "/**\n * Called when a purchase flow is about to start for the given package.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "onPurchaseStarted?: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "(rcPackage: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "Package",
-                  "canonicalReference": "@revenuecat/purchases-js!Package:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ") => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "onPurchaseStarted",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 4
-              }
-            }
-          ],
-          "extendsTokenRanges": []
+          "typeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 2
+          }
         },
         {
           "kind": "Interface",
@@ -4162,6 +4162,313 @@
         },
         {
           "kind": "Interface",
+          "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams:interface",
+          "docComment": "/**\n * Parameters for the {@link Purchases.presentExpressPurchaseButton} method.\n *\n * @example\n * ```ts\n * const offerings = await purchases.getOfferings();\n * const pkg = offerings.current?.availablePackages[0];\n * const htmlTarget = document.getElementById(\"express-purchase-button\");\n * const fallbackButton = document.getElementById(\"checkout-button\");\n *\n * if (pkg && htmlTarget) {\n *   let expressButtonUpdater: ExpressPurchaseButtonUpdater | undefined;\n *\n *   void purchases.presentExpressPurchaseButton({\n *     rcPackage: pkg,\n *     htmlTarget,\n *     onButtonReady: (updater, walletsAvailable) => {\n *       expressButtonUpdater = updater;\n *       htmlTarget.hidden = !walletsAvailable;\n *\n *       if (fallbackButton) {\n *         fallbackButton.hidden = walletsAvailable;\n *       }\n *     },\n *   });\n *\n *   // If the customer selects a different package later, update the button\n *   // instead of rendering a new one.\n *   function onSelectedPackageChanged(nextPackage: Package) {\n *     expressButtonUpdater?.updatePurchase(nextPackage);\n *   }\n * }\n * ```\n *\n * @experimental @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare interface PresentExpressPurchaseButtonParams "
+            }
+          ],
+          "fileUrlPath": "dist/Purchases.es.d.ts",
+          "releaseTag": "Public",
+          "name": "PresentExpressPurchaseButtonParams",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#customerEmail:member",
+              "docComment": "/**\n * The email of the user. If undefined, RevenueCat will ask the customer for their email.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "customerEmail?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "customerEmail",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#defaultLocale:member",
+              "docComment": "/**\n * The default locale to use if the selectedLocale is not available. Defaults to english.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "defaultLocale?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "defaultLocale",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#htmlTarget:member",
+              "docComment": "/**\n * The HTML element where the express purchase button should be rendered.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "htmlTarget: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "HTMLElement",
+                  "canonicalReference": "!HTMLElement:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "htmlTarget",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#listener:member",
+              "docComment": "/**\n * Optional listener for purchase lifecycle events.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "listener?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PurchaseListener",
+                  "canonicalReference": "@revenuecat/purchases-js!PurchaseListener:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "listener",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#metadata:member",
+              "docComment": "/**\n * The purchase metadata to be passed to the backend. Any information provided here will be propagated to the payment gateway and to the RC transaction as metadata.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "metadata?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PurchaseMetadata",
+                  "canonicalReference": "@revenuecat/purchases-js!PurchaseMetadata:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "metadata",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#onButtonReady:member",
+              "docComment": "/**\n * Callback to be called when the express purchase button is ready to be clicked.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onButtonReady?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(updater: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "ExpressPurchaseButtonUpdater",
+                  "canonicalReference": "@revenuecat/purchases-js!ExpressPurchaseButtonUpdater:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", walletsAvailable: boolean) => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "onButtonReady",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#purchaseOption:member",
+              "docComment": "/**\n * The option to be used for this purchase. If not specified or null the default one will be used.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "purchaseOption?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PurchaseOption",
+                  "canonicalReference": "@revenuecat/purchases-js!PurchaseOption:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | null"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "purchaseOption",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#rcPackage:member",
+              "docComment": "/**\n * The package you want to purchase. Obtained from {@link Purchases.getOfferings}.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "rcPackage: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Package",
+                  "canonicalReference": "@revenuecat/purchases-js!Package:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "rcPackage",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#selectedLocale:member",
+              "docComment": "/**\n * The locale to use for the purchase flow. If not specified, English will be used\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "selectedLocale?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "selectedLocale",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#walletButtonTheme:member",
+              "docComment": "/**\n * Theme for the Stripe wallet button appearance. Matches Apple Pay button styles: 'black', 'white', or 'white-outline' Defaults to \"black\".\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "walletButtonTheme?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "WalletButtonTheme",
+                  "canonicalReference": "@revenuecat/purchases-ui-js!WalletButtonTheme:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "walletButtonTheme",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
+          "extendsTokenRanges": []
+        },
+        {
+          "kind": "Interface",
           "canonicalReference": "@revenuecat/purchases-js!PresentPaywallParams:interface",
           "docComment": "/**\n * Parameters for the {@link Purchases.presentPaywall} method.\n *\n * @public\n */\n",
           "excerptTokens": [
@@ -4324,7 +4631,7 @@
                 {
                   "kind": "Reference",
                   "text": "PaywallListener",
-                  "canonicalReference": "@revenuecat/purchases-js!PaywallListener:interface"
+                  "canonicalReference": "@revenuecat/purchases-js!PaywallListener:type"
                 },
                 {
                   "kind": "Content",
@@ -5550,6 +5857,123 @@
               "name": "Subscription"
             }
           ]
+        },
+        {
+          "kind": "Interface",
+          "canonicalReference": "@revenuecat/purchases-js!PurchaseListener:interface",
+          "docComment": "/**\n * Listener for purchase lifecycle events.\n *\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare interface PurchaseListener "
+            }
+          ],
+          "fileUrlPath": "dist/Purchases.es.d.ts",
+          "releaseTag": "Public",
+          "name": "PurchaseListener",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PurchaseListener#onPurchaseCancelled:member",
+              "docComment": "/**\n * Called when the user cancels the purchase flow.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onPurchaseCancelled?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "onPurchaseCancelled",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PurchaseListener#onPurchaseError:member",
+              "docComment": "/**\n * Callback called when an error that won't close the paywall occurs. For example, a retryable error during the purchase process.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onPurchaseError?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(error: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Error",
+                  "canonicalReference": "!Error:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ") => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "onPurchaseError",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PurchaseListener#onPurchaseStarted:member",
+              "docComment": "/**\n * Called when a purchase flow is about to start for the given package.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onPurchaseStarted?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(rcPackage: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Package",
+                  "canonicalReference": "@revenuecat/purchases-js!Package:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ") => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "onPurchaseStarted",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              }
+            }
+          ],
+          "extendsTokenRanges": []
         },
         {
           "kind": "TypeAlias",
@@ -7004,6 +7428,69 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "preload"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@revenuecat/purchases-js!Purchases#presentExpressPurchaseButton:member(1)",
+              "docComment": "/**\n * Renders an Express Purchase button for the supported wallets (Apple Pay/Google Pay). When clicked it uses the wallet UI to execute the purchase instead of the checkout flow that would be shown with `.purchase`.\n *\n * @param params - The parameters object to customise the purchase flow. Check {@link PresentExpressPurchaseButtonParams}\n *\n * @returns Promise<PurchaseResult>\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "presentExpressPurchaseButton(params: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PresentExpressPurchaseButtonParams",
+                  "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PurchaseResult",
+                  "canonicalReference": "@revenuecat/purchases-js!PurchaseResult:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ">"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 7
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "params",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "presentExpressPurchaseButton"
             },
             {
               "kind": "Method",

--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -1932,69 +1932,6 @@
         },
         {
           "kind": "Interface",
-          "canonicalReference": "@revenuecat/purchases-js!ExpressPurchaseButtonUpdater:interface",
-          "docComment": "/**\n * Callback to be called when the express purchase button is ready to be updated.\n *\n * @experimental @public\n */\n",
-          "excerptTokens": [
-            {
-              "kind": "Content",
-              "text": "export declare interface ExpressPurchaseButtonUpdater "
-            }
-          ],
-          "fileUrlPath": "dist/Purchases.es.d.ts",
-          "releaseTag": "Public",
-          "name": "ExpressPurchaseButtonUpdater",
-          "preserveMemberOrder": false,
-          "members": [
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!ExpressPurchaseButtonUpdater#updatePurchase:member",
-              "docComment": "/**\n * Updates the purchase option of the express purchase button.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "updatePurchase: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "(pkg: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "Package",
-                  "canonicalReference": "@revenuecat/purchases-js!Package:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ", purchaseOption?: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "PurchaseOption",
-                  "canonicalReference": "@revenuecat/purchases-js!PurchaseOption:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ") => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "updatePurchase",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 6
-              }
-            }
-          ],
-          "extendsTokenRanges": []
-        },
-        {
-          "kind": "Interface",
           "canonicalReference": "@revenuecat/purchases-js!FlagsConfig:interface",
           "docComment": "/**\n * Flags used to enable or disable certain features in the sdk.\n *\n * @public\n */\n",
           "excerptTokens": [
@@ -3671,31 +3608,121 @@
           ]
         },
         {
-          "kind": "TypeAlias",
-          "canonicalReference": "@revenuecat/purchases-js!PaywallListener:type",
+          "kind": "Interface",
+          "canonicalReference": "@revenuecat/purchases-js!PaywallListener:interface",
           "docComment": "/**\n * Listener for paywall purchase lifecycle events.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type PaywallListener = "
-            },
-            {
-              "kind": "Reference",
-              "text": "PurchaseListener",
-              "canonicalReference": "@revenuecat/purchases-js!PurchaseListener:interface"
-            },
-            {
-              "kind": "Content",
-              "text": ";"
+              "text": "export declare interface PaywallListener "
             }
           ],
           "fileUrlPath": "dist/Purchases.es.d.ts",
           "releaseTag": "Public",
           "name": "PaywallListener",
-          "typeTokenRange": {
-            "startIndex": 1,
-            "endIndex": 2
-          }
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PaywallListener#onPurchaseCancelled:member",
+              "docComment": "/**\n * Called when the user cancels the purchase flow.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onPurchaseCancelled?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "() => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "onPurchaseCancelled",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PaywallListener#onPurchaseError:member",
+              "docComment": "/**\n * Callback called when an error that won't close the paywall occurs. For example, a retryable error during the purchase process.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onPurchaseError?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(error: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Error",
+                  "canonicalReference": "!Error:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ") => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "onPurchaseError",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PaywallListener#onPurchaseStarted:member",
+              "docComment": "/**\n * Called when a purchase flow is about to start for the given package.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "onPurchaseStarted?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(rcPackage: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Package",
+                  "canonicalReference": "@revenuecat/purchases-js!Package:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ") => void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "onPurchaseStarted",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              }
+            }
+          ],
+          "extendsTokenRanges": []
         },
         {
           "kind": "Interface",
@@ -4135,313 +4162,6 @@
         },
         {
           "kind": "Interface",
-          "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams:interface",
-          "docComment": "/**\n * Parameters for the {@link Purchases.presentExpressPurchaseButton} method.\n *\n * @example\n * ```ts\n * const offerings = await purchases.getOfferings();\n * const pkg = offerings.current?.availablePackages[0];\n * const htmlTarget = document.getElementById(\"express-purchase-button\");\n * const fallbackButton = document.getElementById(\"checkout-button\");\n *\n * if (pkg && htmlTarget) {\n *   let expressButtonUpdater: ExpressPurchaseButtonUpdater | undefined;\n *\n *   void purchases.presentExpressPurchaseButton({\n *     rcPackage: pkg,\n *     htmlTarget,\n *     onButtonReady: (updater, walletsAvailable) => {\n *       expressButtonUpdater = updater;\n *       htmlTarget.hidden = !walletsAvailable;\n *\n *       if (fallbackButton) {\n *         fallbackButton.hidden = walletsAvailable;\n *       }\n *     },\n *   });\n *\n *   // If the customer selects a different package later, update the button\n *   // instead of rendering a new one.\n *   function onSelectedPackageChanged(nextPackage: Package) {\n *     expressButtonUpdater?.updatePurchase(nextPackage);\n *   }\n * }\n * ```\n *\n * @experimental @public\n */\n",
-          "excerptTokens": [
-            {
-              "kind": "Content",
-              "text": "export declare interface PresentExpressPurchaseButtonParams "
-            }
-          ],
-          "fileUrlPath": "dist/Purchases.es.d.ts",
-          "releaseTag": "Public",
-          "name": "PresentExpressPurchaseButtonParams",
-          "preserveMemberOrder": false,
-          "members": [
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#customerEmail:member",
-              "docComment": "/**\n * The email of the user. If undefined, RevenueCat will ask the customer for their email.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "customerEmail?: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "string"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "customerEmail",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#defaultLocale:member",
-              "docComment": "/**\n * The default locale to use if the selectedLocale is not available. Defaults to english.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "defaultLocale?: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "string"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "defaultLocale",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#htmlTarget:member",
-              "docComment": "/**\n * The HTML element where the express purchase button should be rendered.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "htmlTarget: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "HTMLElement",
-                  "canonicalReference": "!HTMLElement:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "htmlTarget",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#listener:member",
-              "docComment": "/**\n * Optional listener for purchase lifecycle events.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "listener?: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "PurchaseListener",
-                  "canonicalReference": "@revenuecat/purchases-js!PurchaseListener:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "listener",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#metadata:member",
-              "docComment": "/**\n * The purchase metadata to be passed to the backend. Any information provided here will be propagated to the payment gateway and to the RC transaction as metadata.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "metadata?: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "PurchaseMetadata",
-                  "canonicalReference": "@revenuecat/purchases-js!PurchaseMetadata:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "metadata",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#onButtonReady:member",
-              "docComment": "/**\n * Callback to be called when the express purchase button is ready to be clicked.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "onButtonReady?: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "(updater: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "ExpressPurchaseButtonUpdater",
-                  "canonicalReference": "@revenuecat/purchases-js!ExpressPurchaseButtonUpdater:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ", walletsAvailable: boolean) => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "onButtonReady",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 4
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#purchaseOption:member",
-              "docComment": "/**\n * The option to be used for this purchase. If not specified or null the default one will be used.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "purchaseOption?: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "PurchaseOption",
-                  "canonicalReference": "@revenuecat/purchases-js!PurchaseOption:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": " | null"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "purchaseOption",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 3
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#rcPackage:member",
-              "docComment": "/**\n * The package you want to purchase. Obtained from {@link Purchases.getOfferings}.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "rcPackage: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "Package",
-                  "canonicalReference": "@revenuecat/purchases-js!Package:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "rcPackage",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#selectedLocale:member",
-              "docComment": "/**\n * The locale to use for the purchase flow. If not specified, English will be used\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "selectedLocale?: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "string"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "selectedLocale",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams#walletButtonTheme:member",
-              "docComment": "/**\n * Theme for the Stripe wallet button appearance. Matches Apple Pay button styles: 'black', 'white', or 'white-outline' Defaults to \"black\".\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "walletButtonTheme?: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "WalletButtonTheme",
-                  "canonicalReference": "@revenuecat/purchases-ui-js!WalletButtonTheme:type"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "walletButtonTheme",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            }
-          ],
-          "extendsTokenRanges": []
-        },
-        {
-          "kind": "Interface",
           "canonicalReference": "@revenuecat/purchases-js!PresentPaywallParams:interface",
           "docComment": "/**\n * Parameters for the {@link Purchases.presentPaywall} method.\n *\n * @public\n */\n",
           "excerptTokens": [
@@ -4604,7 +4324,7 @@
                 {
                   "kind": "Reference",
                   "text": "PaywallListener",
-                  "canonicalReference": "@revenuecat/purchases-js!PaywallListener:type"
+                  "canonicalReference": "@revenuecat/purchases-js!PaywallListener:interface"
                 },
                 {
                   "kind": "Content",
@@ -5830,123 +5550,6 @@
               "name": "Subscription"
             }
           ]
-        },
-        {
-          "kind": "Interface",
-          "canonicalReference": "@revenuecat/purchases-js!PurchaseListener:interface",
-          "docComment": "/**\n * Listener for purchase lifecycle events.\n *\n * @public\n */\n",
-          "excerptTokens": [
-            {
-              "kind": "Content",
-              "text": "export declare interface PurchaseListener "
-            }
-          ],
-          "fileUrlPath": "dist/Purchases.es.d.ts",
-          "releaseTag": "Public",
-          "name": "PurchaseListener",
-          "preserveMemberOrder": false,
-          "members": [
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!PurchaseListener#onPurchaseCancelled:member",
-              "docComment": "/**\n * Called when the user cancels the purchase flow.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "onPurchaseCancelled?: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "() => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "onPurchaseCancelled",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!PurchaseListener#onPurchaseError:member",
-              "docComment": "/**\n * Callback called when an error that won't close the paywall occurs. For example, a retryable error during the purchase process.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "onPurchaseError?: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "(error: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "Error",
-                  "canonicalReference": "!Error:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ") => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "onPurchaseError",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 4
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!PurchaseListener#onPurchaseStarted:member",
-              "docComment": "/**\n * Called when a purchase flow is about to start for the given package.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "onPurchaseStarted?: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "(rcPackage: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "Package",
-                  "canonicalReference": "@revenuecat/purchases-js!Package:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ") => void"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "onPurchaseStarted",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 4
-              }
-            }
-          ],
-          "extendsTokenRanges": []
         },
         {
           "kind": "TypeAlias",
@@ -7401,69 +7004,6 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "preload"
-            },
-            {
-              "kind": "Method",
-              "canonicalReference": "@revenuecat/purchases-js!Purchases#presentExpressPurchaseButton:member(1)",
-              "docComment": "/**\n * Renders an Express Purchase button for the supported wallets (Apple Pay/Google Pay). When clicked it uses the wallet UI to execute the purchase instead of the checkout flow that would be shown with `.purchase`.\n *\n * @param params - The parameters object to customise the purchase flow. Check {@link PresentExpressPurchaseButtonParams}\n *\n * @returns Promise<PurchaseResult>\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "presentExpressPurchaseButton(params: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "PresentExpressPurchaseButtonParams",
-                  "canonicalReference": "@revenuecat/purchases-js!PresentExpressPurchaseButtonParams:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": "): "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "Promise",
-                  "canonicalReference": "!Promise:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": "<"
-                },
-                {
-                  "kind": "Reference",
-                  "text": "PurchaseResult",
-                  "canonicalReference": "@revenuecat/purchases-js!PurchaseResult:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ">"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isStatic": false,
-              "returnTypeTokenRange": {
-                "startIndex": 3,
-                "endIndex": 7
-              },
-              "releaseTag": "Public",
-              "isProtected": false,
-              "overloadIndex": 1,
-              "parameters": [
-                {
-                  "parameterName": "params",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 1,
-                    "endIndex": 2
-                  },
-                  "isOptional": false
-                }
-              ],
-              "isOptional": false,
-              "isAbstract": false,
-              "name": "presentExpressPurchaseButton"
             },
             {
               "kind": "Method",

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -6,7 +6,6 @@
 
 import { CustomVariables } from '@revenuecat/purchases-ui-js';
 import { CustomVariableValue } from '@revenuecat/purchases-ui-js';
-import { WalletButtonTheme } from '@revenuecat/purchases-ui-js';
 
 // @public
 export interface BrandingAppearance {
@@ -146,11 +145,6 @@ export enum ErrorCode {
 }
 
 // @public
-export interface ExpressPurchaseButtonUpdater {
-    updatePurchase: (pkg: Package, purchaseOption?: PurchaseOption) => void;
-}
-
-// @public
 export interface FlagsConfig {
     autoCollectUTMAsMetadata?: boolean;
     collectAnalyticsEvents?: boolean;
@@ -270,7 +264,11 @@ export enum PackageType {
 }
 
 // @public
-export type PaywallListener = PurchaseListener;
+export interface PaywallListener {
+    onPurchaseCancelled?: () => void;
+    onPurchaseError?: (error: Error) => void;
+    onPurchaseStarted?: (rcPackage: Package) => void;
+}
 
 // @public
 export interface PaywallPurchaseResult extends PurchaseResult {
@@ -309,20 +307,6 @@ export interface PresentedOfferingContext {
     readonly offeringIdentifier: string;
     readonly placementIdentifier: string | null;
     readonly targetingContext: TargetingContext | null;
-}
-
-// @public
-export interface PresentExpressPurchaseButtonParams {
-    customerEmail?: string;
-    defaultLocale?: string;
-    htmlTarget: HTMLElement;
-    listener?: PurchaseListener;
-    metadata?: PurchaseMetadata;
-    onButtonReady?: (updater: ExpressPurchaseButtonUpdater, walletsAvailable: boolean) => void;
-    purchaseOption?: PurchaseOption | null;
-    rcPackage: Package;
-    selectedLocale?: string;
-    walletButtonTheme?: WalletButtonTheme;
 }
 
 // @public
@@ -400,13 +384,6 @@ export enum ProductType {
 }
 
 // @public
-export interface PurchaseListener {
-    onPurchaseCancelled?: () => void;
-    onPurchaseError?: (error: Error) => void;
-    onPurchaseStarted?: (rcPackage: Package) => void;
-}
-
-// @public
 export type PurchaseMetadata = Record<string, string | null>;
 
 // @public
@@ -478,7 +455,6 @@ export class Purchases {
     // (undocumented)
     isSandbox(): boolean;
     preload(): Promise<void>;
-    presentExpressPurchaseButton(params: PresentExpressPurchaseButtonParams): Promise<PurchaseResult>;
     presentPaywall(paywallParams: PresentPaywallParams): Promise<PaywallPurchaseResult>;
     purchase(params: PurchaseParams): Promise<PurchaseResult>;
     // @deprecated

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -6,6 +6,7 @@
 
 import { CustomVariables } from '@revenuecat/purchases-ui-js';
 import { CustomVariableValue } from '@revenuecat/purchases-ui-js';
+import { WalletButtonTheme } from '@revenuecat/purchases-ui-js';
 
 // @public
 export interface BrandingAppearance {
@@ -145,9 +146,15 @@ export enum ErrorCode {
 }
 
 // @public
+export interface ExpressPurchaseButtonUpdater {
+    updatePurchase: (pkg: Package, purchaseOption?: PurchaseOption) => void;
+}
+
+// @public
 export interface FlagsConfig {
     autoCollectUTMAsMetadata?: boolean;
     collectAnalyticsEvents?: boolean;
+    hideBackButton?: boolean;
     // @deprecated
     storeLoadTime?: StoreLoadTime;
 }
@@ -264,11 +271,7 @@ export enum PackageType {
 }
 
 // @public
-export interface PaywallListener {
-    onPurchaseCancelled?: () => void;
-    onPurchaseError?: (error: Error) => void;
-    onPurchaseStarted?: (rcPackage: Package) => void;
-}
+export type PaywallListener = PurchaseListener;
 
 // @public
 export interface PaywallPurchaseResult extends PurchaseResult {
@@ -307,6 +310,20 @@ export interface PresentedOfferingContext {
     readonly offeringIdentifier: string;
     readonly placementIdentifier: string | null;
     readonly targetingContext: TargetingContext | null;
+}
+
+// @public
+export interface PresentExpressPurchaseButtonParams {
+    customerEmail?: string;
+    defaultLocale?: string;
+    htmlTarget: HTMLElement;
+    listener?: PurchaseListener;
+    metadata?: PurchaseMetadata;
+    onButtonReady?: (updater: ExpressPurchaseButtonUpdater, walletsAvailable: boolean) => void;
+    purchaseOption?: PurchaseOption | null;
+    rcPackage: Package;
+    selectedLocale?: string;
+    walletButtonTheme?: WalletButtonTheme;
 }
 
 // @public
@@ -384,6 +401,13 @@ export enum ProductType {
 }
 
 // @public
+export interface PurchaseListener {
+    onPurchaseCancelled?: () => void;
+    onPurchaseError?: (error: Error) => void;
+    onPurchaseStarted?: (rcPackage: Package) => void;
+}
+
+// @public
 export type PurchaseMetadata = Record<string, string | null>;
 
 // @public
@@ -455,6 +479,7 @@ export class Purchases {
     // (undocumented)
     isSandbox(): boolean;
     preload(): Promise<void>;
+    presentExpressPurchaseButton(params: PresentExpressPurchaseButtonParams): Promise<PurchaseResult>;
     presentPaywall(paywallParams: PresentPaywallParams): Promise<PaywallPurchaseResult>;
     purchase(params: PurchaseParams): Promise<PurchaseResult>;
     // @deprecated

--- a/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
+++ b/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
@@ -97,6 +97,7 @@ export async function navigateToLandingUrl(
     email?: string;
     $displayName?: string;
     nickname?: string;
+    hideCheckoutBackButton?: boolean;
     hideBackButtons?: boolean;
     discountCode?: string;
     storeLoadTime?: StoreLoadTime;
@@ -121,6 +122,7 @@ export async function navigateToLandingUrl(
     email,
     $displayName,
     nickname,
+    hideCheckoutBackButton,
     discountCode,
     storeLoadTime,
   } = queryString ?? {};
@@ -158,6 +160,9 @@ export async function navigateToLandingUrl(
   }
   if (nickname) {
     params.append("nickname", nickname);
+  }
+  if (hideCheckoutBackButton !== undefined) {
+    params.append("hideCheckoutBackButton", hideCheckoutBackButton.toString());
   }
   if (queryString?.hideBackButtons !== undefined) {
     params.append("hideBackButtons", queryString.hideBackButtons.toString());

--- a/examples/webbilling-demo/src/tests/purchase-flow.test.ts
+++ b/examples/webbilling-demo/src/tests/purchase-flow.test.ts
@@ -47,6 +47,21 @@ test.describe("Purchase flow", () => {
   );
 
   integrationTest(
+    "Hides the checkout back button when hideCheckoutBackButton=true",
+    async ({ page, userId }) => {
+      page = await navigateToLandingUrl(page, userId, {
+        hideCheckoutBackButton: true,
+      });
+
+      const packageCards = await getPackageCards(page);
+      await startPurchaseFlow(packageCards[1]);
+
+      await expect(page.getByText("Secure Checkout")).toBeVisible();
+      await expect(page.locator(".rcb-back-button")).toHaveCount(0);
+    },
+  );
+
+  integrationTest(
     "Purchase a subscription product with delayed store load",
     async ({ page, userId, email }) => {
       await page.goto(

--- a/examples/webbilling-demo/src/util/PurchasesLoader.ts
+++ b/examples/webbilling-demo/src/util/PurchasesLoader.ts
@@ -39,6 +39,8 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
   const offeringId = searchParams.get("offeringId");
   const discountCode = searchParams.get("discountCode") || undefined;
   const rcSource = searchParams.get("rcSource") || undefined;
+  const hideCheckoutBackButton =
+    searchParams.get("hideCheckoutBackButton") === "true";
   const optOutOfAutoUTM =
     searchParams.get("optOutOfAutoUTM") === "true" || false;
   const useCustomLogger = searchParams.get("useCustomLogger") === "true";
@@ -62,6 +64,7 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
 
   const flagsConfig: FlagsConfig = {
     autoCollectUTMAsMetadata: !optOutOfAutoUTM,
+    hideBackButton: hideCheckoutBackButton,
     ...(storeLoadTime ? { storeLoadTime } : {}),
   };
   if (rcSource) {

--- a/src/entities/flags-config.ts
+++ b/src/entities/flags-config.ts
@@ -27,6 +27,12 @@ export interface FlagsConfig {
   collectAnalyticsEvents?: boolean;
 
   /**
+   * If set to true, the checkout back button will be hidden.
+   * @defaultValue false
+   */
+  hideBackButton?: boolean;
+
+  /**
    * Describes the platform that originated the purchase.
    * This does not technically belong here but since the public Purchase configuration
    * does not use objects, it is the easiest way to pass this internal parameter.

--- a/src/main.ts
+++ b/src/main.ts
@@ -1688,6 +1688,7 @@ export class Purchases {
           discountCode,
           onDiscountCodeChanged,
           skipSuccessPage,
+          hideBackButton: this.shouldHideCheckoutBackButton(),
         },
       });
     });
@@ -1806,6 +1807,7 @@ export class Purchases {
             metadata,
             unmountPaddlePurchaseUi,
             paddleService,
+            hideBackButton: this.shouldHideCheckoutBackButton(),
           },
         });
       }
@@ -1860,6 +1862,14 @@ export class Purchases {
     };
 
     return onClose;
+  }
+
+  private shouldHideCheckoutBackButton(): boolean {
+    return (
+      this._flags.hideBackButton === true ||
+      (!!this._flags.rcSource &&
+        supportedRCSources.includes(this._flags.rcSource))
+    );
   }
 
   private createCheckoutOnFinishedHandler(

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -748,6 +748,29 @@ describe("Purchases.purchase()", () => {
     document.body.innerHTML = "";
   });
 
+  test("does not show the back button when hideBackButton is true", async () => {
+    const purchases = Purchases.configure({
+      apiKey: testApiKey,
+      appUserId: testUserId,
+      flags: {
+        hideBackButton: true,
+      },
+    });
+    purchases.purchase({
+      rcPackage: createMonthlyPackageMock(),
+    });
+
+    await waitFor(() => {
+      const container = document.querySelector(".rcb-ui-root");
+      expect(container).not.toBeNull();
+      expect(document.querySelector(".rcb-back-button")).toBeNull();
+    });
+
+    purchases.close();
+    // Forcing the body to cleanup to not affect other tests
+    document.body.innerHTML = "";
+  });
+
   test("routes purchases to Paddle flow for pdl_ api keys", async () => {
     const purchases = configurePurchases(
       testUserId,

--- a/src/tests/ui/paddle-purchases-ui.test.ts
+++ b/src/tests/ui/paddle-purchases-ui.test.ts
@@ -706,6 +706,29 @@ describe("PaddlePurchasesUI", () => {
       ).not.toBeInTheDocument();
     });
 
+    test("does not render the return button when hideBackButton is true", async () => {
+      const paddleServiceMock = createPaddleServiceMock({
+        inlineCheckoutEnabled: true,
+      });
+      vi.spyOn(paddleServiceMock, "purchase").mockImplementation(
+        () => new Promise(() => {}),
+      );
+
+      render(PaddlePurchasesUI, {
+        props: {
+          ...baseProps,
+          hideBackButton: true,
+          paddleService: paddleServiceMock,
+        },
+        context: defaultContext,
+      });
+
+      await screen.findByTestId("paddle-inline-checkout-container");
+      expect(
+        screen.queryByTestId("paddle-return-button"),
+      ).not.toBeInTheDocument();
+    });
+
     test("passes onCheckoutTotals to purchase when inline", async () => {
       const paddleServiceMock = createPaddleServiceMock({
         inlineCheckoutEnabled: true,

--- a/src/ui/paddle-inline-checkout-page.svelte
+++ b/src/ui/paddle-inline-checkout-page.svelte
@@ -42,6 +42,7 @@
     isSandbox,
     isInElement,
     onClose,
+    hideBackButton = false,
     productDetails,
     purchaseOption,
     totals,
@@ -59,7 +60,7 @@
 
 <Template {brandingInfo} {isInElement} {isSandbox} {onClose}>
   {#snippet navbarHeaderContent()}
-    {#if !isInElement}
+    {#if !isInElement && !hideBackButton}
       <!-- Inline checkout embeds Paddle's iframe in our page, so we provide the
            back affordance (Paddle's own "Return to <seller>" link only exists in
            the overlay/hosted checkout, not inline). -->

--- a/src/ui/paddle-inline-checkout-page.svelte
+++ b/src/ui/paddle-inline-checkout-page.svelte
@@ -25,6 +25,7 @@
     isSandbox: boolean;
     isInElement: boolean;
     onClose: () => void;
+    hideBackButton?: boolean;
     productDetails: Product;
     purchaseOption: PurchaseOption;
     // Live order totals from Paddle's checkout events; render the order summary.

--- a/src/ui/paddle-purchases-ui.svelte
+++ b/src/ui/paddle-purchases-ui.svelte
@@ -48,6 +48,7 @@
     attributionMetadata?: AttributionMetadata;
     unmountPaddlePurchaseUi: () => void;
     paddleService: PaddleService;
+    hideBackButton?: boolean;
   }
 
   const {
@@ -70,6 +71,7 @@
     attributionMetadata,
     unmountPaddlePurchaseUi,
     paddleService,
+    hideBackButton = false,
   }: Props = $props();
 
   let translator: Translator = new Translator(
@@ -289,6 +291,7 @@
     {isSandbox}
     {isInElement}
     onClose={handleInlineClose}
+    {hideBackButton}
     {productDetails}
     {purchaseOption}
     totals={paddleTotals}

--- a/src/ui/purchases-ui-inner.svelte
+++ b/src/ui/purchases-ui-inner.svelte
@@ -83,6 +83,7 @@
     onContinue,
     onError,
     onClose = undefined,
+    hideBackButton = false,
   }: Props = $props();
 
   const initialPrice = getInitialPriceFromPurchaseOption(
@@ -127,7 +128,7 @@
     <BrandingHeader
       {brandingInfo}
       {onClose}
-      showCloseButton={!isInElement && !!onClose}
+      showCloseButton={!isInElement && !!onClose && !hideBackButton}
     />
   {/snippet}
   {#snippet navbarBodyContent()}

--- a/src/ui/purchases-ui-inner.svelte
+++ b/src/ui/purchases-ui-inner.svelte
@@ -50,6 +50,7 @@
     onContinue: () => void;
     onError: (error: PurchaseFlowError) => void;
     onClose?: () => void;
+    hideBackButton?: boolean;
   }
 
   let {

--- a/src/ui/purchases-ui.svelte
+++ b/src/ui/purchases-ui.svelte
@@ -68,6 +68,7 @@
     onFinished: (operationResult: OperationSessionSuccessfulResult) => void;
     onError: (error: PurchaseFlowError) => void;
     onClose: (() => void) | undefined;
+    hideBackButton?: boolean;
   }
 
   const {
@@ -96,6 +97,7 @@
     onFinished,
     onError,
     onClose,
+    hideBackButton = false,
   }: Props = $props();
 
   const emailError = customerEmail ? validateEmail(customerEmail) : null;
@@ -467,4 +469,5 @@
   onContinue={handleContinue}
   onError={handleError}
   {onClose}
+  {hideBackButton}
 />


### PR DESCRIPTION
## Summary
- Add `flags.hideBackButton` to the purchases-js configuration surface
- Propagate the flag through RevenueCat Web Billing and Paddle checkout UI paths
- Hide RevenueCat-rendered checkout back/return buttons when the flag is enabled
- Add coverage for Web Billing and Paddle inline checkout behavior

## Testing
- `pnpm typecheck`
- `pnpm test src/tests/main.test.ts src/tests/ui/paddle-purchases-ui.test.ts`

## Notes
- This does not change Paddle callback behavior; it only hides RevenueCat-rendered back/return UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only visibility for checkout navigation; purchase cancel/close logic is unchanged aside from reusing existing rcSource rules.
> 
> **Overview**
> Adds **`flags.hideBackButton`** on purchases-js configure so integrators can hide RevenueCat-rendered checkout back/return controls on Web Billing and Paddle inline checkout.
> 
> **`shouldHideCheckoutBackButton()`** in the purchase router sets visibility for both flows: explicit `hideBackButton: true`, or when **`rcSource`** is `app` / `embedded` (same sources that already alter close behavior). That value is passed into **`PurchasesUI`** / **`PaddleInlineCheckoutPage`**, which suppress the navbar close button and Paddle return button respectively—without changing cancel/callback semantics.
> 
> The webbilling demo maps **`hideCheckoutBackButton`** query params into the flag; unit and integration tests cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e10f360cabb382a98556136e3edb04a561d78ef2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->