### PR TITLE
[WEB-4434] feat: collect full billing address for tax-relevant countries

### DIFF
--- a/examples/webbilling-demo/src/tests/helpers/fixtures.ts
+++ b/examples/webbilling-demo/src/tests/helpers/fixtures.ts
@@ -89,6 +89,15 @@ export const NEW_YORK_FULL_ADDRESS = {
   countryCode: "US",
 };
 
+export const CANADA_FULL_ADDRESS = {
+  name: "Jane Doe",
+  line1: "290 Bremner Blvd",
+  city: "Toronto",
+  state: "ON",
+  postalCode: "M5V 3L9",
+  countryCode: "CA",
+};
+
 export const SPAIN_TAX_RESPONSE: RouteFulfillOptions = {
   status: 200,
   contentType: "application/json",
@@ -214,6 +223,36 @@ export const NEW_YORK_TAX_RESPONSE: RouteFulfillOptions = {
     ],
     tax_amount_in_micros: 0,
     total_amount_in_micros: 9990000,
+    total_excluding_tax_in_micros: 9990000,
+    tax_inclusive: false,
+  } as CheckoutPricingResponse),
+};
+
+export const CANADA_TAX_RESPONSE: RouteFulfillOptions = {
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({
+    mocked: true,
+    currency: "USD",
+    failed_reason: undefined,
+    gateway_params: {
+      elements_configuration: {
+        amount: 1129,
+        currency: "usd",
+        mode: "payment",
+        payment_method_types: ["card"],
+        setup_future_usage: "off_session",
+      },
+    },
+    operation_session_id: "MOCKED",
+    tax_breakdown: [
+      {
+        display_name: "HST - Ontario (13%)",
+        tax_amount_in_micros: 1298700,
+      },
+    ],
+    tax_amount_in_micros: 1298700,
+    total_amount_in_micros: 11288700,
     total_excluding_tax_in_micros: 9990000,
     tax_inclusive: false,
   } as CheckoutPricingResponse),

--- a/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
+++ b/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
@@ -324,10 +324,14 @@ export async function enterBillingAddress(
     await addressFrame.getByLabel("City").fill(details.city);
   }
   if (details.state !== undefined) {
-    await addressFrame.getByLabel("State").selectOption(details.state);
+    // The label depends on the country (e.g. "State" in the US, "Province" in
+    // Canada).
+    await addressFrame.getByLabel(/State|Province/).selectOption(details.state);
   }
   if (details.postalCode !== undefined) {
-    await addressFrame.getByLabel("ZIP").fill(details.postalCode);
+    // The label depends on the country (e.g. "ZIP" in the US, "Postal code" in
+    // Canada).
+    await addressFrame.getByLabel(/ZIP|Postal code/).fill(details.postalCode);
   }
 }
 

