### PR TITLE
[WEB-4481] Support consent checkbox at checkout

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -6451,6 +6451,33 @@
                 "startIndex": 1,
                 "endIndex": 2
               }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PurchaseParams#termsAndConditionsUrl:member",
+              "docComment": "/**\n * Link to the terms and conditions that should be shown in the checkout footer.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "termsAndConditionsUrl?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "termsAndConditionsUrl",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
             }
           ],
           "extendsTokenRanges": []

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -432,9 +432,7 @@ export interface PurchaseParams {
     selectedLocale?: string;
     showDiscountCodeField?: boolean;
     skipSuccessPage?: boolean;
-    /* Excluded from this release type: brandingAppearanceOverride */
-    /* Excluded from this release type: labelsOverride */
-    /* Excluded from this release type: termsAndConditionsUrl */
+    termsAndConditionsUrl?: string;
 }
 
 // @public

--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -64,7 +64,7 @@ def translate_text(text, target_language, keys_context=None):
                 system_prompt += f"- {key}: {context}\n"
 
     data = {
-        "model": "gemini-2.0-flash",
+        "model": "gemini-2.5-flash",
         "messages": [
             {
                 "role": "system",

--- a/src/entities/purchase-params.ts
+++ b/src/entities/purchase-params.ts
@@ -174,8 +174,6 @@ export interface PurchaseParams {
 
   /**
    * Link to the terms and conditions that should be shown in the checkout footer.
-   *
-   * @internal
    */
   termsAndConditionsUrl?: string;
 }

--- a/src/helpers/checkout-consent-helper.ts
+++ b/src/helpers/checkout-consent-helper.ts
@@ -1,0 +1,22 @@
+import { ProductType, type Product } from "../entities/offerings";
+import type { BrandingInfoResponse } from "../networking/responses/branding-response";
+
+/**
+ * Consent checkbox is shown only when branding requires it, a terms URL is
+ * available, and the purchase is a subscription.
+ */
+export function isCheckoutConsentRequired({
+  brandingInfo,
+  termsAndConditionsUrl,
+  productDetails,
+}: {
+  brandingInfo: BrandingInfoResponse | null | undefined;
+  termsAndConditionsUrl?: string | null;
+  productDetails: Pick<Product, "productType">;
+}): boolean {
+  return (
+    !!brandingInfo?.require_checkout_consent &&
+    !!termsAndConditionsUrl &&
+    productDetails.productType === ProductType.Subscription
+  );
+}

--- a/src/networking/responses/branding-response.ts
+++ b/src/networking/responses/branding-response.ts
@@ -21,6 +21,7 @@ export type BrandingInfoResponse = {
   support_email?: string | null;
   gateway_tax_collection_enabled: boolean;
   full_address_collection_mode?: FullAddressCollectionMode;
+  require_checkout_consent?: boolean | null;
   brand_font_config: BrandFontConfig | null;
   sandbox_configuration?: {
     checkout_feedback_form_url: string | null;

--- a/src/stories/fixtures.ts
+++ b/src/stories/fixtures.ts
@@ -518,6 +518,7 @@ export const brandingInfo: BrandingInfoResponse = {
   appearance: null,
   gateway_tax_collection_enabled: false,
   full_address_collection_mode: "if_required",
+  require_checkout_consent: false,
   brand_font_config: null,
 };
 

--- a/src/stories/pages/payment-entry-page.stories.svelte
+++ b/src/stories/pages/payment-entry-page.stories.svelte
@@ -65,6 +65,7 @@
     full_address_collection_mode:
       args.fullAddressCollectionMode ??
       brandingInfos[context.globals.brandingName].full_address_collection_mode,
+    require_checkout_consent: args.requireCheckoutConsent ?? false,
   }}
   <PurchasesInner
     isSandbox={args.isSandbox}
@@ -103,6 +104,21 @@
 <Story
   name="Default"
   args={{ ...defaultArgs, currentPage: "payment-entry" }}
+  parameters={{
+    chromatic: {
+      delay: 1000,
+    },
+  }}
+/>
+
+<Story
+  name="With Checkout Consent"
+  args={{
+    ...defaultArgs,
+    currentPage: "payment-entry",
+    requireCheckoutConsent: true,
+    termsAndConditionsUrl: "https://example.com/terms",
+  }}
   parameters={{
     chromatic: {
       delay: 1000,

--- a/src/tests/helpers/checkout-consent-helper.test.ts
+++ b/src/tests/helpers/checkout-consent-helper.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+import { ProductType } from "../../entities/offerings";
+import { isCheckoutConsentRequired } from "../../helpers/checkout-consent-helper";
+import { brandingInfo } from "../../stories/fixtures";
+
+describe("isCheckoutConsentRequired", () => {
+  test("returns true when branding requires consent, terms URL exists, and product is a subscription", () => {
+    expect(
+      isCheckoutConsentRequired({
+        brandingInfo: { ...brandingInfo, require_checkout_consent: true },
+        termsAndConditionsUrl: "https://example.com/terms",
+        productDetails: { productType: ProductType.Subscription },
+      }),
+    ).toBe(true);
+  });
+
+  test("returns false when branding does not require consent", () => {
+    expect(
+      isCheckoutConsentRequired({
+        brandingInfo: { ...brandingInfo, require_checkout_consent: false },
+        termsAndConditionsUrl: "https://example.com/terms",
+        productDetails: { productType: ProductType.Subscription },
+      }),
+    ).toBe(false);
+  });
+
+  test("returns false when terms URL is missing", () => {
+    expect(
+      isCheckoutConsentRequired({
+        brandingInfo: { ...brandingInfo, require_checkout_consent: true },
+        termsAndConditionsUrl: null,
+        productDetails: { productType: ProductType.Subscription },
+      }),
+    ).toBe(false);
+  });
+
+  test("returns false for one-time purchases", () => {
+    expect(
+      isCheckoutConsentRequired({
+        brandingInfo: { ...brandingInfo, require_checkout_consent: true },
+        termsAndConditionsUrl: "https://example.com/terms",
+        productDetails: { productType: ProductType.Consumable },
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/tests/ui/pages/payment-entry-page.test.ts
+++ b/src/tests/ui/pages/payment-entry-page.test.ts
@@ -5,6 +5,7 @@ import {
   brandingInfo,
   checkoutPricingResponse,
   checkoutStartResponse,
+  consumableProduct,
   rcPackage,
   subscriptionOption,
   stripeElementsConfiguration,
@@ -64,6 +65,11 @@ vi.mock("../../../stripe/stripe-service", async () => {
         destroy: vi.fn(),
       }),
       createAddressElement: vi.fn().mockReturnValue({
+        mount: vi.fn(),
+        on: vi.fn(),
+        destroy: vi.fn(),
+      }),
+      createExpressCheckoutElement: vi.fn().mockReturnValue({
         mount: vi.fn(),
         on: vi.fn(),
         destroy: vi.fn(),
@@ -1031,5 +1037,153 @@ describe("PurchasesUI", () => {
     // the stale "unavailable"/"loading" value after `finally` ran.
     const lastBreakdown = onPriceBreakdownUpdated.mock.calls.at(-1)?.[0];
     expect(lastBreakdown?.taxCalculationStatus).toBe("calculated");
+  });
+
+  describe("checkout consent", () => {
+    const consentBranding = {
+      ...brandingInfo,
+      require_checkout_consent: true,
+    };
+    const termsUrl = "https://example.com/terms";
+
+    test("hides the consent checkbox when branding does not require it", async () => {
+      render(PaymentEntryPage, {
+        props: {
+          ...basicProps,
+          brandingInfo: { ...brandingInfo, require_checkout_consent: false },
+          termsAndConditionsUrl: termsUrl,
+        },
+        context: defaultContext,
+      });
+
+      await vi.advanceTimersToNextTimerAsync();
+      expect(screen.queryByTestId("CheckoutConsent")).toBeNull();
+    });
+
+    test("hides the consent checkbox when terms URL is missing", async () => {
+      render(PaymentEntryPage, {
+        props: {
+          ...basicProps,
+          brandingInfo: consentBranding,
+          termsAndConditionsUrl: null,
+        },
+        context: defaultContext,
+      });
+
+      await vi.advanceTimersToNextTimerAsync();
+      expect(screen.queryByTestId("CheckoutConsent")).toBeNull();
+    });
+
+    test("hides the consent checkbox for one-time purchases", async () => {
+      render(PaymentEntryPage, {
+        props: {
+          ...basicProps,
+          productDetails: consumableProduct,
+          purchaseOption: consumableProduct.defaultPurchaseOption,
+          brandingInfo: consentBranding,
+          termsAndConditionsUrl: termsUrl,
+        },
+        context: defaultContext,
+      });
+
+      await vi.advanceTimersToNextTimerAsync();
+      expect(screen.queryByTestId("CheckoutConsent")).toBeNull();
+    });
+
+    test("shows the consent checkbox for subscriptions when branding requires it and terms URL exists", async () => {
+      render(PaymentEntryPage, {
+        props: {
+          ...basicProps,
+          brandingInfo: consentBranding,
+          termsAndConditionsUrl: termsUrl,
+        },
+        context: defaultContext,
+      });
+
+      await vi.advanceTimersToNextTimerAsync();
+      expect(screen.getByTestId("CheckoutConsent")).toBeTruthy();
+      expect(
+        screen.getByTestId("CheckoutConsentTermsLink").getAttribute("href"),
+      ).toBe(termsUrl);
+    });
+
+    test("keeps Pay disabled until consent is checked", async () => {
+      vi.mocked(StripeService.createExpressCheckoutElement).mockReturnValue({
+        // @ts-expect-error - This is a mock
+        mount: vi.fn(),
+        on: vi.fn(
+          (
+            eventType: string,
+            callback: (event?: { availablePaymentMethods?: object }) => void,
+          ) => {
+            if (eventType === "ready") {
+              setTimeout(
+                () => callback({ availablePaymentMethods: { applePay: true } }),
+                0,
+              );
+            }
+          },
+        ),
+        destroy: vi.fn(),
+      });
+
+      const paymentElement = {
+        on: (
+          eventType: string,
+          callback: (event?: StripePaymentElementChangeEvent) => void,
+        ) => {
+          if (eventType === "ready") {
+            setTimeout(() => callback(), 0);
+          }
+          if (eventType === "change") {
+            setTimeout(() => {
+              callback({
+                complete: true,
+                value: {
+                  type: "card",
+                  billingDetails: { address: { country: "US" } },
+                },
+              } as StripePaymentElementChangeEvent);
+            }, 0);
+          }
+        },
+        mount: vi.fn(),
+        destroy: vi.fn(),
+      };
+      vi.mocked(StripeService.createPaymentElement).mockReturnValue(
+        // @ts-expect-error - This is a mock
+        paymentElement,
+      );
+      vi.mocked(StripeService.createLinkAuthenticationElement).mockReturnValue({
+        // @ts-expect-error - This is a mock
+        mount: vi.fn(),
+        on: vi.fn((eventType: string, callback: () => void) => {
+          if (eventType === "ready") {
+            setTimeout(() => callback(), 0);
+          }
+        }),
+        destroy: vi.fn(),
+      });
+
+      render(PaymentEntryPage, {
+        props: {
+          ...basicProps,
+          customerEmail: "test@test.com",
+          brandingInfo: consentBranding,
+          termsAndConditionsUrl: termsUrl,
+        },
+        context: defaultContext,
+      });
+
+      for (let i = 0; i < 4; i++) {
+        await vi.advanceTimersToNextTimerAsync();
+      }
+
+      const payButton = screen.getByTestId("PayButton") as HTMLButtonElement;
+      expect(payButton.disabled).toBe(true);
+
+      await fireEvent.click(screen.getByTestId("CheckoutConsentCheckbox"));
+      expect(payButton.disabled).toBe(false);
+    });
   });
 });

--- a/src/tests/ui/pages/payment-entry-page.test.ts
+++ b/src/tests/ui/pages/payment-entry-page.test.ts
@@ -69,11 +69,9 @@ vi.mock("../../../stripe/stripe-service", async () => {
         on: vi.fn(),
         destroy: vi.fn(),
       }),
-      createExpressCheckoutElement: vi.fn().mockReturnValue({
-        mount: vi.fn(),
-        on: vi.fn(),
-        destroy: vi.fn(),
-      }),
+      // Bare mock so create throws and the error path completes form loading.
+      // A stub that never fires `ready` leaves the form stuck loading.
+      createExpressCheckoutElement: vi.fn(),
       countryRequiresFullAddressForTaxes:
         actual.StripeService.countryRequiresFullAddressForTaxes,
       isStripeHandledFormError: vi.fn(),
@@ -1108,24 +1106,25 @@ describe("PurchasesUI", () => {
     });
 
     test("keeps Pay disabled until consent is checked", async () => {
-      vi.mocked(StripeService.createExpressCheckoutElement).mockReturnValue({
-        // @ts-expect-error - This is a mock
+      const expressCheckoutElement = {
         mount: vi.fn(),
-        on: vi.fn(
-          (
-            eventType: string,
-            callback: (event?: { availablePaymentMethods?: object }) => void,
-          ) => {
-            if (eventType === "ready") {
-              setTimeout(
-                () => callback({ availablePaymentMethods: { applePay: true } }),
-                0,
-              );
-            }
-          },
-        ),
+        on: (
+          eventType: string,
+          callback: (event?: { availablePaymentMethods?: object }) => void,
+        ) => {
+          if (eventType === "ready") {
+            setTimeout(
+              () => callback({ availablePaymentMethods: { applePay: true } }),
+              0,
+            );
+          }
+        },
         destroy: vi.fn(),
-      });
+      };
+      vi.mocked(StripeService.createExpressCheckoutElement).mockReturnValue(
+        // @ts-expect-error - This is a mock
+        expressCheckoutElement,
+      );
 
       const paymentElement = {
         on: (
@@ -1154,16 +1153,19 @@ describe("PurchasesUI", () => {
         // @ts-expect-error - This is a mock
         paymentElement,
       );
-      vi.mocked(StripeService.createLinkAuthenticationElement).mockReturnValue({
-        // @ts-expect-error - This is a mock
+      const linkAuthenticationElement = {
         mount: vi.fn(),
-        on: vi.fn((eventType: string, callback: () => void) => {
+        on: (eventType: string, callback: () => void) => {
           if (eventType === "ready") {
             setTimeout(() => callback(), 0);
           }
-        }),
+        },
         destroy: vi.fn(),
-      });
+      };
+      vi.mocked(StripeService.createLinkAuthenticationElement).mockReturnValue(
+        // @ts-expect-error - This is a mock
+        linkAuthenticationElement,
+      );
 
       render(PaymentEntryPage, {
         props: {

--- a/src/ui/localization/locale/ar.json
+++ b/src/ui/localization/locale/ar.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "خصم",
   "pricing_table.subtotal": "المجموع الفرعي",
   "pricing_dropdown.add_promo_code": "أضف رمزًا ترويجيًا",
-  "discount_input.label": "رمز ترويجي"
+  "discount_input.label": "رمز ترويجي",
+  "payment_entry_page.checkout_consent_terms_of_service": "شروط الخدمة",
+  "payment_entry_page.checkout_consent_agreement": "أوافق على {{termsOfService}} لـ {{appName}}."
 }

--- a/src/ui/localization/locale/ca.json
+++ b/src/ui/localization/locale/ca.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Descompte",
   "pricing_table.subtotal": "Subtotal",
   "pricing_dropdown.add_promo_code": "Afegir codi promocional",
-  "discount_input.label": "Codi promocional"
+  "discount_input.label": "Codi promocional",
+  "payment_entry_page.checkout_consent_terms_of_service": "termes del servei",
+  "payment_entry_page.checkout_consent_agreement": "Accepto els {{termsOfService}} de {{appName}}."
 }

--- a/src/ui/localization/locale/cs.json
+++ b/src/ui/localization/locale/cs.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Sleva",
   "pricing_table.subtotal": "Mezisoučet",
   "pricing_dropdown.add_promo_code": "Přidat promo kód",
-  "discount_input.label": "Promo kód"
+  "discount_input.label": "Promo kód",
+  "payment_entry_page.checkout_consent_terms_of_service": "podmínkami služby",
+  "payment_entry_page.checkout_consent_agreement": "Souhlasím s {{appName}} {{termsOfService}}."
 }

--- a/src/ui/localization/locale/da.json
+++ b/src/ui/localization/locale/da.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Rabat",
   "pricing_table.subtotal": "Subtotal",
   "pricing_dropdown.add_promo_code": "Tilføj rabatkode",
-  "discount_input.label": "Kampagnekode"
+  "discount_input.label": "Kampagnekode",
+  "payment_entry_page.checkout_consent_terms_of_service": "servicevilkår",
+  "payment_entry_page.checkout_consent_agreement": "Jeg accepterer {{appName}}'s {{termsOfService}}."
 }

--- a/src/ui/localization/locale/de.json
+++ b/src/ui/localization/locale/de.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Rabatt",
   "pricing_table.subtotal": "Zwischensumme",
   "pricing_dropdown.add_promo_code": "Promo-Code hinzufügen",
-  "discount_input.label": "Gutscheincode"
+  "discount_input.label": "Gutscheincode",
+  "payment_entry_page.checkout_consent_terms_of_service": "Nutzungsbedingungen",
+  "payment_entry_page.checkout_consent_agreement": "Ich stimme den {{appName}} {{termsOfService}} zu."
 }

--- a/src/ui/localization/locale/el.json
+++ b/src/ui/localization/locale/el.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Έκπτωση",
   "pricing_table.subtotal": "Υποσύνολο",
   "pricing_dropdown.add_promo_code": "Προσθήκη κωδικού προσφοράς",
-  "discount_input.label": "Κωδικός προσφοράς"
+  "discount_input.label": "Κωδικός προσφοράς",
+  "payment_entry_page.checkout_consent_terms_of_service": "όρους χρήσης",
+  "payment_entry_page.checkout_consent_agreement": "Συμφωνώ με τους {{appName}} {{termsOfService}}."
 }

--- a/src/ui/localization/locale/en.json
+++ b/src/ui/localization/locale/en.json
@@ -46,6 +46,8 @@
   "payment_entry_page.subscription_terms_info": "By subscribing, you agree to allow {{appName}} to charge you according to their terms until you cancel.",
   "payment_entry_page.otp_terms_info": "By purchasing, you agree to allow {{appName}} to charge you according to their terms.",
   "payment_entry_page.terms_link_label": "Terms",
+  "payment_entry_page.checkout_consent_agreement": "I agree to the {{appName}} {{termsOfService}}.",
+  "payment_entry_page.checkout_consent_terms_of_service": "terms of service",
   "payment_entry_page.subscription_info": "Subscription renews automatically. Cancel anytime.",
   "payment_entry_page.button_pay": "Pay now",
   "payment_entry_page.button_start_trial": "Start trial",

--- a/src/ui/localization/locale/es.json
+++ b/src/ui/localization/locale/es.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Descuento",
   "pricing_table.subtotal": "Subtotal",
   "pricing_dropdown.add_promo_code": "Añadir código promocional",
-  "discount_input.label": "Código promocional"
+  "discount_input.label": "Código promocional",
+  "payment_entry_page.checkout_consent_terms_of_service": "términos de servicio",
+  "payment_entry_page.checkout_consent_agreement": "Acepto los {{termsOfService}} de {{appName}}."
 }

--- a/src/ui/localization/locale/fi.json
+++ b/src/ui/localization/locale/fi.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Alennus",
   "pricing_table.subtotal": "Välisumma",
   "pricing_dropdown.add_promo_code": "Lisää kampanjakoodi",
-  "discount_input.label": "Kampanjakoodi"
+  "discount_input.label": "Kampanjakoodi",
+  "payment_entry_page.checkout_consent_terms_of_service": "käyttöehdot",
+  "payment_entry_page.checkout_consent_agreement": "Hyväksyn {{appName}}-palvelun {{termsOfService}}."
 }

--- a/src/ui/localization/locale/fr.json
+++ b/src/ui/localization/locale/fr.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Remise",
   "pricing_table.subtotal": "Sous-total",
   "pricing_dropdown.add_promo_code": "Ajouter un code promotionnel",
-  "discount_input.label": "Code promo"
+  "discount_input.label": "Code promo",
+  "payment_entry_page.checkout_consent_terms_of_service": "conditions d'utilisation",
+  "payment_entry_page.checkout_consent_agreement": "J'accepte les {{termsOfService}} de {{appName}}."
 }

--- a/src/ui/localization/locale/he.json
+++ b/src/ui/localization/locale/he.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "הנחה",
   "pricing_table.subtotal": "סכום ביניים",
   "pricing_dropdown.add_promo_code": "הוסף קוד קידום מכירות",
-  "discount_input.label": "קוד פרומו"
+  "discount_input.label": "קוד פרומו",
+  "payment_entry_page.checkout_consent_terms_of_service": "תנאי השירות",
+  "payment_entry_page.checkout_consent_agreement": "אני מסכים/ה ל{{termsOfService}} של {{appName}}."
 }

--- a/src/ui/localization/locale/hi.json
+++ b/src/ui/localization/locale/hi.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "छूट",
   "pricing_table.subtotal": "उपकुल योग",
   "pricing_dropdown.add_promo_code": "प्रोमो_कोड_जोड़ें",
-  "discount_input.label": "प्रोमो कोड"
+  "discount_input.label": "प्रोमो कोड",
+  "payment_entry_page.checkout_consent_terms_of_service": "सेवा की शर्तें",
+  "payment_entry_page.checkout_consent_agreement": "मैं {{appName}} की {{termsOfService}} से सहमत हूँ।"
 }

--- a/src/ui/localization/locale/hr.json
+++ b/src/ui/localization/locale/hr.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Popust",
   "pricing_table.subtotal": "Međuzbroj",
   "pricing_dropdown.add_promo_code": "Dodaj promotivni kod",
-  "discount_input.label": "Promo kod"
+  "discount_input.label": "Promo kod",
+  "payment_entry_page.checkout_consent_terms_of_service": "uvjetima korištenja",
+  "payment_entry_page.checkout_consent_agreement": "Slažem se s {{appName}} {{termsOfService}}."
 }

--- a/src/ui/localization/locale/hu.json
+++ b/src/ui/localization/locale/hu.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Kedvezmény",
   "pricing_table.subtotal": "Részösszeg",
   "pricing_dropdown.add_promo_code": "Promóciós kód hozzáadása",
-  "discount_input.label": "Promóciós kód"
+  "discount_input.label": "Promóciós kód",
+  "payment_entry_page.checkout_consent_terms_of_service": "szolgáltatási feltételek",
+  "payment_entry_page.checkout_consent_agreement": "Elfogadom a {{appName}} {{termsOfService}}."
 }

--- a/src/ui/localization/locale/id.json
+++ b/src/ui/localization/locale/id.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Diskon",
   "pricing_table.subtotal": "Subtotal",
   "pricing_dropdown.add_promo_code": "Tambahkan kode promo",
-  "discount_input.label": "Kode promo"
+  "discount_input.label": "Kode promo",
+  "payment_entry_page.checkout_consent_terms_of_service": "ketentuan layanan",
+  "payment_entry_page.checkout_consent_agreement": "Saya menyetujui {{termsOfService}} {{appName}}."
 }

--- a/src/ui/localization/locale/it.json
+++ b/src/ui/localization/locale/it.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Sconto",
   "pricing_table.subtotal": "Subtotale",
   "pricing_dropdown.add_promo_code": "Aggiungi codice promozionale",
-  "discount_input.label": "Codice promozionale"
+  "discount_input.label": "Codice promozionale",
+  "payment_entry_page.checkout_consent_terms_of_service": "termini di servizio",
+  "payment_entry_page.checkout_consent_agreement": "Accetto i {{termsOfService}} di {{appName}}."
 }

--- a/src/ui/localization/locale/ja.json
+++ b/src/ui/localization/locale/ja.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "割引",
   "pricing_table.subtotal": "小計",
   "pricing_dropdown.add_promo_code": "プロモーションコードを追加",
-  "discount_input.label": "プロモーションコード"
+  "discount_input.label": "プロモーションコード",
+  "payment_entry_page.checkout_consent_terms_of_service": "利用規約",
+  "payment_entry_page.checkout_consent_agreement": "{{appName}}の{{termsOfService}}に同意します。"
 }

--- a/src/ui/localization/locale/ko.json
+++ b/src/ui/localization/locale/ko.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "할인",
   "pricing_table.subtotal": "소계",
   "pricing_dropdown.add_promo_code": "프로모션 코드 추가",
-  "discount_input.label": "프로모션 코드"
+  "discount_input.label": "프로모션 코드",
+  "payment_entry_page.checkout_consent_terms_of_service": "이용 약관",
+  "payment_entry_page.checkout_consent_agreement": "{{appName}} {{termsOfService}}에 동의합니다."
 }

--- a/src/ui/localization/locale/ms.json
+++ b/src/ui/localization/locale/ms.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Diskaun",
   "pricing_table.subtotal": "Subtotal",
   "pricing_dropdown.add_promo_code": "Tambah kod promo",
-  "discount_input.label": "Kod promo"
+  "discount_input.label": "Kod promo",
+  "payment_entry_page.checkout_consent_terms_of_service": "syarat perkhidmatan",
+  "payment_entry_page.checkout_consent_agreement": "Saya bersetuju dengan {{appName}} {{termsOfService}}."
 }

--- a/src/ui/localization/locale/nl.json
+++ b/src/ui/localization/locale/nl.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Korting",
   "pricing_table.subtotal": "Subtotaal",
   "pricing_dropdown.add_promo_code": "Promotiecode toevoegen",
-  "discount_input.label": "Promotiecode"
+  "discount_input.label": "Promotiecode",
+  "payment_entry_page.checkout_consent_terms_of_service": "servicevoorwaarden",
+  "payment_entry_page.checkout_consent_agreement": "Ik ga akkoord met de {{appName}} {{termsOfService}}."
 }

--- a/src/ui/localization/locale/no.json
+++ b/src/ui/localization/locale/no.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Rabatt",
   "pricing_table.subtotal": "Subtotal",
   "pricing_dropdown.add_promo_code": "Legg til kampanjekode",
-  "discount_input.label": "Kampanjekode"
+  "discount_input.label": "Kampanjekode",
+  "payment_entry_page.checkout_consent_terms_of_service": "vilkår for bruk",
+  "payment_entry_page.checkout_consent_agreement": "Jeg godtar {{appName}} {{termsOfService}}."
 }

--- a/src/ui/localization/locale/pl.json
+++ b/src/ui/localization/locale/pl.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Rabat",
   "pricing_table.subtotal": "Suma częściowa",
   "pricing_dropdown.add_promo_code": "Dodaj kod promocyjny",
-  "discount_input.label": "Kod promocyjny"
+  "discount_input.label": "Kod promocyjny",
+  "payment_entry_page.checkout_consent_terms_of_service": "regulamin",
+  "payment_entry_page.checkout_consent_agreement": "Akceptuję {{appName}} {{termsOfService}}."
 }

--- a/src/ui/localization/locale/pt.json
+++ b/src/ui/localization/locale/pt.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Desconto",
   "pricing_table.subtotal": "Subtotal",
   "pricing_dropdown.add_promo_code": "Adicionar código promocional",
-  "discount_input.label": "Código promocional"
+  "discount_input.label": "Código promocional",
+  "payment_entry_page.checkout_consent_terms_of_service": "termos de serviço",
+  "payment_entry_page.checkout_consent_agreement": "Concordo com os {{termsOfService}} do {{appName}}."
 }

