### PR TITLE
ci: bump sdks-common-config orb to 4.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  revenuecat: revenuecat/sdks-common-config@4.1.0
+  revenuecat: revenuecat/sdks-common-config@4.5.0
   aws-cli: circleci/aws-cli@4.1.3
   node: circleci/node@7.2.1
 


### PR DESCRIPTION
### Motivation

`danger` and `automatic-bump` relied on the orb's old default Ruby `3.1.2`, which no longer satisfies gems requiring Ruby >= 3.2 — `bundle install` fails as Bundler backtracks to an unbuildable `nokogiri`.

### Summary

- Bump `revenuecat/sdks-common-config` to `4.5.0`, whose `danger`/`automatic-bump` default to Ruby 3.2.0 (sdks-circleci-orb#81).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only orb version change with no application or runtime code touched.
> 
> **Overview**
> Updates the shared CircleCI orb **`revenuecat/sdks-common-config`** from **4.1.0** to **4.5.0** so **`revenuecat/danger`** and **`revenuecat/automatic-bump`** run on the orb’s newer default Ruby (**3.2.0** instead of **3.1.2**).
> 
> That unblocks **`bundle install`** for those workflows, which was failing when Bundler resolved gems (e.g. **nokogiri**) that require Ruby **≥ 3.2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9c86f1412714988e26d6a6ac35d97f8b6b8aba3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->