--- a/examples/webbilling-demo/src/tests/tax-calculation.test.ts
+++ b/examples/webbilling-demo/src/tests/tax-calculation.test.ts
@@ -1,6 +1,8 @@
 import type { Page, Request, Route } from "@playwright/test";
 import { expect } from "@playwright/test";
 import {
+  CANADA_FULL_ADDRESS,
+  CANADA_TAX_RESPONSE,
   FLORIDA_CUSTOMER_DETAILS,
   FULL_ADDRESS_TEST_API_KEY,
   FULL_ADDRESS_TAX_TEST_OFFERING_ID,
@@ -177,6 +179,52 @@ const trackPricingRefreshRequests = async (page: Page, mockMode: boolean) => {
 
           const packageCards = await getPackageCards(page);
           await startPurchaseFlow(packageCards[0]);
+          await expect(page.getByText("Total excluding tax")).toBeVisible();
+          await expect(page.getByText("Total due today")).toBeVisible();
+        },
+      );
+
+      integrationTest(
+        "Reveals the full billing address when a tax-relevant country (Canada) is selected",
+        async ({ page, userId, email, browserName }) => {
+          // Stripe Address Element interactions are only reliable in Chromium.
+          integrationTest.skip(
+            browserName !== "chromium",
+            "Address Element interactions only run in Chromium",
+          );
+
+          if (mockMode) {
+            // Registered LIFO: the first request (initial calculation on mount)
+            // resolves to Spain, the second (after the Canadian address is
+            // entered) resolves to Canada.
+            await mockTaxCalculationRequest(page, CANADA_TAX_RESPONSE);
+            await mockTaxCalculationRequest(page, SPAIN_TAX_RESPONSE);
+          }
+
+          page = await navigateToTaxesLandingUrl(page, userId);
+
+          const packageCards = await getPackageCards(page);
+          await startPurchaseFlow(packageCards[0]);
+
+          await expect(page.getByText("Total due today")).toBeVisible();
+
+          await enterEmail(page, email);
+
+          // The country lives in the payment element initially, so the full
+          // address element is not rendered yet.
+          await expect(page.locator("#address-element")).toHaveCount(0);
+
+          // Selecting Canada (a tax-relevant country) triggers the transition to
+          // the full billing address form.
+          await enterCreditCardDetails(page, "4242 4242 4242 4242", {
+            countryCode: "CA",
+          });
+
+          await expect(page.locator("#address-element")).toBeVisible();
+
+          await enterBillingAddress(page, CANADA_FULL_ADDRESS);
+
+          await confirmTaxCalculation(page);
           await expect(page.getByText("Total excluding tax")).toBeVisible();
           await expect(page.getByText("Total due today")).toBeVisible();
         },

--- a/src/networking/responses/branding-response.ts
+++ b/src/networking/responses/branding-response.ts
@@ -28,22 +28,15 @@ export type BrandingInfoResponse = {
 };
 
 /**
- * Country codes (ISO 3166-1 alpha-2) that require the full billing address to be
- * collected when tax collection is enabled, because country alone
- * is not enough to resolve the tax rate.
- * see https://docs.stripe.com/tax/customer-locations?#supported-formats
- */
-export const FULL_ADDRESS_REQUIRED_TAX_COUNTRY_CODES = ["CA", "PR", "IN"];
-
-/**
  * Resolves whether the full billing address UI should be presented, based on the
- * branding configuration and the currently selected country.
+ * branding configuration and whether the selected country requires the full
+ * address to resolve taxes.
  *
  * The full address is collected when either:
  * - `full_address_collection_mode` is `always`, or
- * - tax collection is enabled and the selected country is one that requires the
- *   full address to resolve taxes (see
- *   {@link FULL_ADDRESS_REQUIRED_TAX_COUNTRY_CODES}).
+ * - tax collection is enabled and the selected country requires the full address
+ *   to resolve taxes (determined by the payment gateway, e.g.
+ *   `StripeService.countryRequiresFullAddressForTaxes`).
  *
  * Treats a missing mode and any unknown/future mode as `if_required`.
  */
@@ -55,7 +48,7 @@ export function shouldCollectFullAddress(
       >
     | null
     | undefined,
-  selectedCountryCode?: string | null,
+  selectedCountryRequiresFullAddressForTaxes: boolean = false,
 ): boolean {
   if (brandingInfo?.full_address_collection_mode === "always") {
     return true;
@@ -63,7 +56,6 @@ export function shouldCollectFullAddress(
 
   return (
     !!brandingInfo?.gateway_tax_collection_enabled &&
-    !!selectedCountryCode &&
-    FULL_ADDRESS_REQUIRED_TAX_COUNTRY_CODES.includes(selectedCountryCode)
+    selectedCountryRequiresFullAddressForTaxes
   );
 }

--- a/src/networking/responses/branding-response.ts
+++ b/src/networking/responses/branding-response.ts
@@ -28,15 +28,42 @@ export type BrandingInfoResponse = {
 };
 
 /**
- * Resolves whether the full billing address UI should always be presented,
- * based on the branding configuration. Treats a missing mode and any
- * unknown/future mode as `if_required`.
+ * Country codes (ISO 3166-1 alpha-2) that require the full billing address to be
+ * collected when tax collection is enabled, because country alone
+ * is not enough to resolve the tax rate.
+ * see https://docs.stripe.com/tax/customer-locations?#supported-formats
+ */
+export const FULL_ADDRESS_REQUIRED_TAX_COUNTRY_CODES = ["CA", "PR", "IN"];
+
+/**
+ * Resolves whether the full billing address UI should be presented, based on the
+ * branding configuration and the currently selected country.
+ *
+ * The full address is collected when either:
+ * - `full_address_collection_mode` is `always`, or
+ * - tax collection is enabled and the selected country is one that requires the
+ *   full address to resolve taxes (see
+ *   {@link FULL_ADDRESS_REQUIRED_TAX_COUNTRY_CODES}).
+ *
+ * Treats a missing mode and any unknown/future mode as `if_required`.
  */
 export function shouldCollectFullAddress(
   brandingInfo:
-    | Pick<BrandingInfoResponse, "full_address_collection_mode">
+    | Pick<
+        BrandingInfoResponse,
+        "full_address_collection_mode" | "gateway_tax_collection_enabled"
+      >
     | null
     | undefined,
+  selectedCountryCode?: string | null,
 ): boolean {
-  return brandingInfo?.full_address_collection_mode === "always";
+  if (brandingInfo?.full_address_collection_mode === "always") {
+    return true;
+  }
+
+  return (
+    !!brandingInfo?.gateway_tax_collection_enabled &&
+    !!selectedCountryCode &&
+    FULL_ADDRESS_REQUIRED_TAX_COUNTRY_CODES.includes(selectedCountryCode)
+  );
 }

--- a/src/stripe/stripe-service.ts
+++ b/src/stripe/stripe-service.ts
@@ -283,6 +283,29 @@ export class StripeService {
     });
   }
 
+  /**
+   * Country codes (ISO 3166-1 alpha-2) that require the full billing address to
+   * be collected when tax collection is enabled, because country alone is not
+   * enough to resolve the tax rate.
+   * See https://docs.stripe.com/tax/customer-locations?#supported-formats
+   */
+  private static FULL_ADDRESS_REQUIRED_TAX_COUNTRY_CODES = ["CA", "PR", "IN"];
+
+  /**
+   * Whether the given country requires the full billing address to be collected
+   * to resolve taxes via Stripe Tax.
+   */
+  static countryRequiresFullAddressForTaxes(
+    countryCode?: string | null,
+  ): boolean {
+    return (
+      !!countryCode &&
+      StripeService.FULL_ADDRESS_REQUIRED_TAX_COUNTRY_CODES.includes(
+        countryCode,
+      )
+    );
+  }
+
   static createAddressElement(
     elements: StripeElements,
     defaultCountryCode?: string,

--- a/src/stripe/stripe-service.ts
+++ b/src/stripe/stripe-service.ts
@@ -283,12 +283,20 @@ export class StripeService {
     });
   }
 
