### PR TITLE
[WEB-4491] Make discount code APIs stable

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -4594,7 +4594,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@revenuecat/purchases-js!PresentPaywallParams#discountCode:member",
-              "docComment": "/**\n * Initial discount code to apply to the checkout when one already exists outside of the paywall UI, for example in the hosting page's URL.\n *\n * @experimental\n */\n",
+              "docComment": "/**\n * Initial discount code to apply to the checkout when one already exists outside of the paywall UI, for example in the hosting page's URL.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -4759,7 +4759,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@revenuecat/purchases-js!PresentPaywallParams#onDiscountCodeChanged:member",
-              "docComment": "/**\n * Called when the applied discount code changes in the checkout shown from the paywall. This can be used to sync host state such as URL parameters.\n *\n * @experimental\n */\n",
+              "docComment": "/**\n * Called when the applied discount code changes in the checkout shown from the paywall. This can be used to sync host state such as URL parameters.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -4931,7 +4931,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@revenuecat/purchases-js!PresentPaywallParams#showDiscountCodeField:member",
-              "docComment": "/**\n * If set to true, the Web Billing checkout shown from the paywall will display a discount input code field.\n *\n * @experimental\n */\n",
+              "docComment": "/**\n * If set to true, the Web Billing checkout shown from the paywall will display a discount input code field.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -6204,7 +6204,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@revenuecat/purchases-js!PurchaseParams#discountCode:member",
-              "docComment": "/**\n * Initial discount code to display as applied in the Web Billing checkout. This is useful when the code originated outside of the checkout UI, for example from a URL parameter.\n *\n * @experimental\n */\n",
+              "docComment": "/**\n * Initial discount code to display as applied in the Web Billing checkout. This is useful when the code originated outside of the checkout UI, for example from a URL parameter.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -6287,7 +6287,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@revenuecat/purchases-js!PurchaseParams#onDiscountCodeChanged:member",
-              "docComment": "/**\n * Called when the applied discount code changes in the Web Billing checkout. This can be used by host applications to keep external state, such as the URL, in sync with the checkout.\n *\n * @experimental\n */\n",
+              "docComment": "/**\n * Called when the applied discount code changes in the Web Billing checkout. This can be used by host applications to keep external state, such as the URL, in sync with the checkout.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -6401,7 +6401,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@revenuecat/purchases-js!PurchaseParams#showDiscountCodeField:member",
-              "docComment": "/**\n * If set to true, the Web Billing checkout will show a discount input code field.\n *\n * @experimental\n */\n",
+              "docComment": "/**\n * If set to true, the Web Billing checkout will show a discount input code field.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",

--- a/src/entities/present-paywall-params.ts
+++ b/src/entities/present-paywall-params.ts
@@ -37,21 +37,18 @@ export interface PresentPaywallParams {
   readonly customerEmail?: string;
 
   /**
-   * @experimental
    * If set to true, the Web Billing checkout shown from the paywall
    * will display a discount input code field.
    */
   readonly showDiscountCodeField?: boolean;
 
   /**
-   * @experimental
    * Initial discount code to apply to the checkout when one already exists
    * outside of the paywall UI, for example in the hosting page's URL.
    */
   readonly discountCode?: string;
 
   /**
-   * @experimental
    * Called when the applied discount code changes in the checkout shown from
    * the paywall. This can be used to sync host state such as URL parameters.
    */

--- a/src/entities/purchase-params.ts
+++ b/src/entities/purchase-params.ts
@@ -131,13 +131,11 @@ export interface PurchaseParams {
   skipSuccessPage?: boolean;
 
   /**
-   * @experimental
    * If set to true, the Web Billing checkout will show a discount input code field.
    */
   showDiscountCodeField?: boolean;
 
   /**
-   * @experimental
    * Initial discount code to display as applied in the Web Billing checkout.
    * This is useful when the code originated outside of the checkout UI,
    * for example from a URL parameter.
@@ -145,7 +143,6 @@ export interface PurchaseParams {
   discountCode?: string;
 
   /**
-   * @experimental
    * Called when the applied discount code changes in the Web Billing checkout.
    * This can be used by host applications to keep external state, such as the URL,
    * in sync with the checkout.


### PR DESCRIPTION
## Why

The public purchases-js fields used to show, prefill, and observe Web Billing discount codes were still marked experimental even though they are now part of the supported purchase and paywall API surface. Keeping those markers made the stability commitment unclear for developers integrating discount-code flows.

## What changed

- Remove the experimental marker from `discountCode`, `showDiscountCodeField`, and `onDiscountCodeChanged` on both `PurchaseParams` and `PresentPaywallParams`.
- Regenerate the public API report so the published documentation matches the source declarations.

## Compatibility

This changes API documentation and stability status only. Field names, types, optionality, and runtime behavior remain unchanged. The internal `GetOfferingsParams.discountCode` field remains internal and experimental.

Linear: [WEB-4491](https://linear.app/revenuecat/issue/WEB-4491/make-purchases-js-discount-code-apis-stable)