--- a/src/ui/localization/locale/ro.json
+++ b/src/ui/localization/locale/ro.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Reducere",
   "pricing_table.subtotal": "Subtotal",
   "pricing_dropdown.add_promo_code": "Adaugă cod promoțional",
-  "discount_input.label": "Cod promoțional"
+  "discount_input.label": "Cod promoțional",
+  "payment_entry_page.checkout_consent_terms_of_service": "condițiile de utilizare",
+  "payment_entry_page.checkout_consent_agreement": "Sunt de acord cu {{termsOfService}} ale {{appName}}."
 }

--- a/src/ui/localization/locale/ru.json
+++ b/src/ui/localization/locale/ru.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Скидка",
   "pricing_table.subtotal": "Итого",
   "pricing_dropdown.add_promo_code": "Добавить промокод",
-  "discount_input.label": "Промокод"
+  "discount_input.label": "Промокод",
+  "payment_entry_page.checkout_consent_terms_of_service": "условиями обслуживания",
+  "payment_entry_page.checkout_consent_agreement": "Я согласен с {{appName}} {{termsOfService}}."
 }

--- a/src/ui/localization/locale/sk.json
+++ b/src/ui/localization/locale/sk.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Zľava",
   "pricing_table.subtotal": "Medzisúčet",
   "pricing_dropdown.add_promo_code": "Pridať promo kód",
