### PR TITLE
[WEB-4505] Web SDK changeProduct + test harness

### DIFF
--- a/examples/webbilling-demo/README.md
+++ b/examples/webbilling-demo/README.md
@@ -32,6 +32,15 @@ npm run dev
 >
 > **Expected behavior:** When using your Web Billing product API key, you should see customers created in Sandbox in your dashboard after completing purchases. View activity at https://app.revenuecat.com/activity after a few minutes to see sandbox transactions and customer data.
 
+### Headless upgrade PoC
+
+The `/upgrade/:app_user_id` page demonstrates the experimental headless product change flow (`Purchases.changeProduct`). It requires the demo token server, a separate process that plays the role of your backend: it holds a **secret** API key and mints short-lived subscriber access tokens via the Developer API `authenticate` endpoint. The secret key is read from a non-`VITE_` env var so it can never be bundled into frontend code.
+
+1. Copy `server/.env.example` to `server/.env` and fill in `RC_SECRET_API_KEY` (a V2 secret key with the `iam:authorization:issue_token` permission), `RC_PROJECT_ID` and `RC_APP_ID`. Point `RC_API_BASE` at your backend if not using production.
+2. Start the token server: `npm run token-server` (listens on port 8010; the Vite dev server proxies `/api` to it).
+3. Start the demo as usual (`npm run dev`) and open `/upgrade/<app_user_id>` for a customer with an active Web Billing subscription.
+4. Pick or type the target product identifier and confirm. A product change path from the current product to the target must be configured in RevenueCat; upgrades apply immediately with proration, downgrades are scheduled for the next renewal.
+
 ### Payment Methods
 
 The demo supports both **Web Billing** and **Paddle** payment flows:

--- a/examples/webbilling-demo/README.md
+++ b/examples/webbilling-demo/README.md
@@ -32,14 +32,24 @@ npm run dev
 >
 > **Expected behavior:** When using your Web Billing product API key, you should see customers created in Sandbox in your dashboard after completing purchases. View activity at https://app.revenuecat.com/activity after a few minutes to see sandbox transactions and customer data.
 
-### Headless upgrade PoC
+### Headless product change (`Purchases.changeProduct`)
 
-The `/upgrade/:app_user_id` page demonstrates the experimental headless product change flow (`Purchases.changeProduct`). It requires the demo token server, a separate process that plays the role of your backend: it holds a **secret** API key and mints short-lived subscriber access tokens via the Developer API `authenticate` endpoint. The secret key is read from a non-`VITE_` env var so it can never be bundled into frontend code.
+#### Note this feature is currently experimental
 
-1. Copy `server/.env.example` to `server/.env` and fill in `RC_SECRET_API_KEY` (a V2 secret key with the `iam:authorization:issue_token` permission), `RC_PROJECT_ID` and `RC_APP_ID`. Point `RC_API_BASE` at your backend if not using production.
-2. Start the token server: `npm run token-server` (listens on port 8010; the Vite dev server proxies `/api` to it).
-3. Start the demo as usual (`npm run dev`) and open `/upgrade/<app_user_id>` for a customer with an active Web Billing subscription.
-4. Pick or type the target product identifier and confirm. A product change path from the current product to the target must be configured in RevenueCat; upgrades apply immediately with proration, downgrades are scheduled for the next renewal.
+The `/upgrade/:app_user_id` page demonstrates the headless product change flow. It uses a small token server to serve as a backend: it holds a **secret** API key and mints short-lived subscriber access tokens via the Developer API `authenticate` endpoint. The secret key is read from a non-`VITE_` env var so it is never bundled into frontend code.
+
+**Prerequisite:** configure a product change path in RevenueCat from the customer's current product to the target product. Without a path, the change returns 404.
+
+1. Copy `server/.env.example` to `server/.env` and set:
+   - `RC_SECRET_API_KEY` — V2 secret key with `iam:authorization:issue_token`
+   - `RC_PROJECT_ID` — project id (`proj...`)
+   - `RC_APP_ID` — Web Billing app id (`app...`)
+   - Optional: `RC_API_BASE` (default `https://api.revenuecat.com`), `RC_CANARY`, `TOKEN_SERVER_PORT` (default `8010`)
+2. Start the token server: `pnpm run token-server`
+3. In another terminal, start the demo: `pnpm run dev` (Vite proxies `/api` → the token server)
+4. Open `/upgrade/<app_user_id>` for a customer with an active Web Billing subscription
+5. Pick or type the target product identifier. If the customer has more than one active subscription, also select the source product.
+6. Click **Confirm change**. Immediate upgrades apply now (prorated); deferred downgrades are scheduled for the next renewal. Errors for missing change paths, bad tokens, or ambiguous multi-sub customers are shown in the page.
 
 ### Payment Methods
 

--- a/examples/webbilling-demo/package.json
+++ b/examples/webbilling-demo/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "token-server": "node server/index.mjs",
+    "token-server": "node server/index.js",
     "dev-fake-https": "vite --config vite-https.config.ts",
     "build": "tsc && vite build",
     "lint": "eslint \"**/*.{ts,tsx}\" --report-unused-disable-directives --max-warnings 0",

--- a/examples/webbilling-demo/package.json
+++ b/examples/webbilling-demo/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "token-server": "node server/index.mjs",
     "dev-fake-https": "vite --config vite-https.config.ts",
     "build": "tsc && vite build",
     "lint": "eslint \"**/*.{ts,tsx}\" --report-unused-disable-directives --max-warnings 0",

--- a/examples/webbilling-demo/server/.env.example
+++ b/examples/webbilling-demo/server/.env.example
@@ -1,5 +1,4 @@
-# Secret API key (V2, with the iam:authorization:issue_token permission).
-# NEVER expose this to the browser or prefix it with VITE_.
+# Secret API key (V2, needs the iam:authorization:issue_token permission).
 RC_SECRET_API_KEY=sk_...
 
 # The RevenueCat project id (proj...) and Web Billing app id (app...).

