### PR TITLE
WFL-377 | Make it easier to test web paywalls

### DIFF
--- a/examples/webbilling-demo/README.md
+++ b/examples/webbilling-demo/README.md
@@ -3,22 +3,22 @@
 ### Development
 
 - Install and build dependencies in the root `purchases-js`
-  - `npm i`
-  - `npm run build`
+  - `pnpm i`
+  - `pnpm run build`
 - Install dependencies for the webbilling-demo app
 
-  - `npm i`
+  - `pnpm i`
 
 - Set the following env variables. You can set them in a `.env` file in the root of this demo app.
 
 ```bash
-export VITE_RC_API_KEY = 'your public api key'
+export VITE_RC_API_KEY = 'your public web billing api key (prefixed with rcb_)'
 ```
 
 - Start the server
 
 ```bash
-npm run dev
+pnpm run dev
 ```
 
 > **NOTE:** In development mode, the SDK connects to `localhost:8000` by default (set in the root `.env.development`). If you want to point the demo at production or a custom backend instead, set the following env vars in your `.env` file in this demo directory:
@@ -116,3 +116,14 @@ sudo npm run dev-fake-https -- --host somedomain.com --port 443
 ```
 
 Now you should be able to run safari with Apple Pay just by visiting `somedomain.com`.
+
+### Viewing Paywalls
+
+Before a paywall will appear, you need an offering configured in the [RevenueCat dashboard](https://app.revenuecat.com) with packages and a paywall attached.
+
+1. Go to the landing page and click **"Subscribe now"**
+2. Enter your app user ID
+3. Optionally enter an **offering identifier** to load a specific offering — leave blank to use the default offering
+4. Click **"Continue (RC Paywall)"** to view the RC paywall
+
+If you see a blank page or "No offering found!", check that your offering is set as the **default offering** in the dashboard (or that the identifier you entered is correct) and has a paywall configured.

--- a/examples/webbilling-demo/README.md
+++ b/examples/webbilling-demo/README.md
@@ -18,7 +18,7 @@ export VITE_RC_API_KEY = 'your public web billing api key (prefixed with rcb_)'
 - Start the server
 
 ```bash