-  "discount_input.label": "Propagačný kód"
+  "discount_input.label": "Propagačný kód",
+  "payment_entry_page.checkout_consent_terms_of_service": "podmienkami používania",
+  "payment_entry_page.checkout_consent_agreement": "Súhlasím s {{appName}} {{termsOfService}}."
 }

--- a/src/ui/localization/locale/sl.json
+++ b/src/ui/localization/locale/sl.json
@@ -101,5 +101,7 @@
   "price_update.title": "Posodobitev cene",
   "price_update.base_message": "Skupna cena je bila posodobljena z davkom glede na vaš naslov za obračun. Preglejte in poskusite znova. Vaša kartica bo bremenjena samo enkrat.",
   "price_update.trial_message": "Cena naročnine je bila posodobljena, da vključuje davek glede na vaš naslov za obračun. Brezplačni preizkus še vedno velja. Preglejte in poskusite znova.",
-  "apple_pay.free_trial": "Brezplačni preizkus"
+  "apple_pay.free_trial": "Brezplačni preizkus",
+  "payment_entry_page.checkout_consent_terms_of_service": "pogoji storitve",
+  "payment_entry_page.checkout_consent_agreement": "Strinjam se s/z {{appName}} {{termsOfService}}."
 }

--- a/src/ui/localization/locale/sv.json
+++ b/src/ui/localization/locale/sv.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Rabatt",
   "pricing_table.subtotal": "Delsumma",
   "pricing_dropdown.add_promo_code": "Lägg till kampanjkod",
