### PR TITLE
feat(offerings): WST-823 build composite product id from the plan field

### DIFF
--- a/src/entities/offerings.ts
+++ b/src/entities/offerings.ts
@@ -890,13 +890,25 @@ const toSubscriptionProduct = (
   };
 };
 
+/**
+ * The product key for a package. Composite Stripe products carry the price on a
+ * separate plan field, so they key by `{product}:{plan}` and each price variant
+ * resolves to its own product.
+ */
+export const packageProductIdentifier = (
+  packageData: PackageResponse,
+): string =>
+  packageData.platform_product_plan_identifier
+    ? `${packageData.platform_product_identifier}:${packageData.platform_product_plan_identifier}`
+    : packageData.platform_product_identifier;
+
 const toPackage = (
   presentedOfferingContext: PresentedOfferingContext,
   packageData: PackageResponse,
   productDetailsData: { [productId: string]: ProductResponse },
 ): Package | null => {
   const webBillingProduct =
-    productDetailsData[packageData.platform_product_identifier];
+    productDetailsData[packageProductIdentifier(packageData)];
   if (webBillingProduct === undefined) return null;
   const product = toProduct(webBillingProduct, presentedOfferingContext);
   if (product === null) return null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import type {
   Package,
   Product,
 } from "./entities/offerings";
+import { packageProductIdentifier } from "./entities/offerings";
 import PurchasesUi from "./ui/purchases-ui.svelte";
 import PaddlePurchasesUi from "./ui/paddle-purchases-ui.svelte";
 import StripeCheckoutPurchasesUi from "./ui/stripe-checkout-purchases-ui.svelte";
@@ -1210,7 +1211,7 @@ export class Purchases {
   ): Promise<Offerings> {
     const productIds = offeringsResponse.offerings
       .flatMap((o: OfferingResponse) => o.packages)
-      .map((p: PackageResponse) => p.platform_product_identifier);
+      .map((p: PackageResponse) => packageProductIdentifier(p));
 
     const productsResponse = await this.backend.getProducts(
       appUserId,

--- a/src/networking/responses/offerings-response.ts
+++ b/src/networking/responses/offerings-response.ts
@@ -3,6 +3,7 @@ import type { PaywallData, UIConfig } from "@revenuecat/purchases-ui-js";
 export interface PackageResponse {
   identifier: string;
   platform_product_identifier: string;
+  platform_product_plan_identifier?: string | null;
   web_checkout_url?: string | null;
 }
 

--- a/src/tests/entities/offerings.test.ts
+++ b/src/tests/entities/offerings.test.ts
@@ -1,12 +1,16 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
+  packageProductIdentifier,
   ProductType,
+  toOffering,
   toPurchaseOptionForProductType,
 } from "../../entities/offerings";
 import type {
   NonSubscriptionOptionResponse,
   SubscriptionOptionResponse,
 } from "../../networking/responses/products-response";
+import type { PackageResponse } from "../../networking/responses/offerings-response";
+import { productsResponse } from "../test-responses";
 
 const subscriptionOptionResponse: SubscriptionOptionResponse = {
   id: "sub_option",
@@ -84,5 +88,60 @@ describe("toPurchaseOptionForProductType", () => {
     );
 
     expect(result).toBeNull();
+  });
+});
+
+describe("packageProductIdentifier", () => {
+  test("returns the composite id when the package has a plan identifier", () => {
+    const pkg: PackageResponse = {
+      identifier: "$rc_weekly",
+      platform_product_identifier: "prod_abc",
+      platform_product_plan_identifier: "price_weekly",
+    };
+
+    expect(packageProductIdentifier(pkg)).toBe("prod_abc:price_weekly");
+  });
+
+  test("returns the bare product id when there is no plan identifier", () => {
+    const pkg: PackageResponse = {
+      identifier: "$rc_annual",
+      platform_product_identifier: "prod_legacy",
+    };
+
+    expect(packageProductIdentifier(pkg)).toBe("prod_legacy");
+  });
+});
+
+describe("toOffering with composite products", () => {
+  test("resolves a composite package's product by its composite id", () => {
+    const compositeProduct = {
+      ...productsResponse.product_details[0],
+      identifier: "prod_abc:price_weekly",
+    };
+
+    const offering = toOffering(
+      true,
+      {
+        identifier: "offering_composite",
+        description: "Composite Offering",
+        metadata: null,
+        paywall_components: null,
+        packages: [
+          {
+            identifier: "$rc_weekly",
+            platform_product_identifier: "prod_abc",
+            platform_product_plan_identifier: "price_weekly",
+          },
+        ],
+      },
+      {
+        "prod_abc:price_weekly": compositeProduct,
+      },
+    );
+
+    expect(offering?.availablePackages).toHaveLength(1);
+    expect(offering?.availablePackages[0].webBillingProduct.identifier).toBe(
+      "prod_abc:price_weekly",
+    );
   });
 });


### PR DESCRIPTION
## What

Composite Stripe products carry their price on a separate `platform_product_plan_identifier` field (the same shape Google Play uses for base plans). The web SDK now keys a package's product by the composite id `{product}:{plan}` whenever that plan field is present, so two price variants of one Stripe product resolve to their own products instead of collapsing onto the shared bare product id. Packages with no plan field (legacy / non-composite) key by the product id alone, unchanged.

## Changes

- `PackageResponse` models `platform_product_plan_identifier`.
- New `packageProductIdentifier(pkg)` helper - the single source of truth for a package's product key.
- `getAllOfferings` fetches products by that key, and `toPackage` looks them up by the same key. Same helper on both sides, so the fetch and the map can't drift.

## Behavior

| Package | Product key |
|---------|-------------|
| Composite (plan field present) | `prod:price` |
| Legacy / non-composite | `prod` (unchanged) |

## Tests

- `packageProductIdentifier` returns the composite id with a plan field, the bare id without.
- `toOffering` resolves a composite package's product by the composite id.
- Existing offerings suite (32 tests) green - non-composite packages unchanged.

## Backend dependency + version coordination

Pairs with the khepri offerings gate `offering-stripe-composite` (`sdk='js'`): the backend serves the bare id + plan field only to clients at or above that gate version, and folds the composite id into `platform_product_identifier` for everything below. So this SDK must release at the gate's `js` min version (currently `1.47.0`) - confirm the two line up when it ships. Composite price resolution in `/products` requires khepri WST-730.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core offerings/product resolution for purchases; legacy non-composite behavior is preserved, but mismatched backend/SDK versions could drop packages if composite products are missing from `/products`.
> 
> **Overview**
> Composite Stripe packages can now resolve **distinct products per price** instead of sharing one bare product id when multiple packages point at the same Stripe product.
> 
> `PackageResponse` gains optional `platform_product_plan_identifier`, and **`packageProductIdentifier`** centralizes the lookup key: `{platform_product_identifier}:{platform_product_plan_identifier}` when a plan is present, otherwise the bare product id (unchanged for legacy packages). **`getAllOfferings`** requests products with that key, and **`toPackage`** reads from the product map with the same key so fetch and resolution stay aligned.
> 
> Tests cover the helper’s composite vs bare behavior and **`toOffering`** wiring for a composite package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d175b7b70ff459e5cdef44425c0e75adadd2bcf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->