### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# CODEOWNERS for purchases-js
+
+# Default owners
+* @RevenueCat/sdk


### PR DESCRIPTION
Add missing CODEOWNERS file to automatically ping the SDK team on PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repository metadata only; no application or runtime behavior changes.
> 
> **Overview**
> Adds a new `.github/CODEOWNERS` file so GitHub automatically requests review from **@RevenueCat/sdk** on every pull request in this repo via a default `*` rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3962d7027f96ddf1bb01fcf83078a45c7fa5f54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->