-  "discount_input.label": "Kampanjkod"
+  "discount_input.label": "Kampanjkod",
+  "payment_entry_page.checkout_consent_terms_of_service": "användarvillkor",
+  "payment_entry_page.checkout_consent_agreement": "Jag godkänner {{appName}} {{termsOfService}}."
 }

--- a/src/ui/localization/locale/th.json
+++ b/src/ui/localization/locale/th.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "ส่วนลด",
   "pricing_table.subtotal": "ราคารวมย่อย",
   "pricing_dropdown.add_promo_code": "เพิ่มรหัสโปรโมชั่น",
-  "discount_input.label": "รหัสโปรโมชั่น"
+  "discount_input.label": "รหัสโปรโมชั่น",
+  "payment_entry_page.checkout_consent_terms_of_service": "ข้อกำหนดในการให้บริการ",
+  "payment_entry_page.checkout_consent_agreement": "ฉันยอมรับ{{termsOfService}}ของ{{appName}}"
 }

--- a/src/ui/localization/locale/tr.json
+++ b/src/ui/localization/locale/tr.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "İndirim",
   "pricing_table.subtotal": "Ara Toplam",
   "pricing_dropdown.add_promo_code": "kupon kodu ekle",
-  "discount_input.label": "Promosyon kodu"
+  "discount_input.label": "Promosyon kodu",
+  "payment_entry_page.checkout_consent_terms_of_service": "hizmet şartları",
+  "payment_entry_page.checkout_consent_agreement": "{{appName}} {{termsOfService}}'ni kabul ediyorum."
 }

