### PR TITLE
[WEB-4434] test(stories): add full billing address payment entry story

### DIFF
--- a/src/stories/pages/payment-entry-page.stories.svelte
+++ b/src/stories/pages/payment-entry-page.stories.svelte
@@ -62,6 +62,9 @@
   {@const brandingInfo = {
     ...brandingInfos[context.globals.brandingName],
     gateway_tax_collection_enabled: args.withTaxes ?? false,
+    full_address_collection_mode:
+      args.fullAddressCollectionMode ??
+      brandingInfos[context.globals.brandingName].full_address_collection_mode,
   }}
   <PurchasesInner
     isSandbox={args.isSandbox}
@@ -281,6 +284,20 @@
     ...defaultArgs,
     currentPage: "payment-entry",
     withTaxes: true,
+  }}
+  parameters={{
+    chromatic: {
+      delay: 1000,
+    },
+  }}
+/>
+
+<Story
+  name="With Full Billing Address"
+  args={{
+    ...defaultArgs,
+    currentPage: "payment-entry",
+    fullAddressCollectionMode: "always",
   }}
   parameters={{
     chromatic: {


### PR DESCRIPTION
## Motivation / Description

Adds a Storybook story that renders the payment entry page with the full billing address form via full_address_collection_mode "always", threading a fullAddressCollectionMode arg through the template.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Storybook stories and visual regression setup; no production checkout or payment logic is modified.
> 
> **Overview**
> Adds Storybook/Chromatic coverage for the payment entry page when **full billing address** collection is required.
> 
> The shared story template now passes **`full_address_collection_mode`** on `brandingInfo`, using a new **`fullAddressCollectionMode`** story arg when set and otherwise keeping the value from the branding fixtures. A new **"With Full Billing Address"** story sets `fullAddressCollectionMode` to **`"always"`** on the payment-entry page (with the usual Chromatic delay).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3cf18e2f88461eb55ff77e160f98e6f06ce42cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->