-pnpm run dev
+npm run dev
 ```
 
 > **NOTE:** In development mode, the SDK connects to `localhost:8000` by default (set in the root `.env.development`). If you want to point the demo at production or a custom backend instead, set the following env vars in your `.env` file in this demo directory:

--- a/examples/webbilling-demo/src/pages/login/index.tsx
+++ b/examples/webbilling-demo/src/pages/login/index.tsx
@@ -9,8 +9,9 @@ const LoginPage: React.FC = () => {
   const [displayName, setDisplayName] = useState("");
   const [nickname, setNickname] = useState("");
   const [appUserId, setAppUserId] = useState("");
-  const [useCustomLogger, setUseCustomLogger] = useState(true);
   const [offeringId, setOfferingId] = useState("");
+  const [useCustomLogger, setUseCustomLogger] = useState(true);
+  const [enableWorkflows, setEnableWorkflows] = useState(false);
 
   const navigateToAppUserIDPaywall = (
     appUserId?: string,
@@ -24,12 +25,15 @@ const LoginPage: React.FC = () => {
       if (nickname) {
         params.append("nickname", nickname);
       }
-      // Add custom logger preference
-      params.append("useCustomLogger", useCustomLogger.toString());
-
       if (offeringId.trim()) {
         params.append("offeringId", offeringId.trim());
       }
+      // Add custom logger preference
+      params.append("useCustomLogger", useCustomLogger.toString());
+      if (enableWorkflows) {
+        params.append("enableWorkflows", "true");
+      }
+
       const queryString = params.toString();
       const base = useRCPaywall ? "rc_paywall" : "paywall";
       const url = `/${base}/${encodeURIComponent(appUserId)}${queryString ? `?${queryString}` : ""}`;
@@ -88,6 +92,17 @@ const LoginPage: React.FC = () => {
             />
             <span className="checkbox-text">
               🏥 Use custom health logger (adds health icon to SDK logs)
+            </span>
+          </label>
+          <label className="checkbox-label">
+            <input
+              type="checkbox"
+              checked={enableWorkflows}
+              onChange={(e) => setEnableWorkflows(e.target.checked)}
+              className="checkbox-input"
+            />
+            <span className="checkbox-text">
+              Enable multipage paywalls (workflows)
             </span>
           </label>
         </div>

--- a/examples/webbilling-demo/src/pages/login/index.tsx
+++ b/examples/webbilling-demo/src/pages/login/index.tsx
@@ -10,8 +10,12 @@ const LoginPage: React.FC = () => {
   const [nickname, setNickname] = useState("");
   const [appUserId, setAppUserId] = useState("");
   const [useCustomLogger, setUseCustomLogger] = useState(true);
+  const [offeringId, setOfferingId] = useState("");
 
-  const navigateToAppUserIDPaywall = (appUserId?: string) => {
+  const navigateToAppUserIDPaywall = (
+    appUserId?: string,
+    useRCPaywall = false,
+  ) => {
     if (appUserId) {
       const params = new URLSearchParams();
       if (displayName) {
@@ -23,8 +27,12 @@ const LoginPage: React.FC = () => {
       // Add custom logger preference
       params.append("useCustomLogger", useCustomLogger.toString());
 
+      if (offeringId.trim()) {
+        params.append("offeringId", offeringId.trim());
+      }
       const queryString = params.toString();
-      const url = `/paywall/${encodeURIComponent(appUserId)}${queryString ? `?${queryString}` : ""}`;
+      const base = useRCPaywall ? "rc_paywall" : "paywall";
+      const url = `/${base}/${encodeURIComponent(appUserId)}${queryString ? `?${queryString}` : ""}`;
       navigate(url);
     }
   };
@@ -42,22 +50,33 @@ const LoginPage: React.FC = () => {
           value={appUserId}
           onChange={(e) => setAppUserId(e.target.value)}
         />
-        <div className="attributes-section">
+        <div className="attributes-section" style={{ marginTop: "16px" }}>
           <h3>Optional Attributes</h3>
-          <input
-            type="text"
-            placeholder="Display Name"
-            value={displayName}
-            onChange={(e) => setDisplayName(e.target.value)}
-            className="input-field"
-          />
-          <input
-            type="text"
-            placeholder="Nickname"
-            value={nickname}
-            onChange={(e) => setNickname(e.target.value)}
-            className="input-field"
-          />
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "12px" }}
+          >
+            <input
+              type="text"
+              placeholder="Offering identifier (leave blank for default offering)"
+              value={offeringId}
+              onChange={(e) => setOfferingId(e.target.value)}
+              className="input-field"
+            />
+            <input
+              type="text"
+              placeholder="Display Name"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              className="input-field"
+            />
+            <input
+              type="text"
+              placeholder="Nickname"
+              value={nickname}
+              onChange={(e) => setNickname(e.target.value)}
+              className="input-field"
+            />
+          </div>
         </div>
         <div className="logger-section">
           <label className="checkbox-label">
@@ -77,6 +96,12 @@ const LoginPage: React.FC = () => {
             caption="Continue"
             onClick={() => {
               navigateToAppUserIDPaywall(appUserId);
+            }}
+          />
+          <Button
+            caption="Continue (RC Paywall)"
+            onClick={() => {
+              navigateToAppUserIDPaywall(appUserId, true);
             }}
           />
           <Button

--- a/examples/webbilling-demo/src/util/PurchasesLoader.ts
+++ b/examples/webbilling-demo/src/util/PurchasesLoader.ts
@@ -46,6 +46,8 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
   const useCustomLogger = searchParams.get("useCustomLogger") === "true";
   const storeLoadTime =
     (searchParams.get("storeLoadTime") as StoreLoadTime) || undefined;
+  const enableWorkflows =
+    searchParams.get("enableWorkflows") === "true" || false;
 
   if (!appUserId) {
     throw redirect("/");
@@ -66,6 +68,7 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
     autoCollectUTMAsMetadata: !optOutOfAutoUTM,
     hideBackButton: hideCheckoutBackButton,
     ...(storeLoadTime ? { storeLoadTime } : {}),
+    ...(enableWorkflows ? { workflowsEndpointEnabled: true } : {}),
   };
   if (rcSource) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
## Motivation / Description

Update to the web billing demo app to make it easier to test RC web paywalls

## Changes introduced

- Updated readme
- Added a specific input and button to show RC paywalls easier

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Demo-app and documentation only; no production SDK or billing logic changes.
> 
> **Overview**
> Improves the **web billing demo** so RC web paywalls are easier to exercise without digging through routes or env flags.
> 
> The login flow now accepts an optional **offering identifier** (passed through as `offeringId`), adds **Continue (RC Paywall)** to navigate to `/rc_paywall/...` instead of the generic paywall path, and exposes a **multipage paywalls (workflows)** toggle that sets `workflowsEndpointEnabled` via the `enableWorkflows` query param in `PurchasesLoader`.
> 
> The **README** switches root/demo install instructions to **pnpm**, clarifies the public key should be a **web billing** key (`rcb_`), and documents how to view paywalls and troubleshoot missing offerings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f545b724d2456b000bd09ce976b0a486ed7f216. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->