--- a/src/ui/localization/locale/uk.json
+++ b/src/ui/localization/locale/uk.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Знижка",
   "pricing_table.subtotal": "Сума до сплати",
   "pricing_dropdown.add_promo_code": "Додати промокод",
-  "discount_input.label": "Промокод"
+  "discount_input.label": "Промокод",
+  "payment_entry_page.checkout_consent_terms_of_service": "умовами надання послуг",
+  "payment_entry_page.checkout_consent_agreement": "Я погоджуюся з {{appName}} {{termsOfService}}."
 }

--- a/src/ui/localization/locale/vi.json
+++ b/src/ui/localization/locale/vi.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "Giảm giá",
   "pricing_table.subtotal": "Tổng cộng",
   "pricing_dropdown.add_promo_code": "Thêm mã khuyến mãi",
-  "discount_input.label": "Mã khuyến mãi"
+  "discount_input.label": "Mã khuyến mãi",
+  "payment_entry_page.checkout_consent_terms_of_service": "điều khoản dịch vụ",
+  "payment_entry_page.checkout_consent_agreement": "Tôi đồng ý với {{termsOfService}} của {{appName}}."
 }

--- a/src/ui/localization/locale/zh_Hans.json
+++ b/src/ui/localization/locale/zh_Hans.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "折扣",
   "pricing_table.subtotal": "小计",
   "pricing_dropdown.add_promo_code": "添加优惠码",
