### PR TITLE
Fix unbounded product detail request URLs

### DIFF
--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -42,7 +42,7 @@ import type { IdentifyResponse } from "./responses/identify-response";
 import type { CheckoutPrepareResponse } from "./responses/checkout-prepare-response";
 import type { AttributionMetadata } from "../entities/purchase-params";
 
-const MAX_GET_PRODUCTS_URL_PATH_LENGTH = 3500;
+const MAX_GET_PRODUCTS_URL_PATH_LENGTH = 2000;
 
 interface CheckoutStartRequestParams {
   // Purchase identity
@@ -165,27 +165,25 @@ export class Backend {
       discountCode,
     );
 
-    const responses = await Promise.all(
-      productIdBatches.map((productIdBatch) =>
-        performRequest<null, ProductsResponse>(
-          new GetProductsEndpoint(
-            appUserId,
-            productIdBatch,
-            currency,
-            discountCode,
-          ),
-          {
-            apiKey: this.API_KEY,
-            httpConfig: this.httpConfig,
-          },
+    const productDetails: ProductsResponse["product_details"] = [];
+    for (const productIdBatch of productIdBatches) {
+      const response = await performRequest<null, ProductsResponse>(
+        new GetProductsEndpoint(
+          appUserId,
+          productIdBatch,
+          currency,
+          discountCode,
         ),
-      ),
-    );
+        {
+          apiKey: this.API_KEY,
+          httpConfig: this.httpConfig,
+        },
+      );
+      productDetails.push(...response.product_details);
+    }
 
     return {
-      product_details: responses.flatMap(
-        (response) => response.product_details,
-      ),
+      product_details: productDetails,
     };
   }
 

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -42,6 +42,8 @@ import type { IdentifyResponse } from "./responses/identify-response";
 import type { CheckoutPrepareResponse } from "./responses/checkout-prepare-response";
 import type { AttributionMetadata } from "../entities/purchase-params";
 
+const MAX_GET_PRODUCTS_URL_PATH_LENGTH = 3500;
+
 interface CheckoutStartRequestParams {
   // Purchase identity
   appUserId: string;
@@ -155,13 +157,72 @@ export class Backend {
     currency?: string,
     discountCode?: string,
   ): Promise<ProductsResponse> {
-    return await performRequest<null, ProductsResponse>(
-      new GetProductsEndpoint(appUserId, productIds, currency, discountCode),
-      {
-        apiKey: this.API_KEY,
-        httpConfig: this.httpConfig,
-      },
+    const uniqueProductIds = Array.from(new Set(productIds));
+    const productIdBatches = this.batchProductIdsByUrlLength(
+      appUserId,
+      uniqueProductIds,
+      currency,
+      discountCode,
     );
+
+    const responses = await Promise.all(
+      productIdBatches.map((productIdBatch) =>
+        performRequest<null, ProductsResponse>(
+          new GetProductsEndpoint(
+            appUserId,
+            productIdBatch,
+            currency,
+            discountCode,
+          ),
+          {
+            apiKey: this.API_KEY,
+            httpConfig: this.httpConfig,
+          },
+        ),
+      ),
+    );
+
+    return {
+      product_details: responses.flatMap(
+        (response) => response.product_details,
+      ),
+    };
+  }
+
+  private batchProductIdsByUrlLength(
+    appUserId: string,
+    productIds: string[],
+    currency?: string,
+    discountCode?: string,
+  ): string[][] {
+    const batches: string[][] = [];
+    let currentBatch: string[] = [];
+
+    for (const productId of productIds) {
+      const candidateBatch = [...currentBatch, productId];
+      const candidateUrlLength = new GetProductsEndpoint(
+        appUserId,
+        candidateBatch,
+        currency,
+        discountCode,
+      ).urlPath().length;
+
+      if (
+        currentBatch.length > 0 &&
+        candidateUrlLength > MAX_GET_PRODUCTS_URL_PATH_LENGTH
+      ) {
+        batches.push(currentBatch);
+        currentBatch = [productId];
+      } else {
+        currentBatch = candidateBatch;
+      }
+    }
+
+    if (currentBatch.length > 0) {
+      batches.push(currentBatch);
+    }
+
+    return batches;
   }
 
   async getBrandingInfo(): Promise<BrandingInfoResponse> {

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -485,6 +485,31 @@ describe("getProducts request", () => {
     ).toEqual(["monthly", "monthly_2"]);
   });
 
+  test("returns an empty response without a request when there are no product IDs", async () => {
+    let requestCount = 0;
+    server.events.on("request:start", () => {
+      requestCount += 1;
+    });
+
+    const response = await backend.getProducts("someAppUserId", []);
+
+    expect(response).toEqual({ product_details: [] });
+    expect(requestCount).toBe(0);
+  });
+
+  test("handles an empty product details response", async () => {
+    setProductsResponse(
+      HttpResponse.json({ product_details: [] }, { status: 200 }),
+    );
+
+    const response = await backend.getProducts("someAppUserId", [
+      "monthly",
+      "monthly_2",
+    ]);
+
+    expect(response).toEqual({ product_details: [] });
+  });
+
   test("batches large product catalogues into bounded URLs", async () => {
     const productIds = Array.from(
       { length: 250 },
@@ -493,14 +518,24 @@ describe("getProducts request", () => {
     );
     const requestedBatches: string[][] = [];
     const requestedUrlLengths: number[] = [];
+    let activeRequests = 0;
+    let maximumConcurrentRequests = 0;
     server.use(
       http.get(
         "http://localhost:8000/rcbilling/v1/subscribers/someAppUserId/products",
-        ({ request }) => {
+        async ({ request }) => {
+          activeRequests += 1;
+          maximumConcurrentRequests = Math.max(
+            maximumConcurrentRequests,
+            activeRequests,
+          );
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
           const url = new URL(request.url);
           const requestedProductIds = url.searchParams.getAll("id");
           requestedBatches.push(requestedProductIds);
           requestedUrlLengths.push(`${url.pathname}${url.search}`.length);
+          activeRequests -= 1;
           return HttpResponse.json({
             product_details: requestedProductIds.map((identifier) => ({
               ...productsResponse.product_details[0],
@@ -514,11 +549,54 @@ describe("getProducts request", () => {
     const response = await backend.getProducts("someAppUserId", productIds);
 
     expect(requestedBatches.length).toBeGreaterThan(1);
-    expect(requestedUrlLengths.every((length) => length <= 3500)).toBe(true);
+    expect(requestedUrlLengths.every((length) => length <= 2000)).toBe(true);
+    expect(maximumConcurrentRequests).toBe(1);
     expect(requestedBatches.flat()).toEqual(productIds);
     expect(
       response.product_details.map(({ identifier }) => identifier),
     ).toEqual(productIds);
+  });
+
+  test("stops requesting batches when one batch fails", async () => {
+    const productIds = Array.from(
+      { length: 250 },
+      (_, index) =>
+        `product_${index.toString().padStart(4, "0")}_long_identifier`,
+    );
+    let requestCount = 0;
+    server.use(
+      http.get(
+        "http://localhost:8000/rcbilling/v1/subscribers/someAppUserId/products",
+        ({ request }) => {
+          requestCount += 1;
+          if (requestCount === 2) {
+            return HttpResponse.json(null, {
+              status: StatusCodes.INTERNAL_SERVER_ERROR,
+            });
+          }
+
+          const requestedProductIds = new URL(request.url).searchParams.getAll(
+            "id",
+          );
+          return HttpResponse.json({
+            product_details: requestedProductIds.map((identifier) => ({
+              ...productsResponse.product_details[0],
+              identifier,
+            })),
+          });
+        },
+      ),
+    );
+
+    await expectPromiseToError(
+      backend.getProducts("someAppUserId", productIds),
+      new PurchasesError(
+        ErrorCode.UnknownBackendError,
+        "Unknown backend error.",
+        "Request: getProducts. Status code: 500. Body: null.",
+      ),
+    );
+    expect(requestCount).toBe(2);
   });
 
   test("passes request with currency successfully", async () => {

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -454,6 +454,73 @@ describe("getProducts request", () => {
     ).toEqual(productsResponse);
   });
 
+  test("requests each product only once", async () => {
+    const requestedProductIds: string[] = [];
+    server.use(
+      http.get(
+        "http://localhost:8000/rcbilling/v1/subscribers/someAppUserId/products",
+        ({ request }) => {
+          const productIds = new URL(request.url).searchParams.getAll("id");
+          requestedProductIds.push(...productIds);
+          return HttpResponse.json({
+            product_details: productIds.map((identifier) => ({
+              ...productsResponse.product_details[0],
+              identifier,
+            })),
+          });
+        },
+      ),
+    );
+
+    const response = await backend.getProducts("someAppUserId", [
+      "monthly",
+      "monthly_2",
+      "monthly",
+      "monthly_2",
+    ]);
+
+    expect(requestedProductIds).toEqual(["monthly", "monthly_2"]);
+    expect(
+      response.product_details.map(({ identifier }) => identifier),
+    ).toEqual(["monthly", "monthly_2"]);
+  });
+
+  test("batches large product catalogues into bounded URLs", async () => {
+    const productIds = Array.from(
+      { length: 250 },
+      (_, index) =>
+        `product_${index.toString().padStart(4, "0")}_long_identifier`,
+    );
+    const requestedBatches: string[][] = [];
+    const requestedUrlLengths: number[] = [];
+    server.use(
+      http.get(
+        "http://localhost:8000/rcbilling/v1/subscribers/someAppUserId/products",
+        ({ request }) => {
+          const url = new URL(request.url);
+          const requestedProductIds = url.searchParams.getAll("id");
+          requestedBatches.push(requestedProductIds);
+          requestedUrlLengths.push(`${url.pathname}${url.search}`.length);
+          return HttpResponse.json({
+            product_details: requestedProductIds.map((identifier) => ({
+              ...productsResponse.product_details[0],
+              identifier,
+            })),
+          });
+        },
+      ),
+    );
+
+    const response = await backend.getProducts("someAppUserId", productIds);
+
+    expect(requestedBatches.length).toBeGreaterThan(1);
+    expect(requestedUrlLengths.every((length) => length <= 3500)).toBe(true);
+    expect(requestedBatches.flat()).toEqual(productIds);
+    expect(
+      response.product_details.map(({ identifier }) => identifier),
+    ).toEqual(productIds);
+  });
+
   test("passes request with currency successfully", async () => {
     setProductsResponse(
       HttpResponse.json(productsResponse, { status: 200 }),


### PR DESCRIPTION
## Summary

`getOfferings()` could send every package's product identifier in one product-details GET request. Products shared by multiple offerings appeared more than once, and catalogues with many unique products could produce a URL longer than the server accepts.

This change:

- removes duplicate product identifiers while preserving their order
- splits product lookups into requests whose URL paths stay below 2 KB
- sends multiple batches sequentially to avoid a burst of concurrent requests
- merges the product details from every response before building the offerings

## Compatibility

The public API and backend contract are unchanged. Currency and discount-code parameters are forwarded to every batch, and a failed batch continues to reject the overall product lookup.

Linear: [WEB-4528](https://linear.app/revenuecat/issue/WEB-4528/web-sdk-getofferings-builds-an-unbounded-duplicate-filled-product-url)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes product-fetch behavior for large/duplicate-heavy catalogs (more round trips, sequential latency) but fixes server URL limits; failure semantics remain fail-fast on any batch error.
> 
> **Overview**
> **`Backend.getProducts`** no longer sends every product ID in a single GET. It **deduplicates** IDs (first-seen order), **splits** them into batches whose `GetProductsEndpoint` URL path stays under **2000** characters, issues those requests **sequentially**, and **concatenates** `product_details` into one response. Empty ID lists return `{ product_details: [] }` without a network call; currency and discount code still apply to each batch, and a failed batch still fails the whole lookup.
> 
> Tests cover deduplication, no-request empty input, large-catalog batching (URL length and single concurrency), and aborting after a mid-batch error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d945f09b5169e1e369557d71b10c5b0e65a23f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->