### PR TITLE
chore: bump purchases-ui-js to 4.8.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@babel/runtime": "^7.26.10",
     "@eslint/js": "^9.16.0",
     "@microsoft/api-extractor": "^7.48.0",
-    "@revenuecat/purchases-ui-js": "4.8.4",
+    "@revenuecat/purchases-ui-js": "4.8.6",
     "@paddle/paddle-js": "^1.6.4",
     "@storybook/addon-essentials": "^8.6.15",
     "@storybook/addon-interactions": "^8.6.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^1.6.4
         version: 1.6.4
       "@revenuecat/purchases-ui-js":
-        specifier: 4.8.4
-        version: 4.8.4(svelte@5.46.4)
+        specifier: 4.8.6
+        version: 4.8.6(svelte@5.46.4)
       "@storybook/addon-essentials":
         specifier: ^8.6.15
         version: 8.6.15(@types/react@19.0.10)(storybook@8.6.15(prettier@3.4.2))
@@ -722,10 +722,10 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
 
-  "@revenuecat/purchases-ui-js@4.8.4":
+  "@revenuecat/purchases-ui-js@4.8.6":
     resolution:
       {
-        integrity: sha512-D3SjVeOnoSvxPOY5m7hdLzdJVWjgUWyY7TLES+mDmzREjHp+C1AWcDLMJzEHIvjPo/mKkLFBRQK/C5xLiBB3hA==,
+        integrity: sha512-yzylRJOdwufonJouTb/hQcqg5SWXUa7wwA2dd+HvTmf4qn7DtSqnCn7Eb0gimqT4kq6pm9i/5KQG6TNk875AtQ==,
       }
     engines: { node: ^22.18 || ^24.11 }
     peerDependencies:
@@ -6155,7 +6155,7 @@ snapshots:
 
   "@pkgr/core@0.1.1": {}
 
-  "@revenuecat/purchases-ui-js@4.8.4(svelte@5.46.4)":
+  "@revenuecat/purchases-ui-js@4.8.6(svelte@5.46.4)":
     dependencies:
       qrcode: 1.5.4
       svelte: 5.46.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -731,6 +731,13 @@ packages:
     peerDependencies:
       svelte: ^5.46.4
 
+  "@revenuecat/workflow-web-components-sdk@0.1.4":
+    resolution:
+      {
+        integrity: sha512-8LGZkqNNE7MgziVSnH6s6yjVkK32g6Rzi92UYy9o5bhtBuYwtz5+qRVh+QG5cU+AVfaUCAMjm2Ep7iBwHNW7mw==,
+      }
+    engines: { node: ">=18" }
+
   "@rollup/pluginutils@5.1.4":
     resolution:
       {
@@ -6157,8 +6164,11 @@ snapshots:
 
   "@revenuecat/purchases-ui-js@4.8.6(svelte@5.46.4)":
     dependencies:
+      "@revenuecat/workflow-web-components-sdk": 0.1.4
       qrcode: 1.5.4
       svelte: 5.46.4
+
+  "@revenuecat/workflow-web-components-sdk@0.1.4": {}
 
   "@rollup/pluginutils@5.1.4(rollup@4.41.1)":
     dependencies:


### PR DESCRIPTION
## Summary

Bumps `@revenuecat/purchases-ui-js` from `4.8.4` → `4.8.6`

### purchases-ui-js changes included

- [#343](https://github.com/RevenueCat/purchases-ui-js/pull/343) - Fixes z-layer overlay blocking clicks in empty regions
- [#342](https://github.com/RevenueCat/purchases-ui-js/pull/342) - Fixes embedded purchase button resolving its own package via context
- [#341](https://github.com/RevenueCat/purchases-ui-js/pull/341) - Handles missing wallet button in express checkout (prevents paywall getting stuck)

## Test plan

- [x] CI passes
- [x] Paywall rendering smoke test in Storybook

Made with [Cursor](https://cursor.com)