### PR TITLE
[WEB-4322] feat(stripe): Collect and send the full billing address for tax calculation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,18 @@ jobs:
       - run:
           name: Update ENV for E2E test
           command: |
-            echo 'export VITE_RC_API_KEY=${E2E_RC_API_KEY}; export VITE_RC_TAX_E2E_API_KEY=${E2E_RC_TAX_E2E_API_KEY}; export VITE_RC_STRIPE_CHECKOUT_E2E_API_KEY=${E2E_RC_STRIPE_CHECKOUT_E2E_API_KEY}; export VITE_RC_PADDLE_E2E_API_KEY=${E2E_RC_PADDLE_E2E_API_KEY}; export VITE_SKIP_TAX_REAL_TESTS_UNTIL=${VITE_SKIP_TAX_REAL_TESTS_UNTIL}; export VITE_SKIP_STRIPE_TESTS=${VITE_SKIP_STRIPE_TESTS:-false}; export VITE_SKIP_PADDLE_TESTS=${VITE_SKIP_PADDLE_TESTS:-false}; export VITE_SKIP_STRIPE_TESTS_ON_CAPTCHA=${VITE_SKIP_STRIPE_TESTS_ON_CAPTCHA:-true}; export VITE_ALLOW_PAYWALLS_TESTS=true' >> "$BASH_ENV"
+            {
+              echo 'export VITE_RC_API_KEY=${E2E_RC_API_KEY}'
+              echo 'export VITE_RC_TAX_E2E_API_KEY=${E2E_RC_TAX_E2E_API_KEY}'
+              echo 'export VITE_RC_STRIPE_CHECKOUT_E2E_API_KEY=${E2E_RC_STRIPE_CHECKOUT_E2E_API_KEY}'
+              echo 'export VITE_RC_PADDLE_E2E_API_KEY=${E2E_RC_PADDLE_E2E_API_KEY}'
+              echo 'export VITE_RC_FULL_ADDRESS_E2E_API_KEY=${E2E_RC_FULL_ADDRESS_E2E_API_KEY}'
+              echo 'export VITE_SKIP_TAX_REAL_TESTS_UNTIL=${VITE_SKIP_TAX_REAL_TESTS_UNTIL}'
+              echo 'export VITE_SKIP_STRIPE_TESTS=${VITE_SKIP_STRIPE_TESTS:-false}'
+              echo 'export VITE_SKIP_PADDLE_TESTS=${VITE_SKIP_PADDLE_TESTS:-false}'
+              echo 'export VITE_SKIP_STRIPE_TESTS_ON_CAPTCHA=${VITE_SKIP_STRIPE_TESTS_ON_CAPTCHA:-true}'
+              echo 'export VITE_ALLOW_PAYWALLS_TESTS=true'
+            } >> "$BASH_ENV"
             source "$BASH_ENV"
       - install-dependencies
       - run:

--- a/examples/webbilling-demo/.env.example
+++ b/examples/webbilling-demo/.env.example
@@ -1,6 +1,9 @@
 VITE_RC_API_KEY="rcb_abcdef1234567890abcdef"
 VITE_RC_NON_TAX_E2E_API_KEY="rcb_abcdef1234567890abcdef"
 VITE_RC_TAX_E2E_API_KEY="rcb_abcdef1234567890abcdef"
+# API key of a project with BOTH tax collection and full billing address
+# collection enabled. Required for the address-change tax tests.
+VITE_RC_FULL_ADDRESS_E2E_API_KEY="rcb_abcdef1234567890abcdef"
 VITE_RC_STRIPE_CHECKOUT_E2E_API_KEY="strp_abcdef1234567890abcdef"
 VITE_RC_PADDLE_E2E_API_KEY="pdl_abcdef1234567890abcdef"
 VITE_SKIP_STRIPE_TESTS=false

--- a/examples/webbilling-demo/README.md
+++ b/examples/webbilling-demo/README.md
@@ -56,6 +56,7 @@ The SDK automatically detects Paddle API keys and routes to the Paddle flow. The
 ```bash
 export VITE_RC_NON_TAX_E2E_API_KEY = 'your e2e tests public api key'
 export VITE_RC_TAX_E2E_API_KEY = 'your e2e tests public api key'
+export VITE_RC_FULL_ADDRESS_E2E_API_KEY = 'your e2e tests public api key'
 export VITE_RC_STRIPE_CHECKOUT_E2E_API_KEY = 'your stripe checkout e2e tests public api key'
 export VITE_RC_PADDLE_E2E_API_KEY = 'your paddle e2e tests public api key'
 ```

--- a/examples/webbilling-demo/src/tests/helpers/fixtures.ts
+++ b/examples/webbilling-demo/src/tests/helpers/fixtures.ts
@@ -42,11 +42,14 @@ export const RC_PAYWALL_WITH_LATAM_TRANSLATION_OFFERING_ID =
   "rc_paywalls_e2e_test_latam_es";
 export const NON_TAX_TEST_API_KEY = process.env.VITE_RC_NON_TAX_E2E_API_KEY;
 export const TAX_TEST_API_KEY = process.env.VITE_RC_TAX_E2E_API_KEY;
+export const FULL_ADDRESS_TEST_API_KEY =
+  process.env.VITE_RC_FULL_ADDRESS_E2E_API_KEY;
 export const STRIPE_CHECKOUT_TEST_API_KEY =
   process.env.VITE_RC_STRIPE_CHECKOUT_E2E_API_KEY;
 export const PADDLE_TEST_API_KEY = process.env.VITE_RC_PADDLE_E2E_API_KEY;
 export const TAX_TEST_OFFERING_ID = "rcb_e2e_taxes";
 export const TAX_TEST_OFFERING_ID_WITH_DISCOUNT = "rcb_e2e_taxes_discounted";
+export const FULL_ADDRESS_TAX_TEST_OFFERING_ID = "rcb_e2e_taxes_full_address";
 export const TAX_TEST_DISCOUNT_CODE = "FOREVER10";
 export const LOCAL_URL = "http://localhost:3001/";
 export const BASE_URL =
