### PR TITLE
ci: capture Playwright artifacts on E2E failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,21 @@ jobs:
           name: E2E tests webbilling-demo
           working_directory: examples/webbilling-demo
           command: pnpm run test:ci
+      # Capture Playwright artifacts (error-context.md, traces, screenshots) so
+      # failures can be diagnosed after the run. `when: always` so they upload
+      # even when the E2E step fails.
+      - store_artifacts:
+          path: examples/webbilling-demo/test-results
+          destination: playwright-test-results
+          when: always
+      - store_artifacts:
+          path: examples/webbilling-demo/playwright-report
+          destination: playwright-report
+          when: always
+      - store_artifacts:
+          path: examples/webbilling-demo/results.xml
+          destination: playwright-results.xml
+          when: always
 
 workflows:
   danger:

--- a/examples/webbilling-demo/playwright.config.ts
+++ b/examples/webbilling-demo/playwright.config.ts
@@ -49,8 +49,8 @@ export default defineConfig({
           viewport: { width: 1280, height: 720 }, // Set a smaller viewport
           ignoreHTTPSErrors: true, // Ignore HTTPS errors
           video: "off", // Disable video recording
-          screenshot: "off", // Disable screenshots
-          trace: "off", // Disable tracing
+          screenshot: "only-on-failure", // Capture a screenshot on failure for debugging
+          trace: "on-first-retry", // Capture a Playwright trace on retry for debugging
         }
       : {}),
   },


### PR DESCRIPTION
## Motivation / Description

The `test-e2e` job currently makes failures impossible to diagnose after the fact: `playwright.config.ts` sets `trace: "off"` / `screenshot: "off"` under `CI`, and the job has no `store_artifacts`, so Playwright's `error-context.md`, traces, and JUnit `results.xml` are generated inside the container and then discarded. There's nothing to open in the CircleCI UI or download.

This is blocking diagnosis of the currently-failing Stripe Address Element tax tests (`tax-calculation.test.ts`, red on `main`).

## Changes introduced

- `playwright.config.ts`: re-enable failure-only capture in CI — `screenshot: "only-on-failure"`, `trace: "on-first-retry"` (video stays off). Traces are only produced for failing/retried tests, so overhead is minimal.
- `.circleci/config.yml`: `store_artifacts` (`when: always`) for `test-results/`, `playwright-report/`, and `results.xml`, so artifacts upload even when the E2E step fails.

## Linear ticket (if any)

## Additional comments

Debug enabler — no test/source behavior changes. After this merges, a re-run of the failing E2E job will attach the Address Element DOM snapshot + trace so we can fix the tax tests at the root.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and Playwright reporting only; no application or test logic changes.
> 
> **Overview**
> **Makes failed `test-e2e` runs debuggable in CircleCI** by persisting Playwright outputs instead of discarding them when the container exits.
> 
> In **`playwright.config.ts`**, the CI-specific overrides no longer force `screenshot: "off"` and `trace: "off"`; they now use **`only-on-failure`** screenshots and **`on-first-retry`** traces (video stays off), so failures and retries produce lightweight debug material without full-run overhead.
> 
> In **`.circleci/config.yml`**, the **`test-e2e`** job adds three **`store_artifacts`** steps with **`when: always`** for `test-results/`, `playwright-report/`, and JUnit **`results.xml`**, so artifacts upload even when the E2E step fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d16adcd8bd0469587240a660c684c7c0999eccb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->