--- a/examples/webbilling-demo/server/.env.example
+++ b/examples/webbilling-demo/server/.env.example
@@ -1,0 +1,12 @@
+# Secret API key (V2, with the iam:authorization:issue_token permission).
+# NEVER expose this to the browser or prefix it with VITE_.
+RC_SECRET_API_KEY=sk_...
+
+# The RevenueCat project id (proj...) and Web Billing app id (app...).
+RC_PROJECT_ID=
+RC_APP_ID=
+
+# Optional overrides.
+# RC_API_BASE=https://api.revenuecat.com
+# RC_CANARY=your-canary-name
+# TOKEN_SERVER_PORT=8010

--- a/examples/webbilling-demo/server/index.js
+++ b/examples/webbilling-demo/server/index.js
@@ -1,20 +1,20 @@
 /**
  * Standalone demo token server.
  *
- * Plays the role of the developer's backend in the upgrade PoC: it holds the
- * secret API key and mints short-lived subscriber access tokens via the
- * RevenueCat Developer API `authenticate` endpoint. The browser only ever
+ * Plays the role of the developer's backend for headless product changes: it
+ * holds the secret API key and mints short-lived subscriber access tokens via
+ * the RevenueCat Developer API `authenticate` endpoint. The browser only ever
  * receives the short-lived token, never the secret key.
  *
  * This is intentionally a separate process from the Vite dev server so the
  * secret key never lives anywhere in the frontend source tree or its env.
  *
- * Usage: copy `.env.example` to `.env`, fill it in, then `npm run token-server`.
+ * Usage: copy `.env.example` to `.env`, fill it in, then `pnpm run token-server`.
  */
 
-import { Buffer } from "node:buffer";
 import { createServer } from "node:http";
 import process from "node:process";
+import { text } from "node:stream/consumers";
 import { fileURLToPath } from "node:url";
 import { config } from "dotenv";
 