-  "discount_input.label": "优惠码"
+  "discount_input.label": "优惠码",
+  "payment_entry_page.checkout_consent_terms_of_service": "服务条款",
+  "payment_entry_page.checkout_consent_agreement": "我同意{{appName}}的{{termsOfService}}。"
 }

--- a/src/ui/localization/locale/zh_Hant.json
+++ b/src/ui/localization/locale/zh_Hant.json
@@ -101,5 +101,7 @@
   "pricing_table.discount": "折扣",
   "pricing_table.subtotal": "小計",
   "pricing_dropdown.add_promo_code": "新增優惠碼",
-  "discount_input.label": "促銷代碼"
+  "discount_input.label": "促銷代碼",
+  "payment_entry_page.checkout_consent_terms_of_service": "服務條款",
+  "payment_entry_page.checkout_consent_agreement": "我同意{{appName}}的{{termsOfService}}。"
 }

--- a/src/ui/localization/supportedLanguages.ts
+++ b/src/ui/localization/supportedLanguages.ts
@@ -81,6 +81,8 @@ export enum LocalizationKeys {
   PaymentEntryPageSubscriptionTermsInfo = "payment_entry_page.subscription_terms_info",
   PaymentEntryPageOtpTermsInfo = "payment_entry_page.otp_terms_info",
   PaymentEntryPageTermsLinkLabel = "payment_entry_page.terms_link_label",
+  PaymentEntryPageCheckoutConsentAgreement = "payment_entry_page.checkout_consent_agreement",
+  PaymentEntryPageCheckoutConsentTermsOfService = "payment_entry_page.checkout_consent_terms_of_service",
   PaymentEntryPageSubscriptionInfo = "payment_entry_page.subscription_info",
   PaymentEntryPageButtonPay = "payment_entry_page.button_pay",
   PaymentEntryPageButtonStartTrial = "payment_entry_page.button_start_trial",

--- a/src/ui/molecules/checkout-consent.svelte
+++ b/src/ui/molecules/checkout-consent.svelte
@@ -49,10 +49,10 @@
   };
 </script>
 
-<label class="rc-checkout-consent" data-testid="CheckoutConsent">
+<label class="rcb-checkout-consent" data-testid="CheckoutConsent">
   <input
     type="checkbox"
-    class="rc-checkout-consent-checkbox"
+    class="rcb-checkout-consent-checkbox"
     data-testid="CheckoutConsentCheckbox"
     {checked}
     onchange={handleChange}
@@ -71,7 +71,7 @@
 </label>
 
 <style>