@@ -74,6 +77,16 @@ export const NEW_YORK_CUSTOMER_DETAILS = {
 
 export const ITALY_CUSTOMER_DETAILS = {
   countryCode: "IT",
+};
+
+export const NEW_YORK_FULL_ADDRESS = {
+  name: "Jane Doe",
+  line1: "350 5th Ave",
+  line2: "Floor 21",
+  city: "New York",
+  state: "NY",
+  postalCode: "10118",
+  countryCode: "US",
 };
 
 export const SPAIN_TAX_RESPONSE: RouteFulfillOptions = {

--- a/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
+++ b/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
@@ -227,9 +227,73 @@ export interface BillingAddressDetails {
   countryCode?: string;
 }
 
+type StripeAddressFrame = ReturnType<typeof getStripeAddressFrame>;
+
 /**
- * Fills the Stripe Address Element. Only the provided fields are filled, so it
- * can be used to populate a partial address (e.g. everything except the name).
+ * Reveals the structured address fields (line 1/2, city, state, ZIP) when the
+ * Address Element is collapsed behind Google autocomplete.
+ *
+ * When the Address Element runs alongside the Payment Element, Stripe enables
+ * autocomplete and initially shows only a country dropdown and a single
+ * "Address" search field. Focusing/typing in that field opens a dropdown that
+ * always contains a static "Enter address manually" option — regardless of
+ * whether Google returns any predictions (they don't load on localhost, where
+ * Stripe's built-in Google Maps key is referrer-restricted). Clicking it
+ * expands the structured fields.
+ *
+ * The dropdown renders in a separate, dynamically-named Stripe iframe (not
+ * inside `#address-element`), so we scan every frame for the option and
+ * dispatch the click directly (a plain `.click()` can be flaky here).
+ */
+async function revealStructuredAddressFields(
+  page: Page,
+  addressFrame: StripeAddressFrame,
+): Promise<void> {
+  // Already expanded (autocomplete unavailable for this country, or a previous
+  // call already switched to manual entry): nothing to do.
+  if ((await addressFrame.getByLabel("Address line 1").count()) > 0) {
+    return;
+  }
+
+  const tryClickManualEntry = async (): Promise<boolean> => {
+    for (const frame of page.frames()) {
+      const manualEntry = frame.getByText("Enter address manually").first();
+      if (
+        (await manualEntry.count()) > 0 &&
+        (await manualEntry.isVisible().catch(() => false))
+      ) {
+        await manualEntry.dispatchEvent("click");
+        return true;
+      }
+    }
+    return false;
+  };
+
+  // Focus and type a character into the search field to surface the dropdown.
+  const searchField = addressFrame.getByLabel("Address", { exact: true });
+  await searchField.click();
+  if (!(await tryClickManualEntry())) {
+    await searchField.pressSequentially("5th avenue", { delay: 100 });
+  }
+
+  await expect
+    .poll(tryClickManualEntry, {
+      timeout: 10_000,
+      message:
+        "Could not find the Stripe 'Enter address manually' option to reveal the structured address fields",
+    })
+    .toBe(true);
+
+  // Wait for the structured fields to actually render before callers fill them.
+  await expect(addressFrame.getByLabel("Address line 1")).toBeVisible();
+}
+
+/**
+ * Fills the Stripe Address Element. The element runs alongside the Payment
+ * Element, so Stripe enables Google autocomplete and collapses the form into a
+ * single search field; we first switch to manual entry to reveal the structured
+ * fields, then fill them directly. Only the provided fields are filled, so a
+ * partial address can be populated (e.g. everything except the name).
  */
 export async function enterBillingAddress(
   page: Page,
@@ -243,6 +307,10 @@ export async function enterBillingAddress(
       .getByLabel("Country or region")
       .selectOption(details.countryCode);
   }
+
+  // Expand the structured fields if they're hidden behind autocomplete.
+  await revealStructuredAddressFields(page, addressFrame);
+
   if (details.name !== undefined) {
     await addressFrame.getByLabel("Name").fill(details.name);
   }

--- a/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
+++ b/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
@@ -212,6 +212,57 @@ export const getStripePaymentFrame = (page: Page) =>
 export const getStripeEmailFrame = (page: Page) =>
   page.frameLocator("iframe[title='Secure email input frame']");
 
+// The Address Element is mounted inside the `#address-element` container.
+// Scope to that container so we don't match the payment/email iframes.
+export const getStripeAddressFrame = (page: Page) =>
+  page.frameLocator("#address-element iframe").first();
+
+export interface BillingAddressDetails {
+  name?: string;
+  line1?: string;
+  line2?: string;
+  city?: string;
+  state?: string;
+  postalCode?: string;
+  countryCode?: string;
+}
+
+/**
+ * Fills the Stripe Address Element. Only the provided fields are filled, so it
+ * can be used to populate a partial address (e.g. everything except the name).
+ */
+export async function enterBillingAddress(
+  page: Page,
+  details: BillingAddressDetails,
+): Promise<void> {
+  const addressFrame = getStripeAddressFrame(page);
+
+  // Set the country first so dependent fields (e.g. the state dropdown) render.
+  if (details.countryCode !== undefined) {
+    await addressFrame
+      .getByLabel("Country or region")
+      .selectOption(details.countryCode);
+  }
+  if (details.name !== undefined) {
+    await addressFrame.getByLabel("Name").fill(details.name);
+  }
+  if (details.line1 !== undefined) {
+    await addressFrame.getByLabel("Address line 1").fill(details.line1);
+  }
+  if (details.line2 !== undefined) {
+    await addressFrame.getByLabel("Address line 2").fill(details.line2);
+  }
+  if (details.city !== undefined) {
+    await addressFrame.getByLabel("City").fill(details.city);
+  }
+  if (details.state !== undefined) {
+    await addressFrame.getByLabel("State").selectOption(details.state);
+  }
+  if (details.postalCode !== undefined) {
+    await addressFrame.getByLabel("ZIP").fill(details.postalCode);
+  }
+}
+
 export const getStripe3DSFrame = (page: Page) =>
   page.frameLocator(
     "iframe[src*='https://js.stripe.com/v3/three-ds-2-challenge']",
@@ -258,14 +309,27 @@ export async function enterCreditCardDetails(
   await expect(numberInput).toBeVisible();
   await numberInput.fill(cardNumber);
 
+  // When full billing address collection is enabled, the country/postal code
+  // live in the separate Address Element instead of the Payment Element. The
+  // `#address-element` container is only rendered in that case, so use its
+  // presence to decide where to fill the country.
+  const collectsFullAddress =
+    (await page.locator("#address-element").count()) > 0;
+
   // Inserting the country first just to make sure that the change event is triggered by Stripe
   // This is a bug that we are trying to workaround, however we know that setting the country/postal code as last
   // might not trigger the update event.
   // Also changing it might not trigger it.
-  await stripeFrame.getByLabel("Country").selectOption(countryCode);
+  if (collectsFullAddress) {
+    await getStripeAddressFrame(page)
+      .getByLabel("Country or region")
+      .selectOption(countryCode);
+  } else {
+    await stripeFrame.getByLabel("Country").selectOption(countryCode);
 
-  if (postalCode !== undefined) {
-    await stripeFrame.getByPlaceholder("12345").fill(postalCode);
+    if (postalCode !== undefined) {
+      await stripeFrame.getByPlaceholder("12345").fill(postalCode);
+    }
   }
 
   await stripeFrame.getByPlaceholder("MM / YY").fill(expiration);

--- a/examples/webbilling-demo/src/tests/tax-calculation.test.ts
+++ b/examples/webbilling-demo/src/tests/tax-calculation.test.ts
@@ -2,9 +2,12 @@ import type { Page, Request, Route } from "@playwright/test";
 import { expect } from "@playwright/test";
 import {
   FLORIDA_CUSTOMER_DETAILS,
+  FULL_ADDRESS_TEST_API_KEY,
+  FULL_ADDRESS_TAX_TEST_OFFERING_ID,
   INVALID_CUSTOMER_DETAILS,
   ITALY_CUSTOMER_DETAILS,
   NEW_YORK_CUSTOMER_DETAILS,
+  NEW_YORK_FULL_ADDRESS,
   SPAIN_TAX_RESPONSE,
   SPAIN_TAX_INCLUSIVE_DISCOUNTED_RESPONSE,
   TAX_TEST_API_KEY,
@@ -31,10 +34,12 @@ import {
   confirmTaxCalculating,
   confirmTaxCalculation,
   confirmTaxNotCalculating,
+  enterBillingAddress,
   enterCreditCardDetails,
   enterEmail,
   enterSecurityCode,
   getPackageCards,
+  getStripeAddressFrame,
   getStripePaymentFrame,
   navigateToLandingUrl,
   startPurchaseFlow,
@@ -89,6 +94,30 @@ const mockTaxCalculationRequest = async (
       await route.fallback();
     }
   });
+};
+
+/**
+ * Counts pricing refresh (tax calculation) requests. In mocked mode every
+ * request is fulfilled with a canned response; in real mode the request is
+ * proxied to the backend (failing the test if the rate limit is hit). Returns
+ * a counter object whose `count` reflects the number of requests observed.
+ */
+const trackPricingRefreshRequests = async (page: Page, mockMode: boolean) => {
+  const counter = { count: 0 };
+  await routePricingRefreshRequest(page, async (route) => {
+    counter.count++;
+    if (mockMode) {
+      await route.fulfill(NEW_YORK_TAX_RESPONSE);
+    } else {
+      const response = await route.fetch();
+      const json = await response.json();
+      if (json["failed_reason"] === "rate_limit_exceeded") {
+        throw new Error("Stripe Tax Calculation API rate limit reached.");
+      }
+      await route.fulfill({ response, json });
+    }
+  });
+  return counter;
 };
 
 [true, false].forEach((mockMode) => {
@@ -580,6 +609,127 @@ integrationTest.describe("Tax calculation setup errors", () => {
       const packageCards = await getPackageCards(page);
       await startPurchaseFlow(packageCards[0]);
       await confirmPaymentError(page, "Missing Stripe permission");
+    },
+  );
+});
+
+const navigateToFullAddressLandingUrl = (page: Page, userId: string) =>
+  navigateToLandingUrl(
+    page,
+    userId,
+    { offeringId: FULL_ADDRESS_TAX_TEST_OFFERING_ID },
+    FULL_ADDRESS_TEST_API_KEY,
+  );
+
+// Allow any pending debounced tax refresh (and its request) to flush before we
+// snapshot or assert request counts. Slightly larger than the client-side
+// debounce window (500ms).
+const DEBOUNCE_FLUSH_MS = 1500;
+
+[true, false].forEach((mockMode) => {
+  integrationTest.describe(
+    `Tax calculation with full address collection (${mockMode ? "mocked" : "real"})`,
+    () => {
+      integrationTest.skip(
+        !FULL_ADDRESS_TEST_API_KEY,
+        `Full billing address tax tests are disabled. To enable, set
+        VITE_RC_FULL_ADDRESS_E2E_API_KEY to an API key whose project has both
+        tax collection and full billing address collection enabled.`,
+      );
+
+      integrationTest.skip(
+        !mockMode && SKIP_TAX_REAL_TESTS,
+        `Real tax calculation tests are disabled.
+        To enable, set VITE_SKIP_TAX_REAL_TESTS_UNTIL=2025-02-21 in the environment variables.`,
+      );
+
+      // Stripe Address Element interactions are only reliable in Chromium.
+      integrationTest.skip(
+        ({ browserName }) => browserName !== "chromium",
+        "Full billing address tax tests only run in Chromium",
+      );
+
+      integrationTest(
+        "Debounces tax recalculation while typing the address line 1",
+        async ({ page, userId, email }) => {
+          const pricing = await trackPricingRefreshRequests(page, mockMode);
+
+          page = await navigateToFullAddressLandingUrl(page, userId);
+
+          const packageCards = await getPackageCards(page);
+          await startPurchaseFlow(packageCards[0]);
+
+          await enterEmail(page, email);
+          await enterCreditCardDetails(
+            page,
+            "4242 4242 4242 4242",
+            NEW_YORK_CUSTOMER_DETAILS,
+          );
+
+          // Fill the complete billing address (including the name) so the form
+          // validates and the initial tax calculation succeeds.
+          await enterBillingAddress(page, NEW_YORK_FULL_ADDRESS);
+
+          await confirmTaxCalculation(page);
+          // Let any debounced refresh triggered by the steps above flush.
+          await page.waitForTimeout(DEBOUNCE_FLUSH_MS);
+
+          const requestsBeforeTyping = pricing.count;
+
+          // Re-type the address line 1 character by character to emit a burst
+          // of `change` events. The debounce should coalesce them into a
+          // single tax calculation.
+          const line1Input =
+            getStripeAddressFrame(page).getByLabel("Address line 1");
+          await line1Input.fill("");
+          await line1Input.pressSequentially("1 Times Square");
+
+          await confirmTaxCalculation(page);
+          await page.waitForTimeout(DEBOUNCE_FLUSH_MS);
+
+          expect(pricing.count).toBe(requestsBeforeTyping + 1);
+        },
+      );
+
+      integrationTest(
+        "Does NOT recalculate taxes when only the name changes",
+        async ({ page, userId, email }) => {
+          const pricing = await trackPricingRefreshRequests(page, mockMode);
+
+          page = await navigateToFullAddressLandingUrl(page, userId);
+
+          const packageCards = await getPackageCards(page);
+          await startPurchaseFlow(packageCards[0]);
+
+          await enterEmail(page, email);
+          await enterCreditCardDetails(
+            page,
+            "4242 4242 4242 4242",
+            NEW_YORK_CUSTOMER_DETAILS,
+          );
+
+          // Fill the complete billing address (including the name) so the form
+          // validates and the initial tax calculation succeeds.
+          await enterBillingAddress(page, NEW_YORK_FULL_ADDRESS);
+
+          await confirmTaxCalculation(page);
+          await page.waitForTimeout(DEBOUNCE_FLUSH_MS);
+
+          const requestsBeforeName = pricing.count;
+
+          // Changing ONLY the name must neither show the loading skeleton nor
+          // trigger a tax recalculation, since the name is not a tax-relevant
+          // field.
+          const nameInput = getStripeAddressFrame(page).getByLabel("Name");
+          await nameInput.fill("");
+          await nameInput.pressSequentially("John Smith");
+
+          await confirmTaxNotCalculating(page);
+          await page.waitForTimeout(DEBOUNCE_FLUSH_MS);
+
+          expect(pricing.count).toBe(requestsBeforeName);
+        },
+      );
     },
   );
 });

--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -139,6 +139,10 @@ interface CheckoutStartParams {
 interface CheckoutRefreshPricingParams {
   countryCode?: string;
   postalCode?: string;
+  state?: string;
+  city?: string;
+  addressLine1?: string;
+  addressLine2?: string;
   discountCode?: string | null;
   signal?: AbortSignal | null;
 }
@@ -297,6 +301,10 @@ export class PurchaseOperationHelper {
   async checkoutRefreshPricing({
     countryCode,
     postalCode,
+    state,
+    city,
+    addressLine1,
+    addressLine2,
     discountCode,
     signal,
   }: CheckoutRefreshPricingParams = {}): Promise<CheckoutPricingResponse> {
@@ -314,6 +322,10 @@ export class PurchaseOperationHelper {
         {
           countryCode,
           postalCode,
+          state,
+          city,
+          addressLine1,
+          addressLine2,
           discountCode,
           signal,
         },

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -67,6 +67,10 @@ interface CheckoutStartRequestParams {
 interface CheckoutRefreshPricingParams {
   countryCode?: string;
   postalCode?: string;
+  state?: string;
+  city?: string;
+  addressLine1?: string;
+  addressLine2?: string;
   discountCode?: string | null;
   signal?: AbortSignal | null;
 }
@@ -306,6 +310,10 @@ export class Backend {
     {
       countryCode,
       postalCode,
+      state,
+      city,
+      addressLine1,
+      addressLine2,
       discountCode,
       signal,
     }: CheckoutRefreshPricingParams = {},
@@ -313,12 +321,20 @@ export class Backend {
     type CheckoutRefreshPricingRequestBody = {
       country_code?: string;
       postal_code?: string;
+      state?: string;
+      city?: string;
+      address_line1?: string;
+      address_line2?: string;
       discount_code?: string | null;
     };
 
     const requestBody: CheckoutRefreshPricingRequestBody = {
       country_code: countryCode,
       postal_code: postalCode,
+      state,
+      city,
+      address_line1: addressLine1,
+      address_line2: addressLine2,
       discount_code: discountCode,
     };
 

--- a/src/networking/responses/branding-response.ts
+++ b/src/networking/responses/branding-response.ts
@@ -3,11 +3,12 @@ import type { BrandingAppearance } from "../../entities/branding";
 
 /**
  * Controls how the billing address is collected during checkout.
- * - `never`: the full address UI is never presented. Only country and postal
- *   code are collected, and postal code is US-only. (default behavior)
+ * - `if_required`: the full address UI is only presented when it is required,
+ *   e.g. for tax collection in the customer's country. Otherwise only country
+ *   and postal code are collected, and postal code is US-only. (default behavior)
  * - `always`: the full address UI is always presented.
  */
-export type FullAddressCollectionMode = "never" | "always";
+export type FullAddressCollectionMode = "if_required" | "always";
 
 export type BrandingInfoResponse = {
   app_icon: string | null;
@@ -27,9 +28,9 @@ export type BrandingInfoResponse = {
 };
 
 /**
- * Resolves whether the full billing address UI should be presented, based on
- * the branding configuration. Treats a missing mode and any unknown/future
- * mode as `never`.
+ * Resolves whether the full billing address UI should always be presented,
+ * based on the branding configuration. Treats a missing mode and any
+ * unknown/future mode as `if_required`.
  */
 export function shouldCollectFullAddress(
   brandingInfo:

--- a/src/networking/responses/branding-response.ts
+++ b/src/networking/responses/branding-response.ts
@@ -11,6 +11,7 @@ export type BrandingInfoResponse = {
   app_name: string | null;
   support_email?: string | null;
   gateway_tax_collection_enabled: boolean;
+  full_address_collection_enabled?: boolean;
   brand_font_config: BrandFontConfig | null;
   sandbox_configuration?: {
     checkout_feedback_form_url: string | null;

--- a/src/networking/responses/branding-response.ts
+++ b/src/networking/responses/branding-response.ts
@@ -1,6 +1,14 @@
 import type { BrandFontConfig } from "src/ui/theme/text";
 import type { BrandingAppearance } from "../../entities/branding";
 
+/**
+ * Controls how the billing address is collected during checkout.
+ * - `never`: the full address UI is never presented. Only country and postal
+ *   code are collected, and postal code is US-only. (default behavior)
+ * - `always`: the full address UI is always presented.
+ */
+export type FullAddressCollectionMode = "never" | "always";
+
 export type BrandingInfoResponse = {
   app_icon: string | null;
   app_icon_webp: string | null;
@@ -11,9 +19,23 @@ export type BrandingInfoResponse = {
   app_name: string | null;
   support_email?: string | null;
   gateway_tax_collection_enabled: boolean;
-  full_address_collection_enabled?: boolean;
+  full_address_collection_mode?: FullAddressCollectionMode;
   brand_font_config: BrandFontConfig | null;
   sandbox_configuration?: {
     checkout_feedback_form_url: string | null;
   };
 };
+
+/**
+ * Resolves whether the full billing address UI should be presented, based on
+ * the branding configuration. Treats a missing mode and any unknown/future
+ * mode as `never`.
+ */
+export function shouldCollectFullAddress(
+  brandingInfo:
+    | Pick<BrandingInfoResponse, "full_address_collection_mode">
+    | null
+    | undefined,
+): boolean {
+  return brandingInfo?.full_address_collection_mode === "always";
+}

--- a/src/stories/fixtures.ts
+++ b/src/stories/fixtures.ts
@@ -517,7 +517,7 @@ export const brandingInfo: BrandingInfoResponse = {
   app_wordmark_webp: null,
   appearance: null,
   gateway_tax_collection_enabled: false,
-  full_address_collection_mode: "never",
+  full_address_collection_mode: "if_required",
   brand_font_config: null,
 };
 

--- a/src/stories/fixtures.ts
+++ b/src/stories/fixtures.ts
@@ -517,6 +517,7 @@ export const brandingInfo: BrandingInfoResponse = {
   app_wordmark_webp: null,
   appearance: null,
   gateway_tax_collection_enabled: false,
+  full_address_collection_enabled: false,
   brand_font_config: null,
 };
 

--- a/src/stories/fixtures.ts
+++ b/src/stories/fixtures.ts
@@ -517,7 +517,7 @@ export const brandingInfo: BrandingInfoResponse = {
   app_wordmark_webp: null,
   appearance: null,
   gateway_tax_collection_enabled: false,
-  full_address_collection_enabled: false,
+  full_address_collection_mode: "never",
   brand_font_config: null,
 };
 

--- a/src/stripe/stripe-service.ts
+++ b/src/stripe/stripe-service.ts
@@ -43,6 +43,10 @@ export class StripeServiceError {
 export type TaxCustomerDetails = {
   countryCode: string | undefined;
   postalCode: string | undefined;
+  state: string | undefined;
+  city: string | undefined;
+  addressLine1: string | undefined;
+  addressLine2: string | undefined;
 };
 
 export class StripeService {
@@ -409,6 +413,10 @@ export class StripeService {
       customerDetails: {
         countryCode: billingAddress?.country ?? undefined,
         postalCode: billingAddress?.postal_code ?? undefined,
+        state: billingAddress?.state ?? undefined,
+        city: billingAddress?.city ?? undefined,
+        addressLine1: billingAddress?.line1 ?? undefined,
+        addressLine2: billingAddress?.line2 ?? undefined,
       },
       confirmationTokenId: confirmationToken.id,
     };

--- a/src/stripe/stripe-service.ts
+++ b/src/stripe/stripe-service.ts
@@ -279,6 +279,15 @@ export class StripeService {
     });
   }
 
+  static createAddressElement(elements: StripeElements) {
+    return elements.create("address", {
+      mode: "billing",
+      display: {
+        name: "full",
+      },
+    });
+  }
+
   static createExpressCheckoutElement(
     elements: StripeElements,
     forceEnableWalletMethods: boolean,

--- a/src/tests/stripe/stripe-service.test.ts
+++ b/src/tests/stripe/stripe-service.test.ts
@@ -392,6 +392,23 @@ describe("StripeService", () => {
     });
   });
 
+  describe("createAddressElement", () => {
+    test("creates a billing address element collecting the full name", () => {
+      const mockElements: Partial<StripeElements> = {
+        create: vi.fn(),
+      };
+
+      StripeService.createAddressElement(mockElements as StripeElements);
+
+      expect(mockElements.create).toHaveBeenCalledWith("address", {
+        mode: "billing",
+        display: {
+          name: "full",
+        },
+      });
+    });
+  });
+
   describe("createLinkAuthenticationElement", () => {
     test("creates link authentication element with email", () => {
       const mockElements: Partial<StripeElements> = {

--- a/src/tests/stripe/stripe-service.test.ts
+++ b/src/tests/stripe/stripe-service.test.ts
@@ -409,6 +409,70 @@ describe("StripeService", () => {
     });
   });
 
+  describe("extractTaxCustomerDetails", () => {
+    test("returns the full billing address from the confirmation token", async () => {
+      const mockElements = {} as StripeElements;
+      const mockStripe = {
+        createConfirmationToken: vi.fn().mockResolvedValue({
+          confirmationToken: {
+            id: "ctoken_123",
+            payment_method_preview: {
+              billing_details: {
+                address: {
+                  country: "US",
+                  postal_code: "10001",
+                  state: "NY",
+                  city: "New York",
+                  line1: "123 Main St",
+                  line2: "Apt 4",
+                },
+              },
+            },
+          },
+        }),
+      } as unknown as Stripe;
+
+      const { customerDetails, confirmationTokenId } =
+        await StripeService.extractTaxCustomerDetails(mockElements, mockStripe);
+
+      expect(confirmationTokenId).toBe("ctoken_123");
+      expect(customerDetails).toEqual({
+        countryCode: "US",
+        postalCode: "10001",
+        state: "NY",
+        city: "New York",
+        addressLine1: "123 Main St",
+        addressLine2: "Apt 4",
+      });
+    });
+
+    test("returns undefined fields when the billing address is missing", async () => {
+      const mockElements = {} as StripeElements;
+      const mockStripe = {
+        createConfirmationToken: vi.fn().mockResolvedValue({
+          confirmationToken: {
+            id: "ctoken_456",
+            payment_method_preview: {},
+          },
+        }),
+      } as unknown as Stripe;
+
+      const { customerDetails } = await StripeService.extractTaxCustomerDetails(
+        mockElements,
+        mockStripe,
+      );
+
+      expect(customerDetails).toEqual({
+        countryCode: undefined,
+        postalCode: undefined,
+        state: undefined,
+        city: undefined,
+        addressLine1: undefined,
+        addressLine2: undefined,
+      });
+    });
+  });
+
   describe("createLinkAuthenticationElement", () => {
     test("creates link authentication element with email", () => {
       const mockElements: Partial<StripeElements> = {

--- a/src/tests/ui/pages/payment-entry-page.test.ts
+++ b/src/tests/ui/pages/payment-entry-page.test.ts
@@ -15,12 +15,13 @@ import { createEventsTrackerMock } from "../../mocks/events-tracker-mock-provide
 import { eventsTrackerContextKey } from "../../../ui/constants";
 import type { PurchaseOperationHelper } from "../../../helpers/purchase-operation-helper";
 import type { CheckoutStartResponse } from "../../../networking/responses/checkout-start-response";
-import { writable } from "svelte/store";
+import { get, writable } from "svelte/store";
 import { Translator } from "../../../ui/localization/translator";
 import { translatorContextKey } from "../../../ui/localization/constants";
 import type {
   StripeServiceError,
   StripeServiceErrorCode,
+  TaxCustomerDetails,
 } from "../../../stripe/stripe-service";
 import { StripeService } from "../../../stripe/stripe-service";
 import type {
@@ -71,6 +72,7 @@ vi.mock("../../../stripe/stripe-service", async () => {
       updateElementsConfiguration: vi.fn(),
       getStripeLocale: vi.fn().mockImplementation((locale: string) => locale),
       confirmIntent: vi.fn(),
+      extractTaxCustomerDetails: vi.fn(),
     },
   };
 });
@@ -530,5 +532,96 @@ describe("PurchasesUI", () => {
 
     expect(container.querySelector("#address-element")).not.toBeNull();
     expect(StripeService.createAddressElement).toHaveBeenCalled();
+  });
+
+  test("forwards the full billing address and publishes it to the shared tax customer details store", async () => {
+    const taxCustomerDetails: TaxCustomerDetails = {
+      countryCode: "US",
+      postalCode: "94107",
+      state: "CA",
+      city: "San Francisco",
+      addressLine1: "354 Oyster Point Blvd",
+      addressLine2: "Floor 2",
+    };
+    vi.mocked(StripeService.extractTaxCustomerDetails).mockResolvedValue({
+      customerDetails: taxCustomerDetails,
+      confirmationTokenId: "ctoken-id",
+    });
+
+    const paymentElement = {
+      on: (
+        eventType: string,
+        callback: (event?: StripePaymentElementChangeEvent) => void,
+      ) => {
+        if (eventType === "ready") {
+          setTimeout(() => callback(), 0);
+        }
+        if (eventType === "change") {
+          setTimeout(() => {
+            callback({
+              complete: true,
+              value: { type: "card" },
+              elementType: "payment",
+              empty: false,
+              collapsed: false,
+            });
+          }, 100);
+        }
+      },
+      mount: vi.fn(),
+      destroy: vi.fn(),
+    };
+    vi.mocked(StripeService.createPaymentElement).mockReturnValue(
+      // @ts-expect-error - This is a mock
+      paymentElement,
+    );
+
+    const checkoutRefreshPricingSpy = vi.spyOn(
+      purchaseOperationHelperMock,
+      "checkoutRefreshPricing",
+    );
+
+    // Shared store lifted into the parent so discount-code refreshes can reuse
+    // the latest known tax location.
+    const lastTaxCustomerDetailsStore = writable<TaxCustomerDetails | null>(
+      null,
+    );
+
+    render(PaymentEntryPage, {
+      props: {
+        ...basicProps,
+        customerEmail: "test@test.com",
+        brandingInfo: {
+          ...brandingInfo,
+          gateway_tax_collection_enabled: true,
+          full_address_collection_enabled: true,
+        },
+        lastTaxCustomerDetailsStore,
+      },
+      context: defaultContext,
+    });
+
+    // Flush stripe initialization and the payment element ready/change events.
+    for (let i = 0; i < 6; i++) {
+      await vi.advanceTimersToNextTimerAsync();
+    }
+
+    expect(StripeService.extractTaxCustomerDetails).toHaveBeenCalled();
+
+    // The page forwards the full billing address on the pricing refresh.
+    expect(checkoutRefreshPricingSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        countryCode: "US",
+        postalCode: "94107",
+        state: "CA",
+        city: "San Francisco",
+        addressLine1: "354 Oyster Point Blvd",
+        addressLine2: "Floor 2",
+      }),
+    );
+
+    // And it publishes the details to the shared store so the parent can reuse
+    // them on discount-code refreshes.
+    expect(get(lastTaxCustomerDetailsStore)).toEqual(taxCustomerDetails);
   });
 });

--- a/src/tests/ui/pages/payment-entry-page.test.ts
+++ b/src/tests/ui/pages/payment-entry-page.test.ts
@@ -646,4 +646,99 @@ describe("PurchasesUI", () => {
     // them on discount-code refreshes.
     expect(get(lastTaxCustomerDetailsStore)).toEqual(taxCustomerDetails);
   });
+
+  test("keeps the tax status as 'calculated' after a successful debounced refresh in the checkout shell", async () => {
+    // Repro for the debounced-refresh revert bug.
+    //
+    // The refresh flow is: a form change schedules a debounced refresh that
+    // optimistically flips `taxCalculationStatus` to "loading" (showing the
+    // skeleton). When the timer fires, `refreshTaxes` recalculates and then a
+    // `finally` handler restores the *previous* status if the status is still
+    // "loading" (a safety net for aborted/short-circuited refreshes).
+    //
+    // In the checkout shell (`onSessionPricingUpdated` provided) the parent owns
+    // the canonical pricing, so a successful recalculation used to forward the
+    // result to the parent WITHOUT updating the local status. That left the
+    // status at "loading" when `finally` ran, so it reverted to the stale
+    // previous value (here "unavailable") instead of "calculated" until the
+    // parent's async round-trip landed -- briefly disabling pay / showing stale
+    // tax UI. The fix applies the breakdown locally too, so this stays
+    // "calculated" throughout.
+    vi.mocked(StripeService.extractTaxCustomerDetails).mockResolvedValue({
+      customerDetails: {
+        countryCode: "US",
+        postalCode: "94107",
+        state: "CA",
+        city: "San Francisco",
+        addressLine1: "354 Oyster Point Blvd",
+        addressLine2: "Floor 2",
+      },
+      confirmationTokenId: "ctoken-id",
+    });
+
+    const paymentElement = {
+      on: (
+        eventType: string,
+        callback: (event?: StripePaymentElementChangeEvent) => void,
+      ) => {
+        if (eventType === "ready") {
+          setTimeout(() => callback(), 0);
+        }
+        if (eventType === "change") {
+          setTimeout(() => {
+            callback({
+              complete: true,
+              value: { type: "card" },
+              elementType: "payment",
+              empty: false,
+              collapsed: false,
+            });
+          }, 100);
+        }
+      },
+      mount: vi.fn(),
+      destroy: vi.fn(),
+    };
+    vi.mocked(StripeService.createPaymentElement).mockReturnValue(
+      // @ts-expect-error - This is a mock
+      paymentElement,
+    );
+
+    const onPriceBreakdownUpdated = vi.fn();
+    // Shell mode: the parent owns the canonical pricing. We intentionally do
+    // NOT echo it back via `defaultPriceBreakdown`, so the only way the local
+    // status can become "calculated" is the page applying it itself.
+    const onSessionPricingUpdated = vi.fn();
+
+    render(PaymentEntryPage, {
+      props: {
+        ...basicProps,
+        customerEmail: "test@test.com",
+        brandingInfo: {
+          ...brandingInfo,
+          gateway_tax_collection_enabled: true,
+        },
+        onPriceBreakdownUpdated,
+        onSessionPricingUpdated,
+      },
+      context: defaultContext,
+    });
+
+    // Flush stripe init, the payment element ready/change events, the debounce
+    // timer and the refresh promise chain (including its `finally`).
+    for (let i = 0; i < 6; i++) {
+      await vi.advanceTimersToNextTimerAsync();
+    }
+
+    // The parent received the recalculated, "calculated" pricing.
+    expect(onSessionPricingUpdated).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ taxCalculationStatus: "calculated" }),
+    );
+
+    // The local status must reflect that success and must not have reverted to
+    // the stale "unavailable"/"loading" value after `finally` ran.
+    const lastBreakdown = onPriceBreakdownUpdated.mock.calls.at(-1)?.[0];
+    expect(lastBreakdown?.taxCalculationStatus).toBe("calculated");
+  });
 });

--- a/src/tests/ui/pages/payment-entry-page.test.ts
+++ b/src/tests/ui/pages/payment-entry-page.test.ts
@@ -498,14 +498,14 @@ describe("PurchasesUI", () => {
     );
   });
 
-  test("does not render the address element when full_address_collection_mode is never", async () => {
+  test("does not render the address element when full_address_collection_mode is if_required", async () => {
     vi.mocked(StripeService.createAddressElement).mockClear();
     const { container } = render(PaymentEntryPage, {
       props: {
         ...basicProps,
         brandingInfo: {
           ...brandingInfo,
-          full_address_collection_mode: "never",
+          full_address_collection_mode: "if_required",
         },
       },
       context: defaultContext,
@@ -535,7 +535,7 @@ describe("PurchasesUI", () => {
     expect(StripeService.createAddressElement).toHaveBeenCalled();
   });
 
-  test("treats unknown full_address_collection_mode values as never", async () => {
+  test("treats unknown full_address_collection_mode values as if_required", async () => {
     vi.mocked(StripeService.createAddressElement).mockClear();
     const { container } = render(PaymentEntryPage, {
       props: {
@@ -544,7 +544,7 @@ describe("PurchasesUI", () => {
           ...brandingInfo,
           // Simulate a future mode this client version does not understand.
           full_address_collection_mode:
-            "some_future_mode" as unknown as "never",
+            "some_future_mode" as unknown as "if_required",
         },
       },
       context: defaultContext,

--- a/src/tests/ui/pages/payment-entry-page.test.ts
+++ b/src/tests/ui/pages/payment-entry-page.test.ts
@@ -62,6 +62,11 @@ vi.mock("../../../stripe/stripe-service", async () => {
         on: vi.fn(),
         destroy: vi.fn(),
       }),
+      createAddressElement: vi.fn().mockReturnValue({
+        mount: vi.fn(),
+        on: vi.fn(),
+        destroy: vi.fn(),
+      }),
       isStripeHandledFormError: vi.fn(),
       updateElementsConfiguration: vi.fn(),
       getStripeLocale: vi.fn().mockImplementation((locale: string) => locale),
@@ -489,5 +494,41 @@ describe("PurchasesUI", () => {
         totalAmountInMicros: 1230000,
       }),
     );
+  });
+
+  test("does not render the address element when full_address_collection_enabled is disabled", async () => {
+    const { container } = render(PaymentEntryPage, {
+      props: {
+        ...basicProps,
+        brandingInfo: {
+          ...brandingInfo,
+          full_address_collection_enabled: false,
+        },
+      },
+      context: defaultContext,
+    });
+
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(container.querySelector("#address-element")).toBeNull();
+    expect(StripeService.createAddressElement).not.toHaveBeenCalled();
+  });
+
+  test("renders the address element when full_address_collection_enabled is enabled", async () => {
+    const { container } = render(PaymentEntryPage, {
+      props: {
+        ...basicProps,
+        brandingInfo: {
+          ...brandingInfo,
+          full_address_collection_enabled: true,
+        },
+      },
+      context: defaultContext,
+    });
+
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(container.querySelector("#address-element")).not.toBeNull();
+    expect(StripeService.createAddressElement).toHaveBeenCalled();
   });
 });

--- a/src/tests/ui/pages/payment-entry-page.test.ts
+++ b/src/tests/ui/pages/payment-entry-page.test.ts
@@ -498,13 +498,14 @@ describe("PurchasesUI", () => {
     );
   });
 
-  test("does not render the address element when full_address_collection_enabled is disabled", async () => {
+  test("does not render the address element when full_address_collection_mode is never", async () => {
+    vi.mocked(StripeService.createAddressElement).mockClear();
     const { container } = render(PaymentEntryPage, {
       props: {
         ...basicProps,
         brandingInfo: {
           ...brandingInfo,
-          full_address_collection_enabled: false,
+          full_address_collection_mode: "never",
         },
       },
       context: defaultContext,
@@ -516,13 +517,13 @@ describe("PurchasesUI", () => {
     expect(StripeService.createAddressElement).not.toHaveBeenCalled();
   });
 
-  test("renders the address element when full_address_collection_enabled is enabled", async () => {
+  test("renders the address element when full_address_collection_mode is always", async () => {
     const { container } = render(PaymentEntryPage, {
       props: {
         ...basicProps,
         brandingInfo: {
           ...brandingInfo,
-          full_address_collection_enabled: true,
+          full_address_collection_mode: "always",
         },
       },
       context: defaultContext,
@@ -532,6 +533,27 @@ describe("PurchasesUI", () => {
 
     expect(container.querySelector("#address-element")).not.toBeNull();
     expect(StripeService.createAddressElement).toHaveBeenCalled();
+  });
+
+  test("treats unknown full_address_collection_mode values as never", async () => {
+    vi.mocked(StripeService.createAddressElement).mockClear();
+    const { container } = render(PaymentEntryPage, {
+      props: {
+        ...basicProps,
+        brandingInfo: {
+          ...brandingInfo,
+          // Simulate a future mode this client version does not understand.
+          full_address_collection_mode:
+            "some_future_mode" as unknown as "never",
+        },
+      },
+      context: defaultContext,
+    });
+
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(container.querySelector("#address-element")).toBeNull();
+    expect(StripeService.createAddressElement).not.toHaveBeenCalled();
   });
 
   test("forwards the full billing address and publishes it to the shared tax customer details store", async () => {
@@ -594,7 +616,7 @@ describe("PurchasesUI", () => {
         brandingInfo: {
           ...brandingInfo,
           gateway_tax_collection_enabled: true,
-          full_address_collection_enabled: true,
+          full_address_collection_mode: "always",
         },
         lastTaxCustomerDetailsStore,
       },

--- a/src/tests/ui/pages/payment-entry-page.test.ts
+++ b/src/tests/ui/pages/payment-entry-page.test.ts
@@ -118,6 +118,45 @@ const defaultContext = new Map(
   }),
 );
 
+/**
+ * Builds an Address Element mock that immediately fires `ready` and then a
+ * `change` event reporting the address as complete. Used to exercise the full
+ * address collection flow, where tax refreshes are gated on the billing
+ * address being complete.
+ */
+const createCompleteAddressElementMock = () => ({
+  on: (
+    eventType: string,
+    callback: (event?: {
+      complete: boolean;
+      value: { address: Record<string, string> };
+    }) => void,
+  ) => {
+    if (eventType === "ready") {
+      setTimeout(() => callback(), 0);
+    }
+    if (eventType === "change") {
+      setTimeout(() => {
+        callback({
+          complete: true,
+          value: {
+            address: {
+              country: "US",
+              postal_code: "94107",
+              state: "CA",
+              city: "San Francisco",
+              line1: "354 Oyster Point Blvd",
+              line2: "Floor 2",
+            },
+          },
+        });
+      }, 50);
+    }
+  },
+  mount: vi.fn(),
+  destroy: vi.fn(),
+});
+
 describe("PurchasesUI", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -598,6 +637,13 @@ describe("PurchasesUI", () => {
       paymentElement,
     );
 
+    // The billing address must report completion for tax refreshes to run when
+    // full address collection is enabled.
+    vi.mocked(StripeService.createAddressElement).mockReturnValue(
+      // @ts-expect-error - This is a mock
+      createCompleteAddressElementMock(),
+    );
+
     const checkoutRefreshPricingSpy = vi.spyOn(
       purchaseOperationHelperMock,
       "checkoutRefreshPricing",
@@ -645,6 +691,110 @@ describe("PurchasesUI", () => {
     // And it publishes the details to the shared store so the parent can reuse
     // them on discount-code refreshes.
     expect(get(lastTaxCustomerDetailsStore)).toEqual(taxCustomerDetails);
+  });
+
+  test("does not recalculate taxes while the full billing address is incomplete", async () => {
+    // Repro for the partial-address tax bug.
+    //
+    // With full address collection enabled, the pay button is gated on the
+    // billing address being complete (`isFormReady`). Tax refreshes must be
+    // gated the same way: otherwise, as soon as the email and card are
+    // complete, taxes would be calculated and displayed from partial/missing
+    // address data while the customer is still typing the address, so the shown
+    // tax could differ from the address being entered.
+    vi.mocked(StripeService.extractTaxCustomerDetails).mockClear();
+    vi.mocked(StripeService.extractTaxCustomerDetails).mockResolvedValue({
+      customerDetails: {
+        countryCode: "US",
+        postalCode: "94107",
+        state: "CA",
+        city: "San Francisco",
+        addressLine1: "354 Oyster Point Blvd",
+        addressLine2: "Floor 2",
+      },
+      confirmationTokenId: "ctoken-id",
+    });
+
+    const paymentElement = {
+      on: (
+        eventType: string,
+        callback: (event?: StripePaymentElementChangeEvent) => void,
+      ) => {
+        if (eventType === "ready") {
+          setTimeout(() => callback(), 0);
+        }
+        if (eventType === "change") {
+          setTimeout(() => {
+            callback({
+              complete: true,
+              value: { type: "card" },
+              elementType: "payment",
+              empty: false,
+              collapsed: false,
+            });
+          }, 100);
+        }
+      },
+      mount: vi.fn(),
+      destroy: vi.fn(),
+    };
+    vi.mocked(StripeService.createPaymentElement).mockReturnValue(
+      // @ts-expect-error - This is a mock
+      paymentElement,
+    );
+
+    // The Address Element reports the address as incomplete (e.g. the customer
+    // has only typed part of it).
+    const incompleteAddressElement = {
+      on: (
+        eventType: string,
+        callback: (event?: {
+          complete: boolean;
+          value: { address: Record<string, string> };
+        }) => void,
+      ) => {
+        if (eventType === "ready") {
+          setTimeout(() => callback(), 0);
+        }
+        if (eventType === "change") {
+          setTimeout(() => {
+            callback({
+              complete: false,
+              value: { address: { country: "US", line1: "354 Oyster" } },
+            });
+          }, 50);
+        }
+      },
+      mount: vi.fn(),
+      destroy: vi.fn(),
+    };
+    vi.mocked(StripeService.createAddressElement).mockReturnValue(
+      // @ts-expect-error - This is a mock
+      incompleteAddressElement,
+    );
+
+    render(PaymentEntryPage, {
+      props: {
+        ...basicProps,
+        customerEmail: "test@test.com",
+        brandingInfo: {
+          ...brandingInfo,
+          gateway_tax_collection_enabled: true,
+          full_address_collection_mode: "always",
+        },
+      },
+      context: defaultContext,
+    });
+
+    // Flush stripe init, the element ready/change events, the debounce timer
+    // and any refresh promise chain.
+    for (let i = 0; i < 6; i++) {
+      await vi.advanceTimersToNextTimerAsync();
+    }
+
+    // Because the address is incomplete, the gated refresh path must never run,
+    // so the customer details are never extracted for a tax calculation.
+    expect(StripeService.extractTaxCustomerDetails).not.toHaveBeenCalled();
   });
 
   test("keeps the tax status as 'calculated' after a successful debounced refresh in the checkout shell", async () => {

--- a/src/tests/ui/purchases-ui.test.ts
+++ b/src/tests/ui/purchases-ui.test.ts
@@ -27,6 +27,17 @@ import type { SubscriptionOptionResponse } from "../../networking/responses/prod
 
 const eventsTrackerMock = createEventsTrackerMock();
 
+// Before the customer enters an address, every pricing refresh forwards the tax
+// location fields as undefined and lets the backend fall back to IP geolocation.
+const noTaxLocation = {
+  countryCode: undefined,
+  postalCode: undefined,
+  state: undefined,
+  city: undefined,
+  addressLine1: undefined,
+  addressLine2: undefined,
+};
+
 const createCheckoutPricingResponse = (
   discountCode: string | null,
   options?: {
@@ -367,6 +378,7 @@ describe("PurchasesUI", () => {
         }),
       );
       expect(checkoutRefreshPricingSpy).toHaveBeenCalledWith({
+        ...noTaxLocation,
         discountCode: "SAVE10",
       });
       expect(
@@ -483,6 +495,7 @@ describe("PurchasesUI", () => {
 
     await waitFor(() => {
       expect(checkoutRefreshPricingSpy).toHaveBeenCalledWith({
+        ...noTaxLocation,
         discountCode: "SAVE10",
       });
       expect(onDiscountCodeChanged).toHaveBeenCalledWith("SAVE10");
@@ -566,6 +579,7 @@ describe("PurchasesUI", () => {
 
     await waitFor(() => {
       expect(checkoutRefreshPricingSpy).toHaveBeenNthCalledWith(2, {
+        ...noTaxLocation,
         discountCode: null,
       });
       expect(onDiscountCodeChanged).toHaveBeenCalledWith(null);

--- a/src/ui/molecules/stripe-address-element.svelte
+++ b/src/ui/molecules/stripe-address-element.svelte
@@ -24,6 +24,11 @@
   let addressElement: StripeAddressElement | null = null;
   const addressElementId = "address-element";
 
+  let lastComplete: boolean | null = null;
+  let lastTaxRelevantAddress:
+    | StripeAddressElementChangeEvent["value"]["address"]
+    | null = null;
+
   const onLoadErrorCallback = async (event: {
     elementType: "address";
     error: StripeError;
@@ -32,7 +37,40 @@
   };
 
   const onAddressChange = async (event: StripeAddressElementChangeEvent) => {
-    await onChange(event.complete);
+    const { complete } = event;
+    const address = event.value.address;
+
+    // Stripe emits a `change` event for any edit to the address element,
+    // including the name, which does not affect tax calculation. Only notify
+    // the parent when the completeness changes (so it can recalculate taxes
+    // once the address becomes valid) or when a tax-relevant field (country,
+    // postal code, state, city, line1, line2) actually changes.
+    const completeChanged = complete !== lastComplete;
+    const taxRelevantChanged = !isSameTaxRelevantAddress(
+      lastTaxRelevantAddress,
+      address,
+    );
+    if (!completeChanged && !taxRelevantChanged) {
+      return;
+    }
+
+    lastComplete = complete;
+    lastTaxRelevantAddress = address;
+    await onChange(complete);
+  };
+
+  const isSameTaxRelevantAddress = (
+    a: StripeAddressElementChangeEvent["value"]["address"] | null,
+    b: StripeAddressElementChangeEvent["value"]["address"],
+  ): boolean => {
+    return (
+      a?.country === b.country &&
+      a?.postal_code === b.postal_code &&
+      a?.state === b.state &&
+      a?.city === b.city &&
+      a?.line1 === b.line1 &&
+      a?.line2 === b.line2
+    );
   };
 
   onMount(() => {

--- a/src/ui/molecules/stripe-address-element.svelte
+++ b/src/ui/molecules/stripe-address-element.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import type {
+    StripeError,
+    StripeElements,
+    StripeAddressElement,
+    StripeAddressElementChangeEvent,
+  } from "@stripe/stripe-js";
+  import {
+    StripeService,
+    StripeServiceError,
+  } from "../../stripe/stripe-service";
+
+  import { onDestroy, onMount } from "svelte";
+
+  interface Props {
+    onChange: (complete: boolean) => void | Promise<void>;
+    onError: (error: StripeServiceError) => void | Promise<void>;
+    onReady: () => void | Promise<void>;
+    elements: StripeElements;
+  }
+
+  const { onChange, onError, onReady, elements }: Props = $props();
+
+  let addressElement: StripeAddressElement | null = null;
+  const addressElementId = "address-element";
+
+  const onLoadErrorCallback = async (event: {
+    elementType: "address";
+    error: StripeError;
+  }) => {
+    await onError(StripeService.mapInitializationError(event.error));
+  };
+
+  const onAddressChange = async (event: StripeAddressElementChangeEvent) => {
+    await onChange(event.complete);
+  };
+
+  onMount(() => {
+    try {
+      addressElement = StripeService.createAddressElement(elements);
+      addressElement.mount(`#${addressElementId}`);
+      addressElement.on("ready", onReady);
+      addressElement.on("change", onAddressChange);
+      addressElement.on("loaderror", onLoadErrorCallback);
+    } catch (e) {
+      onError(StripeService.mapInitializationError(e as StripeError));
+    }
+  });
+
+  onDestroy(() => {
+    addressElement?.destroy();
+    addressElement = null;
+  });
+</script>
+
+<div id={addressElementId}></div>

--- a/src/ui/molecules/stripe-address-element.svelte
+++ b/src/ui/molecules/stripe-address-element.svelte
@@ -13,7 +13,10 @@
   import { onDestroy, onMount } from "svelte";
 
   interface Props {
-    onChange: (complete: boolean) => void | Promise<void>;
+    onChange: (
+      complete: boolean,
+      address: StripeAddressElementChangeEvent["value"]["address"],
+    ) => void | Promise<void>;
     onError: (error: StripeServiceError) => void | Promise<void>;
     onReady: () => void | Promise<void>;
     elements: StripeElements;
@@ -56,7 +59,7 @@
 
     lastComplete = complete;
     lastTaxRelevantAddress = address;
-    await onChange(complete);
+    await onChange(complete, address);
   };
 
   const isSameTaxRelevantAddress = (

--- a/src/ui/molecules/stripe-elements.svelte
+++ b/src/ui/molecules/stripe-elements.svelte
@@ -3,6 +3,7 @@
   import type {
     Appearance,
     Stripe,
+    StripeAddressElementChangeEvent,
     StripeElements,
     StripeLinkAuthenticationElementChangeEvent,
     StripePaymentElementChangeEvent,
@@ -46,7 +47,10 @@
       complete: boolean;
       paymentMethod: string | undefined;
     }) => void;
-    onAddressInfoChange: (complete: boolean) => void;
+    onAddressInfoChange: (
+      complete: boolean,
+      address: StripeAddressElementChangeEvent["value"]["address"],
+    ) => void;
     onExpressCheckoutElementSubmit: (
       paymentMethod: string,
       emailValue: string,
@@ -166,8 +170,11 @@
     }
   };
 
-  const onAddressElementChange = async (complete: boolean) => {
-    onAddressInfoChange(complete);
+  const onAddressElementChange = async (
+    complete: boolean,
+    address: StripeAddressElementChangeEvent["value"]["address"],
+  ) => {
+    onAddressInfoChange(complete, address);
   };
 
   const onPaymentElementChange = async (

--- a/src/ui/molecules/stripe-elements.svelte
+++ b/src/ui/molecules/stripe-elements.svelte
@@ -8,7 +8,10 @@
     StripePaymentElementChangeEvent,
   } from "@stripe/stripe-js";
 
-  import { type BrandingInfoResponse } from "../../networking/responses/branding-response";
+  import {
+    type BrandingInfoResponse,
+    shouldCollectFullAddress,
+  } from "../../networking/responses/branding-response";
   import PaymentElement from "./stripe-payment-element.svelte";
   import LinkAuthenticationElement from "./stripe-authentication-link-element.svelte";
   import ExpressCheckoutElement from "./stripe-express-checkout-element.svelte";
@@ -74,14 +77,14 @@
   );
 
   const collectFullBillingAddress = $derived(
-    brandingInfo?.full_address_collection_enabled ?? false,
+    shouldCollectFullAddress(brandingInfo),
   );
 
   let paymentElementReadyForSubmission = $state(false);
   let emailElementReadyForSubmission = $state(skipEmail);
   let expressCheckoutElementReadyForSubmission = $state(false);
   let addressElementReadyForSubmission = $state(
-    !brandingInfo?.full_address_collection_enabled,
+    !shouldCollectFullAddress(brandingInfo),
   );
 
   let stripeVariables: undefined | Appearance["variables"] = $state(undefined);

--- a/src/ui/molecules/stripe-elements.svelte
+++ b/src/ui/molecules/stripe-elements.svelte
@@ -12,6 +12,7 @@
   import PaymentElement from "./stripe-payment-element.svelte";
   import LinkAuthenticationElement from "./stripe-authentication-link-element.svelte";
   import ExpressCheckoutElement from "./stripe-express-checkout-element.svelte";
+  import AddressElement from "./stripe-address-element.svelte";
 
   import { translatorContextKey } from "../localization/constants";
   import { Translator } from "../localization/translator";
@@ -42,6 +43,7 @@
       complete: boolean;
       paymentMethod: string | undefined;
     }) => void;
+    onAddressInfoChange: (complete: boolean) => void;
     onExpressCheckoutElementSubmit: (
       paymentMethod: string,
       emailValue: string,
@@ -62,6 +64,7 @@
     onError,
     onEmailChange,
     onPaymentInfoChange,
+    onAddressInfoChange,
     onExpressCheckoutElementSubmit,
   }: Props = $props();
 
@@ -70,9 +73,16 @@
     $translator.bcp47Locale || $translator.fallbackBcp47Locale,
   );
 
+  const collectFullBillingAddress = $derived(
+    brandingInfo?.full_address_collection_enabled ?? false,
+  );
+
   let paymentElementReadyForSubmission = $state(false);
   let emailElementReadyForSubmission = $state(skipEmail);
   let expressCheckoutElementReadyForSubmission = $state(false);
+  let addressElementReadyForSubmission = $state(
+    !brandingInfo?.full_address_collection_enabled,
+  );
 
   let stripeVariables: undefined | Appearance["variables"] = $state(undefined);
   let viewport: "mobile" | "desktop" = $state("mobile");
@@ -114,43 +124,47 @@
     onLoadingComplete();
   };
 
+  const maybeCompleteLoading = () => {
+    if (
+      emailElementReadyForSubmission &&
+      paymentElementReadyForSubmission &&
+      expressCheckoutElementReadyForSubmission &&
+      addressElementReadyForSubmission
+    ) {
+      onLoadingComplete();
+    }
+  };
+
   const onLinkAuthenticationElementReady = async () => {
     if (!emailElementReadyForSubmission) {
       emailElementReadyForSubmission = true;
-      if (
-        emailElementReadyForSubmission &&
-        paymentElementReadyForSubmission &&
-        expressCheckoutElementReadyForSubmission
-      ) {
-        onLoadingComplete();
-      }
+      maybeCompleteLoading();
     }
   };
 
   const onExpressCheckoutElementReady = async () => {
     if (!expressCheckoutElementReadyForSubmission) {
       expressCheckoutElementReadyForSubmission = true;
-      if (
-        emailElementReadyForSubmission &&
-        paymentElementReadyForSubmission &&
-        expressCheckoutElementReadyForSubmission
-      ) {
-        onLoadingComplete();
-      }
+      maybeCompleteLoading();
     }
   };
 
   const onPaymentElementReady = async () => {
     if (!paymentElementReadyForSubmission) {
       paymentElementReadyForSubmission = true;
-      if (
-        emailElementReadyForSubmission &&
-        paymentElementReadyForSubmission &&
-        expressCheckoutElementReadyForSubmission
-      ) {
-        onLoadingComplete();
-      }
+      maybeCompleteLoading();
     }
+  };
+
+  const onAddressElementReady = async () => {
+    if (!addressElementReadyForSubmission) {
+      addressElementReadyForSubmission = true;
+      maybeCompleteLoading();
+    }
+  };
+
+  const onAddressElementChange = async (complete: boolean) => {
+    onAddressInfoChange(complete);
   };
 
   const onPaymentElementChange = async (
@@ -239,6 +253,14 @@
       onChange={onPaymentElementChange}
       onError={onStripeElementsLoadingError}
     />
+    {#if collectFullBillingAddress}
+      <AddressElement
+        {elements}
+        onReady={onAddressElementReady}
+        onChange={onAddressElementChange}
+        onError={onStripeElementsLoadingError}
+      />
+    {/if}
   </div>
 {/if}
 

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -283,6 +283,10 @@
       .checkoutRefreshPricing({
         countryCode: taxCustomerDetails?.countryCode,
         postalCode: taxCustomerDetails?.postalCode,
+        state: taxCustomerDetails?.state,
+        city: taxCustomerDetails?.city,
+        addressLine1: taxCustomerDetails?.addressLine1,
+        addressLine2: taxCustomerDetails?.addressLine2,
         signal,
       })
       .then((taxCalculation) => {
@@ -551,7 +555,12 @@
 
     const sameDetails =
       taxCustomerDetails.postalCode === lastTaxCustomerDetails?.postalCode &&
-      taxCustomerDetails.countryCode === lastTaxCustomerDetails?.countryCode;
+      taxCustomerDetails.countryCode === lastTaxCustomerDetails?.countryCode &&
+      taxCustomerDetails.state === lastTaxCustomerDetails?.state &&
+      taxCustomerDetails.city === lastTaxCustomerDetails?.city &&
+      taxCustomerDetails.addressLine1 ===
+        lastTaxCustomerDetails?.addressLine1 &&
+      taxCustomerDetails.addressLine2 === lastTaxCustomerDetails?.addressLine2;
 
     if (!sameDetails) {
       await recalculatePriceBreakdown(taxCustomerDetails, signal);

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -46,7 +46,11 @@
     type CheckoutPricingResponse,
     type TaxBreakdown,
   } from "../../networking/responses/checkout-pricing-response";
-  import type { Stripe, StripeElements } from "@stripe/stripe-js";
+  import type {
+    Stripe,
+    StripeAddressElementChangeEvent,
+    StripeElements,
+  } from "@stripe/stripe-js";
   import {
     StripeService,
     StripeServiceError,
@@ -193,6 +197,12 @@
 
   let previousTaxCalculationStatus: TaxCalculationStatus =
     $state("unavailable");
+
+  // The tax location the last calculation ran for, used to skip redundant
+  // recalculations. Kept separate from `lastTaxCustomerDetailsStore` (which is
+  // published eagerly as the address is typed) so those eager writes don't make
+  // recalculateTaxes think nothing changed and skip the tax call.
+  let lastCalculatedTaxCustomerDetails: TaxCustomerDetails | null = null;
 
   let isFormReady = $derived(
     !processing &&
@@ -374,7 +384,19 @@
         pricingResponse.gateway_params.elements_configuration;
     }
 
-    $lastTaxCustomerDetailsStore = taxCustomerDetails;
+    lastCalculatedTaxCustomerDetails = taxCustomerDetails;
+    publishTaxLocation(taxCustomerDetails);
+  }
+
+  // Publishes the entered tax location to the shared store so pricing refreshes
+  // triggered outside this page (e.g. discount-code refreshes in the parent) use
+  // the address on the form. Only publishes once a country is known, so we never
+  // downgrade a set location back to the IP-based fallback (nor let the initial
+  // recalculatePriceBreakdown(null) clobber an address already being typed).
+  function publishTaxLocation(details: TaxCustomerDetails | null) {
+    if (details?.countryCode) {
+      $lastTaxCustomerDetailsStore = details;
+    }
   }
 
   function handleStripeLoadingComplete() {
@@ -405,8 +427,22 @@
     scheduleRefreshTaxes();
   }
 
-  function handleAddressInfoChange(complete: boolean) {
+  function handleAddressInfoChange(
+    complete: boolean,
+    address: StripeAddressElementChangeEvent["value"]["address"],
+  ) {
     isAddressComplete = complete;
+    // Publish the address as it's typed so a discount refresh fired before the
+    // debounced tax recalculation lands still carries it (instead of falling
+    // back to IP geolocation).
+    publishTaxLocation({
+      countryCode: address.country ?? undefined,
+      postalCode: address.postal_code ?? undefined,
+      state: address.state ?? undefined,
+      city: address.city ?? undefined,
+      addressLine1: address.line1 ?? undefined,
+      addressLine2: address.line2 ?? undefined,
+    });
     scheduleRefreshTaxes();
   }
 
@@ -631,7 +667,7 @@
 
     signal?.throwIfAborted();
 
-    const lastTaxCustomerDetails = $lastTaxCustomerDetailsStore;
+    const lastTaxCustomerDetails = lastCalculatedTaxCustomerDetails;
     const sameDetails =
       taxCustomerDetails.postalCode === lastTaxCustomerDetails?.postalCode &&
       taxCustomerDetails.countryCode === lastTaxCustomerDetails?.countryCode &&

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -358,10 +358,18 @@
       nextTaxCalculationStatus,
     );
 
+    // Apply the breakdown locally regardless of mode. In the checkout shell the
+    // parent owns the canonical pricing (via onSessionPricingUpdated) and echoes
+    // it back through defaultPriceBreakdown, but that round-trip is asynchronous.
+    // Without an immediate local update, the page's taxCalculationStatus would
+    // stay "loading" when refreshTaxes' finally handler runs, causing it to
+    // revert to a stale previousTaxCalculationStatus (e.g. "pending") and briefly
+    // disable the pay button / show stale tax UI until the parent sync lands.
+    applyLocalPriceBreakdown(nextPriceBreakdown);
+
     if (onSessionPricingUpdated) {
       onSessionPricingUpdated(pricingResponse, nextPriceBreakdown);
     } else {
-      applyLocalPriceBreakdown(nextPriceBreakdown);
       elementsConfiguration =
         pricingResponse.gateway_params.elements_configuration;
     }

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -491,7 +491,17 @@
    * when multiple tax refresh requests are triggered in quick succession.
    */
   async function refreshTaxes(): Promise<void> {
-    if (!canRefreshTaxes()) return;
+    if (!canRefreshTaxes()) {
+      // The form state may have changed between scheduling the debounced
+      // refresh (which optimistically shows the loading skeleton) and this
+      // timer firing. If a recalculation is no longer valid, restore the
+      // previous status so the UI doesn't get stuck calculating taxes (which
+      // would keep the pay button disabled).
+      if (taxCalculationStatus === "loading") {
+        taxCalculationStatus = previousTaxCalculationStatus;
+      }
+      return;
+    }
 
     if (taxCalculationStatus !== "loading") {
       previousTaxCalculationStatus = taxCalculationStatus;

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -31,7 +31,7 @@
   } from "../../behavioural-events/sdk-event-helpers";
   import { SDKEventName } from "../../behavioural-events/sdk-events";
   import Loading from "../molecules/loading.svelte";
-  import { type Writable } from "svelte/store";
+  import { writable, type Writable } from "svelte/store";
   import PaymentButton from "../molecules/payment-button.svelte";
   import type {
     GatewayParams,
@@ -76,6 +76,12 @@
       priceBreakdown: PriceBreakdown,
     ) => void;
     onProcessingStateChange?: (isProcessing: boolean) => void;
+    /**
+     * Shared store holding the last known tax customer details. It is lifted to
+     * the parent so that pricing refreshes triggered outside of this page (e.g.
+     * discount-code refreshes) can also forward the latest known tax location.
+     */
+    lastTaxCustomerDetailsStore?: Writable<TaxCustomerDetails | null>;
   }
 
   class TaxCustomerDetailsMissMatchError extends Error {}
@@ -100,6 +106,7 @@
     onPriceBreakdownUpdated,
     onSessionPricingUpdated = undefined,
     onProcessingStateChange = undefined,
+    lastTaxCustomerDetailsStore = writable<TaxCustomerDetails | null>(null),
   }: Props = $props();
 
   const eventsTracker = getContext(eventsTrackerContextKey) as IEventsTracker;
@@ -151,8 +158,6 @@
     gatewayParams.elements_configuration,
   );
 
-  let lastTaxCustomerDetails: TaxCustomerDetails | null = $state(null);
-
   let stripe: Stripe | null = $state(null);
   let elements: StripeElements | null = $state(null);
 
@@ -160,7 +165,9 @@
   let isEmailComplete = $state(customerEmail ? true : false);
   let isStripeLoading = $state(true);
   let isPaymentInfoComplete = $state(false);
-  let isAddressComplete = $state(!brandingInfo?.full_address_collection_enabled);
+  let isAddressComplete = $state(
+    !brandingInfo?.full_address_collection_enabled,
+  );
   let selectedPaymentMethod: string | undefined = $state(undefined);
   let modalErrorMessage: string | undefined = $state(undefined);
   let clientSecret: string | undefined = $state(undefined);
@@ -345,7 +352,7 @@
         pricingResponse.gateway_params.elements_configuration;
     }
 
-    lastTaxCustomerDetails = taxCustomerDetails;
+    $lastTaxCustomerDetailsStore = taxCustomerDetails;
   }
 
   function handleStripeLoadingComplete() {
@@ -553,6 +560,7 @@
 
     signal?.throwIfAborted();
 
+    const lastTaxCustomerDetails = $lastTaxCustomerDetailsStore;
     const sameDetails =
       taxCustomerDetails.postalCode === lastTaxCustomerDetails?.postalCode &&
       taxCustomerDetails.countryCode === lastTaxCustomerDetails?.countryCode &&

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -468,14 +468,20 @@
 
   /**
    * Whether a tax recalculation can run given the current form state. Tax
-   * refreshes are only valid for card payments once the email and payment
-   * information are complete and tax collection is enabled.
+   * refreshes are only valid for card payments once the email, payment
+   * information and billing address are complete and tax collection is enabled.
+   *
+   * The billing address must be complete so we never calculate (and display)
+   * taxes from partial or missing address data while the customer is still
+   * filling in the Address Element. When full address collection is not enabled,
+   * `isAddressComplete` is always true, so this has no effect on that flow.
    */
   function canRefreshTaxes(): boolean {
     return (
       selectedPaymentMethod === "card" &&
       isEmailComplete &&
       isPaymentInfoComplete &&
+      isAddressComplete &&
       !processing &&
       taxCalculationStatus !== "disabled"
     );

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -160,6 +160,7 @@
   let isEmailComplete = $state(customerEmail ? true : false);
   let isStripeLoading = $state(true);
   let isPaymentInfoComplete = $state(false);
+  let isAddressComplete = $state(!brandingInfo?.full_address_collection_enabled);
   let selectedPaymentMethod: string | undefined = $state(undefined);
   let modalErrorMessage: string | undefined = $state(undefined);
   let clientSecret: string | undefined = $state(undefined);
@@ -180,6 +181,7 @@
     !processing &&
       isPaymentInfoComplete &&
       isEmailComplete &&
+      isAddressComplete &&
       (taxCalculationStatus === "disabled" ||
         taxCalculationStatus === "calculated" ||
         taxCalculationStatus === "miss-match"),
@@ -367,6 +369,11 @@
   }) {
     selectedPaymentMethod = paymentMethod;
     isPaymentInfoComplete = complete;
+    await refreshTaxes();
+  }
+
+  async function handleAddressInfoChange(complete: boolean) {
+    isAddressComplete = complete;
     await refreshTaxes();
   }
 
@@ -683,6 +690,7 @@
           onError={handleStripeElementError}
           onEmailChange={handleEmailChange}
           onPaymentInfoChange={handlePaymentInfoChange}
+          onAddressInfoChange={handleAddressInfoChange}
           onExpressCheckoutElementSubmit={handleExpressCheckoutElementSubmit}
           {expressCheckoutOptions}
         />

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -6,7 +6,10 @@
     type PurchaseOption,
     type SubscriptionOption,
   } from "../../entities/offerings";
-  import { type BrandingInfoResponse } from "../../networking/responses/branding-response";
+  import {
+    type BrandingInfoResponse,
+    shouldCollectFullAddress,
+  } from "../../networking/responses/branding-response";
   import IconError from "../atoms/icons/icon-error.svelte";
   import MessageLayout from "../layout/message-layout.svelte";
 
@@ -173,9 +176,7 @@
   let isEmailComplete = $state(customerEmail ? true : false);
   let isStripeLoading = $state(true);
   let isPaymentInfoComplete = $state(false);
-  let isAddressComplete = $state(
-    !brandingInfo?.full_address_collection_enabled,
-  );
+  let isAddressComplete = $state(!shouldCollectFullAddress(brandingInfo));
   let selectedPaymentMethod: string | undefined = $state(undefined);
   let modalErrorMessage: string | undefined = $state(undefined);
   let clientSecret: string | undefined = $state(undefined);

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -85,6 +85,14 @@
   }
 
   class TaxCustomerDetailsMissMatchError extends Error {}
+
+  /**
+   * Delay applied before triggering a tax recalculation in response to form
+   * changes. This debounces bursts of `change` events (e.g. while the customer
+   * is typing the address line 1 or line 2) so we only recalculate taxes once
+   * they pause, instead of firing a request on every keystroke.
+   */
+  const TAX_REFRESH_DEBOUNCE_MS = 500;
 </script>
 
 <script lang="ts">
@@ -173,6 +181,7 @@
   let clientSecret: string | undefined = $state(undefined);
   let processing = $state(false);
   let abortController: AbortController | null = $state(null);
+  let refreshTaxesTimeout: ReturnType<typeof setTimeout> | null = null;
   let view: View = $derived(
     isStripeLoading || processing
       ? "loading"
@@ -276,6 +285,10 @@
   });
 
   onDestroy(() => {
+    if (refreshTaxesTimeout) {
+      clearTimeout(refreshTaxesTimeout);
+      refreshTaxesTimeout = null;
+    }
     if (abortController) {
       abortController.abort();
       abortController = null;
@@ -365,13 +378,13 @@
     isStripeLoading = false;
   }
 
-  async function handleEmailChange(complete: boolean, emailValue: string) {
+  function handleEmailChange(complete: boolean, emailValue: string) {
     email = emailValue;
     isEmailComplete = complete;
-    await refreshTaxes();
+    scheduleRefreshTaxes();
   }
 
-  async function handlePaymentInfoChange({
+  function handlePaymentInfoChange({
     complete,
     paymentMethod,
   }: {
@@ -380,12 +393,37 @@
   }) {
     selectedPaymentMethod = paymentMethod;
     isPaymentInfoComplete = complete;
-    await refreshTaxes();
+    scheduleRefreshTaxes();
   }
 
-  async function handleAddressInfoChange(complete: boolean) {
+  function handleAddressInfoChange(complete: boolean) {
     isAddressComplete = complete;
-    await refreshTaxes();
+    scheduleRefreshTaxes();
+  }
+
+  /**
+   * Debounces tax recalculations triggered by form `change` events. Successive
+   * changes within {@link TAX_REFRESH_DEBOUNCE_MS} (e.g. while typing the
+   * address) reset the timer, so the recalculation only runs once the customer
+   * pauses, avoiding a burst of redundant tax calculations.
+   *
+   * The loading state is applied immediately (not debounced) so the UI reacts
+   * as soon as the customer starts typing, while the actual calculation only
+   * fires after the cooldown.
+   */
+  function scheduleRefreshTaxes(): void {
+    if (canRefreshTaxes() && taxCalculationStatus !== "loading") {
+      previousTaxCalculationStatus = taxCalculationStatus;
+      taxCalculationStatus = "loading";
+    }
+
+    if (refreshTaxesTimeout) {
+      clearTimeout(refreshTaxesTimeout);
+    }
+    refreshTaxesTimeout = setTimeout(() => {
+      refreshTaxesTimeout = null;
+      void refreshTaxes();
+    }, TAX_REFRESH_DEBOUNCE_MS);
   }
 
   async function handleSubmit(e?: Event): Promise<void> {
@@ -420,6 +458,21 @@
   }
 
   /**
+   * Whether a tax recalculation can run given the current form state. Tax
+   * refreshes are only valid for card payments once the email and payment
+   * information are complete and tax collection is enabled.
+   */
+  function canRefreshTaxes(): boolean {
+    return (
+      selectedPaymentMethod === "card" &&
+      isEmailComplete &&
+      isPaymentInfoComplete &&
+      !processing &&
+      taxCalculationStatus !== "disabled"
+    );
+  }
+
+  /**
    * Refreshes taxes in real-time as the customer enters payment details.
    *
    * This method can only be used for card payments, as it will trigger a native prompt
@@ -437,14 +490,7 @@
    * when multiple tax refresh requests are triggered in quick succession.
    */
   async function refreshTaxes(): Promise<void> {
-    if (
-      selectedPaymentMethod !== "card" ||
-      !isEmailComplete ||
-      !isPaymentInfoComplete ||
-      processing ||
-      taxCalculationStatus === "disabled"
-    )
-      return;
+    if (!canRefreshTaxes()) return;
 
     if (taxCalculationStatus !== "loading") {
       previousTaxCalculationStatus = taxCalculationStatus;

--- a/src/ui/purchases-ui-inner.svelte
+++ b/src/ui/purchases-ui-inner.svelte
@@ -16,6 +16,8 @@
   import { type GatewayParams } from "../networking/responses/stripe-elements";
   import BrandingHeader from "./molecules/branding-header.svelte";
   import type { CheckoutPricingResponse } from "../networking/responses/checkout-pricing-response";
+  import { writable, type Writable } from "svelte/store";
+  import type { TaxCustomerDetails } from "../stripe/stripe-service";
 
   interface Props {
     currentPage: CurrentPage;
@@ -51,6 +53,7 @@
     onError: (error: PurchaseFlowError) => void;
     onClose?: () => void;
     hideBackButton?: boolean;
+    lastTaxCustomerDetailsStore?: Writable<TaxCustomerDetails | null>;
   }
 
   let {
@@ -84,6 +87,7 @@
     onError,
     onClose = undefined,
     hideBackButton = false,
+    lastTaxCustomerDetailsStore = writable<TaxCustomerDetails | null>(null),
   }: Props = $props();
 
   const initialPrice = getInitialPriceFromPurchaseOption(
@@ -170,6 +174,7 @@
         {onPriceBreakdownUpdated}
         {onSessionPricingUpdated}
         onProcessingStateChange={onPaymentProcessingChange}
+        {lastTaxCustomerDetailsStore}
       />
     {/if}
 

--- a/src/ui/purchases-ui.svelte
+++ b/src/ui/purchases-ui.svelte
@@ -30,8 +30,9 @@
     AttributionMetadata,
     WorkflowPurchaseContext,
   } from "../entities/purchase-params";
-  import { writable } from "svelte/store";
+  import { get, writable } from "svelte/store";
   import type { BrandingAppearance } from "../entities/branding";
+  import type { TaxCustomerDetails } from "../stripe/stripe-service";
   import { type GatewayParams } from "../networking/responses/stripe-elements";
   import {
     CheckoutPricingFailedReason,
@@ -107,6 +108,10 @@
   let latestCheckoutPricingResponse = $state<CheckoutPricingResponse | null>(
     null,
   );
+  // Shared with the payment entry page so that every pricing refresh (including
+  // discount-code refreshes triggered here) forwards the latest known tax
+  // location. It stays null until the customer provides an address.
+  const lastTaxCustomerDetailsStore = writable<TaxCustomerDetails | null>(null);
   let purchaseOptionToUse: PurchaseOption = $derived(
     getActiveCheckoutPurchaseOption(
       productDetails,
@@ -273,6 +278,21 @@
       PurchaseFlowErrorCode.StripeMissingRequiredPermission,
     ].includes(error.errorCode);
 
+  // Spreads the latest known tax location (when available) so the backend
+  // always receives it. Each field is sent as undefined until the customer
+  // provides an address, in which case the backend falls back to IP geolocation.
+  const buildTaxLocationParams = () => {
+    const details = get(lastTaxCustomerDetailsStore);
+    return {
+      countryCode: details?.countryCode,
+      postalCode: details?.postalCode,
+      state: details?.state,
+      city: details?.city,
+      addressLine1: details?.addressLine1,
+      addressLine2: details?.addressLine2,
+    };
+  };
+
   const applyPricingResponse = (
     response: CheckoutPricingResponse,
     nextPriceBreakdown?: PriceBreakdown,
@@ -302,6 +322,7 @@
         try {
           const pricingResponse =
             await purchaseOperationHelper.checkoutRefreshPricing({
+              ...buildTaxLocationParams(),
               discountCode,
             });
           applyPricingResponse(pricingResponse);
@@ -362,6 +383,7 @@
     try {
       const pricingResponse =
         await purchaseOperationHelper.checkoutRefreshPricing({
+          ...buildTaxLocationParams(),
           discountCode: normalizedDiscountCode,
         });
       applyPricingResponse(pricingResponse);
@@ -470,4 +492,5 @@
   onError={handleError}
   {onClose}
   {hideBackButton}
+  {lastTaxCustomerDetailsStore}
 />


### PR DESCRIPTION
## Motivation / Description

When tax collection is enabled, we were only sending the country and postal code to the backend, which limits Stripe Tax to ZIP-level accuracy. For projects that need rooftop-level accuracy (e.g. US destinations where the tax can change between two addresses in the same ZIP) we need to collect and forward the full billing address.

This PR adds an opt-in full billing address collection flow on the payment entry page, gated by a new `full_address_collection_mode` field on the branding response. This is modeled as a string enum (`"if_required" | "always"`) rather than a boolean so additional modes can be added later without breaking compatibility:
- `if_required`: the full address UI is only presented when it is required, e.g. for tax collection in the customer's country. Otherwise only country and postal code are collected, and postal code is US-only. (default behavior)
- `always`: the full address UI is always presented.

When the mode is `always`, a Stripe Address Element is rendered alongside the Payment Element and the structured address (state, city, line1, line2) is forwarded to the `checkoutRefreshPricing` call so taxes are computed against the exact address the customer typed.

## Changes introduced

- **Address Element**
  - New `stripe-address-element.svelte` component that mounts the Stripe Address Element in `billing` mode with `display.name = "full"`.
  - `StripeService.createAddressElement` factory + unit tests.
  - Wired into `stripe-elements.svelte` behind the `full_address_collection_mode` branding field, including a new ready gate so the loading state only completes once the address element is also ready.
  - A `shouldCollectFullAddress(brandingInfo)` helper centralizes the resolution (`mode === "always"`). A missing mode or any unknown/future mode safely degrades to the default `if_required` behavior.

- **Full address in pricing refreshes**
  - `TaxCustomerDetails`, `Backend.checkoutRefreshPricing` and `PurchaseOperationHelper.checkoutRefreshPricing` now accept `state`, `city`, `addressLine1`, `addressLine2` (mapped to `state`, `city`, `address_line1`, `address_line2` in the request body).
  - `StripeService.extractTaxCustomerDetails` returns the full billing address from the confirmation token.
  - `payment-entry-page.svelte` forwards every field on each refresh.

- **Shared tax customer details store**
  - Lifted `lastTaxCustomerDetails` into a `Writable<TaxCustomerDetails | null>` shared with the purchases-ui parent so discount-code refreshes (and other out-of-page pricing refreshes) reuse the latest known location. Fields stay `undefined` until the customer provides an address, preserving the backend IP-geolocation fallback.

- **Debounce + name-change handling**
  - Bursts of `change` events (typing the address line, etc.) are coalesced into a single tax recalculation after a 500ms pause. The loading state is applied immediately so the UI reacts as soon as typing starts.
  - The Address Element emits `change` for any edit, including the cardholder name. The component now only forwards a change when completeness flips or when a tax-relevant field (country, postal_code, state, city, line1, line2) actually changes, so typing the name does not trigger a tax recalculation.

- **Tests**
  - Unit tests for `createAddressElement`, `extractTaxCustomerDetails`, the new render conditions on the payment entry page (`always` renders the address element, `if_required` and unknown modes do not), and the updated `checkoutRefreshPricing` call shape (existing `purchases-ui` tests now also assert the new `state`/`city`/`addressLine1`/`addressLine2` undefined fields).
  - New e2e suite `Tax calculation with full address collection` (mocked + real variants, Chromium-only) covering:
    - Typing into address line 1 debounces into a single tax calculation.
    - Editing only the name does not trigger a tax recalculation and does not show the tax-calculating skeleton.
  - New `enterBillingAddress` / `getStripeAddressFrame` helpers and `NEW_YORK_FULL_ADDRESS` fixture. `enterCreditCardDetails` now detects the presence of `#address-element` and routes the country/ZIP entry to the Address Element when full address collection is enabled.

- **Configuration**
  - New `VITE_RC_FULL_ADDRESS_E2E_API_KEY` env var (project with both tax collection and `full_address_collection_mode: always` enabled) and `rcb_e2e_taxes_full_address` offering id used by the new e2e suite. `.env.example` and the demo README are updated accordingly.

## Linear ticket (if any)

[WEB-4322](https://linear.app/revenuecat/issue/WEB-4322)

## Additional comments

- The new e2e suite is skipped automatically when `VITE_RC_FULL_ADDRESS_E2E_API_KEY` is not set, so CI continues to pass in environments that haven't provisioned the new key yet.
- The new branding field is optional (`full_address_collection_mode?: FullAddressCollectionMode`) and defaults to `if_required`, so behaviour is unchanged for projects that don't opt in.
- The Stripe Address Element interactions in Playwright are flaky outside of Chromium, so the new e2e suite is intentionally Chromium-only (same convention as some of the existing tax tests).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live checkout tax/pricing refresh behavior and payment UI when projects opt into `always`, though default `if_required` is unchanged and coverage is extensive.
> 
> **Overview**
> Adds **opt-in full billing address collection** for checkout when branding sets `full_address_collection_mode` to **`always`** (missing/unknown modes stay on the existing country + postal flow via `shouldCollectFullAddress`).
> 
> When enabled, a **Stripe Address Element** is mounted and structured fields (**state, city, line1, line2**) are sent on **`checkoutRefreshPricing`** / `PATCH` checkout pricing. Tax refreshes are **debounced (500ms)**, gated on a **complete** address, and **name-only** edits do not trigger recalculation. A **shared `lastTaxCustomerDetailsStore`** keeps discount-code and other parent-driven refreshes aligned with the address on the form.
> 
> Also fixes checkout-shell behavior so a successful debounced tax refresh **keeps local `taxCalculationStatus` as `calculated`** instead of briefly reverting to a stale status while waiting on the parent.
> 
> **Tests & CI:** new unit/e2e coverage (Chromium-only full-address tax suite), Playwright helpers (`enterBillingAddress`), and **`VITE_RC_FULL_ADDRESS_E2E_API_KEY`** in CircleCI / demo env docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd7ea8e4bec0ce0ee8da282002f678dd96a2fe31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->