### PR TITLE
feat(vega): add amazon api key validation

### DIFF
--- a/src/helpers/api-key-helper.ts
+++ b/src/helpers/api-key-helper.ts
@@ -2,6 +2,7 @@ const rc_api_key_regex = /^rcb_[a-zA-Z0-9_.-]+$/;
 const paddle_api_key_regex = /^pdl_[a-zA-Z0-9_.-]+$/;
 const rc_simulated_store_api_key_regex = /^test_[a-zA-Z0-9_.-]+$/;
 const stripe_api_key_regex = /^strp_[a-zA-Z0-9_.-]+$/;
+const amazon_api_key_regex = /^amzn_[a-zA-Z0-9_.-]+$/;
 
 export function isWebBillingSandboxApiKey(apiKey: string): boolean {
   return apiKey ? apiKey.startsWith("rcb_sb_") : false;
@@ -17,6 +18,10 @@ export function isPaddleApiKey(apiKey: string): boolean {
 
 export function isStripeApiKey(apiKey: string): boolean {
   return apiKey ? stripe_api_key_regex.test(apiKey) : false;
+}
+
+export function isAmazonApiKey(apiKey: string): boolean {
+  return apiKey ? amazon_api_key_regex.test(apiKey) : false;
 }
 
 export function isSimulatedStoreApiKey(apiKey: string): boolean {

--- a/src/helpers/configuration-validators.ts
+++ b/src/helpers/configuration-validators.ts
@@ -1,6 +1,7 @@
 import { ErrorCode, PurchasesError } from "../entities/errors";
 import { SDK_HEADERS } from "../networking/http-client";
 import {
+  isAmazonApiKey,
   isPaddleApiKey,
   isSimulatedStoreApiKey,
   isStripeApiKey,
@@ -12,7 +13,8 @@ export function validateApiKey(apiKey: string) {
     isWebBillingApiKey(apiKey) ||
     isSimulatedStoreApiKey(apiKey) ||
     isPaddleApiKey(apiKey) ||
-    isStripeApiKey(apiKey);
+    isStripeApiKey(apiKey) ||
+    isAmazonApiKey(apiKey);
 
   if (!isValidApiKey) {
     throw new PurchasesError(

--- a/src/tests/helpers/api-key-helper.test.ts
+++ b/src/tests/helpers/api-key-helper.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+import { isAmazonApiKey } from "../../helpers/api-key-helper";
+
+describe("isAmazonApiKey", () => {
+  test.each([
+    "amzn_key",
+    "amzn_key.with-dashes_and_underscores",
+    "amzn_1234567890",
+  ])("returns true for a valid Amazon API key: %s", (apiKey) => {
+    expect(isAmazonApiKey(apiKey)).toBe(true);
+  });
+
+  test.each([
+    "",
+    "amzn_",
+    "amzn_key with spaces",
+    "amzn_key/with/slashes",
+    "amzn_key!",
+    "goog_valid_key",
+    "appl_valid_key",
+    "galx_valid_key",
+    "test_valid_key",
+    "pdl_valid_key",
+    "rcb_valid_key",
+    "AMZN_valid_key",
+  ])("returns false for an invalid Amazon API key: %s", (apiKey) => {
+    expect(isAmazonApiKey(apiKey)).toBe(false);
+  });
+});

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -208,6 +208,24 @@ describe("Purchases.configure()", () => {
     ).not.toThrow();
   });
 
+  test("throws error if given invalid Amazon API key", () => {
+    expect(() =>
+      Purchases.configure({
+        apiKey: "amzn_test invalidchar",
+        appUserId: testUserId,
+      }),
+    ).toThrowError(PurchasesError);
+  });
+
+  test("does not throw error if given valid Amazon API key", () => {
+    expect(() =>
+      Purchases.configure({
+        apiKey: "amzn_valid_key",
+        appUserId: testUserId,
+      }),
+    ).not.toThrow();
+  });
+
   test("does not throw error if given valid web billing api key", () => {
     expect(() =>
       Purchases.configure({


### PR DESCRIPTION
## Motivation / Description
This is PR 1/X in a PR stack that introduces support for Amazon Vega IAP to the `purchases-js` SDK. Once approved, we won't merge this PR into `main` until the entire PR stack is complete with support for Amazon Vega IAPs in the SDK.

## Changes introduced

This PR introduces the ability for the `purchases-js` SDK to validate `amzn` API keys, along with unit tests to validate the new functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation-only change: Amazon keys can now pass configure. No purchase routing, auth, or network behavior is added yet.
> 
> **Overview**
> Allows `Purchases.configure` to accept Amazon Vega API keys (`amzn_…`) instead of rejecting them as invalid credentials.
> 
> Adds `isAmazonApiKey` (same prefix/charset pattern as other store keys) and includes it in `validateApiKey`. Unit tests cover helper matching and configure success/failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebc037b043eb973dbec9f455a7a46cae2a5d2de4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->