-  .rc-checkout-consent {
+  .rcb-checkout-consent {
     display: flex;
     align-items: flex-start;
     gap: 8px;
@@ -79,12 +79,12 @@
     cursor: pointer;
   }
 
-  .rc-checkout-consent-checkbox {
+  .rcb-checkout-consent-checkbox {
     margin-top: 2px;
     flex-shrink: 0;
   }
 
-  .rc-checkout-consent :global(a) {
+  .rcb-checkout-consent :global(a) {
     color: inherit;
     text-decoration: underline;
   }

--- a/src/ui/molecules/checkout-consent.svelte
+++ b/src/ui/molecules/checkout-consent.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import { getContext } from "svelte";
+  import { type Writable } from "svelte/store";
+  import { translatorContextKey } from "../localization/constants";
+  import { LocalizationKeys } from "../localization/supportedLanguages";
+  import { Translator } from "../localization/translator";
+  import Typography from "../atoms/typography.svelte";
+
+  const TERMS_PLACEHOLDER = "__TERMS_OF_SERVICE__";
+
+  interface Props {
+    appName: string | null | undefined;
+    termsAndConditionsUrl: string;
+    checked?: boolean;
+    onChange: (checked: boolean) => void;
+  }
+
+  let {
+    appName,
+    termsAndConditionsUrl,
+    checked = $bindable(false),
+    onChange,
+  }: Props = $props();
+
+  const translator = getContext<Writable<Translator>>(translatorContextKey);
+
+  const termsLabel = $derived(
+    $translator.translate(
+      LocalizationKeys.PaymentEntryPageCheckoutConsentTermsOfService,
+    ),
+  );
+
+  const agreementParts = $derived.by(() => {
+    const agreement = $translator.translate(
+      LocalizationKeys.PaymentEntryPageCheckoutConsentAgreement,
+      {
+        appName: appName ?? "",
+        termsOfService: TERMS_PLACEHOLDER,
+      },
+    );
+    const [before = "", after = ""] = agreement.split(TERMS_PLACEHOLDER);
+    return { before, after };
+  });
+
+  const handleChange = (event: Event) => {
+    const target = event.currentTarget as HTMLInputElement;
+    checked = target.checked;
+    onChange(target.checked);
+  };
+</script>
+
+<label class="rc-checkout-consent" data-testid="CheckoutConsent">
+  <input
+    type="checkbox"
+    class="rc-checkout-consent-checkbox"
+    data-testid="CheckoutConsentCheckbox"
+    {checked}
+    onchange={handleChange}
+  />
+  <Typography size="caption-default">
+    {agreementParts.before}<a
+      href={termsAndConditionsUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      data-testid="CheckoutConsentTermsLink"
+      onclick={(event) => event.stopPropagation()}
+    >
+      {termsLabel}
+    </a>{agreementParts.after}
+  </Typography>
+</label>
+
+<style>
+  .rc-checkout-consent {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    margin-bottom: 12px;
+    cursor: pointer;
+  }
+
+  .rc-checkout-consent-checkbox {
+    margin-top: 2px;
+    flex-shrink: 0;
+  }
+
+  .rc-checkout-consent :global(a) {
+    color: inherit;
+    text-decoration: underline;
+  }
+</style>

--- a/src/ui/molecules/stripe-elements.svelte
+++ b/src/ui/molecules/stripe-elements.svelte
@@ -56,6 +56,7 @@
       paymentMethod: string,
       emailValue: string,
     ) => void;
+    allowExpressCheckout?: boolean;
   }
 
   let {
@@ -74,6 +75,7 @@
     onPaymentInfoChange,
     onAddressInfoChange,
     onExpressCheckoutElementSubmit,
+    allowExpressCheckout = true,
   }: Props = $props();
 
   const translator = getContext<Writable<Translator>>(translatorContextKey);
@@ -277,6 +279,7 @@
       onSubmit={onExpressCheckoutElementSubmit}
       {expressCheckoutOptions}
       {forceEnableWalletMethods}
+      {allowExpressCheckout}
     />
     {#if !skipEmail}
       <LinkAuthenticationElement

--- a/src/ui/molecules/stripe-express-checkout-element.svelte
+++ b/src/ui/molecules/stripe-express-checkout-element.svelte
@@ -135,13 +135,22 @@
   });
 </script>
 
-{#if !hideExpressCheckoutElement}
-  <div id={expressCheckoutElementId}></div>
-  {#if !hideCheckoutSeparator}
-    <TextSeparator
-      text={$translator.translate(
-        LocalizationKeys.PaymentEntryPageExpressCheckoutDivider,
-      )}
-    />
-  {/if}
+<div
+  id={expressCheckoutElementId}
+  class:rc-express-checkout-hidden={!expressCheckoutAllowed ||
+    hideExpressCheckoutElement}
+  aria-hidden={!expressCheckoutAllowed || hideExpressCheckoutElement}
+></div>
+{#if !hideCheckoutSeparator && expressCheckoutAllowed && !hideExpressCheckoutElement}
+  <TextSeparator
+    text={$translator.translate(
+      LocalizationKeys.PaymentEntryPageExpressCheckoutDivider,
+    )}
+  />
 {/if}
+
+<style>
+  .rc-express-checkout-hidden {
+    display: none;
+  }
+</style>

--- a/src/ui/molecules/stripe-express-checkout-element.svelte
+++ b/src/ui/molecules/stripe-express-checkout-element.svelte
@@ -43,6 +43,7 @@
     forceEnableWalletMethods: boolean;
     expressCheckoutOptions?: StripeExpressCheckoutConfiguration;
     hideCheckoutSeparator?: boolean;
+    allowExpressCheckout?: boolean;
   }
 
   const {
@@ -55,12 +56,19 @@
     forceEnableWalletMethods,
     expressCheckoutOptions,
     hideCheckoutSeparator = false,
+    allowExpressCheckout = true,
   }: Props = $props();
 
   const translator = getContext<Writable<Translator>>(translatorContextKey);
 
   let expressCheckoutElement: StripeExpressCheckoutElement | null = null;
   let hideExpressCheckoutElement = $state(false);
+  // Mirror the prop into state so the onMount click handler always reads the
+  // latest value (destructured $props are not live inside that closure).
+  let expressCheckoutAllowed = $state(true);
+  $effect(() => {
+    expressCheckoutAllowed = allowExpressCheckout;
+  });
   // Allows having more than one in the page.
   const expressCheckoutElementId = `express-checkout-element-${generateUUID()}`;
 
@@ -71,6 +79,9 @@
   const onClickCallback = async (
     event: StripeExpressCheckoutElementClickEvent,
   ) => {
+    if (!expressCheckoutAllowed) {
+      return;
+    }
     const { business: _business, ...options } = expressCheckoutOptions ?? {};
     onClick && onClick(event);
     event.resolve(options as ClickResolveDetails);

--- a/src/ui/molecules/stripe-express-checkout-element.svelte
+++ b/src/ui/molecules/stripe-express-checkout-element.svelte
@@ -131,7 +131,7 @@
 
 <div
   id={expressCheckoutElementId}
-  class:rc-express-checkout-hidden={!allowExpressCheckout ||
+  class:rcb-express-checkout-hidden={!allowExpressCheckout ||
     hideExpressCheckoutElement}
   aria-hidden={!allowExpressCheckout || hideExpressCheckoutElement}
 ></div>
@@ -144,7 +144,7 @@
 {/if}
 
 <style>
-  .rc-express-checkout-hidden {
+  .rcb-express-checkout-hidden {
     display: none;
   }
 </style>

--- a/src/ui/molecules/stripe-express-checkout-element.svelte
+++ b/src/ui/molecules/stripe-express-checkout-element.svelte
@@ -63,12 +63,6 @@
 
   let expressCheckoutElement: StripeExpressCheckoutElement | null = null;
   let hideExpressCheckoutElement = $state(false);
-  // Mirror the prop into state so the onMount click handler always reads the
-  // latest value (destructured $props are not live inside that closure).
-  let expressCheckoutAllowed = $state(true);
-  $effect(() => {
-    expressCheckoutAllowed = allowExpressCheckout;
-  });
   // Allows having more than one in the page.
   const expressCheckoutElementId = `express-checkout-element-${generateUUID()}`;
 
@@ -79,7 +73,7 @@
   const onClickCallback = async (
     event: StripeExpressCheckoutElementClickEvent,
   ) => {
-    if (!expressCheckoutAllowed) {
+    if (!allowExpressCheckout) {
       return;
     }
     const { business: _business, ...options } = expressCheckoutOptions ?? {};
@@ -137,11 +131,11 @@
 
 <div
   id={expressCheckoutElementId}
-  class:rc-express-checkout-hidden={!expressCheckoutAllowed ||
+  class:rc-express-checkout-hidden={!allowExpressCheckout ||
     hideExpressCheckoutElement}
-  aria-hidden={!expressCheckoutAllowed || hideExpressCheckoutElement}
+  aria-hidden={!allowExpressCheckout || hideExpressCheckoutElement}
 ></div>
-{#if !hideCheckoutSeparator && expressCheckoutAllowed && !hideExpressCheckoutElement}
+{#if !hideCheckoutSeparator && allowExpressCheckout && !hideExpressCheckoutElement}
   <TextSeparator
     text={$translator.translate(
       LocalizationKeys.PaymentEntryPageExpressCheckoutDivider,

--- a/src/ui/pages/payment-entry-page.svelte
+++ b/src/ui/pages/payment-entry-page.svelte
@@ -18,6 +18,8 @@
 
   import { LocalizationKeys } from "../localization/supportedLanguages";
   import SecureCheckoutRc from "../molecules/secure-checkout-rc.svelte";
+  import CheckoutConsent from "../molecules/checkout-consent.svelte";
+  import { isCheckoutConsentRequired } from "../../helpers/checkout-consent-helper";
   import {
     PurchaseFlowError,
     PurchaseFlowErrorCode,
@@ -224,11 +226,21 @@
   // recalculateTaxes think nothing changed and skip the tax call.
   let lastCalculatedTaxCustomerDetails: TaxCustomerDetails | null = null;
 
+  let checkoutConsentRequired = $derived(
+    isCheckoutConsentRequired({
+      brandingInfo,
+      termsAndConditionsUrl,
+      productDetails,
+    }),
+  );
+  let checkoutConsentAccepted = $state(false);
+
   let isFormReady = $derived(
     !processing &&
       isPaymentInfoComplete &&
       isEmailComplete &&
       isAddressComplete &&
+      (!checkoutConsentRequired || checkoutConsentAccepted) &&
       (taxCalculationStatus === "disabled" ||
         taxCalculationStatus === "calculated" ||
         taxCalculationStatus === "miss-match"),
@@ -498,6 +510,7 @@
     e?.preventDefault();
 
     if (processing) return;
+    if (checkoutConsentRequired && !checkoutConsentAccepted) return;
 
     const event = createCheckoutPaymentFormSubmitEvent({
       selectedPaymentMethod: selectedPaymentMethod ?? null,
@@ -840,6 +853,8 @@
           onAddressInfoChange={handleAddressInfoChange}
           onExpressCheckoutElementSubmit={handleExpressCheckoutElementSubmit}
           {expressCheckoutOptions}
+          allowExpressCheckout={!checkoutConsentRequired ||
+            checkoutConsentAccepted}
         />
       </div>
 
@@ -855,6 +870,14 @@
         class="rc-checkout-pay-container"
         class:fully-hidden={view !== "form"}
       >
+        {#if checkoutConsentRequired && termsAndConditionsUrl}
+          <CheckoutConsent
+            appName={brandingInfo?.app_name}
+            {termsAndConditionsUrl}
+            bind:checked={checkoutConsentAccepted}
+            onChange={(accepted) => (checkoutConsentAccepted = accepted)}
+          />
+        {/if}
         <PaymentButton
           disabled={!isFormReady}
           {subscriptionOption}


### PR DESCRIPTION
## Motivation / Description

Adds the option to opt in to display an explicit consent checkbox to unlock the purchase. If opted into the payment will not be able to be triggered until the checkbox is checked. This also means wallet payment methods are hidden until the checkbox is checked.

Made the `termsAndConditionsUrl` param not-internal - it was added a few months back as a customer request, I don't think theres a reason not to do this? Unlocks support for using the consent checkbox via the SDK.

Bumped translation model to `"gemini-2.5-flash",`.

Checkout consent only displays if we have the terms URL, the explicit opt-in, and if the product is a subscription. 

We need to do some mildly clever string manip to get the link on the correct part of the string, while remaining localisation friendly.

See https://github.com/RevenueCat/revenuecat-app/pull/10858 for recording.

## Changes introduced

## Linear ticket (if any)

## Additional comments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payment submission and wallet express-checkout gating on the payment entry page, which is checkout-critical but scoped to an opt-in branding flag and subscriptions only.
> 
> **Overview**
> Adds an **optional checkout consent checkbox** for subscription purchases when branding sets `require_checkout_consent`, a **`termsAndConditionsUrl`** is provided, and the product is a subscription. Until the box is checked, **Pay stays disabled** and **express/wallet checkout is blocked** (hidden and non-interactive).
> 
> **`termsAndConditionsUrl`** on `PurchaseParams` is now **public** (no longer `@internal`) so SDK integrators can supply the terms link for the consent UI.
> 
> Branding responses gain **`require_checkout_consent`**. A new **`CheckoutConsent`** molecule renders localized copy with an inline terms link (placeholder-based splitting for i18n). **`isCheckoutConsentRequired`** centralizes the gating rules.
> 
> Locale strings were added across languages; the locale translation script model was bumped to **gemini-2.5-flash**. Tests, Storybook, and API reports were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65e9d9d6332be7ac0703078daf9cb2af6b9b7a0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->