@@ -38,9 +38,7 @@ if (!RC_SECRET_API_KEY || !RC_PROJECT_ID || !RC_APP_ID) {
 }
 
 async function readJsonBody(req) {
-  const chunks = [];
-  for await (const chunk of req) chunks.push(chunk);
-  return JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+  return JSON.parse((await text(req)) || "{}");
 }
 
 function sendJson(res, statusCode, body) {
@@ -61,8 +59,8 @@ const server = createServer(async (req, res) => {
       return;
     }
 
-    // In a real backend this is where you would check that the request comes
-    // from an authenticated session belonging to `appUserId`.
+    // In a production application this is where the session authentication for the appUserId would be checked.
+
     const headers = {
       Authorization: `Bearer ${RC_SECRET_API_KEY}`,
       "Content-Type": "application/json",

--- a/examples/webbilling-demo/server/index.mjs
+++ b/examples/webbilling-demo/server/index.mjs
@@ -1,0 +1,107 @@
+/**
+ * Standalone demo token server.
+ *
+ * Plays the role of the developer's backend in the upgrade PoC: it holds the
+ * secret API key and mints short-lived subscriber access tokens via the
+ * RevenueCat Developer API `authenticate` endpoint. The browser only ever
+ * receives the short-lived token, never the secret key.
+ *
+ * This is intentionally a separate process from the Vite dev server so the
+ * secret key never lives anywhere in the frontend source tree or its env.
+ *
+ * Usage: copy `.env.example` to `.env`, fill it in, then `npm run token-server`.
+ */
+
+import { Buffer } from "node:buffer";
+import { createServer } from "node:http";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { config } from "dotenv";
+
+config({ path: fileURLToPath(new URL("./.env", import.meta.url)) });
+
+const PORT = Number(process.env.TOKEN_SERVER_PORT ?? 8010);
+const RC_API_BASE = process.env.RC_API_BASE ?? "https://api.revenuecat.com";
+// Deliberately NOT prefixed with VITE_ so Vite can never bundle it into
+// client code.
+const RC_SECRET_API_KEY = process.env.RC_SECRET_API_KEY;
+const RC_PROJECT_ID = process.env.RC_PROJECT_ID;
+const RC_APP_ID = process.env.RC_APP_ID;
+const RC_CANARY = process.env.RC_CANARY;
+
+if (!RC_SECRET_API_KEY || !RC_PROJECT_ID || !RC_APP_ID) {
+  console.error(
+    "Missing configuration. Copy server/.env.example to server/.env and set " +
+      "RC_SECRET_API_KEY, RC_PROJECT_ID and RC_APP_ID.",
+  );
+  process.exit(1);
+}
+
+async function readJsonBody(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  return JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+}
+
+function sendJson(res, statusCode, body) {
+  res.writeHead(statusCode, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+const server = createServer(async (req, res) => {
+  if (req.method !== "POST" || req.url !== "/api/upgrade-token") {
+    sendJson(res, 404, { error: "Not found" });
+    return;
+  }
+
+  try {
+    const { appUserId } = await readJsonBody(req);
+    if (!appUserId) {
+      sendJson(res, 400, { error: "appUserId is required" });
+      return;
+    }
+
+    // In a real backend this is where you would check that the request comes
+    // from an authenticated session belonging to `appUserId`.
+    const headers = {
+      Authorization: `Bearer ${RC_SECRET_API_KEY}`,
+      "Content-Type": "application/json",
+    };
+    if (RC_CANARY) {
+      headers["X-RC-Canary"] = RC_CANARY;
+    }
+
+    const rcResponse = await fetch(
+      `${RC_API_BASE}/v2/projects/${RC_PROJECT_ID}/apps/${RC_APP_ID}/authenticate`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ app_user_id: appUserId }),
+      },
+    );
+
+    const data = await rcResponse.json();
+
+    if (!rcResponse.ok) {
+      console.error("authenticate call failed:", rcResponse.status, data);
+      sendJson(res, rcResponse.status, data);
+      return;
+    }
+
+    sendJson(res, 200, {
+      access_token: data.access_token,
+      expires_at: data.expires_at,
+    });
+  } catch (error) {
+    console.error("Token server error:", error);
+    sendJson(res, 500, { error: "Internal error" });
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Demo token server listening on http://localhost:${PORT}`);
+  console.log(`Minting tokens against ${RC_API_BASE} for app ${RC_APP_ID}`);
+  if (RC_CANARY) {
+    console.log(`Using canary: ${RC_CANARY}`);
+  }
+});

--- a/examples/webbilling-demo/src/App.tsx
+++ b/examples/webbilling-demo/src/App.tsx
@@ -116,8 +116,6 @@ const router = createBrowserRouter([
     ),
   },
   {
-    // Headless upgrade PoC: no entitlement wrapper on purpose, since the
-    // whole point is that the user already has an active subscription.
     path: "/upgrade/:app_user_id",
     loader: loadPurchases,
     element: <UpgradePage />,

--- a/examples/webbilling-demo/src/App.tsx
+++ b/examples/webbilling-demo/src/App.tsx
@@ -22,6 +22,7 @@ import RedemptionLinksTester from "./pages/redemption_links_tester";
 import RCPaywallLauncherPage from "./pages/rc_paywall_launcher";
 import ExpressPurchaseButtonsPackageSelector from "./pages/express_purchase_buttons";
 import RCPaywallSettingsPage from "./pages/rc_paywall_settings";
+import UpgradePage from "./pages/upgrade";
 
 const router = createBrowserRouter([
   {
@@ -113,6 +114,13 @@ const router = createBrowserRouter([
         <RedemptionLinksTester />
       </WithoutEntitlement>
     ),
+  },
+  {
+    // Headless upgrade PoC: no entitlement wrapper on purpose, since the
+    // whole point is that the user already has an active subscription.
+    path: "/upgrade/:app_user_id",
+    loader: loadPurchases,
+    element: <UpgradePage />,
   },
   {
     path: "/success/:app_user_id",

--- a/examples/webbilling-demo/src/pages/upgrade/index.tsx
+++ b/examples/webbilling-demo/src/pages/upgrade/index.tsx
@@ -1,0 +1,145 @@
+import type { ProductChangeResult } from "@revenuecat/purchases-js";
+import { PurchasesError } from "@revenuecat/purchases-js";
+import React, { useState } from "react";
+import { usePurchasesLoaderData } from "../../util/PurchasesLoader";
+import LogoutButton from "../../components/LogoutButton";
+
+/**
+ * PoC page for headless subscription upgrades through the web purchase flow.
+ *
+ * It fetches a short-lived subscriber access token from the demo token server
+ * (which holds the secret API key, mimicking the developer's backend) and
+ * then calls Purchases.changeProduct with it. No checkout UI is shown and no
+ * payment details are collected: the change is applied to the customer's
+ * existing subscription using the payment method on file.
+ */
+const UpgradePage: React.FC = () => {
+  const { purchases, customerInfo, offering } = usePurchasesLoaderData();
+  const [newProductId, setNewProductId] = useState("");
+  const [inProgress, setInProgress] = useState(false);
+  const [result, setResult] = useState<ProductChangeResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const activeProductIds = Array.from(customerInfo.activeSubscriptions);
+  const offeredProductIds = (offering?.availablePackages ?? [])
+    .map((pkg) => pkg.webBillingProduct?.identifier)
+    .filter((identifier): identifier is string => Boolean(identifier));
+
+  const performUpgrade = async () => {
+    setInProgress(true);
+    setResult(null);
+    setError(null);
+
+    try {
+      // Step 1: ask "our backend" (the demo token server) for a short-lived
+      // subscriber token. The secret API key never reaches the browser.
+      const tokenResponse = await fetch("/api/upgrade-token", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ appUserId: purchases.getAppUserId() }),
+      });
+      if (!tokenResponse.ok) {
+        throw new Error(
+          `Token server error (${tokenResponse.status}): ${await tokenResponse.text()}`,
+        );
+      }
+      const { access_token: subscriberToken } = await tokenResponse.json();
+
+      // Step 2: perform the headless product change with the token.
+      const changeResult = await purchases.changeProduct({
+        newProductId,
+        subscriberToken,
+      });
+      setResult(changeResult);
+    } catch (e) {
+      if (e instanceof PurchasesError) {
+        setError(`PurchasesError: ${e.message} ${e.underlyingErrorMessage}`);
+      } else {
+        setError(String(e));
+      }
+    } finally {
+      setInProgress(false);
+    }
+  };
+
+  return (
+    <>
+      <LogoutButton />
+      <div className="rc-paywall">
+        <h1>Upgrade PoC (headless)</h1>
+
+        <p>
+          Current user: <code>{purchases.getAppUserId()}</code>
+        </p>
+        <p>
+          Active subscription product(s):{" "}
+          <code>
+            {activeProductIds.length > 0 ? activeProductIds.join(", ") : "none"}
+          </code>
+        </p>
+
+        {offeredProductIds.length > 0 && (
+          <p>
+            Products in current offering:{" "}
+            {offeredProductIds.map((identifier) => (
+              <button
+                key={identifier}
+                style={{ marginRight: "8px" }}
+                onClick={() => setNewProductId(identifier)}
+              >
+                {identifier}
+              </button>
+            ))}
+          </p>
+        )}
+
+        <p>
+          <label>
+            Change to product:{" "}
+            <input
+              type="text"
+              value={newProductId}
+              placeholder="target product identifier"
+              onChange={(event) => setNewProductId(event.target.value)}
+              style={{ width: "300px" }}
+            />
+          </label>
+        </p>
+
+        <button
+          className="button"
+          disabled={inProgress || !newProductId}
+          onClick={performUpgrade}
+        >
+          {inProgress ? "Changing..." : "Change subscription"}
+        </button>
+
+        {result && (
+          <div>
+            <h2>
+              {result.changeTiming === "immediate"
+                ? "Upgrade applied immediately"
+                : "Downgrade scheduled for next renewal"}
+            </h2>
+            <pre>{JSON.stringify(result, null, 2)}</pre>
+          </div>
+        )}
+
+        {error && (
+          <div>
+            <h2>Change failed</h2>
+            <pre>{error}</pre>
+          </div>
+        )}
+
+        <div className="notice">
+          This is a proof of concept. The token server must be running (
+          <code>npm run token-server</code>) and a product change path must be
+          configured between the current and target products.
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default UpgradePage;

--- a/examples/webbilling-demo/src/pages/upgrade/index.tsx
+++ b/examples/webbilling-demo/src/pages/upgrade/index.tsx
@@ -1,59 +1,79 @@
-import type { ProductChangeResult } from "@revenuecat/purchases-js";
 import { PurchasesError } from "@revenuecat/purchases-js";
 import React, { useState } from "react";
 import { usePurchasesLoaderData } from "../../util/PurchasesLoader";
-import LogoutButton from "../../components/LogoutButton";
+
+// Local mirror of the internal ProductChangeResult type — changeProduct is
+// @internal and excluded from the public .d.ts for now.
+type ProductChangeResult = {
+  operationSessionId: string;
+  changeType: "immediate" | "deferred";
+  newProductId: string;
+};
 
 /**
- * PoC page for headless subscription upgrades through the web purchase flow.
+ * Demo page for headless subscription product changes through the web SDK.
  *
- * It fetches a short-lived subscriber access token from the demo token server
+ * Fetches a short-lived subscriber access token from the demo token server
  * (which holds the secret API key, mimicking the developer's backend) and
  * then calls Purchases.changeProduct with it. No checkout UI is shown and no
  * payment details are collected: the change is applied to the customer's
  * existing subscription using the payment method on file.
  */
 const UpgradePage: React.FC = () => {
-  const { purchases, customerInfo, offering } = usePurchasesLoaderData();
+  const { purchases, customerInfo } = usePurchasesLoaderData();
   const [newProductId, setNewProductId] = useState("");
+  const [sourceProductId, setSourceProductId] = useState("");
   const [inProgress, setInProgress] = useState(false);
   const [result, setResult] = useState<ProductChangeResult | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const activeProductIds = Array.from(customerInfo.activeSubscriptions);
-  const offeredProductIds = (offering?.availablePackages ?? [])
-    .map((pkg) => pkg.webBillingProduct?.identifier)
-    .filter((identifier): identifier is string => Boolean(identifier));
+  const hasMultipleActiveSubscriptions = activeProductIds.length > 1;
 
-  const performUpgrade = async () => {
+  const canConfirm =
+    Boolean(newProductId) &&
+    (!hasMultipleActiveSubscriptions || Boolean(sourceProductId));
+
+  const performChange = async () => {
     setInProgress(true);
     setResult(null);
     setError(null);
 
     try {
-      // Step 1: ask "our backend" (the demo token server) for a short-lived
-      // subscriber token. The secret API key never reaches the browser.
+      // Ask the demo token server for a short-lived subscriber token.
       const tokenResponse = await fetch("/api/upgrade-token", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ appUserId: purchases.getAppUserId() }),
       });
       if (!tokenResponse.ok) {
+        const body = await tokenResponse.text();
         throw new Error(
-          `Token server error (${tokenResponse.status}): ${await tokenResponse.text()}`,
+          `Failed to mint subscriber token (${tokenResponse.status}). ` +
+            `Check the token server env and secret API key. ${body}`,
         );
       }
       const { access_token: subscriberToken } = await tokenResponse.json();
 
-      // Step 2: perform the headless product change with the token.
-      const changeResult = await purchases.changeProduct({
+      // Perform the product change with the token.
+      // @ts-expect-error changeProduct is marked as internal for now
+      const changeResult: ProductChangeResult = await purchases.changeProduct({
         newProductId,
         subscriberToken,
+        ...(sourceProductId ? { sourceProductId } : {}),
       });
       setResult(changeResult);
     } catch (e) {
       if (e instanceof PurchasesError) {
-        setError(`PurchasesError: ${e.message} ${e.underlyingErrorMessage}`);
+        const underlying = e.underlyingErrorMessage
+          ? `\n${e.underlyingErrorMessage}`
+          : "";
+        setError(
+          `${e.message}${underlying}\n\n` +
+            "Common causes: missing product change path (404), " +
+            "expired/invalid subscriber token (401), or multiple active " +
+            "subscriptions without sourceProductId.",
+        );
       } else {
         setError(String(e));
       }
@@ -64,9 +84,8 @@ const UpgradePage: React.FC = () => {
 
   return (
     <>
-      <LogoutButton />
       <div className="rc-paywall">
-        <h1>Upgrade PoC (headless)</h1>
+        <h1>Change subscription</h1>
 
         <p>
           Current user: <code>{purchases.getAppUserId()}</code>
@@ -77,21 +96,6 @@ const UpgradePage: React.FC = () => {
             {activeProductIds.length > 0 ? activeProductIds.join(", ") : "none"}
           </code>
         </p>
-
-        {offeredProductIds.length > 0 && (
-          <p>
-            Products in current offering:{" "}
-            {offeredProductIds.map((identifier) => (
-              <button
-                key={identifier}
-                style={{ marginRight: "8px" }}
-                onClick={() => setNewProductId(identifier)}
-              >
-                {identifier}
-              </button>
-            ))}
-          </p>
-        )}
 
         <p>
           <label>
@@ -106,18 +110,47 @@ const UpgradePage: React.FC = () => {
           </label>
         </p>
 
+        {hasMultipleActiveSubscriptions && (
+          <>
+            <p>
+              <label>
+                Source product (required — multiple active subscriptions):{" "}
+                <input
+                  type="text"
+                  value={sourceProductId}
+                  placeholder="product identifier to change from"
+                  onChange={(event) => setSourceProductId(event.target.value)}
+                  style={{ width: "300px" }}
+                />
+              </label>
+            </p>
+            <p>
+              {activeProductIds.map((identifier) => (
+                <button
+                  key={identifier}
+                  style={{ marginRight: "8px" }}
+                  onClick={() => setSourceProductId(identifier)}
+                >
+                  Use source: {identifier}
+                </button>
+              ))}
+            </p>
+          </>
+        )}
+
         <button
           className="button"
-          disabled={inProgress || !newProductId}
-          onClick={performUpgrade}
+          disabled={inProgress || !canConfirm}
+          onClick={performChange}
+          style={{ marginTop: "8px" }}
         >
-          {inProgress ? "Changing..." : "Change subscription"}
+          {inProgress ? "Changing..." : "Confirm change"}
         </button>
 
         {result && (
           <div>
             <h2>
-              {result.changeTiming === "immediate"
+              {result.changeType === "immediate"
                 ? "Upgrade applied immediately"
                 : "Downgrade scheduled for next renewal"}
             </h2>
@@ -133,9 +166,8 @@ const UpgradePage: React.FC = () => {
         )}
 
         <div className="notice">
-          This is a proof of concept. The token server must be running (
-          <code>npm run token-server</code>) and a product change path must be
-          configured between the current and target products.
+          Requires the token server (<code>npm run token-server</code>) and a
+          configured product change path between the source and target products.
         </div>
       </div>
     </>

--- a/examples/webbilling-demo/vite.config.ts
+++ b/examples/webbilling-demo/vite.config.ts
@@ -10,6 +10,11 @@ export default defineConfig({
   },
   server: {
     port: 3001,
+    proxy: {
+      // Forwards token requests to the standalone demo token server
+      // (server/index.mjs), which holds the secret API key.
+      "/api": "http://localhost:8010",
+    },
     fs: {
       allow: [".."],
     },

--- a/examples/webbilling-demo/vite.config.ts
+++ b/examples/webbilling-demo/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     port: 3001,
     proxy: {
       // Forwards token requests to the standalone demo token server
-      // (server/index.mjs), which holds the secret API key.
+      // (server/index.js), which holds the secret API key.
       "/api": "http://localhost:8010",
     },
     fs: {

--- a/src/entities/product-change-params.ts
+++ b/src/entities/product-change-params.ts
@@ -1,0 +1,40 @@
+/**
+ * Parameters for {@link Purchases.changeProduct}.
+ * @experimental
+ */
+export interface ChangeProductParams {
+  /**
+   * The product identifier of the Web Billing product to change the
+   * customer's current subscription to. A product change path from the
+   * current product to this product must be configured in RevenueCat.
+   */
+  newProductId: string;
+  /**
+   * A short-lived subscriber access token authenticating the current
+   * customer. This must be minted server-side using a secret API key via the
+   * RevenueCat Developer API `authenticate` endpoint, and passed to the
+   * browser. Never use a RevenueCat API key here.
+   */
+  subscriberToken: string;
+}
+
+/**
+ * Result of {@link Purchases.changeProduct}.
+ * @experimental
+ */
+export interface ProductChangeResult {
+  /**
+   * Identifier of the RC Billing operation session tracking the change.
+   */
+  operationSessionId: string;
+  /**
+   * Whether the change was applied immediately (upgrade, charged now with a
+   * prorated credit for unused time) or deferred to the end of the current
+   * billing cycle (downgrade).
+   */
+  changeTiming: "immediate" | "deferred";
+  /**
+   * The product identifier the subscription was (or will be) changed to.
+   */
+  newProductId: string;
+}

--- a/src/entities/product-change-params.ts
+++ b/src/entities/product-change-params.ts
@@ -1,6 +1,6 @@
 /**
  * Parameters for {@link Purchases.changeProduct}.
- * @experimental
+ * @internal
  */
 export interface ChangeProductParams {
   /**
@@ -16,11 +16,18 @@ export interface ChangeProductParams {
    * browser. Never use a RevenueCat API key here.
    */
   subscriberToken: string;
+  /**
+   * Optional product identifier of the subscription to change. Required when
+   * the customer has more than one active Web Billing subscription; if
+   * omitted and exactly one active subscription exists, that subscription is
+   * used.
+   */
+  sourceProductId?: string;
 }
 
 /**
  * Result of {@link Purchases.changeProduct}.
- * @experimental
+ * @internal
  */
 export interface ProductChangeResult {
   /**
@@ -30,9 +37,10 @@ export interface ProductChangeResult {
   /**
    * Whether the change was applied immediately (upgrade, charged now with a
    * prorated credit for unused time) or deferred to the end of the current
-   * billing cycle (downgrade).
+   * billing cycle (downgrade). Matches the configured product change path
+   * `change_type`.
    */
-  changeTiming: "immediate" | "deferred";
+  changeType: "immediate" | "deferred";
   /**
    * The product identifier the subscription was (or will be) changed to.
    */

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,10 @@ import {
   validateProxyUrl,
 } from "./helpers/configuration-validators";
 import { type PurchaseParams } from "./entities/purchase-params";
+import {
+  type ChangeProductParams,
+  type ProductChangeResult,
+} from "./entities/product-change-params";
 import { defaultHttpConfig, type HttpConfig } from "./entities/http-config";
 import {
   type GetOfferingsParams,
@@ -212,6 +216,10 @@ export type {
   PurchaseResponseAttributionMetadata,
   PurchaseParams,
 } from "./entities/purchase-params";
+export type {
+  ChangeProductParams,
+  ProductChangeResult,
+} from "./entities/product-change-params";
 export type { RedemptionInfo } from "./entities/redemption-info";
 export type {
   PurchaseResult,
@@ -2136,6 +2144,68 @@ export class Purchases {
       customerInfo: toCustomerInfo(result),
       wasCreated: result.was_created,
     };
+  }
+
+  /**
+   * Changes the current customer's active Web Billing subscription to a new
+   * product, following the product change paths configured in RevenueCat.
+   * Upgrades are applied immediately (charging the payment method on file,
+   * with a prorated credit for unused time); downgrades are deferred to the
+   * end of the current billing cycle.
+   *
+   * This is a headless operation: no UI is displayed and the customer does
+   * not re-enter payment details. The request is authenticated with a
+   * short-lived subscriber access token that your backend must mint with a
+   * secret API key via the RevenueCat Developer API `authenticate` endpoint.
+   *
+   * @param params - The {@link ChangeProductParams} for the change.
+   * @returns The {@link ProductChangeResult} describing the applied change.
+   * @throws {@link PurchasesError} if the token is invalid, no active Web
+   * Billing subscription exists, or no product change path is configured
+   * from the current product to the requested one.
+   * @experimental
+   */
+  public async changeProduct(
+    params: ChangeProductParams,
+  ): Promise<ProductChangeResult> {
+    const { newProductId, subscriberToken } = params;
+
+    this.validateSubscriberToken(subscriberToken);
+
+    const response = await this.backend.postSubscriptionChange(
+      newProductId,
+      subscriberToken,
+    );
+
+    return {
+      operationSessionId: response.operation_session_id,
+      changeTiming: response.change_timing,
+      newProductId: response.new_product_id,
+    };
+  }
+
+  /**
+   * Rejects anything shaped like a RevenueCat API key so a secret or public
+   * key is never sent (or exposed) where a subscriber token belongs.
+   */
+  private validateSubscriberToken(subscriberToken: string): void {
+    const looksLikeApiKey =
+      isWebBillingApiKey(subscriberToken) ||
+      isPaddleApiKey(subscriberToken) ||
+      isStripeApiKey(subscriberToken) ||
+      isSimulatedStoreApiKey(subscriberToken) ||
+      subscriberToken.startsWith("sk_");
+
+    if (looksLikeApiKey || !subscriberToken) {
+      throw new PurchasesError(
+        ErrorCode.ConfigurationError,
+        "Invalid subscriber token.",
+        "The subscriberToken must be a short-lived subscriber access token " +
+          "minted server-side with a secret API key via the RevenueCat " +
+          "Developer API authenticate endpoint. Never pass a RevenueCat API " +
+          "key from the browser.",
+      );
+    }
   }
 
   private async replaceUserId(newAppUserId: string): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2153,33 +2153,30 @@ export class Purchases {
    * with a prorated credit for unused time); downgrades are deferred to the
    * end of the current billing cycle.
    *
-   * This is a headless operation: no UI is displayed and the customer does
-   * not re-enter payment details. The request is authenticated with a
-   * short-lived subscriber access token that your backend must mint with a
-   * secret API key via the RevenueCat Developer API `authenticate` endpoint.
-   *
    * @param params - The {@link ChangeProductParams} for the change.
    * @returns The {@link ProductChangeResult} describing the applied change.
    * @throws {@link PurchasesError} if the token is invalid, no active Web
-   * Billing subscription exists, or no product change path is configured
-   * from the current product to the requested one.
-   * @experimental
+   * Billing subscription exists, multiple active subscriptions exist without
+   * {@link ChangeProductParams.sourceProductId}, or no product change path
+   * is configured from the current product to the requested one.
+   * @internal
    */
   public async changeProduct(
     params: ChangeProductParams,
   ): Promise<ProductChangeResult> {
-    const { newProductId, subscriberToken } = params;
+    const { newProductId, subscriberToken, sourceProductId } = params;
 
     this.validateSubscriberToken(subscriberToken);
 
     const response = await this.backend.postSubscriptionChange(
       newProductId,
       subscriberToken,
+      sourceProductId,
     );
 
     return {
       operationSessionId: response.operation_session_id,
-      changeTiming: response.change_timing,
+      changeType: response.change_type,
       newProductId: response.new_product_id,
     };
   }

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -394,26 +394,22 @@ export class Backend {
     );
   }
 
-  /**
-   * Changes the customer's Web Billing subscription to a new product,
-   * following the product change paths configured in RevenueCat.
-   *
-   * Unlike the other RC Billing calls, this request is authenticated with a
-   * short-lived subscriber access token (minted server-side by the developer
-   * via the Developer API `authenticate` endpoint) instead of the public API
-   * key, since it mutates an existing subscription.
-   */
   async postSubscriptionChange(
     newProductId: string,
     subscriberToken: string,
+    sourceProductId?: string,
   ): Promise<SubscriptionChangeResponse> {
     type SubscriptionChangeRequestBody = {
       new_product_id: string;
+      source_product_id?: string;
     };
 
     const requestBody: SubscriptionChangeRequestBody = {
       new_product_id: newProductId,
     };
+    if (sourceProductId !== undefined) {
+      requestBody.source_product_id = sourceProductId;
+    }
 
     return await performRequest<
       SubscriptionChangeRequestBody,

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -16,12 +16,14 @@ import {
   IdentifyEndpoint,
   PostReceiptEndpoint,
   SetAttributesEndpoint,
+  SubscriptionChangeEndpoint,
 } from "./endpoints";
 import { type SubscriberResponse } from "./responses/subscriber-response";
 import type { CheckoutStartResponse } from "./responses/checkout-start-response";
 import { type ProductsResponse } from "./responses/products-response";
 import { type BrandingInfoResponse } from "./responses/branding-response";
 import { type CheckoutStatusResponse } from "./responses/checkout-status-response";
+import { type SubscriptionChangeResponse } from "./responses/subscription-change-response";
 import { type VirtualCurrenciesResponse } from "./responses/virtual-currencies-response";
 import type {
   WorkflowDataAction,
@@ -390,6 +392,38 @@ export class Backend {
         httpConfig: this.httpConfig,
       },
     );
+  }
+
+  /**
+   * Changes the customer's Web Billing subscription to a new product,
+   * following the product change paths configured in RevenueCat.
+   *
+   * Unlike the other RC Billing calls, this request is authenticated with a
+   * short-lived subscriber access token (minted server-side by the developer
+   * via the Developer API `authenticate` endpoint) instead of the public API
+   * key, since it mutates an existing subscription.
+   */
+  async postSubscriptionChange(
+    newProductId: string,
+    subscriberToken: string,
+  ): Promise<SubscriptionChangeResponse> {
+    type SubscriptionChangeRequestBody = {
+      new_product_id: string;
+    };
+
+    const requestBody: SubscriptionChangeRequestBody = {
+      new_product_id: newProductId,
+    };
+
+    return await performRequest<
+      SubscriptionChangeRequestBody,
+      SubscriptionChangeResponse
+    >(new SubscriptionChangeEndpoint(), {
+      apiKey: this.API_KEY,
+      body: requestBody,
+      headers: { Authorization: `Bearer ${subscriberToken}` },
+      httpConfig: this.httpConfig,
+    });
   }
 
   async setAttributes(

--- a/src/networking/endpoints.ts
+++ b/src/networking/endpoints.ts
@@ -161,6 +161,15 @@ export class GetCheckoutStatusEndpoint implements Endpoint {
   }
 }
 
+export class SubscriptionChangeEndpoint implements Endpoint {
+  method: HttpMethodType = "POST";
+  name: string = "postSubscriptionChange";
+
+  urlPath(): string {
+    return `${RC_BILLING_PATH}/subscription/change`;
+  }
+}
+
 export class SetAttributesEndpoint implements Endpoint {
   method: HttpMethodType = "POST";
   name: string = "setAttributes";
@@ -237,6 +246,7 @@ export type SupportedEndpoint =
   | GetCustomerInfoEndpoint
   | GetBrandingInfoEndpoint
   | GetCheckoutStatusEndpoint
+  | SubscriptionChangeEndpoint
   | SetAttributesEndpoint
   | PostReceiptEndpoint
   | GetVirtualCurrenciesEndpoint

--- a/src/networking/responses/subscription-change-response.ts
+++ b/src/networking/responses/subscription-change-response.ts
@@ -1,0 +1,5 @@
+export interface SubscriptionChangeResponse {
+  operation_session_id: string;
+  change_timing: "immediate" | "deferred";
+  new_product_id: string;
+}

--- a/src/networking/responses/subscription-change-response.ts
+++ b/src/networking/responses/subscription-change-response.ts
@@ -1,5 +1,5 @@
 export interface SubscriptionChangeResponse {
   operation_session_id: string;
-  change_timing: "immediate" | "deferred";
+  change_type: "immediate" | "deferred";
   new_product_id: string;
 }

--- a/src/tests/change-product.test.ts
+++ b/src/tests/change-product.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+import { http, HttpResponse } from "msw";
+import { configurePurchases, server } from "./base.purchases_test";
+import { ErrorCode, PurchasesError } from "../entities/errors";
+import { expectPromiseToError } from "./test-helpers";
+
+describe("Purchases.changeProduct", () => {
+  const subscriptionChangeResponse = {
+    operation_session_id: "rcbopsess_test_id",
+    change_timing: "immediate",
+    new_product_id: "annual_product",
+  };
+
+  function setSubscriptionChangeResponse(httpResponse: HttpResponse) {
+    server.use(
+      http.post(
+        "http://localhost:8000/rcbilling/v1/subscription/change",
+        () => {
+          return httpResponse;
+        },
+      ),
+    );
+  }
+
+  test("performs the change and returns the mapped result", async () => {
+    setSubscriptionChangeResponse(
+      HttpResponse.json(subscriptionChangeResponse, { status: 201 }),
+    );
+    const purchases = configurePurchases();
+
+    const result = await purchases.changeProduct({
+      newProductId: "annual_product",
+      subscriberToken: "eyJhbGciOiJSUzI1NiJ9.subscriber.token",
+    });
+
+    expect(result).toEqual({
+      operationSessionId: "rcbopsess_test_id",
+      changeTiming: "immediate",
+      newProductId: "annual_product",
+    });
+  });
+
+  test.each([
+    "rcb_public_key_like",
+    "rcb_sb_sandbox_key_like",
+    "sk_secret_key_like",
+    "pdl_paddle_key_like",
+    "strp_stripe_key_like",
+    "",
+  ])(
+    "rejects tokens that look like API keys or are empty: '%s'",
+    async (badToken: string) => {
+      const purchases = configurePurchases();
+
+      await expectPromiseToError(
+        purchases.changeProduct({
+          newProductId: "annual_product",
+          subscriberToken: badToken,
+        }),
+        new PurchasesError(
+          ErrorCode.ConfigurationError,
+          "Invalid subscriber token.",
+          "The subscriberToken must be a short-lived subscriber access token " +
+            "minted server-side with a secret API key via the RevenueCat " +
+            "Developer API authenticate endpoint. Never pass a RevenueCat API " +
+            "key from the browser.",
+        ),
+      );
+    },
+  );
+});

--- a/src/tests/change-product.test.ts
+++ b/src/tests/change-product.test.ts
@@ -7,7 +7,7 @@ import { expectPromiseToError } from "./test-helpers";
 describe("Purchases.changeProduct", () => {
   const subscriptionChangeResponse = {
     operation_session_id: "rcbopsess_test_id",
-    change_timing: "immediate",
+    change_type: "immediate",
     new_product_id: "annual_product",
   };
 
@@ -35,8 +35,34 @@ describe("Purchases.changeProduct", () => {
 
     expect(result).toEqual({
       operationSessionId: "rcbopsess_test_id",
-      changeTiming: "immediate",
+      changeType: "immediate",
       newProductId: "annual_product",
+    });
+  });
+
+  test("sends sourceProductId when provided", async () => {
+    let requestBody: { new_product_id?: string; source_product_id?: string } =
+      {};
+    server.use(
+      http.post(
+        "http://localhost:8000/rcbilling/v1/subscription/change",
+        async ({ request }) => {
+          requestBody = (await request.json()) as typeof requestBody;
+          return HttpResponse.json(subscriptionChangeResponse, { status: 201 });
+        },
+      ),
+    );
+    const purchases = configurePurchases();
+
+    await purchases.changeProduct({
+      newProductId: "annual_product",
+      subscriberToken: "eyJhbGciOiJSUzI1NiJ9.subscriber.token",
+      sourceProductId: "monthly_product",
+    });
+
+    expect(requestBody).toEqual({
+      new_product_id: "annual_product",
+      source_product_id: "monthly_product",
     });
   });
 

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -1317,6 +1317,84 @@ describe("setAttributes request", () => {
   });
 });
 
+describe("postSubscriptionChange request", () => {
+  const subscriptionChangeResponse = {
+    operation_session_id: "rcbopsess_test_id",
+    change_timing: "immediate",
+    new_product_id: "annual_product",
+  };
+
+  function setSubscriptionChangeResponse(httpResponse: HttpResponse) {
+    server.use(
+      http.post(
+        "http://localhost:8000/rcbilling/v1/subscription/change",
+        () => {
+          return httpResponse;
+        },
+      ),
+    );
+  }
+
+  test("performs the change and returns the parsed response", async () => {
+    setSubscriptionChangeResponse(
+      HttpResponse.json(subscriptionChangeResponse, { status: 201 }),
+    );
+
+    let requestPerformed: Request | undefined;
+    server.events.on("request:start", (req) => {
+      requestPerformed = req.request;
+    });
+
+    const response = await backend.postSubscriptionChange(
+      "annual_product",
+      "subscriber-token-jwt",
+    );
+
+    expect(response).toEqual(subscriptionChangeResponse);
+    expect(requestPerformed).not.toBeUndefined();
+    const body = await requestPerformed?.json();
+    expect(body).toEqual({ new_product_id: "annual_product" });
+  });
+
+  test("authenticates with the subscriber token instead of the API key", async () => {
+    setSubscriptionChangeResponse(
+      HttpResponse.json(subscriptionChangeResponse, { status: 201 }),
+    );
+
+    let requestPerformed: Request | undefined;
+    server.events.on("request:start", (req) => {
+      requestPerformed = req.request;
+    });
+
+    await backend.postSubscriptionChange(
+      "annual_product",
+      "subscriber-token-jwt",
+    );
+
+    const headers = requestPerformed?.headers;
+    expect(headers?.get("Authorization")).toEqual(
+      "Bearer subscriber-token-jwt",
+    );
+    // Other SDK headers are still sent.
+    expect(headers?.get("X-Platform")).toEqual("web");
+  });
+
+  test("throws an error if the backend returns an error", async () => {
+    setSubscriptionChangeResponse(
+      HttpResponse.json({}, { status: StatusCodes.NOT_FOUND }),
+    );
+
+    await expectPromiseToError(
+      backend.postSubscriptionChange("annual_product", "subscriber-token-jwt"),
+      new PurchasesError(
+        ErrorCode.UnknownBackendError,
+        "Unknown backend error.",
+        "Request: postSubscriptionChange. Status code: 404. Body: {}.",
+      ),
+    );
+  });
+});
+
 describe("postReceipt request", () => {
   const postReceiptAPIMock = vi.fn();
 

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -1320,7 +1320,7 @@ describe("setAttributes request", () => {
 describe("postSubscriptionChange request", () => {
   const subscriptionChangeResponse = {
     operation_session_id: "rcbopsess_test_id",
-    change_timing: "immediate",
+    change_type: "immediate",
     new_product_id: "annual_product",
   };
 
@@ -1354,6 +1354,29 @@ describe("postSubscriptionChange request", () => {
     expect(requestPerformed).not.toBeUndefined();
     const body = await requestPerformed?.json();
     expect(body).toEqual({ new_product_id: "annual_product" });
+  });
+
+  test("includes source_product_id in the body when provided", async () => {
+    setSubscriptionChangeResponse(
+      HttpResponse.json(subscriptionChangeResponse, { status: 201 }),
+    );
+
+    let requestPerformed: Request | undefined;
+    server.events.on("request:start", (req) => {
+      requestPerformed = req.request;
+    });
+
+    await backend.postSubscriptionChange(
+      "annual_product",
+      "subscriber-token-jwt",
+      "monthly_product",
+    );
+
+    const body = await requestPerformed?.json();
+    expect(body).toEqual({
+      new_product_id: "annual_product",
+      source_product_id: "monthly_product",
+    });
   });
 
   test("authenticates with the subscriber token instead of the API key", async () => {


### PR DESCRIPTION
## Motivation / Description

#### Note I've marked the new method as internal, but I think we could forego putting it on `Purchases` entirely. Pros and cons I guess but open to thoughts on this!

#### Note I started under the PoC ticket but https://linear.app/revenuecat/issue/WEB-4511/sdk-implement-changeproduct-method and https://linear.app/revenuecat/issue/WEB-4512/sdk-locally-testable-upgrade-harness are now more accurate to the goal.

We want to support product changes via the web checkout. 

This PR calls the new endpoint added in https://github.com/RevenueCat/khepri/pull/23019 which supports making product changes from the checkout.

Additionally, this includes a testing harness - composed of a basic `node` backend, a new example webpage, and setup instructions.
  

## Changes introduced

https://github.com/user-attachments/assets/a749e62a-fde4-4c84-b915-fcd6dbe739e1


## Linear ticket (if any)

## Additional comments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subscription billing and auth (subscriber tokens vs API keys); mistakes could mis-authenticate or trigger unintended plan changes, though the API is internal and guarded by token validation.
> 
> **Overview**
> Adds an experimental, **@internal** `Purchases.changeProduct` API so Web Billing customers can switch subscription products without checkout UI, using a server-minted subscriber token and configured product change paths.
> 
> The SDK posts to `POST /rcbilling/v1/subscription/change` with `Authorization: Bearer <subscriberToken>` (not the public API key), maps `immediate` vs `deferred` results, and **rejects** values that look like RC API keys before the request is sent.
> 
> The **webbilling-demo** gains a separate token server (`pnpm run token-server`), Vite `/api` proxy, `/upgrade/:app_user_id` page, and README steps for the end-to-end PoC. Unit tests cover the client method and backend wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5127a5ac6f25d7a017adea1d38bfb703801f507. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->