### PR TITLE
chore: bump purchases-ui-js to 4.8.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,21 @@ jobs:
           name: E2E tests webbilling-demo
           working_directory: examples/webbilling-demo
           command: pnpm run test:ci
+      # Capture Playwright artifacts (error-context.md, traces, screenshots) so
+      # failures can be diagnosed after the run. `when: always` so they upload
+      # even when the E2E step fails.
+      - store_artifacts:
+          path: examples/webbilling-demo/test-results
+          destination: playwright-test-results
+          when: always
+      - store_artifacts:
+          path: examples/webbilling-demo/playwright-report
+          destination: playwright-report
+          when: always
+      - store_artifacts:
+          path: examples/webbilling-demo/results.xml
+          destination: playwright-results.xml
+          when: always
 
 workflows:
   danger:

--- a/examples/webbilling-demo/playwright.config.ts
+++ b/examples/webbilling-demo/playwright.config.ts
@@ -49,8 +49,8 @@ export default defineConfig({
           viewport: { width: 1280, height: 720 }, // Set a smaller viewport
           ignoreHTTPSErrors: true, // Ignore HTTPS errors
           video: "off", // Disable video recording
-          screenshot: "off", // Disable screenshots
-          trace: "off", // Disable tracing
+          screenshot: "only-on-failure", // Capture a screenshot on failure for debugging
+          trace: "on-first-retry", // Capture a Playwright trace on retry for debugging
         }
       : {}),
   },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@babel/runtime": "^7.26.10",
     "@eslint/js": "^9.16.0",
     "@microsoft/api-extractor": "^7.48.0",
-    "@revenuecat/purchases-ui-js": "4.8.6",
+    "@revenuecat/purchases-ui-js": "4.8.9",
     "@paddle/paddle-js": "^1.6.4",
     "@storybook/addon-essentials": "^8.6.15",
     "@storybook/addon-interactions": "^8.6.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^1.6.4
         version: 1.6.4
       "@revenuecat/purchases-ui-js":
-        specifier: 4.8.6
-        version: 4.8.6(svelte@5.46.4)
+        specifier: 4.8.9
+        version: 4.8.9(svelte@5.46.4)
       "@storybook/addon-essentials":
         specifier: ^8.6.15
         version: 8.6.15(@types/react@19.0.10)(storybook@8.6.15(prettier@3.4.2))
@@ -722,10 +722,10 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
 
-  "@revenuecat/purchases-ui-js@4.8.6":
+  "@revenuecat/purchases-ui-js@4.8.9":
     resolution:
       {
-        integrity: sha512-yzylRJOdwufonJouTb/hQcqg5SWXUa7wwA2dd+HvTmf4qn7DtSqnCn7Eb0gimqT4kq6pm9i/5KQG6TNk875AtQ==,
+        integrity: sha512-DxgY6aI+3v+3lFKcuR1dLC63jWAfRnyv6PkGeCSK6adV/L+kS5iCf0kL+tz5dBLIQ5+DqsIL4YO5OHT+MwnNTA==,
       }
     engines: { node: ^22.18 || ^24.11 }
     peerDependencies:
@@ -6162,7 +6162,7 @@ snapshots:
 
   "@pkgr/core@0.1.1": {}
 
-  "@revenuecat/purchases-ui-js@4.8.6(svelte@5.46.4)":
+  "@revenuecat/purchases-ui-js@4.8.9(svelte@5.46.4)":
     dependencies:
       "@revenuecat/workflow-web-components-sdk": 0.1.4
       qrcode: 1.5.4


### PR DESCRIPTION
## Summary

Bumps `@revenuecat/purchases-ui-js` from `4.8.6` → `4.8.9`

### purchases-ui-js changes included

- [#339](https://github.com/RevenueCat/purchases-ui-js/pull/339) - Fixes carousel not switching pages on swipe flicks (advance on a normal swipe via a 20% distance threshold; `clientX`-based tracking so touch swipes work on Safari)
- [#340](https://github.com/RevenueCat/purchases-ui-js/pull/340) - Password inputs with `onSensitiveInputChanged` for auth screens
- [#344](https://github.com/RevenueCat/purchases-ui-js/pull/344) - Support transparent sticky footers
- [#345](https://github.com/RevenueCat/purchases-ui-js/pull/345) - Use `size.*.default` for web_view fit placeholder

## Test plan

- [ ] CI passes
- [ ] Paywall rendering smoke test in Storybook

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The purchases-ui-js bump affects paywall rendering and checkout UI paths; CI-only Playwright changes are low risk.
> 
> **Overview**
> **Dependency:** `@revenuecat/purchases-ui-js` is updated from **4.8.6** to **4.8.9** in root `package.json` and `pnpm-lock.yaml`, pulling in upstream paywall/UI fixes (carousel swipe, auth password inputs, sticky footers, web view sizing).
> 
> **CI / E2E:** The `test-e2e` job now **stores Playwright artifacts** (`test-results`, `playwright-report`, `results.xml`) with `when: always` so failures are diagnosable after the run. In `playwright.config.ts`, CI no longer disables screenshots and traces entirely—it uses **`screenshot: only-on-failure`** and **`trace: on-first-retry`** instead of `off`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9fc674dd5aad1a8941a09aa9d66600e4a7de8a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->