### PR TITLE
Expose autoResumeDate on SubscriptionInfo

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -217,33 +217,6 @@
             },
             {
               "kind": "PropertySignature",
-              "canonicalReference": "@revenuecat/purchases-js!BrandingAppearance#color_buttons_primary:member",
-              "docComment": "",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "color_buttons_primary: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "string"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "color_buttons_primary",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            },
-            {
-              "kind": "PropertySignature",
               "canonicalReference": "@revenuecat/purchases-js!BrandingAppearance#color_buttons_primary_text:member",
               "docComment": "",
               "excerptTokens": [
@@ -264,6 +237,33 @@
               "isOptional": true,
               "releaseTag": "Public",
               "name": "color_buttons_primary_text",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!BrandingAppearance#color_buttons_primary:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "color_buttons_primary: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "color_buttons_primary",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
@@ -9617,6 +9617,38 @@
           "name": "SubscriptionInfo",
           "preserveMemberOrder": false,
           "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!SubscriptionInfo#autoResumeDate:member",
+              "docComment": "/**\n * Date when a paused subscription is expected to automatically resume. Only set for Google Play subscriptions that have been paused; null otherwise.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly autoResumeDate: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Date",
+                  "canonicalReference": "!Date:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | null"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "autoResumeDate",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              }
+            },
             {
               "kind": "PropertySignature",
               "canonicalReference": "@revenuecat/purchases-js!SubscriptionInfo#billingIssuesDetectedAt:member",

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -597,6 +597,7 @@ export interface StoreTransaction {
 
 // @public
 export interface SubscriptionInfo {
+    readonly autoResumeDate: Date | null;
     readonly billingIssuesDetectedAt: Date | null;
     readonly displayName: string | null;
     readonly expiresDate: Date | null;

--- a/src/entities/customer-info.ts
+++ b/src/entities/customer-info.ts
@@ -253,6 +253,11 @@ export interface SubscriptionInfo {
    */
   readonly displayName: string | null;
   /**
+   * Date when a paused subscription is expected to automatically resume.
+   * Only set for Google Play subscriptions that have been paused; null otherwise.
+   */
+  readonly autoResumeDate: Date | null;
+  /**
    * Paid price for the subscription.
    */
   readonly price: Price | null;
@@ -519,6 +524,7 @@ export function toCustomerInfo(
             isActive: isActive(response.expires_date),
             willRenew: getWillRenew(response.expires_date, response),
             displayName: response.display_name ?? null,
+            autoResumeDate: toDateIfNotNull(response.auto_resume_date),
             price: toSubscriptionPrice(response.price),
           },
         ],

--- a/src/tests/entities/customer-info.test.ts
+++ b/src/tests/entities/customer-info.test.ts
@@ -159,6 +159,7 @@ describe("customer info parsing", () => {
           isActive: true,
           willRenew: true,
           displayName: null,
+          autoResumeDate: null,
           price: null,
         },
       },
@@ -430,6 +431,7 @@ describe("customer info parsing", () => {
           unsubscribeDetectedAt: null,
           willRenew: true,
           displayName: null,
+          autoResumeDate: null,
           price: null,
         },
         pro: {
@@ -451,6 +453,7 @@ describe("customer info parsing", () => {
           unsubscribeDetectedAt: null,
           willRenew: true,
           displayName: null,
+          autoResumeDate: null,
           price: null,
         },
       },
@@ -575,6 +578,7 @@ describe("customer info parsing", () => {
           isActive: true,
           willRenew: true,
           displayName: null,
+          autoResumeDate: null,
           price: null,
         },
       },
@@ -628,5 +632,42 @@ describe("customer info parsing", () => {
       currency: "EUR",
       formattedPrice: "€3.59",
     });
+    expect(subscription.autoResumeDate).toBeNull();
+  });
+
+  test("paused play store subscription has autoResumeDate parsed correctly", () => {
+    const autoResumeDateString = "2024-06-15T10:00:00Z";
+    const subscriberResponse: SubscriberResponse = {
+      request_date: "2024-05-01T00:00:00Z",
+      request_date_ms: 1714521600000,
+      subscriber: {
+        entitlements: {},
+        first_seen: "2024-01-01T00:00:00Z",
+        management_url: null,
+        non_subscriptions: {},
+        original_app_user_id: "pausedUser",
+        original_application_version: null,
+        original_purchase_date: null,
+        other_purchases: {},
+        subscriptions: {
+          play_monthly: {
+            auto_resume_date: autoResumeDateString,
+            billing_issues_detected_at: null,
+            expires_date: "2024-05-15T10:00:00Z",
+            grace_period_expires_date: null,
+            is_sandbox: false,
+            original_purchase_date: "2024-01-01T10:00:00Z",
+            period_type: "normal",
+            purchase_date: "2024-04-15T10:00:00Z",
+            store: "play_store",
+            unsubscribe_detected_at: "2024-05-01T00:00:00Z",
+          },
+        },
+      },
+    };
+    const customerInfo = toCustomerInfo(subscriberResponse);
+    const subscription =
+      customerInfo.subscriptionsByProductIdentifier["play_monthly"];
+    expect(subscription.autoResumeDate).toEqual(new Date(autoResumeDateString));
   });
 });

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -493,6 +493,7 @@ test("can get customer info", async () => {
         isActive: true,
         willRenew: true,
         displayName: null,
+        autoResumeDate: null,
         price: null,
       },
       black_f_friday_worten_2: {
@@ -515,6 +516,7 @@ test("can get customer info", async () => {
         isActive: false,
         willRenew: true,
         displayName: null,
+        autoResumeDate: null,
         price: null,
       },
     },


### PR DESCRIPTION
Exposes `autoResumeDate` on `SubscriptionInfo`, which is provided by BE for subscriptions paused in Google Play.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, read-only customer-info field with no auth or purchase-flow changes; risk is limited to API surface and parsing behavior for an optional backend field.
> 
> **Overview**
> Adds **`autoResumeDate`** to the public **`SubscriptionInfo`** type so apps can read when a paused Google Play subscription is expected to resume.
> 
> **`toCustomerInfo`** now maps the subscriber payload field **`auto_resume_date`** into **`autoResumeDate`** (parsed as a **`Date`**, or **`null`** when absent). Public API reports and existing customer-info expectations are updated, plus a test that verifies parsing for a paused Play Store subscription.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4b035fee57912e4b7381577701345b3872b512e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->