-  static createAddressElement(elements: StripeElements) {
+  static createAddressElement(
+    elements: StripeElements,
+    defaultCountryCode?: string,
+  ) {
     return elements.create("address", {
       mode: "billing",
       display: {
         name: "full",
       },
+      // Seed the country with the one already selected in the payment element so
+      // the full address form opens on the country the customer just picked.
+      ...(defaultCountryCode
+        ? { defaultValues: { address: { country: defaultCountryCode } } }
+        : {}),
     });
   }
 

--- a/src/tests/stripe/stripe-service.test.ts
+++ b/src/tests/stripe/stripe-service.test.ts
@@ -407,6 +407,26 @@ describe("StripeService", () => {
         },
       });
     });
+
+    test("seeds the address element with the provided default country", () => {
+      const mockElements: Partial<StripeElements> = {
+        create: vi.fn(),
+      };
+
+      StripeService.createAddressElement(mockElements as StripeElements, "CA");
+
+      expect(mockElements.create).toHaveBeenCalledWith("address", {
+        mode: "billing",
+        display: {
+          name: "full",
+        },
+        defaultValues: {
+          address: {
+            country: "CA",
+          },
+        },
+      });
+    });
   });
 
   describe("extractTaxCustomerDetails", () => {

--- a/src/tests/ui/pages/payment-entry-page.test.ts
+++ b/src/tests/ui/pages/payment-entry-page.test.ts
@@ -68,6 +68,8 @@ vi.mock("../../../stripe/stripe-service", async () => {
         on: vi.fn(),
         destroy: vi.fn(),
       }),
+      countryRequiresFullAddressForTaxes:
+        actual.StripeService.countryRequiresFullAddressForTaxes,
       isStripeHandledFormError: vi.fn(),
       updateElementsConfiguration: vi.fn(),
       getStripeLocale: vi.fn().mockImplementation((locale: string) => locale),

--- a/src/tests/ui/pages/payment-entry-page.test.ts
+++ b/src/tests/ui/pages/payment-entry-page.test.ts
@@ -595,6 +595,145 @@ describe("PurchasesUI", () => {
     expect(StripeService.createAddressElement).not.toHaveBeenCalled();
   });
 
+  const mockPaymentElementReportingCountries = (
+    countries: (string | null)[],
+  ) => {
+    const paymentElement = {
+      on: (
+        eventType: string,
+        callback: (event?: StripePaymentElementChangeEvent) => void,
+      ) => {
+        if (eventType === "ready") {
+          setTimeout(() => callback(), 0);
+        }
+        if (eventType === "change") {
+          countries.forEach((country, index) => {
+            setTimeout(
+              () => {
+                callback({
+                  complete: true,
+                  value: {
+                    type: "card",
+                    billingDetails: { address: { country } },
+                  },
+                  elementType: "payment",
+                  empty: false,
+                  collapsed: false,
+                } as unknown as StripePaymentElementChangeEvent);
+              },
+              100 * (index + 1),
+            );
+          });
+        }
+      },
+      mount: vi.fn(),
+      destroy: vi.fn(),
+    };
+    vi.mocked(StripeService.createPaymentElement).mockReturnValue(
+      // @ts-expect-error - This is a mock
+      paymentElement,
+    );
+  };
+
+  test("renders the address element when tax collection is enabled and a tax-relevant country is selected", async () => {
+    vi.mocked(StripeService.createAddressElement).mockClear();
+    mockPaymentElementReportingCountries(["CA"]);
+
+    const { container } = render(PaymentEntryPage, {
+      props: {
+        ...basicProps,
+        brandingInfo: {
+          ...brandingInfo,
+          gateway_tax_collection_enabled: true,
+          full_address_collection_mode: "if_required",
+        },
+      },
+      context: defaultContext,
+    });
+
+    for (let i = 0; i < 6; i++) {
+      await vi.advanceTimersToNextTimerAsync();
+    }
+
+    expect(container.querySelector("#address-element")).not.toBeNull();
+    expect(StripeService.createAddressElement).toHaveBeenCalledWith(
+      expect.anything(),
+      "CA",
+    );
+  });
+
+  test("does not render the address element when tax collection is enabled but the country is not tax-relevant", async () => {
+    vi.mocked(StripeService.createAddressElement).mockClear();
+    mockPaymentElementReportingCountries(["US"]);
+
+    const { container } = render(PaymentEntryPage, {
+      props: {
+        ...basicProps,
+        brandingInfo: {
+          ...brandingInfo,
+          gateway_tax_collection_enabled: true,
+          full_address_collection_mode: "if_required",
+        },
+      },
+      context: defaultContext,
+    });
+
+    for (let i = 0; i < 6; i++) {
+      await vi.advanceTimersToNextTimerAsync();
+    }
+
+    expect(container.querySelector("#address-element")).toBeNull();
+    expect(StripeService.createAddressElement).not.toHaveBeenCalled();
+  });
+
+  test("keeps the address element once a tax-relevant country was selected, even after switching to another country", async () => {
+    vi.mocked(StripeService.createAddressElement).mockClear();
+    // Select Canada (tax-relevant) and then Bulgaria (not tax-relevant).
+    mockPaymentElementReportingCountries(["CA", "BG"]);
+
+    const { container } = render(PaymentEntryPage, {
+      props: {
+        ...basicProps,
+        brandingInfo: {
+          ...brandingInfo,
+          gateway_tax_collection_enabled: true,
+          full_address_collection_mode: "if_required",
+        },
+      },
+      context: defaultContext,
+    });
+
+    for (let i = 0; i < 8; i++) {
+      await vi.advanceTimersToNextTimerAsync();
+    }
+
+    expect(container.querySelector("#address-element")).not.toBeNull();
+  });
+
+  test("does not render the address element for a tax-relevant country when tax collection is disabled", async () => {
+    vi.mocked(StripeService.createAddressElement).mockClear();
+    mockPaymentElementReportingCountries(["CA"]);
+
+    const { container } = render(PaymentEntryPage, {
+      props: {
+        ...basicProps,
+        brandingInfo: {
+          ...brandingInfo,
+          gateway_tax_collection_enabled: false,
+          full_address_collection_mode: "if_required",
+        },
+      },
+      context: defaultContext,
+    });
+
+    for (let i = 0; i < 6; i++) {
+      await vi.advanceTimersToNextTimerAsync();
+    }
+
+    expect(container.querySelector("#address-element")).toBeNull();
+    expect(StripeService.createAddressElement).not.toHaveBeenCalled();
+  });
+
   test("forwards the full billing address and publishes it to the shared tax customer details store", async () => {
     const taxCustomerDetails: TaxCustomerDetails = {
       countryCode: "US",

--- a/src/ui/molecules/stripe-address-element.svelte
+++ b/src/ui/molecules/stripe-address-element.svelte
@@ -20,9 +20,11 @@
     onError: (error: StripeServiceError) => void | Promise<void>;
     onReady: () => void | Promise<void>;
     elements: StripeElements;
+    defaultCountryCode?: string;
   }
 
-  const { onChange, onError, onReady, elements }: Props = $props();
+  const { onChange, onError, onReady, elements, defaultCountryCode }: Props =
+    $props();
 
   let addressElement: StripeAddressElement | null = null;
   const addressElementId = "address-element";
@@ -78,7 +80,10 @@
 
   onMount(() => {
     try {
-      addressElement = StripeService.createAddressElement(elements);
+      addressElement = StripeService.createAddressElement(
+        elements,
+        defaultCountryCode,
+      );
       addressElement.mount(`#${addressElementId}`);
       addressElement.on("ready", onReady);
       addressElement.on("change", onAddressChange);

--- a/src/ui/molecules/stripe-elements.svelte
+++ b/src/ui/molecules/stripe-elements.svelte
@@ -46,6 +46,7 @@
     onPaymentInfoChange: (params: {
       complete: boolean;
       paymentMethod: string | undefined;
+      countryCode: string | undefined;
     }) => void;
     onAddressInfoChange: (
       complete: boolean,
@@ -80,9 +81,25 @@
     $translator.bcp47Locale || $translator.fallbackBcp47Locale,
   );
 
-  const collectFullBillingAddress = $derived(
+  // Country selected in the payment element. We listen to the payment element's
+  // `change` events to detect it and decide whether the full billing address is
+  // needed for tax purposes.
+  let selectedCountry: string | undefined = $state(undefined);
+
+  // Once the full billing address is required (a tax-relevant country was
+  // selected) we keep collecting it for the rest of the session. There is no way
+  // to push a country back into the payment element, so switching back to the
+  // minimal form would lose the selection; latching keeps the address element as
+  // the single source of truth and lets the customer freely change the country
+  // afterwards (e.g. Canada -> Bulgaria).
+  let collectFullBillingAddress = $state(
     shouldCollectFullAddress(brandingInfo),
   );
+  $effect(() => {
+    if (shouldCollectFullAddress(brandingInfo, selectedCountry)) {
+      collectFullBillingAddress = true;
+    }
+  });
 
   let paymentElementReadyForSubmission = $state(false);
   let emailElementReadyForSubmission = $state(skipEmail);
@@ -180,9 +197,17 @@
   const onPaymentElementChange = async (
     event: StripePaymentElementChangeEvent,
   ) => {
+    const country = event.value.billingDetails?.address?.country;
+    // Keep the last country reported by the payment element. Once the address
+    // element is shown Stripe stops reporting the billing country here, so we
+    // must not overwrite it with an empty value.
+    if (country) {
+      selectedCountry = country;
+    }
     onPaymentInfoChange({
       complete: event.complete,
       paymentMethod: event.complete ? event.value.type : undefined,
+      countryCode: selectedCountry,
     });
   };
 
@@ -266,6 +291,7 @@
     {#if collectFullBillingAddress}
       <AddressElement
         {elements}
+        defaultCountryCode={selectedCountry}
         onReady={onAddressElementReady}
         onChange={onAddressElementChange}
         onError={onStripeElementsLoadingError}

--- a/src/ui/molecules/stripe-elements.svelte
+++ b/src/ui/molecules/stripe-elements.svelte
@@ -96,7 +96,12 @@
     shouldCollectFullAddress(brandingInfo),
   );
   $effect(() => {
-    if (shouldCollectFullAddress(brandingInfo, selectedCountry)) {
+    if (
+      shouldCollectFullAddress(
+        brandingInfo,
+        StripeService.countryRequiresFullAddressForTaxes(selectedCountry),
+      )
+    ) {
       collectFullBillingAddress = true;
     }
   });

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -189,7 +189,12 @@
     shouldCollectFullAddress(brandingInfo),
   );
   $effect(() => {
-    if (shouldCollectFullAddress(brandingInfo, selectedCountry)) {
+    if (
+      shouldCollectFullAddress(
+        brandingInfo,
+        StripeService.countryRequiresFullAddressForTaxes(selectedCountry),
+      )
+    ) {
       collectFullBillingAddress = true;
     }
   });

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -180,7 +180,22 @@
   let isEmailComplete = $state(customerEmail ? true : false);
   let isStripeLoading = $state(true);
   let isPaymentInfoComplete = $state(false);
-  let isAddressComplete = $state(!shouldCollectFullAddress(brandingInfo));
+  let selectedCountry: string | undefined = $state(undefined);
+  let isFullAddressComplete = $state(false);
+  // Mirrors the latching logic in stripe-elements.svelte: once the full billing
+  // address is required (a tax-relevant country was selected in the payment
+  // element) it stays required for the rest of the session.
+  let collectFullBillingAddress = $state(
+    shouldCollectFullAddress(brandingInfo),
+  );
+  $effect(() => {
+    if (shouldCollectFullAddress(brandingInfo, selectedCountry)) {
+      collectFullBillingAddress = true;
+    }
+  });
+  const isAddressComplete = $derived(
+    !collectFullBillingAddress || isFullAddressComplete,
+  );
   let selectedPaymentMethod: string | undefined = $state(undefined);
   let modalErrorMessage: string | undefined = $state(undefined);
   let clientSecret: string | undefined = $state(undefined);
@@ -418,12 +433,15 @@
   function handlePaymentInfoChange({
     complete,
     paymentMethod,
+    countryCode,
   }: {
     complete: boolean;
     paymentMethod: string | undefined;
+    countryCode: string | undefined;
   }) {
     selectedPaymentMethod = paymentMethod;
     isPaymentInfoComplete = complete;
+    selectedCountry = countryCode;
     scheduleRefreshTaxes();
   }
 
@@ -431,7 +449,7 @@
     complete: boolean,
     address: StripeAddressElementChangeEvent["value"]["address"],
   ) {
-    isAddressComplete = complete;
+    isFullAddressComplete = complete;
     // Publish the address as it's typed so a discount refresh fired before the
     // debounced tax recalculation lands still carries it (instead of falling
     // back to IP geolocation).


### PR DESCRIPTION
## Motivation / Description

Stripe's tax calculation needs the full billing address (not just country +
postal code) to resolve the rate in certain countries. Until now the full
address was only collected when the project had `full_address_collection_mode`
set to `"always"`. This PR makes the checkout form switch to full-address
collection automatically when it's actually required for taxes, while keeping
the minimal country + postal code form for everyone else.

## Changes introduced

- The full billing address element is now shown when **tax collection is enabled**
  and the country selected in the payment element is one that requires the full
  address to resolve taxes (`CA`, `PR`, `IN`).
- The transition is driven by the payment element's `change` event: when a
  tax-relevant country is selected we reveal the dedicated address element and
  seed it with the already-selected country so it opens on the right one.
- Once the full address has been required, it **latches on** for the rest of the
  session. There is no way to push a country back into the payment element, so
  toggling back to the minimal form would lose the selection and flip-flop the
  UI; latching keeps the address element as the single source of truth and lets
  the customer freely change the country afterwards (e.g. Canada → Bulgaria).
- `shouldCollectFullAddress(brandingInfo, selectedCountryCode?)` gains the
  tax + country logic via `FULL_ADDRESS_REQUIRED_TAX_COUNTRY_CODES` (`CA`, `PR`,
  `IN`); `stripe-elements.svelte` and `payment-entry-page.svelte` apply the latch
  (rendering and pay-button gating respectively).
- The existing `full_address_collection_mode: "always"` behavior is unchanged.
- Tests: unit coverage for the dynamic trigger, not-tax-relevant / tax-disabled
  cases, the latch (CA → BG), and the address-element country seed; plus an
  integration test in `tax-calculation.test.ts` where selecting Canada reveals
  the full address form and performs the tax calculation (mocked + real,
  Chromium). The billing-address test helper now fills country-specific labels
  (Province / Postal code).

## Linear ticket (if any)

WEB-4434

## Additional comments

Trade-off: after a tax-relevant country has been selected, switching to a
non-required country keeps the full-address fields rather than collapsing back to
the minimal form. Collapsing would require recreating the payment element (losing
the entered card details), so latching is the deliberate choice that avoids the
mount/unmount loop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout tax/address UX and when tax recalculations run, which can affect displayed totals and pay-button enablement for international customers; behavior is covered by new unit and integration tests.
> 
> **Overview**
> When gateway tax collection is on and `full_address_collection_mode` is `if_required`, checkout now **reveals the Stripe Address Element** after the customer picks a country in the payment form that Stripe Tax cannot rate from country alone (**CA**, **PR**, **IN**), instead of only showing full address when the project forces `always`.
> 
> **`shouldCollectFullAddress`** now considers tax collection plus whether the selected country needs a full address; **`StripeService.countryRequiresFullAddressForTaxes`** encodes those countries. The payment element’s country is tracked, the address element is **seeded** with that country, and once full address is required it **latches** for the session (so switching to a non-required country does not collapse the form). Pay-button and tax-refresh gating follow the same dynamic full-address requirement.
> 
> Tests add Canada fixtures, country-specific E2E helpers (Province / Postal code), a Chromium integration path for Canada → full address → tax, and unit coverage for the new trigger, latch, and seed behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8530d7ab9b86b647451166d4b9da62c3bbfc717d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->