### PR TITLE
feat(vega): Lazily Load Vega SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,14 @@
     "check-version-consistency": "node scripts/check-version-consistency.mjs",
     "prepare": "husky"
   },
+  "peerDependencies": {
+    "@amazon-devices/keplerscript-appstore-iap-lib": "~2.12.10"
+  },
+  "peerDependenciesMeta": {
+    "@amazon-devices/keplerscript-appstore-iap-lib": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@babel/runtime": "^7.26.10",
     "@eslint/js": "^9.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,10 @@ settings:
 
 importers:
   .:
+    dependencies:
+      "@amazon-devices/keplerscript-appstore-iap-lib":
+        specifier: ~2.12.10
+        version: 2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))
     devDependencies:
       "@babel/runtime":
         specifier: ^7.26.10
@@ -33,7 +37,7 @@ importers:
         version: 8.6.15(react@18.3.1)(storybook@8.6.15(prettier@3.4.2))
       "@storybook/addon-svelte-csf":
         specifier: ^5.0.6
-        version: 5.0.8(@storybook/svelte@8.6.15(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4))(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1)))(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))
+        version: 5.0.8(@storybook/svelte@8.6.15(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4))(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)))(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))
       "@storybook/addon-viewport":
         specifier: ^8.5.2
         version: 8.6.4(storybook@8.6.15(prettier@3.4.2))
@@ -45,7 +49,7 @@ importers:
         version: 8.6.15(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4)
       "@storybook/sveltekit":
         specifier: ^8.6.15
-        version: 8.6.15(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1)))(postcss-load-config@3.1.4(postcss@8.5.3))(postcss@8.5.3)(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))
+        version: 8.6.15(@babel/core@7.29.7)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)))(postcss-load-config@3.1.4(postcss@8.5.3))(postcss@8.5.3)(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))
       "@storybook/test":
         specifier: ^8.6.15
         version: 8.6.15(storybook@8.6.15(prettier@3.4.2))
@@ -54,13 +58,13 @@ importers:
         version: 9.7.0
       "@sveltejs/vite-plugin-svelte":
         specifier: ^6.2.1
-        version: 6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))
+        version: 6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))
       "@testing-library/jest-dom":
         specifier: ^6.6.3
         version: 6.6.3
       "@testing-library/svelte":
         specifier: ^5.2.6
-        version: 5.2.7(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))(vitest@3.2.4(@types/node@22.10.5)(jsdom@25.0.1)(msw@2.7.0(@types/node@22.10.5)(typescript@5.8.2))(yaml@2.6.1))
+        version: 5.2.7(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))(vitest@3.2.4(@types/node@22.10.5)(jsdom@25.0.1)(msw@2.7.0(@types/node@22.10.5)(typescript@5.8.2))(terser@5.49.0)(yaml@2.6.1))
       "@tsconfig/svelte":
         specifier: ^5.0.4
         version: 5.0.4
@@ -156,13 +160,13 @@ importers:
         version: 11.0.5
       vite:
         specifier: ^6.4.1
-        version: 6.4.1(@types/node@22.10.5)(yaml@2.6.1)
+        version: 6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@22.10.5)(rollup@4.41.1)(typescript@5.8.2)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))
+        version: 4.5.4(@types/node@22.10.5)(rollup@4.41.1)(typescript@5.8.2)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.10.5)(jsdom@25.0.1)(msw@2.7.0(@types/node@22.10.5)(typescript@5.8.2))(yaml@2.6.1)
+        version: 3.2.4(@types/node@22.10.5)(jsdom@25.0.1)(msw@2.7.0(@types/node@22.10.5)(typescript@5.8.2))(terser@5.49.0)(yaml@2.6.1)
 
 packages:
   "@adobe/css-tools@4.4.1":
@@ -171,10 +175,199 @@ packages:
         integrity: sha512-12WGKBQzjUAI4ayyF4IAtfw2QR/IDoqk6jTddXDhtYTJF9ASmoE1zst7cVtP0aL/F1jUJL5r+JxKXKEgHNbEUQ==,
       }
 
+  "@amazon-devices/keplerscript-appstore-iap-lib@2.12.16":
+    resolution:
+      {
+        integrity: sha512-31Bjn9kaX2ThY7VcezVzEM4+khrLoq2qnEeOs0NkwYZ+VnSMXgTQwdpMlWKxjvKhcBdBD9ZUAPLlrLigNVqQag==,
+      }
+
+  "@amazon-devices/keplerscript-turbomodule-api@1.2.5":
+    resolution:
+      {
+        integrity: sha512-zg4vQ7iZLZkoajyjxYtGs293y3+FfpM5de63Xx6sPdIubNLh6Cjf5o7vxPnJ4+SnXOk4IlcSndnGIpJ7vtgJiw==,
+      }
+    hasBin: true
+
+  "@amazon-devices/react-native-kepler@2.0.9000000000":
+    resolution:
+      {
+        integrity: sha512-hjEkwYkTcQjaFhT3/TegnQarBJacPLU4XCdVBmgMLGLlJKhIRX/5WqvdCEM+8jQYQyHupBl8/DHe5diKkPwOPw==,
+      }
+    engines: { node: ">=16" }
+    hasBin: true
+    peerDependencies:
+      react: 18.2.0
+      react-native: 0.72.0
+
   "@babel/code-frame@7.26.2":
     resolution:
       {
         integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/code-frame@7.29.7":
+    resolution:
+      {
+        integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/compat-data@7.29.7":
+    resolution:
+      {
+        integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/core@7.29.7":
+    resolution:
+      {
+        integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/generator@7.29.7":
+    resolution:
+      {
+        integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-annotate-as-pure@7.29.7":
+    resolution:
+      {
+        integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-compilation-targets@7.29.7":
+    resolution:
+      {
+        integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-create-class-features-plugin@7.29.7":
+    resolution:
+      {
+        integrity: sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/helper-create-regexp-features-plugin@7.29.7":
+    resolution:
+      {
+        integrity: sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/helper-define-polyfill-provider@0.6.8":
+    resolution:
+      {
+        integrity: sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  "@babel/helper-environment-visitor@7.24.7":
+    resolution:
+      {
+        integrity: sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-function-name@7.24.7":
+    resolution:
+      {
+        integrity: sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-globals@7.29.7":
+    resolution:
+      {
+        integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-hoist-variables@7.24.7":
+    resolution:
+      {
+        integrity: sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-member-expression-to-functions@7.29.7":
+    resolution:
+      {
+        integrity: sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-module-imports@7.29.7":
+    resolution:
+      {
+        integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-module-transforms@7.29.7":
+    resolution:
+      {
+        integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/helper-optimise-call-expression@7.29.7":
+    resolution:
+      {
+        integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-plugin-utils@7.29.7":
+    resolution:
+      {
+        integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-remap-async-to-generator@7.29.7":
+    resolution:
+      {
+        integrity: sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/helper-replace-supers@7.29.7":
+    resolution:
+      {
+        integrity: sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/helper-skip-transparent-expression-wrappers@7.29.7":
+    resolution:
+      {
+        integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-split-export-declaration@7.24.7":
+    resolution:
+      {
+        integrity: sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -185,10 +378,45 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@babel/helper-string-parser@7.29.7":
+    resolution:
+      {
+        integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@babel/helper-validator-identifier@7.27.1":
     resolution:
       {
         integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-validator-identifier@7.29.7":
+    resolution:
+      {
+        integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-validator-option@7.29.7":
+    resolution:
+      {
+        integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-wrap-function@7.29.7":
+    resolution:
+      {
+        integrity: sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helpers@7.29.7":
+    resolution:
+      {
+        integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -200,6 +428,849 @@ packages:
     engines: { node: ">=6.0.0" }
     hasBin: true
 
+  "@babel/parser@7.29.7":
+    resolution:
+      {
+        integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==,
+      }
+    engines: { node: ">=6.0.0" }
+    hasBin: true
+
+  "@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.29.7":
+    resolution:
+      {
+        integrity: sha512-j8SrR0zLZrRsC09DlszEx8FpMiwukKffYXMK0d5LmOglO7vGG6sz/BR/20yHqWH+Lnn31JTt2PE3hIWNgM2J6w==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7":
+    resolution:
+      {
+        integrity: sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7":
+    resolution:
+      {
+        integrity: sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7":
+    resolution:
+      {
+        integrity: sha512-oBNVCvnO5tND+xSopWvV8WNGfpTfgP4Zr/YXXSj8zfmcPktp5Ku/aZlsIowgSD4fjmgHn6sGmB9APVsU5zOdhA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.29.7":
+    resolution:
+      {
+        integrity: sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.13.0
+
+  "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7":
+    resolution:
+      {
+        integrity: sha512-pn6QacGLgvCcwc+syUhKE/qSjV2D1IHDB84RNxWYSt1mW3K/SCtjinZ2p0cETJxAWBjPy3K/1lHwG5BjjPxNlw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-proposal-async-generator-functions@7.20.7":
+    resolution:
+      {
+        integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==,
+      }
+    engines: { node: ">=6.9.0" }
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-async-generator-functions instead.
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-proposal-class-properties@7.18.6":
+    resolution:
+      {
+        integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-proposal-export-default-from@7.29.7":
+    resolution:
+      {
+        integrity: sha512-p+G5BNXDcy3bOXplhY4HybQ1GxH3i2Tppmdm/3epyRu2VgJJZuUlZ61MqRTg582Q7ZLBdP7fePYvsumSEkMxcQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-proposal-nullish-coalescing-operator@7.18.6":
+    resolution:
+      {
+        integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==,
+      }
+    engines: { node: ">=6.9.0" }
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-proposal-numeric-separator@7.18.6":
+    resolution:
+      {
+        integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==,
+      }
+    engines: { node: ">=6.9.0" }
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-proposal-object-rest-spread@7.20.7":
+    resolution:
+      {
+        integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==,
+      }
+    engines: { node: ">=6.9.0" }
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-proposal-optional-catch-binding@7.18.6":
+    resolution:
+      {
+        integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==,
+      }
+    engines: { node: ">=6.9.0" }
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-catch-binding instead.
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-proposal-optional-chaining@7.21.0":
+    resolution:
+      {
+        integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==,
+      }
+    engines: { node: ">=6.9.0" }
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2":
+    resolution:
+      {
+        integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-async-generators@7.8.4":
+    resolution:
+      {
+        integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-class-properties@7.12.13":
+    resolution:
+      {
+        integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-dynamic-import@7.8.3":
+    resolution:
+      {
+        integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-export-default-from@7.29.7":
+    resolution:
+      {
+        integrity: sha512-foag0BB37ROhdeIX9O8G0jX7hw0UekJc04cHMrYLOnrErsnBKqJGHJ8eDRpoCFZBvEPPygmmtw4qyU97qa4oOw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-flow@7.29.7":
+    resolution:
+      {
+        integrity: sha512-ajMX6QPcyomotqwpzhkYGxcK2i/us0rs1Qo9QvUpa+Fca0FTmqrzKrctoIYLMxcOhGZldGT/BAVkRGTWBiR8gQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-import-assertions@7.29.7":
+    resolution:
+      {
+        integrity: sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-import-attributes@7.29.7":
+    resolution:
+      {
+        integrity: sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-jsx@7.29.7":
+    resolution:
+      {
+        integrity: sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-nullish-coalescing-operator@7.8.3":
+    resolution:
+      {
+        integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-numeric-separator@7.10.4":
+    resolution:
+      {
+        integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-object-rest-spread@7.8.3":
+    resolution:
+      {
+        integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-optional-catch-binding@7.8.3":
+    resolution:
+      {
+        integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-optional-chaining@7.8.3":
+    resolution:
+      {
+        integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-typescript@7.29.7":
+    resolution:
+      {
+        integrity: sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-unicode-sets-regex@7.18.6":
+    resolution:
+      {
+        integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-transform-arrow-functions@7.29.7":
+    resolution:
+      {
+        integrity: sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-async-generator-functions@7.29.7":
+    resolution:
+      {
+        integrity: sha512-d98gXZkgswvkyohMBABkhm3GeXhYj8psWfwQ2C7gtfrKGTykQa/iOIi+JJhwMjPlZ6Vm2XN+DCf3Es1EoG4ZLA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-async-to-generator@7.29.7":
+    resolution:
+      {
+        integrity: sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-block-scoped-functions@7.29.7":
+    resolution:
+      {
+        integrity: sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-block-scoping@7.29.7":
+    resolution:
+      {
+        integrity: sha512-ONyr4+AZhKh8yKWInVxU9AXA9EbsyeLcL6V0dJy6M2/62vuvpGm29zzuymbTpdc451GEpDIdAyPLP3r+P61yKQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-class-properties@7.29.7":
+    resolution:
+      {
+        integrity: sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-class-static-block@7.29.7":
+    resolution:
+      {
+        integrity: sha512-kibJgmEdX2iMwsHY2tSZNDgj8PwIlCQz7FK9KuGKO8zsuoUwSEhoNnNVp/emKWrbY4HeO6kkXfdMqRKKKXBm2A==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.12.0
+
+  "@babel/plugin-transform-classes@7.29.7":
+    resolution:
+      {
+        integrity: sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-computed-properties@7.29.7":
+    resolution:
+      {
+        integrity: sha512-RK7/IyU5phpuCdBAuig5VkzG/EnbDaui5SQGdU9BFrHdV+mV4cUjLMQ9lJDjLNtWHsqtiefpGZUXQP2BiTYMsA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-destructuring@7.29.7":
+    resolution:
+      {
+        integrity: sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-dotall-regex@7.29.7":
+    resolution:
+      {
+        integrity: sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-duplicate-keys@7.29.7":
+    resolution:
+      {
+        integrity: sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7":
+    resolution:
+      {
+        integrity: sha512-2wiIyo2BjtgU7HufSeDnL9L2O7zr8jmhFKuSr65VpRkUiRKRNpb0mdlk56+XPPKoIrfHqzbMuglDvZun0RISsA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-transform-dynamic-import@7.29.7":
+    resolution:
+      {
+        integrity: sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-explicit-resource-management@7.29.7":
+    resolution:
+      {
+        integrity: sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-exponentiation-operator@7.29.7":
+    resolution:
+      {
+        integrity: sha512-zFpMOTLZBdW5LfObqcSbL6kefg4R4eLdmvS0wbN9M6D5Mym/sKm9toOoWyVOa+xDjvCnuWcHls2YonXwHvH3CQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-export-namespace-from@7.29.7":
+    resolution:
+      {
+        integrity: sha512-24B2nOy2TeJSMheqwPD4DDQOV/elLSIlKxjZt4i05H5AgdPdWR3n18HnNrcJ+j76WJd9gbwb9jPjNYUy6RautA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-flow-strip-types@7.29.7":
+    resolution:
+      {
+        integrity: sha512-wRHeUjUjCZnMHmiO5bRgjFLcoEh7JyTdByOW11ahhwNa4V0bmeGEaIvt51yq0zQp2yWIpqfxXXPyUP6GFJZHOQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-for-of@7.29.7":
+    resolution:
+      {
+        integrity: sha512-zeSIHh0+E1Um1WJRXCFlHQYu2ieJNdivLLjlBEp+dIBu3S51n+SZZmIXjxnItw6pz56Cn+KvK68BIBVsxq2JiQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-function-name@7.29.7":
+    resolution:
+      {
+        integrity: sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-json-strings@7.29.7":
+    resolution:
+      {
+        integrity: sha512-RRnE2+eon1rJAq8MnoF1b5kTpY1vU88twHcvcKMrsqP/jxIRqDVs9iJB5fqPuqyeFAW0wJo4MlUIPpQCq/aRsg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-literals@7.29.7":
+    resolution:
+      {
+        integrity: sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-logical-assignment-operators@7.29.7":
+    resolution:
+      {
+        integrity: sha512-A0H91hh6W8MFRkp5TqJmMr39jzGD1A1E1Ysiv2O06Sfbhkapm+XyIzxWCEh5kqwOZ1/8QZ0dY3SeQ7XBqfJd5Q==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-member-expression-literals@7.29.7":
+    resolution:
+      {
+        integrity: sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-modules-amd@7.29.7":
+    resolution:
+      {
+        integrity: sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-modules-commonjs@7.29.7":
+    resolution:
+      {
+        integrity: sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-modules-systemjs@7.29.7":
+    resolution:
+      {
+        integrity: sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-modules-umd@7.29.7":
+    resolution:
+      {
+        integrity: sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-named-capturing-groups-regex@7.29.7":
+    resolution:
+      {
+        integrity: sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-transform-new-target@7.29.7":
+    resolution:
+      {
+        integrity: sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-nullish-coalescing-operator@7.29.7":
+    resolution:
+      {
+        integrity: sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-numeric-separator@7.29.7":
+    resolution:
+      {
+        integrity: sha512-zR7fv/z14OjgHl4AgRtkDBvBMhIzCxqV/qN/2BCRC7LjFwvuzjYe7gDWxC4Wl/SNsLM6SE1IWvRPYMgSJaUvNw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-object-rest-spread@7.29.7":
+    resolution:
+      {
+        integrity: sha512-Ld98jn4c0smUywL57m7SgsHq3OpThOa6LqZJif3G6jYOovPleoFhVrBJ1WegRApSFB2wu4+RelAj9AC9G08Z4A==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-object-super@7.29.7":
+    resolution:
+      {
+        integrity: sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-optional-catch-binding@7.29.7":
+    resolution:
+      {
+        integrity: sha512-sLsyndxK2VwX6yNUOakMb7Sh553ZTe/vVM1XJ+9Z5aW1ytsc8xOIwmyk05NNjN60vkc5/KqoTH6hB4V41LJhng==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-optional-chaining@7.29.7":
+    resolution:
+      {
+        integrity: sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-parameters@7.29.7":
+    resolution:
+      {
+        integrity: sha512-ZDOBqV/qLYJI0YElr8DcENEyARsFQeESqWXH6gZlghYXuPPjvweuDhP4VyEi4BlUBlLRFZVjxoZDMjxhLW766g==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-private-methods@7.29.7":
+    resolution:
+      {
+        integrity: sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-private-property-in-object@7.29.7":
+    resolution:
+      {
+        integrity: sha512-+BNo06dnrzdNNqCm1X6YUaVv0DKk8Q+JYcoZfOkLhYWNCXzlwTSRq8zGWayT1csjcpNXV9CQTBRRbmTLZac5cA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-property-literals@7.29.7":
+    resolution:
+      {
+        integrity: sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-react-display-name@7.29.7":
+    resolution:
+      {
+        integrity: sha512-+1wdDMGNb4UPeY3Q4L5yLiYe6TXPXubs4NjrgRFw13hPRLJfEMw2Q5OXkee6/IfdqePIeW4Jjwe3aBh7SdKz4Q==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-react-jsx-self@7.29.7":
+    resolution:
+      {
+        integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-react-jsx-source@7.29.7":
+    resolution:
+      {
+        integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-react-jsx@7.29.7":
+    resolution:
+      {
+        integrity: sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-regenerator@7.29.7":
+    resolution:
+      {
+        integrity: sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-regexp-modifiers@7.29.7":
+    resolution:
+      {
+        integrity: sha512-mB5Fs0VWrJ42ZCmc8114v60qetdaUVNkj9PmSZRmanCZM3S9hm0CFRLjRmYIsuXav14l2jvZ+4T8iiCGnhj3nQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-transform-reserved-words@7.29.7":
+    resolution:
+      {
+        integrity: sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-runtime@7.29.7":
+    resolution:
+      {
+        integrity: sha512-xmAscdE/AsqRW7vutbPNoUmu/nF5SrLKPs7aoJgEjo35lLKA/Bc0i2rMv/hr1+Y0o1bQCiVtith3u2vdgRL39Q==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-shorthand-properties@7.29.7":
+    resolution:
+      {
+        integrity: sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-spread@7.29.7":
+    resolution:
+      {
+        integrity: sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-sticky-regex@7.29.7":
+    resolution:
+      {
+        integrity: sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-template-literals@7.29.7":
+    resolution:
+      {
+        integrity: sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-typeof-symbol@7.29.7":
+    resolution:
+      {
+        integrity: sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-typescript@7.29.7":
+    resolution:
+      {
+        integrity: sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-unicode-escapes@7.29.7":
+    resolution:
+      {
+        integrity: sha512-jCfXxSjf94lf4E0hKE0AByxF6F3/pVFqRdUUNkDJhsY0m1ZKjnN6ZYyMeHNpzflxb/0q5b7t3p+BE+SLF1WOtA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-unicode-property-regex@7.29.7":
+    resolution:
+      {
+        integrity: sha512-OgZ+zoAJgZLUCunsTRQ5LAjOywDv5zzZ2/hQ5aMw1pGXyY2rtE8/chXYUmu3AlVHKpm10KEdG9aMwbI/K76ZGw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-unicode-regex@7.29.7":
+    resolution:
+      {
+        integrity: sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-unicode-sets-regex@7.29.7":
+    resolution:
+      {
+        integrity: sha512-BLOhLht9DOJwIxlmp91wHvkXv1lguuHS3/FwUO8HL1H0u8s4hR1gASVFyilu9iGtcTRYqjTZmlsFFeQletntEg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/preset-env@7.29.7":
+    resolution:
+      {
+        integrity: sha512-GYzX36n1nsciIb0uyH0GHwxwtNwPQIcpxSeiVLDtG/B7jB5xXgchnmL1f/jCX5o+pwnaDBtO60ONSJhEBJfxYA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/preset-flow@7.29.7":
+    resolution:
+      {
+        integrity: sha512-KYIRV0BuaN68CDdsqFkAD7MU7yipUqQNuNElwATdxaIdpTjhvtY82QvkBJs7zV3Evxj2jFAAZ1iO8nyy0nhjqA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/preset-modules@0.1.6-no-external-plugins":
+    resolution:
+      {
+        integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0 || ^8.0.0-0 <8.0.0
+
+  "@babel/preset-typescript@7.29.7":
+    resolution:
+      {
+        integrity: sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/register@7.29.7":
+    resolution:
+      {
+        integrity: sha512-AMGJoWuES861riy6pcB0fphE1YXybtQnBYQMuIyPv6mKLiosfa79BKTnAOyx215c/3RJPJpdQwoHZ3earVH7AA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
   "@babel/runtime@7.28.6":
     resolution:
       {
@@ -207,10 +1278,38 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@babel/template@7.29.7":
+    resolution:
+      {
+        integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/traverse@7.23.2":
+    resolution:
+      {
+        integrity: sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/traverse@7.29.7":
+    resolution:
+      {
+        integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@babel/types@7.28.4":
     resolution:
       {
         integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/types@7.29.7":
+    resolution:
+      {
+        integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -507,6 +1606,18 @@ packages:
         integrity: sha512-gHFUvv9f1fU2Piou/5Y7Sx5moYxcERbC7CXc6rkDLQTUBg5Dgg9L4u29/nHqfoQ3Y9R0h0BcOhd14uOEZIBP7Q==,
       }
 
+  "@hapi/hoek@9.3.0":
+    resolution:
+      {
+        integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==,
+      }
+
+  "@hapi/topo@5.1.0":
+    resolution:
+      {
+        integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==,
+      }
+
   "@humanwhocodes/config-array@0.13.0":
     resolution:
       {
@@ -590,6 +1701,61 @@ packages:
       }
     engines: { node: 20 || >=22 }
 
+  "@jest/create-cache-key-function@29.7.0":
+    resolution:
+      {
+        integrity: sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==,
+      }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  "@jest/environment@29.7.0":
+    resolution:
+      {
+        integrity: sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==,
+      }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  "@jest/fake-timers@29.7.0":
+    resolution:
+      {
+        integrity: sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==,
+      }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  "@jest/schemas@29.6.3":
+    resolution:
+      {
+        integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==,
+      }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  "@jest/types@26.6.2":
+    resolution:
+      {
+        integrity: sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==,
+      }
+    engines: { node: ">= 10.14.2" }
+
+  "@jest/types@27.5.1":
+    resolution:
+      {
+        integrity: sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==,
+      }
+    engines: { node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0 }
+
+  "@jest/types@29.6.3":
+    resolution:
+      {
+        integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==,
+      }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  "@jridgewell/gen-mapping@0.3.13":
+    resolution:
+      {
+        integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==,
+      }
+
   "@jridgewell/gen-mapping@0.3.8":
     resolution:
       {
@@ -617,6 +1783,12 @@ packages:
       }
     engines: { node: ">=6.0.0" }
 
+  "@jridgewell/source-map@0.3.11":
+    resolution:
+      {
+        integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==,
+      }
+
   "@jridgewell/sourcemap-codec@1.5.0":
     resolution:
       {
@@ -627,6 +1799,12 @@ packages:
     resolution:
       {
         integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==,
+      }
+
+  "@jridgewell/trace-mapping@0.3.31":
+    resolution:
+      {
+        integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
       }
 
   "@mdx-js/react@3.1.0":
@@ -721,6 +1899,194 @@ packages:
         integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==,
       }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
+
+  "@react-native-community/cli-clean@11.3.2":
+    resolution:
+      {
+        integrity: sha512-OIKeP8fYtaa9qw4bpf1m3WJDWx4GvcxTYkyycH5SDu+pZjYWNix7XtKhwoL3Ol2NJLWxdY4LnmQG1yy8OGeIRw==,
+      }
+
+  "@react-native-community/cli-clean@11.4.1":
+    resolution:
+      {
+        integrity: sha512-cwUbY3c70oBGv3FvQJWe2Qkq6m1+/dcEBonMDTYyH6i+6OrkzI4RkIGpWmbG1IS5JfE9ISUZkNL3946sxyWNkw==,
+      }
+
+  "@react-native-community/cli-config@11.3.2":
+    resolution:
+      {
+        integrity: sha512-hMAIR3QTjzDUmOSsbroXeNkZAcf8lpOGo1fj8CwJNfjuVho1RZZSlHKp8G7FU2sgqZmb8jWN+9tFvCRACXVYoQ==,
+      }
+
+  "@react-native-community/cli-config@11.4.1":
+    resolution:
+      {
+        integrity: sha512-sLdv1HFVqu5xNpeaR1+std0t7FFZaobpmpR0lFCOzKV7H/l611qS2Vo8zssmMK+oQbCs5JsX3SFPciODeIlaWA==,
+      }
+
+  "@react-native-community/cli-debugger-ui@11.3.2":
+    resolution:
+      {
+        integrity: sha512-pAKBcjrNl0iJoi42Ekqn3UH/QZ48pxfAIhsKkc3WmBqYetdByobhkYWfchHq3j9bilgiaBquPQaKzkg69kQw3w==,
+      }
+
+  "@react-native-community/cli-debugger-ui@11.4.1":
+    resolution:
+      {
+        integrity: sha512-+pgIjGNW5TrJF37XG3djIOzP+WNoPp67to/ggDhrshuYgpymfb9XpDVsURJugy0Sy3RViqb83kQNK765QzTIvw==,
+      }
+
+  "@react-native-community/cli-doctor@11.3.2":
+    resolution:
+      {
+        integrity: sha512-tvmAQzz+qOJwtBCVEdhHweMeGaoHauGn3ef4tsHyqlDc0fF1K5No9DGXSESlLHpsopg066sIHWGq0PmAIeChiA==,
+      }
+
+  "@react-native-community/cli-doctor@11.4.1":
+    resolution:
+      {
+        integrity: sha512-O6oPiRsl8pdkcyNktpzvJAXUqdocoY4jh7Tt7wA69B1JKCJA7aPCecwJgpUZb63ZYoxOtRtYM3BYQKzRMLIuUw==,
+      }
+
+  "@react-native-community/cli-hermes@11.3.2":
+    resolution:
+      {
+        integrity: sha512-IfzdYTjxu+BFEvweY9TXpLkOmWq0sxK8PTN+u0BduiT9cJRvcO0CxjOpLHAabVrSJc6o+7aLfEvogBmdN53Xfg==,
+      }
+
+  "@react-native-community/cli-hermes@11.4.1":
+    resolution:
+      {
+        integrity: sha512-1VAjwcmv+i9BJTMMVn5Grw7AcgURhTyfHVghJ1YgBE2euEJxPuqPKSxP54wBOQKnWUwsuDQAtQf+jPJoCxJSSA==,
+      }
+
+  "@react-native-community/cli-platform-android@11.3.2":
+    resolution:
+      {
+        integrity: sha512-NKxyBP0/gwL4/tNWrkevFSjeb7Dw2SByNfE9wFXBaAvZHxbxxJUjZOTOW3ueOXEpgOMU7IYYOiSOz2M10IRQ2A==,
+      }
+
+  "@react-native-community/cli-platform-android@11.4.1":
+    resolution:
+      {
+        integrity: sha512-VMmXWIzk0Dq5RAd+HIEa3Oe7xl2jso7+gOr6E2HALF4A3fCKUjKZQ6iK2t6AfnY04zftvaiKw6zUXtrfl52AVQ==,
+      }
+
+  "@react-native-community/cli-platform-ios@11.3.2":
+    resolution:
+      {
+        integrity: sha512-XPrfsI7dNY3f9crsKDDRIss+GHYX/snuYfMrjg4ZBHpYB5JdLepO8FJ5bFz+/s9KXDm045ijo8QFcIf3XJR0YQ==,
+      }
+
+  "@react-native-community/cli-platform-ios@11.4.1":
+    resolution:
+      {
+        integrity: sha512-RPhwn+q3IY9MpWc9w/Qmzv03mo8sXdah2eSZcECgweqD5SHWtOoRCUt11zM8jASpAQ8Tm5Je7YE9bHvdwGl4hA==,
+      }
+
+  "@react-native-community/cli-plugin-metro@11.3.2":
+    resolution:
+      {
+        integrity: sha512-r1rZYCFfxZWIiUlukjMcDlxfCtm+QNYu+vFyVfE9yvN9gaNPBAi9029eVzkRkFuJ8Rxwr67HnYEAdGYLWQ1uIw==,
+      }
+
+  "@react-native-community/cli-plugin-metro@11.4.1":
+    resolution:
+      {
+        integrity: sha512-JxbIqknYcQ5Z4rWROtu5LNakLfMiKoWcMoPqIrBLrV5ILm1XUJj1/8fATCcotZqV3yzB3SCJ3RrhKx7dQ3YELw==,
+      }
+
+  "@react-native-community/cli-server-api@11.3.2":
+    resolution:
+      {
+        integrity: sha512-6rMb37HYWOdmiMGCxsttHDLIP7KmcJjWvzTJzb2tm9P5FoMvSSmSOn981MuP835Lk1U+IdjVcwtsA247Im4mkg==,
+      }
+
+  "@react-native-community/cli-server-api@11.4.1":
+    resolution:
+      {
+        integrity: sha512-isxXE8X5x+C4kN90yilD08jaLWD34hfqTfn/Xbl1u/igtdTsCaQGvWe9eaFamrpWFWTpVtj6k+vYfy8AtYSiKA==,
+      }
+
+  "@react-native-community/cli-tools@11.3.2":
+    resolution:
+      {
+        integrity: sha512-rAnFPzRITeEhBLwC73ucvWsYjsGyotSOI4c+k8t9wUqcIk1Q+RFnuWozGc13msOPdESvBHt2MPJBwXrtKgKn1g==,
+      }
+
+  "@react-native-community/cli-tools@11.4.1":
+    resolution:
+      {
+        integrity: sha512-GuQIuY/kCPfLeXB1aiPZ5HvF+e/wdO42AYuNEmT7FpH/0nAhdTxA9qjL8m3vatDD2/YK7WNOSVNsl2UBZuOISg==,
+      }
+
+  "@react-native-community/cli-types@11.3.2":
+    resolution:
+      {
+        integrity: sha512-jba1Z1YgC4JIHPADSqpl4ATsrJaOja1zlQCbH/yE8McHRjVBzeYGeHIvG5jw7iU5cw6FFifH5vvr23JPGk8oyw==,
+      }
+
+  "@react-native-community/cli-types@11.4.1":
+    resolution:
+      {
+        integrity: sha512-B3q9A5BCneLDSoK/iSJ06MNyBn1qTxjdJeOgeS3MiCxgJpPcxyn/Yrc6+h0Cu9T9sgWj/dmectQPYWxtZeo5VA==,
+      }
+
+  "@react-native-community/cli@11.3.2":
+    resolution:
+      {
+        integrity: sha512-riyMvro6HH2NLUhcnjUrOFwi2IHb6/GOC1WKf7GvGH1L4KnIo/jP4Sk9QV+pROg1Gd9btrCTnyY7WbWuPWJJ3w==,
+      }
+    engines: { node: ">=16" }
+    hasBin: true
+
+  "@react-native-community/cli@11.4.1":
+    resolution:
+      {
+        integrity: sha512-NdAageVMtNhtvRsrq4NgJf5Ey2nA1CqmLvn7PhSawg+aIzMKmZuzWxGVwr9CoPGyjvNiqJlCWrLGR7NzOyi/sA==,
+      }
+    engines: { node: ">=16" }
+    hasBin: true
+
+  "@react-native/assets-registry@0.72.0":
+    resolution:
+      {
+        integrity: sha512-Im93xRJuHHxb1wniGhBMsxLwcfzdYreSZVQGDoMJgkd6+Iky61LInGEHnQCTN0fKNYF1Dvcofb4uMmE1RQHXHQ==,
+      }
+
+  "@react-native/codegen@0.72.8":
+    resolution:
+      {
+        integrity: sha512-jQCcBlXV7B7ap5VlHhwIPieYz89yiRgwd2FPUBu+unz+kcJ6pAiB2U8RdLDmyIs8fiWd+Vq1xxaWs4TR329/ng==,
+      }
+    peerDependencies:
+      "@babel/preset-env": ^7.1.6
+
+  "@react-native/gradle-plugin@0.72.11":
+    resolution:
+      {
+        integrity: sha512-P9iRnxiR2w7EHcZ0mJ+fmbPzMby77ZzV6y9sJI3lVLJzF7TLSdbwcQyD3lwMsiL+q5lKUHoZJS4sYmih+P2HXw==,
+      }
+
+  "@react-native/js-polyfills@0.72.1":
+    resolution:
+      {
+        integrity: sha512-cRPZh2rBswFnGt5X5EUEPs0r+pAsXxYsifv/fgy9ZLQokuT52bPH+9xjDR+7TafRua5CttGW83wP4TntRcWNDA==,
+      }
+
+  "@react-native/normalize-colors@0.72.0":
+    resolution:
+      {
+        integrity: sha512-285lfdqSXaqKuBbbtP9qL2tDrfxdOFtIMvkKadtleRQkdOxx+uzGvFr82KHmc/sSiMtfXGp7JnFYWVh4sFl7Yw==,
+      }
+
+  "@react-native/virtualized-lists@0.72.8":
+    resolution:
+      {
+        integrity: sha512-J3Q4Bkuo99k7mu+jPS9gSUSgq+lLRSI/+ahXNwV92XgJ/8UgOTxu2LPwhJnBk/sQKxq7E8WkZBnBiozukQMqrw==,
+      }
+    peerDependencies:
+      react-native: "*"
 
   "@revenuecat/purchases-ui-js@4.8.11":
     resolution:
@@ -977,6 +2343,42 @@ packages:
     resolution:
       {
         integrity: sha512-fTIQwLF+Qhuws31iw7Ncl1R3HUDtGwIipiJ9iU+UsDUwMhegFcQKQHd51nZjb7CArq0MvON8rbgCGQYWHUKAdg==,
+      }
+
+  "@sideway/address@4.1.5":
+    resolution:
+      {
+        integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==,
+      }
+
+  "@sideway/formula@3.0.1":
+    resolution:
+      {
+        integrity: sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==,
+      }
+
+  "@sideway/pinpoint@2.0.0":
+    resolution:
+      {
+        integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==,
+      }
+
+  "@sinclair/typebox@0.27.12":
+    resolution:
+      {
+        integrity: sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==,
+      }
+
+  "@sinonjs/commons@3.0.1":
+    resolution:
+      {
+        integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==,
+      }
+
+  "@sinonjs/fake-timers@10.3.0":
+    resolution:
+      {
+        integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==,
       }
 
   "@storybook/addon-actions@8.6.15":
@@ -1391,6 +2793,24 @@ packages:
         integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==,
       }
 
+  "@types/istanbul-lib-coverage@2.0.6":
+    resolution:
+      {
+        integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==,
+      }
+
+  "@types/istanbul-lib-report@3.0.3":
+    resolution:
+      {
+        integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==,
+      }
+
+  "@types/istanbul-reports@3.0.4":
+    resolution:
+      {
+        integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==,
+      }
+
   "@types/json-schema@7.0.15":
     resolution:
       {
@@ -1433,6 +2853,12 @@ packages:
         integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==,
       }
 
+  "@types/stack-utils@2.0.3":
+    resolution:
+      {
+        integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==,
+      }
+
   "@types/statuses@2.0.5":
     resolution:
       {
@@ -1461,6 +2887,30 @@ packages:
     resolution:
       {
         integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==,
+      }
+
+  "@types/yargs-parser@21.0.3":
+    resolution:
+      {
+        integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==,
+      }
+
+  "@types/yargs@15.0.20":
+    resolution:
+      {
+        integrity: sha512-KIkX+/GgfFitlASYCGoSF+T4XRXhOubJLhkLVtSfsRTe9jWMmuM2g28zQ41BtPTG7TRBb2xHW+LCNVE9QR/vsg==,
+      }
+
+  "@types/yargs@16.0.11":
+    resolution:
+      {
+        integrity: sha512-sbtvk8wDN+JvEdabmZExoW/HNr1cB7D/j4LT08rMiuikfA7m/JNJg7ATQcgzs34zHnoScDkY0ZRSl29Fkmk36g==,
+      }
+
+  "@types/yargs@17.0.35":
+    resolution:
+      {
+        integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==,
       }
 
   "@typescript-eslint/eslint-plugin@6.21.0":
@@ -1621,6 +3071,7 @@ packages:
       {
         integrity: sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==,
       }
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   "@vitest/expect@2.0.5":
     resolution:
@@ -1761,6 +3212,20 @@ packages:
         integrity: sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw==,
       }
 
+  abort-controller@3.0.0:
+    resolution:
+      {
+        integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==,
+      }
+    engines: { node: ">=6.5" }
+
+  accepts@1.3.8:
+    resolution:
+      {
+        integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==,
+      }
+    engines: { node: ">= 0.6" }
+
   acorn-jsx@5.3.2:
     resolution:
       {
@@ -1830,6 +3295,12 @@ packages:
         integrity: sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==,
       }
 
+  anser@1.4.10:
+    resolution:
+      {
+        integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==,
+      }
+
   ansi-colors@4.1.3:
     resolution:
       {
@@ -1851,6 +3322,19 @@ packages:
       }
     engines: { node: ">=18" }
 
+  ansi-fragments@0.2.1:
+    resolution:
+      {
+        integrity: sha512-DykbNHxuXQwUDRv5ibc2b0x7uw7wmwOGLBUd5RmaQ5z8Lhx19vwvKV+FAsM5rEA6dEcHxX+/Ad5s9eF2k2bB+w==,
+      }
+
+  ansi-regex@4.1.1:
+    resolution:
+      {
+        integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==,
+      }
+    engines: { node: ">=6" }
+
   ansi-regex@5.0.1:
     resolution:
       {
@@ -1864,6 +3348,13 @@ packages:
         integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==,
       }
     engines: { node: ">=12" }
+
+  ansi-styles@3.2.1:
+    resolution:
+      {
+        integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==,
+      }
+    engines: { node: ">=4" }
 
   ansi-styles@4.3.0:
     resolution:
@@ -1885,6 +3376,19 @@ packages:
         integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==,
       }
     engines: { node: ">=12" }
+
+  anymatch@3.1.3:
+    resolution:
+      {
+        integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==,
+      }
+    engines: { node: ">= 8" }
+
+  appdirsjs@1.2.7:
+    resolution:
+      {
+        integrity: sha512-Quji6+8kLBC3NnBeo14nPDq0+2jUs5s3/xEye+udFHumHhRk4M7aAMXp/PBJqkKYGuuyR9M/6Dq7d2AViiGmhw==,
+      }
 
   argparse@1.0.10:
     resolution:
@@ -1960,6 +3464,12 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  asap@2.0.6:
+    resolution:
+      {
+        integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==,
+      }
+
   assertion-error@2.0.1:
     resolution:
       {
@@ -1967,12 +3477,38 @@ packages:
       }
     engines: { node: ">=12" }
 
+  ast-types@0.15.2:
+    resolution:
+      {
+        integrity: sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==,
+      }
+    engines: { node: ">=4" }
+
   ast-types@0.16.1:
     resolution:
       {
         integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==,
       }
     engines: { node: ">=4" }
+
+  astral-regex@1.0.0:
+    resolution:
+      {
+        integrity: sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==,
+      }
+    engines: { node: ">=4" }
+
+  async-limiter@1.0.1:
+    resolution:
+      {
+        integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==,
+      }
+
+  async@3.2.6:
+    resolution:
+      {
+        integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==,
+      }
 
   asynckit@0.4.0:
     resolution:
@@ -1994,11 +3530,85 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  babel-core@7.0.0-bridge.0:
+    resolution:
+      {
+        integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  babel-plugin-polyfill-corejs2@0.4.17:
+    resolution:
+      {
+        integrity: sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  babel-plugin-polyfill-corejs3@0.13.0:
+    resolution:
+      {
+        integrity: sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  babel-plugin-polyfill-corejs3@0.14.2:
+    resolution:
+      {
+        integrity: sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  babel-plugin-polyfill-regenerator@0.6.8:
+    resolution:
+      {
+        integrity: sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0:
+    resolution:
+      {
+        integrity: sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==,
+      }
+
+  babel-plugin-transform-flow-enums@0.0.2:
+    resolution:
+      {
+        integrity: sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==,
+      }
+
+  babel-preset-fbjs@3.4.0:
+    resolution:
+      {
+        integrity: sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
   balanced-match@1.0.2:
     resolution:
       {
         integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
       }
+
+  base64-js@1.5.1:
+    resolution:
+      {
+        integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
+      }
+
+  baseline-browser-mapping@2.11.5:
+    resolution:
+      {
+        integrity: sha512-xJo6a6YZnwZfnyGmQKWMbVOcii7XRibjOskRh+WJ9UHQoX16xrQrcIgAMQOzfvs8XiLMx6ih/fsLPF73iY2D1A==,
+      }
+    engines: { node: ">=6.0.0" }
+    hasBin: true
 
   better-opn@3.0.2:
     resolution:
@@ -2006,6 +3616,12 @@ packages:
         integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==,
       }
     engines: { node: ">=12.0.0" }
+
+  bl@4.1.0:
+    resolution:
+      {
+        integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==,
+      }
 
   brace-expansion@1.1.11:
     resolution:
@@ -2032,12 +3648,38 @@ packages:
         integrity: sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==,
       }
 
+  browserslist@4.28.7:
+    resolution:
+      {
+        integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==,
+      }
+    engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
+    hasBin: true
+
+  bser@2.1.1:
+    resolution:
+      {
+        integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==,
+      }
+
   buffer-crc32@1.0.0:
     resolution:
       {
         integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==,
       }
     engines: { node: ">=8.0.0" }
+
+  buffer-from@1.1.2:
+    resolution:
+      {
+        integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==,
+      }
+
+  buffer@5.7.1:
+    resolution:
+      {
+        integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==,
+      }
 
   builtin-modules@3.3.0:
     resolution:
@@ -2051,6 +3693,13 @@ packages:
       {
         integrity: sha512-SW9lzGTLvWTP1AY8xeAMZimqDrIaSdLQUcVr9DMef51niJ022Ri87SwRRKYm4A6iHfkPaiVUu/Duw2Wc4J7kKg==,
       }
+
+  bytes@3.1.2:
+    resolution:
+      {
+        integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==,
+      }
+    engines: { node: ">= 0.8" }
 
   cac@6.7.14:
     resolution:
@@ -2080,6 +3729,27 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  caller-callsite@2.0.0:
+    resolution:
+      {
+        integrity: sha512-JuG3qI4QOftFsZyOn1qq87fq5grLIyk1JYd5lJmdA+fG7aQ9pA/i3JIJGcO3q0MrRcHlOt1U+ZeHW8Dq9axALQ==,
+      }
+    engines: { node: ">=4" }
+
+  caller-path@2.0.0:
+    resolution:
+      {
+        integrity: sha512-MCL3sf6nCSXOwCTzvPKhN18TU7AHTvdtam8DAogxcrJ8Rjfbbg7Lgng64H9Iy+vUV6VGFClN/TyxBkAebLRR4A==,
+      }
+    engines: { node: ">=4" }
+
+  callsites@2.0.0:
+    resolution:
+      {
+        integrity: sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ==,
+      }
+    engines: { node: ">=4" }
+
   callsites@3.1.0:
     resolution:
       {
@@ -2093,6 +3763,19 @@ packages:
         integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==,
       }
     engines: { node: ">=6" }
+
+  camelcase@6.3.0:
+    resolution:
+      {
+        integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==,
+      }
+    engines: { node: ">=10" }
+
+  caniuse-lite@1.0.30001806:
+    resolution:
+      {
+        integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==,
+      }
 
   chai@5.2.0:
     resolution:
@@ -2151,12 +3834,39 @@ packages:
       "@chromatic-com/playwright":
         optional: true
 
+  ci-info@2.0.0:
+    resolution:
+      {
+        integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==,
+      }
+
+  ci-info@3.9.0:
+    resolution:
+      {
+        integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==,
+      }
+    engines: { node: ">=8" }
+
+  cli-cursor@3.1.0:
+    resolution:
+      {
+        integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==,
+      }
+    engines: { node: ">=8" }
+
   cli-cursor@5.0.0:
     resolution:
       {
         integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==,
       }
     engines: { node: ">=18" }
+
+  cli-spinners@2.9.2:
+    resolution:
+      {
+        integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==,
+      }
+    engines: { node: ">=6" }
 
   cli-truncate@4.0.0:
     resolution:
@@ -2185,12 +3895,32 @@ packages:
       }
     engines: { node: ">=12" }
 
+  clone-deep@4.0.1:
+    resolution:
+      {
+        integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==,
+      }
+    engines: { node: ">=6" }
+
+  clone@1.0.4:
+    resolution:
+      {
+        integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==,
+      }
+    engines: { node: ">=0.8" }
+
   clsx@2.1.1:
     resolution:
       {
         integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==,
       }
     engines: { node: ">=6" }
+
+  color-convert@1.9.3:
+    resolution:
+      {
+        integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==,
+      }
 
   color-convert@2.0.1:
     resolution:
@@ -2199,10 +3929,22 @@ packages:
       }
     engines: { node: ">=7.0.0" }
 
+  color-name@1.1.3:
+    resolution:
+      {
+        integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==,
+      }
+
   color-name@1.1.4:
     resolution:
       {
         integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
+      }
+
+  colorette@1.4.0:
+    resolution:
+      {
+        integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==,
       }
 
   colorette@2.0.20:
@@ -2218,6 +3960,12 @@ packages:
       }
     engines: { node: ">= 0.8" }
 
+  command-exists@1.2.9:
+    resolution:
+      {
+        integrity: sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==,
+      }
+
   commander@12.1.0:
     resolution:
       {
@@ -2225,11 +3973,50 @@ packages:
       }
     engines: { node: ">=18" }
 
+  commander@2.13.0:
+    resolution:
+      {
+        integrity: sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==,
+      }
+
+  commander@2.20.3:
+    resolution:
+      {
+        integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==,
+      }
+
+  commander@9.5.0:
+    resolution:
+      {
+        integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==,
+      }
+    engines: { node: ^12.20.0 || >=14 }
+
+  commondir@1.0.1:
+    resolution:
+      {
+        integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==,
+      }
+
   compare-versions@6.1.1:
     resolution:
       {
         integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==,
       }
+
+  compressible@2.0.18:
+    resolution:
+      {
+        integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==,
+      }
+    engines: { node: ">= 0.6" }
+
+  compression@1.8.1:
+    resolution:
+      {
+        integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==,
+      }
+    engines: { node: ">= 0.8.0" }
 
   concat-map@0.0.1:
     resolution:
@@ -2249,12 +4036,44 @@ packages:
         integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==,
       }
 
+  connect@3.7.0:
+    resolution:
+      {
+        integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==,
+      }
+    engines: { node: ">= 0.10.0" }
+
+  convert-source-map@2.0.0:
+    resolution:
+      {
+        integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
+      }
+
   cookie@0.7.2:
     resolution:
       {
         integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==,
       }
     engines: { node: ">= 0.6" }
+
+  core-js-compat@3.49.0:
+    resolution:
+      {
+        integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==,
+      }
+
+  core-util-is@1.0.3:
+    resolution:
+      {
+        integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==,
+      }
+
+  cosmiconfig@5.2.1:
+    resolution:
+      {
+        integrity: sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==,
+      }
+    engines: { node: ">=4" }
 
   cross-spawn@7.0.6:
     resolution:
@@ -2318,11 +4137,28 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  dayjs@1.11.21:
+    resolution:
+      {
+        integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==,
+      }
+
   de-indent@1.0.2:
     resolution:
       {
         integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==,
       }
+
+  debug@2.6.9:
+    resolution:
+      {
+        integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==,
+      }
+    peerDependencies:
+      supports-color: "*"
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@3.2.7:
     resolution:
@@ -2397,6 +4233,12 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  defaults@1.0.4:
+    resolution:
+      {
+        integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==,
+      }
+
   define-data-property@1.1.4:
     resolution:
       {
@@ -2425,12 +4267,38 @@ packages:
       }
     engines: { node: ">=0.4.0" }
 
+  denodeify@1.2.1:
+    resolution:
+      {
+        integrity: sha512-KNTihKNmQENUZeKu5fzfpzRqR5S2VMp4gl9RFHiWzj9DfvYQPMJ6XHKNaQxaGCXwPk6y9yme3aUoaiAe+KX+vg==,
+      }
+
+  depd@2.0.0:
+    resolution:
+      {
+        integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==,
+      }
+    engines: { node: ">= 0.8" }
+
+  deprecated-react-native-prop-types@4.1.0:
+    resolution:
+      {
+        integrity: sha512-WfepZHmRbbdTvhcolb8aOKEvQdcmTMn5tKLbqbXmkBvjFjRVWAYqsXk/DBsV8TZxws8SdGHLuHaJrHSQUPRdfw==,
+      }
+
   dequal@2.0.3:
     resolution:
       {
         integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==,
       }
     engines: { node: ">=6" }
+
+  destroy@1.2.0:
+    resolution:
+      {
+        integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==,
+      }
+    engines: { node: ">= 0.8", npm: 1.2.8000 || >= 1.4.16 }
 
   detect-indent@6.1.0:
     resolution:
@@ -2523,6 +4391,18 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  ee-first@1.1.1:
+    resolution:
+      {
+        integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==,
+      }
+
+  electron-to-chromium@1.5.396:
+    resolution:
+      {
+        integrity: sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==,
+      }
+
   emoji-regex@10.4.0:
     resolution:
       {
@@ -2534,6 +4414,20 @@ packages:
       {
         integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
       }
+
+  encodeurl@1.0.2:
+    resolution:
+      {
+        integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==,
+      }
+    engines: { node: ">= 0.8" }
+
+  encodeurl@2.0.0:
+    resolution:
+      {
+        integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==,
+      }
+    engines: { node: ">= 0.8" }
 
   enquirer@2.4.1:
     resolution:
@@ -2555,12 +4449,39 @@ packages:
       }
     engines: { node: ">=0.12" }
 
+  envinfo@7.21.0:
+    resolution:
+      {
+        integrity: sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==,
+      }
+    engines: { node: ">=4" }
+    hasBin: true
+
   environment@1.1.0:
     resolution:
       {
         integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==,
       }
     engines: { node: ">=18" }
+
+  error-ex@1.3.4:
+    resolution:
+      {
+        integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==,
+      }
+
+  error-stack-parser@2.1.4:
+    resolution:
+      {
+        integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==,
+      }
+
+  errorhandler@1.5.2:
+    resolution:
+      {
+        integrity: sha512-kNAL7hESndBCrWwS72QyV3IVOTrVmj9D062FV5BQswNL5zEdeRmz/WJFyh6Aj/plvvSOrzddkxW57HgkZcR9Fw==,
+      }
+    engines: { node: ">= 0.8" }
 
   es-abstract@1.23.9:
     resolution:
@@ -2650,6 +4571,19 @@ packages:
         integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==,
       }
     engines: { node: ">=6" }
+
+  escape-html@1.0.3:
+    resolution:
+      {
+        integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==,
+      }
+
+  escape-string-regexp@2.0.0:
+    resolution:
+      {
+        integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==,
+      }
+    engines: { node: ">=8" }
 
   escape-string-regexp@4.0.0:
     resolution:
@@ -2952,11 +4886,32 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  etag@1.8.1:
+    resolution:
+      {
+        integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==,
+      }
+    engines: { node: ">= 0.6" }
+
+  event-target-shim@5.0.1:
+    resolution:
+      {
+        integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==,
+      }
+    engines: { node: ">=6" }
+
   eventemitter3@5.0.1:
     resolution:
       {
         integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==,
       }
+
+  execa@5.1.1:
+    resolution:
+      {
+        integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==,
+      }
+    engines: { node: ">=10" }
 
   execa@8.0.1:
     resolution:
@@ -3009,10 +4964,23 @@ packages:
         integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
       }
 
+  fast-xml-parser@4.5.7:
+    resolution:
+      {
+        integrity: sha512-a6Qh1RMCNbSrU1+sAyAAZH3rTe+OaWJbNZIq0S+ifZciUUOQtlVxBJwoTUE2bYhysmG/RYyI5WJFIKdBahJdrQ==,
+      }
+    hasBin: true
+
   fastq@1.18.0:
     resolution:
       {
         integrity: sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==,
+      }
+
+  fb-watchman@2.0.2:
+    resolution:
+      {
+        integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==,
       }
 
   fdir@6.4.5:
@@ -3039,6 +5007,27 @@ packages:
         integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==,
       }
     engines: { node: ">=8" }
+
+  finalhandler@1.1.2:
+    resolution:
+      {
+        integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==,
+      }
+    engines: { node: ">= 0.8" }
+
+  find-cache-dir@2.1.0:
+    resolution:
+      {
+        integrity: sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==,
+      }
+    engines: { node: ">=6" }
+
+  find-up@3.0.0:
+    resolution:
+      {
+        integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==,
+      }
+    engines: { node: ">=6" }
 
   find-up@4.1.0:
     resolution:
@@ -3067,6 +5056,19 @@ packages:
         integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==,
       }
 
+  flow-enums-runtime@0.0.5:
+    resolution:
+      {
+        integrity: sha512-PSZF9ZuaZD03sT9YaIs0FrGJ7lSUw7rHZIex+73UYVXg46eL/wxN5PaVcPJFudE2cJu5f0fezitV5aBkLHPUOQ==,
+      }
+
+  flow-parser@0.206.0:
+    resolution:
+      {
+        integrity: sha512-HVzoK3r6Vsg+lKvlIZzaWNBVai+FXTX1wdYhz/wVlH13tb/gOdLXmlTqy6odmTBhT5UoWUbq0k8263Qhr9d88w==,
+      }
+    engines: { node: ">=0.4.0" }
+
   for-each@0.3.3:
     resolution:
       {
@@ -3080,12 +5082,26 @@ packages:
       }
     engines: { node: ">= 6" }
 
+  fresh@0.5.2:
+    resolution:
+      {
+        integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==,
+      }
+    engines: { node: ">= 0.6" }
+
   fs-extra@11.3.2:
     resolution:
       {
         integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==,
       }
     engines: { node: ">=14.14" }
+
+  fs-extra@8.1.0:
+    resolution:
+      {
+        integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==,
+      }
+    engines: { node: ">=6 <7 || >=8" }
 
   fs.realpath@1.0.0:
     resolution:
@@ -3126,6 +5142,13 @@ packages:
         integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==,
       }
 
+  gensync@1.0.0-beta.2:
+    resolution:
+      {
+        integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==,
+      }
+    engines: { node: ">=6.9.0" }
+
   get-caller-file@2.0.5:
     resolution:
       {
@@ -3153,6 +5176,13 @@ packages:
         integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==,
       }
     engines: { node: ">= 0.4" }
+
+  get-stream@6.0.1:
+    resolution:
+      {
+        integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==,
+      }
+    engines: { node: ">=10" }
 
   get-stream@8.0.1:
     resolution:
@@ -3194,6 +5224,13 @@ packages:
         integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==,
       }
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  globals@11.12.0:
+    resolution:
+      {
+        integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==,
+      }
+    engines: { node: ">=4" }
 
   globals@13.24.0:
     resolution:
@@ -3310,6 +5347,37 @@ packages:
         integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==,
       }
 
+  hermes-estree@0.12.0:
+    resolution:
+      {
+        integrity: sha512-+e8xR6SCen0wyAKrMT3UD0ZCCLymKhRgjEB5sS28rKiFir/fXgLoeRilRUssFCILmGHb+OvHDUlhxs0+IEyvQw==,
+      }
+
+  hermes-estree@0.8.0:
+    resolution:
+      {
+        integrity: sha512-W6JDAOLZ5pMPMjEiQGLCXSSV7pIBEgRR5zGkxgmzGSXHOxqV5dC/M1Zevqpbm9TZDE5tu358qZf8Vkzmsc+u7Q==,
+      }
+
+  hermes-parser@0.12.0:
+    resolution:
+      {
+        integrity: sha512-d4PHnwq6SnDLhYl3LHNHvOg7nQ6rcI7QVil418REYksv0Mh3cEkHDcuhGxNQ3vgnLSLl4QSvDrFCwQNYdpWlzw==,
+      }
+
+  hermes-parser@0.8.0:
+    resolution:
+      {
+        integrity: sha512-yZKalg1fTYG5eOiToLUaw69rQfZq/fi+/NtEXRU7N87K/XobNRhRWorh80oSge2lWUiZfTgUvRJH+XgZWrhoqA==,
+      }
+
+  hermes-profile-transformer@0.0.6:
+    resolution:
+      {
+        integrity: sha512-cnN7bQUm65UWOy6cbGcCcZ3rpwW8Q/j4OP5aWRhEry4Z2t2aR1cjrbp0BS+KiBN0smvP1caBgAuxutvyvJILzQ==,
+      }
+    engines: { node: ">=8" }
+
   html-encoding-sniffer@4.0.0:
     resolution:
       {
@@ -3322,6 +5390,13 @@ packages:
       {
         integrity: sha512-+4f4RBFz7Rj2Hp0ZbFbXC+Kzbd6S9PgjiuFtdT76VMNgKogrEZy0pG2UrPycPbrZzVEIM5lAT3lAdkSTCHLPjg==,
       }
+
+  http-errors@2.0.1:
+    resolution:
+      {
+        integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==,
+      }
+    engines: { node: ">= 0.8" }
 
   http-proxy-agent@7.0.2:
     resolution:
@@ -3342,6 +5417,13 @@ packages:
         integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==,
       }
     engines: { node: ">= 14" }
+
+  human-signals@2.1.0:
+    resolution:
+      {
+        integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==,
+      }
+    engines: { node: ">=10.17.0" }
 
   human-signals@5.0.0:
     resolution:
@@ -3365,6 +5447,12 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  ieee754@1.2.1:
+    resolution:
+      {
+        integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==,
+      }
+
   ignore@4.0.6:
     resolution:
       {
@@ -3378,6 +5466,21 @@ packages:
         integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==,
       }
     engines: { node: ">= 4" }
+
+  image-size@1.2.1:
+    resolution:
+      {
+        integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==,
+      }
+    engines: { node: ">=16.x" }
+    hasBin: true
+
+  import-fresh@2.0.0:
+    resolution:
+      {
+        integrity: sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==,
+      }
+    engines: { node: ">=4" }
 
   import-fresh@3.3.0:
     resolution:
@@ -3427,6 +5530,18 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  invariant@2.2.4:
+    resolution:
+      {
+        integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==,
+      }
+
+  ip@1.1.9:
+    resolution:
+      {
+        integrity: sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==,
+      }
+
   is-arguments@1.2.0:
     resolution:
       {
@@ -3440,6 +5555,12 @@ packages:
         integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==,
       }
     engines: { node: ">= 0.4" }
+
+  is-arrayish@0.2.1:
+    resolution:
+      {
+        integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==,
+      }
 
   is-async-function@2.1.0:
     resolution:
@@ -3497,6 +5618,13 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  is-directory@0.3.1:
+    resolution:
+      {
+        integrity: sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==,
+      }
+    engines: { node: ">=0.10.0" }
+
   is-docker@2.2.1:
     resolution:
       {
@@ -3518,6 +5646,13 @@ packages:
         integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==,
       }
     engines: { node: ">= 0.4" }
+
+  is-fullwidth-code-point@2.0.0:
+    resolution:
+      {
+        integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==,
+      }
+    engines: { node: ">=4" }
 
   is-fullwidth-code-point@3.0.0:
     resolution:
@@ -3554,6 +5689,13 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  is-interactive@1.0.0:
+    resolution:
+      {
+        integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==,
+      }
+    engines: { node: ">=8" }
+
   is-map@2.0.3:
     resolution:
       {
@@ -3588,6 +5730,13 @@ packages:
       }
     engines: { node: ">=8" }
 
+  is-plain-object@2.0.4:
+    resolution:
+      {
+        integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==,
+      }
+    engines: { node: ">=0.10.0" }
+
   is-potential-custom-element-name@1.0.1:
     resolution:
       {
@@ -3621,6 +5770,13 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  is-stream@2.0.1:
+    resolution:
+      {
+        integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==,
+      }
+    engines: { node: ">=8" }
+
   is-stream@3.0.0:
     resolution:
       {
@@ -3649,6 +5805,13 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  is-unicode-supported@0.1.0:
+    resolution:
+      {
+        integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==,
+      }
+    engines: { node: ">=10" }
+
   is-weakmap@2.0.2:
     resolution:
       {
@@ -3670,12 +5833,25 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  is-wsl@1.1.0:
+    resolution:
+      {
+        integrity: sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==,
+      }
+    engines: { node: ">=4" }
+
   is-wsl@2.2.0:
     resolution:
       {
         integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==,
       }
     engines: { node: ">=8" }
+
+  isarray@1.0.0:
+    resolution:
+      {
+        integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==,
+      }
 
   isarray@2.0.5:
     resolution:
@@ -3689,10 +5865,86 @@ packages:
         integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
       }
 
+  isobject@3.0.1:
+    resolution:
+      {
+        integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  jest-environment-node@29.7.0:
+    resolution:
+      {
+        integrity: sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==,
+      }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-get-type@29.6.3:
+    resolution:
+      {
+        integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==,
+      }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-message-util@29.7.0:
+    resolution:
+      {
+        integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==,
+      }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-mock@29.7.0:
+    resolution:
+      {
+        integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==,
+      }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-regex-util@27.5.1:
+    resolution:
+      {
+        integrity: sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==,
+      }
+    engines: { node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0 }
+
+  jest-util@27.5.1:
+    resolution:
+      {
+        integrity: sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==,
+      }
+    engines: { node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0 }
+
+  jest-util@29.7.0:
+    resolution:
+      {
+        integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==,
+      }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-validate@29.7.0:
+    resolution:
+      {
+        integrity: sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==,
+      }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  jest-worker@27.5.1:
+    resolution:
+      {
+        integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==,
+      }
+    engines: { node: ">= 10.13.0" }
+
   jju@1.4.0:
     resolution:
       {
         integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==,
+      }
+
+  joi@17.13.4:
+    resolution:
+      {
+        integrity: sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==,
       }
 
   js-tokens@4.0.0:
@@ -3707,12 +5959,40 @@ packages:
         integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==,
       }
 
+  js-yaml@3.15.0:
+    resolution:
+      {
+        integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==,
+      }
+    hasBin: true
+
   js-yaml@4.1.1:
     resolution:
       {
         integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
       }
     hasBin: true
+
+  jsc-android@250231.0.0:
+    resolution:
+      {
+        integrity: sha512-rS46PvsjYmdmuz1OAWXY/1kCYG7pnf1TBqeTiOJr1iDz7s5DLxxC9n/ZMknLDxzYzNVfI7R95MH10emSSG1Wuw==,
+      }
+
+  jsc-safe-url@0.2.4:
+    resolution:
+      {
+        integrity: sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==,
+      }
+
+  jscodeshift@0.14.0:
+    resolution:
+      {
+        integrity: sha512-7eCC1knD7bLUPuSCwXsMZUH51O8jIcoVyKtI6P0XM0IVzlGjckPy3FIwQlorzbN0Sg79oK+RlohN32Mqf/lrYA==,
+      }
+    hasBin: true
+    peerDependencies:
+      "@babel/preset-env": ^7.1.6
 
   jsdoc-type-pratt-parser@4.1.0:
     resolution:
@@ -3733,10 +6013,24 @@ packages:
       canvas:
         optional: true
 
+  jsesc@3.1.0:
+    resolution:
+      {
+        integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==,
+      }
+    engines: { node: ">=6" }
+    hasBin: true
+
   json-buffer@3.0.1:
     resolution:
       {
         integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==,
+      }
+
+  json-parse-better-errors@1.0.2:
+    resolution:
+      {
+        integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==,
       }
 
   json-schema-traverse@0.4.1:
@@ -3764,6 +6058,20 @@ packages:
       }
     hasBin: true
 
+  json5@2.2.3:
+    resolution:
+      {
+        integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==,
+      }
+    engines: { node: ">=6" }
+    hasBin: true
+
+  jsonfile@4.0.0:
+    resolution:
+      {
+        integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==,
+      }
+
   jsonfile@6.2.0:
     resolution:
       {
@@ -3776,6 +6084,20 @@ packages:
         integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==,
       }
 
+  kind-of@6.0.3:
+    resolution:
+      {
+        integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  kleur@3.0.3:
+    resolution:
+      {
+        integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==,
+      }
+    engines: { node: ">=6" }
+
   known-css-properties@0.35.0:
     resolution:
       {
@@ -3787,6 +6109,13 @@ packages:
       {
         integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==,
       }
+
+  leven@3.1.0:
+    resolution:
+      {
+        integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==,
+      }
+    engines: { node: ">=6" }
 
   levn@0.4.1:
     resolution:
@@ -3843,6 +6172,13 @@ packages:
         integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==,
       }
 
+  locate-path@3.0.0:
+    resolution:
+      {
+        integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==,
+      }
+    engines: { node: ">=6" }
+
   locate-path@5.0.0:
     resolution:
       {
@@ -3857,10 +6193,22 @@ packages:
       }
     engines: { node: ">=10" }
 
+  lodash.debounce@4.0.8:
+    resolution:
+      {
+        integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==,
+      }
+
   lodash.merge@4.6.2:
     resolution:
       {
         integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==,
+      }
+
+  lodash.throttle@4.1.1:
+    resolution:
+      {
+        integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==,
       }
 
   lodash@4.17.23:
@@ -3869,12 +6217,26 @@ packages:
         integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==,
       }
 
+  log-symbols@4.1.0:
+    resolution:
+      {
+        integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==,
+      }
+    engines: { node: ">=10" }
+
   log-update@6.1.0:
     resolution:
       {
         integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==,
       }
     engines: { node: ">=18" }
+
+  logkitty@0.7.1:
+    resolution:
+      {
+        integrity: sha512-/3ER20CTTbahrCrpYfPn7Xavv9diBROZpoXGVZDWMw4b/X4uuUwAC0ki85tgsdMRONURyIJbcOvS94QsUBYPbQ==,
+      }
+    hasBin: true
 
   loose-envify@1.4.0:
     resolution:
@@ -3893,6 +6255,12 @@ packages:
     resolution:
       {
         integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==,
+      }
+
+  lru-cache@5.1.1:
+    resolution:
+      {
+        integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
       }
 
   lru-cache@6.0.0:
@@ -3921,6 +6289,19 @@ packages:
         integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==,
       }
 
+  make-dir@2.1.0:
+    resolution:
+      {
+        integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==,
+      }
+    engines: { node: ">=6" }
+
+  makeerror@1.0.12:
+    resolution:
+      {
+        integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==,
+      }
+
   map-or-similar@1.5.0:
     resolution:
       {
@@ -3947,6 +6328,12 @@ packages:
         integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==,
       }
 
+  memoize-one@5.2.1:
+    resolution:
+      {
+        integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==,
+      }
+
   memoizerific@1.11.3:
     resolution:
       {
@@ -3965,6 +6352,274 @@ packages:
         integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==,
       }
     engines: { node: ">= 8" }
+
+  metro-babel-transformer@0.76.5:
+    resolution:
+      {
+        integrity: sha512-KmsMXY6VHjPLRQLwTITjLo//7ih8Ts39HPF2zODkaYav/ZLNq0QP7eGuW54dvk/sZiL9le1kaBwTN4BWQI1VZQ==,
+      }
+    engines: { node: ">=16" }
+
+  metro-babel-transformer@0.76.9:
+    resolution:
+      {
+        integrity: sha512-dAnAmBqRdTwTPVn4W4JrowPolxD1MDbuU97u3MqtWZgVRvDpmr+Cqnn5oSxLQk3Uc+Zy3wkqVrB/zXNRlLDSAQ==,
+      }
+    engines: { node: ">=16" }
+
+  metro-cache-key@0.76.5:
+    resolution:
+      {
+        integrity: sha512-QERX6ejYMt4BPr0ZMf7adnrOivmFSUbCim9FlU6cAeWUib+pV5P/Ph3KicWnOzJpbQz93+tHHG7vcsP6OrvLMw==,
+      }
+    engines: { node: ">=16" }
+
+  metro-cache-key@0.76.9:
+    resolution:
+      {
+        integrity: sha512-ugJuYBLngHVh1t2Jj+uP9pSCQl7enzVXkuh6+N3l0FETfqjgOaSHlcnIhMPn6yueGsjmkiIfxQU4fyFVXRtSTw==,
+      }
+    engines: { node: ">=16" }
+
+  metro-cache@0.76.5:
+    resolution:
+      {
+        integrity: sha512-8XalhoMNWDK6bi41oqxIpecTYRt4WsmtoHdqshgJIYshJ6qov0NuDw0pOfnS8rgMNHxPpuWyXc7NyKERqVRzaw==,
+      }
+    engines: { node: ">=16" }
+
+  metro-cache@0.76.9:
+    resolution:
+      {
+        integrity: sha512-W6QFEU5AJG1gH4Ltv8S2IvhmEhSDYnbPafyj5fGR3YLysdykj+olKv9B0V+YQXtcLGyY5CqpXLYUx595GdiKzA==,
+      }
+    engines: { node: ">=16" }
+
+  metro-config@0.76.5:
+    resolution:
+      {
+        integrity: sha512-SCMVIDOtm8s3H62E9z2IcY4Q9GVMqDurbiJS3PHrWgTZjwZFaL59lrW4W6DvzvFZHa9bbxKric5TFtwvVuyOCg==,
+      }
+    engines: { node: ">=16" }
+
+  metro-config@0.76.9:
+    resolution:
+      {
+        integrity: sha512-oYyJ16PY3rprsfoi80L+gDJhFJqsKI3Pob5LKQbJpvL+gGr8qfZe1eQzYp5Xxxk9DOHKBV1xD94NB8GdT/DA8Q==,
+      }
+    engines: { node: ">=16" }
+
+  metro-core@0.76.5:
+    resolution:
+      {
+        integrity: sha512-yJvIe8a3sAG92U7+E7Bw6m4lae9RB180fp9iQZFBqY437Ilv4nE6PR8EWB6d8c4yt9fXIL1Hc+KyQv7OPFx/rQ==,
+      }
+    engines: { node: ">=16" }
+
+  metro-core@0.76.9:
+    resolution:
+      {
+        integrity: sha512-DSeEr43Wrd5Q7ySfRzYzDwfV89g2OZTQDf1s3exOcLjE5fb7awoLOkA2h46ZzN8NcmbbM0cuJy6hOwF073/yRQ==,
+      }
+    engines: { node: ">=16" }
+
+  metro-file-map@0.76.5:
+    resolution:
+      {
+        integrity: sha512-9VS7zsec7BpTb+0v1DObOXso6XU/7oVBObQWp0EWBQpFcU1iF1lit2nnLQh2AyGCnSr8JVnuUe8gXhNH6xtPMg==,
+      }
+    engines: { node: ">=16" }
+
+  metro-file-map@0.76.9:
+    resolution:
+      {
+        integrity: sha512-7vJd8kksMDTO/0fbf3081bTrlw8SLiploeDf+vkkf0OwlrtDUWPOikfebp+MpZB2S61kamKjCNRfRkgrbPfSwg==,
+      }
+    engines: { node: ">=16" }
+
+  metro-inspector-proxy@0.76.5:
+    resolution:
+      {
+        integrity: sha512-leqwei1qNMKOEbhqlQ37K+7OIp1JRgvS5qERO+J0ZTg7ZeJTaBHSFU7FnCeRHB9Tu7/FSfypY2PxjydZDwvUEQ==,
+      }
+    engines: { node: ">=16" }
+    hasBin: true
+
+  metro-inspector-proxy@0.76.9:
+    resolution:
+      {
+        integrity: sha512-idIiPkb8CYshc0WZmbzwmr4B1QwsQUbpDwBzHwxE1ni27FWKWhV9CD5p+qlXZHgfwJuMRfPN+tIaLSR8+vttYg==,
+      }
+    engines: { node: ">=16" }
+    hasBin: true
+
+  metro-minify-terser@0.76.5:
+    resolution:
+      {
+        integrity: sha512-zizTXqlHcG7PArB5hfz1Djz/oCaOaTSXTZDNp8Y9K2FmmfLU3dU2eoDbNNiCnm5QdDtFIndLMXdqqe6omTfp4g==,
+      }
+    engines: { node: ">=16" }
+
+  metro-minify-terser@0.76.9:
+    resolution:
+      {
+        integrity: sha512-ju2nUXTKvh96vHPoGZH/INhSvRRKM14CbGAJXQ98+g8K5z1v3luYJ/7+dFQB202eVzJdTB2QMtBjI1jUUpooCg==,
+      }
+    engines: { node: ">=16" }
+
+  metro-minify-uglify@0.76.5:
+    resolution:
+      {
+        integrity: sha512-JZNO5eK8r625/cheWSl+y7n0RlHLt03iSMgXPAxirH8BiFqPzs7h+c57r4AvSs793VXcF7L3sI1sAOj+nRqTeg==,
+      }
+    engines: { node: ">=16" }
+
+  metro-minify-uglify@0.76.9:
+    resolution:
+      {
+        integrity: sha512-MXRrM3lFo62FPISlPfTqC6n9HTEI3RJjDU5SvpE7sJFfJKLx02xXQEltsL/wzvEqK+DhRQ5DEYACTwf5W4Z3yA==,
+      }
+    engines: { node: ">=16" }
+
+  metro-react-native-babel-preset@0.76.5:
+    resolution:
+      {
+        integrity: sha512-IlVKeTon5fef77rQ6WreSmrabmbc3dEsLwr/sL80fYjobjsD8FRCnOlbaJdgUf2SMJmSIoawgjh5Yeebv+gJzg==,
+      }
+    engines: { node: ">=16" }
+    deprecated: Use @react-native/babel-preset instead
+    peerDependencies:
+      "@babel/core": "*"
+
+  metro-react-native-babel-preset@0.76.9:
+    resolution:
+      {
+        integrity: sha512-eCBtW/UkJPDr6HlMgFEGF+964DZsUEF9RGeJdZLKWE7d/0nY3ABZ9ZAGxzu9efQ35EWRox5bDMXUGaOwUe5ikQ==,
+      }
+    engines: { node: ">=16" }
+    deprecated: Use @react-native/babel-preset instead
+    peerDependencies:
+      "@babel/core": "*"
+
+  metro-react-native-babel-transformer@0.76.5:
+    resolution:
+      {
+        integrity: sha512-7m2u7jQ1I2mwGm48Vrki5cNNSv4d2HegHMGmE5G2AAa6Pr2O3ajaX2yNoAKF8TCLO38/8pa9fZd0VWAlO/YMcA==,
+      }
+    engines: { node: ">=16" }
+    peerDependencies:
+      "@babel/core": "*"
+
+  metro-react-native-babel-transformer@0.76.9:
+    resolution:
+      {
+        integrity: sha512-xXzHcfngSIkbQj+U7i/anFkNL0q2QVarYSzr34CFkzKLa79Rp16B8ki7z9eVVqo9W3B4TBcTXl3BipgRoOoZSQ==,
+      }
+    engines: { node: ">=16" }
+    peerDependencies:
+      "@babel/core": "*"
+
+  metro-resolver@0.76.5:
+    resolution:
+      {
+        integrity: sha512-QNsbDdf0xL1HefP6fhh1g3umqiX1qWEuCiBaTFroYRqM7u7RATt8mCu4n/FwSYhATuUUujHTIb2EduuQPbSGRQ==,
+      }
+    engines: { node: ">=16" }
+
+  metro-resolver@0.76.9:
+    resolution:
+      {
+        integrity: sha512-s86ipNRas9vNR5lChzzSheF7HoaQEmzxBLzwFA6/2YcGmUCowcoyPAfs1yPh4cjMw9F1T4KlMLaiwniGE7HCyw==,
+      }
+    engines: { node: ">=16" }
+
+  metro-runtime@0.76.5:
+    resolution:
+      {
+        integrity: sha512-1JAf9/v/NDHLhoTfiJ0n25G6dRkX7mjTkaMJ6UUXIyfIuSucoK5yAuOBx8OveNIekoLRjmyvSmyN5ojEeRmpvQ==,
+      }
+    engines: { node: ">=16" }
+
+  metro-runtime@0.76.9:
+    resolution:
+      {
+        integrity: sha512-/5vezDpGUtA0Fv6cJg0+i6wB+QeBbvLeaw9cTSG7L76liP0b91f8vOcYzGaUbHI8pznJCCTerxRzpQ8e3/NcDw==,
+      }
+    engines: { node: ">=16" }
+
+  metro-source-map@0.76.5:
+    resolution:
+      {
+        integrity: sha512-1EhYPcoftONlvnOzgos7daE8hsJKOgSN3nD3Xf/yaY1F0aLeGeuWfpiNLLeFDNyUhfObHSuNxNhDQF/x1GFEbw==,
+      }
+    engines: { node: ">=16" }
+
+  metro-source-map@0.76.9:
+    resolution:
+      {
+        integrity: sha512-q5qsMlu8EFvsT46wUUh+ao+efDsicT30zmaPATNhq+PcTawDbDgnMuUD+FT0bvxxnisU2PWl91RdzKfNc2qPQA==,
+      }
+    engines: { node: ">=16" }
+
+  metro-symbolicate@0.76.5:
+    resolution:
+      {
+        integrity: sha512-7iftzh6G6HO4UDBmjsi2Yu4d6IkApv6Kg+jmBvkTjCXr8HwnKKum89gMg/FRMix+Rhhut0dnMpz6mAbtKTU9JQ==,
+      }
+    engines: { node: ">=16" }
+    hasBin: true
+
+  metro-symbolicate@0.76.9:
+    resolution:
+      {
+        integrity: sha512-Yyq6Ukj/IeWnGST09kRt0sBK8TwzGZWoU7YAcQlh14+AREH454Olx4wbFTpkkhUkV05CzNCvUuXQ0efFxhA1bw==,
+      }
+    engines: { node: ">=16" }
+    hasBin: true
+
+  metro-transform-plugins@0.76.5:
+    resolution:
+      {
+        integrity: sha512-7pJ24aRuvzdQYpX/eOyodr4fnwVJP5ArNLBE1d0DOU9sQxsGplOORDTGAqw2L01+UgaSJiiwEoFMw7Z91HAS+Q==,
+      }
+    engines: { node: ">=16" }
+
+  metro-transform-plugins@0.76.9:
+    resolution:
+      {
+        integrity: sha512-YEQeNlOCt92I7S9A3xbrfaDfwfgcxz9PpD/1eeop3c4cO3z3Q3otYuxw0WJ/rUIW8pZfOm5XCehd+1NRbWlAaw==,
+      }
+    engines: { node: ">=16" }
+
+  metro-transform-worker@0.76.5:
+    resolution:
+      {
+        integrity: sha512-xN6Kb06o9u5A7M1bbl7oPfQFmt4Kmi3CMXp5j9OcK37AFc+u6YXH8x/6e9b3Cq50rlBYuCXDOOYAWI5/tYNt2w==,
+      }
+    engines: { node: ">=16" }
+
+  metro-transform-worker@0.76.9:
+    resolution:
+      {
+        integrity: sha512-F69A0q0qFdJmP2Clqr6TpTSn4WTV9p5A28h5t9o+mB22ryXBZfUQ6BFBBW/6Wp2k/UtPH+oOsBfV9guiqm3d2Q==,
+      }
+    engines: { node: ">=16" }
+
+  metro@0.76.5:
+    resolution:
+      {
+        integrity: sha512-aEQiqNFibfx4ajUXm7Xatsv43r/UQ0xE53T3XqgZBzsxhF235tf1cl8t0giawi0RbLtDS+Fu4kg2bVBKDYFy7A==,
+      }
+    engines: { node: ">=16" }
+    hasBin: true
+
+  metro@0.76.9:
+    resolution:
+      {
+        integrity: sha512-gcjcfs0l5qIPg0lc5P7pj0x7vPJ97tan+OnEjiYLbKjR1D7Oa78CE93YUPyymUPH6q7VzlzMm1UjT35waEkZUw==,
+      }
+    engines: { node: ">=16" }
+    hasBin: true
 
   micromatch@4.0.8:
     resolution:
@@ -3986,6 +6641,29 @@ packages:
         integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==,
       }
     engines: { node: ">= 0.6" }
+
+  mime@1.6.0:
+    resolution:
+      {
+        integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==,
+      }
+    engines: { node: ">=4" }
+    hasBin: true
+
+  mime@2.6.0:
+    resolution:
+      {
+        integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==,
+      }
+    engines: { node: ">=4.0.0" }
+    hasBin: true
+
+  mimic-fn@2.1.0:
+    resolution:
+      {
+        integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==,
+      }
+    engines: { node: ">=6" }
 
   mimic-fn@4.0.0:
     resolution:
@@ -4061,6 +6739,12 @@ packages:
       }
     engines: { node: ">=4" }
 
+  ms@2.0.0:
+    resolution:
+      {
+        integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==,
+      }
+
   ms@2.1.3:
     resolution:
       {
@@ -4107,11 +6791,97 @@ packages:
         integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==,
       }
 
+  negotiator@0.6.3:
+    resolution:
+      {
+        integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==,
+      }
+    engines: { node: ">= 0.6" }
+
+  negotiator@0.6.4:
+    resolution:
+      {
+        integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==,
+      }
+    engines: { node: ">= 0.6" }
+
+  neo-async@2.6.2:
+    resolution:
+      {
+        integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==,
+      }
+
   no-case@3.0.4:
     resolution:
       {
         integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==,
       }
+
+  nocache@3.0.4:
+    resolution:
+      {
+        integrity: sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw==,
+      }
+    engines: { node: ">=12.0.0" }
+
+  node-abort-controller@3.1.1:
+    resolution:
+      {
+        integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==,
+      }
+
+  node-dir@0.1.17:
+    resolution:
+      {
+        integrity: sha512-tmPX422rYgofd4epzrNoOXiE8XFZYOcCq1vD7MAXCDO+O+zndlA2ztdKKMa+EeuBG5tHETpr4ml4RGgpqDCCAg==,
+      }
+    engines: { node: ">= 0.10.5" }
+
+  node-fetch@2.7.0:
+    resolution:
+      {
+        integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==,
+      }
+    engines: { node: 4.x || >=6.0.0 }
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-int64@0.4.0:
+    resolution:
+      {
+        integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==,
+      }
+
+  node-releases@2.0.51:
+    resolution:
+      {
+        integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==,
+      }
+    engines: { node: ">=18" }
+
+  node-stream-zip@1.16.0:
+    resolution:
+      {
+        integrity: sha512-ObaRrRoR8T68wF6suxHd7R4XQNamij6ZQHrwG7Dx1D2zeHcDNLsIOBcWrIwtDm7AsCXBguaPHgXhcjxDa2szrg==,
+      }
+    engines: { node: ">=0.12.0" }
+
+  normalize-path@3.0.0:
+    resolution:
+      {
+        integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  npm-run-path@4.0.1:
+    resolution:
+      {
+        integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==,
+      }
+    engines: { node: ">=8" }
 
   npm-run-path@5.3.0:
     resolution:
@@ -4120,11 +6890,38 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
+  nullthrows@1.1.1:
+    resolution:
+      {
+        integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==,
+      }
+
   nwsapi@2.2.16:
     resolution:
       {
         integrity: sha512-F1I/bimDpj3ncaNDhfyMWuFqmQDBwDB0Fogc2qpL3BWvkQteFD/8BzWuIRl83rq0DXfm8SGt/HFhLXZyljTXcQ==,
       }
+
+  ob1@0.76.5:
+    resolution:
+      {
+        integrity: sha512-HoxZXMXNuY/eIXGoX7gx1C4O3eB4kJJMola6KoFaMm7PGGg39+AnhbgMASYVmSvP2lwU3545NyiR63g8J9PW3w==,
+      }
+    engines: { node: ">=16" }
+
+  ob1@0.76.9:
+    resolution:
+      {
+        integrity: sha512-g0I/OLnSxf6OrN3QjSew3bTDJCdbZoWxnh8adh1z36alwCuGF1dgDeRA25bTYSakrG5WULSaWJPOdgnf1O/oQw==,
+      }
+    engines: { node: ">=16" }
+
+  object-assign@4.1.1:
+    resolution:
+      {
+        integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==,
+      }
+    engines: { node: ">=0.10.0" }
 
   object-inspect@1.13.3:
     resolution:
@@ -4168,11 +6965,39 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  on-finished@2.3.0:
+    resolution:
+      {
+        integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==,
+      }
+    engines: { node: ">= 0.8" }
+
+  on-finished@2.4.1:
+    resolution:
+      {
+        integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==,
+      }
+    engines: { node: ">= 0.8" }
+
+  on-headers@1.1.0:
+    resolution:
+      {
+        integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==,
+      }
+    engines: { node: ">= 0.8" }
+
   once@1.4.0:
     resolution:
       {
         integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==,
       }
+
+  onetime@5.1.2:
+    resolution:
+      {
+        integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==,
+      }
+    engines: { node: ">=6" }
 
   onetime@6.0.0:
     resolution:
@@ -4188,6 +7013,13 @@ packages:
       }
     engines: { node: ">=18" }
 
+  open@6.4.0:
+    resolution:
+      {
+        integrity: sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==,
+      }
+    engines: { node: ">=8" }
+
   open@8.4.2:
     resolution:
       {
@@ -4201,6 +7033,13 @@ packages:
         integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==,
       }
     engines: { node: ">= 0.8.0" }
+
+  ora@5.4.1:
+    resolution:
+      {
+        integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==,
+      }
+    engines: { node: ">=10" }
 
   outvariant@1.4.3:
     resolution:
@@ -4228,6 +7067,13 @@ packages:
         integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==,
       }
     engines: { node: ">=10" }
+
+  p-locate@3.0.0:
+    resolution:
+      {
+        integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==,
+      }
+    engines: { node: ">=6" }
 
   p-locate@4.1.0:
     resolution:
@@ -4257,11 +7103,25 @@ packages:
       }
     engines: { node: ">=6" }
 
+  parse-json@4.0.0:
+    resolution:
+      {
+        integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==,
+      }
+    engines: { node: ">=4" }
+
   parse5@7.2.1:
     resolution:
       {
         integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==,
       }
+
+  parseurl@1.3.3:
+    resolution:
+      {
+        integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==,
+      }
+    engines: { node: ">= 0.8" }
 
   pascal-case@3.1.2:
     resolution:
@@ -4274,6 +7134,13 @@ packages:
       {
         integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==,
       }
+
+  path-exists@3.0.0:
+    resolution:
+      {
+        integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==,
+      }
+    engines: { node: ">=4" }
 
   path-exists@4.0.0:
     resolution:
@@ -4362,6 +7229,27 @@ packages:
       }
     engines: { node: ">=0.10" }
     hasBin: true
+
+  pify@4.0.1:
+    resolution:
+      {
+        integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==,
+      }
+    engines: { node: ">=6" }
+
+  pirates@4.0.7:
+    resolution:
+      {
+        integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==,
+      }
+    engines: { node: ">= 6" }
+
+  pkg-dir@3.0.0:
+    resolution:
+      {
+        integrity: sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==,
+      }
+    engines: { node: ">=6" }
 
   pkg-types@1.3.1:
     resolution:
@@ -4474,12 +7362,32 @@ packages:
     engines: { node: ">=14" }
     hasBin: true
 
+  pretty-format@26.6.2:
+    resolution:
+      {
+        integrity: sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==,
+      }
+    engines: { node: ">= 10" }
+
   pretty-format@27.5.1:
     resolution:
       {
         integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==,
       }
     engines: { node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0 }
+
+  pretty-format@29.7.0:
+    resolution:
+      {
+        integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==,
+      }
+    engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+  process-nextick-args@2.0.1:
+    resolution:
+      {
+        integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==,
+      }
 
   process@0.11.10:
     resolution:
@@ -4494,6 +7402,25 @@ packages:
         integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==,
       }
     engines: { node: ">=0.4.0" }
+
+  promise@8.3.0:
+    resolution:
+      {
+        integrity: sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==,
+      }
+
+  prompts@2.4.2:
+    resolution:
+      {
+        integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==,
+      }
+    engines: { node: ">= 6" }
+
+  prop-types@15.8.1:
+    resolution:
+      {
+        integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==,
+      }
 
   psl@1.15.0:
     resolution:
@@ -4541,6 +7468,25 @@ packages:
         integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
       }
 
+  queue@6.0.2:
+    resolution:
+      {
+        integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==,
+      }
+
+  range-parser@1.2.1:
+    resolution:
+      {
+        integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==,
+      }
+    engines: { node: ">= 0.6" }
+
+  react-devtools-core@4.28.5:
+    resolution:
+      {
+        integrity: sha512-cq/o30z9W2Wb4rzBefjv5fBalHU0rJGZCHAkf/RHSBWSSYwh8PlQTqqOJmgIIbBtpj27T6FIPXeomIjZtCNVqA==,
+      }
+
   react-dom@18.3.1:
     resolution:
       {
@@ -4549,11 +7495,62 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-is@16.13.1:
+    resolution:
+      {
+        integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==,
+      }
+
   react-is@17.0.2:
     resolution:
       {
         integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==,
       }
+
+  react-is@18.3.1:
+    resolution:
+      {
+        integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==,
+      }
+
+  react-native-uuid@2.0.4:
+    resolution:
+      {
+        integrity: sha512-LSJNeh559qC17fgVPBsWuTSW/OygFp2dwTcf94IQBLYft5FzIQS9pCsuT36OPvyvDOMb6yiGr6TafaJDnz9PPQ==,
+      }
+    engines: { node: ">=18.0.0", npm: ">=9.0.0" }
+
+  react-native@0.72.0:
+    resolution:
+      {
+        integrity: sha512-BP2qq5f05pl3zV+eYgW7nmjCV+3zLXs/Vm69xMTCLD34U2bvRhuWbuUhqpauw7fyk5c8+LrY9NKcnARCkqKXcw==,
+      }
+    engines: { node: ">=16" }
+    hasBin: true
+    peerDependencies:
+      react: 18.2.0
+
+  react-refresh@0.4.3:
+    resolution:
+      {
+        integrity: sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  react-shallow-renderer@16.15.0:
+    resolution:
+      {
+        integrity: sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==,
+      }
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0
+
+  react@18.2.0:
+    resolution:
+      {
+        integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==,
+      }
+    engines: { node: ">=0.10.0" }
 
   react@18.3.1:
     resolution:
@@ -4562,12 +7559,38 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  readable-stream@2.3.8:
+    resolution:
+      {
+        integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==,
+      }
+
+  readable-stream@3.6.2:
+    resolution:
+      {
+        integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==,
+      }
+    engines: { node: ">= 6" }
+
   readdirp@4.0.2:
     resolution:
       {
         integrity: sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==,
       }
     engines: { node: ">= 14.16.0" }
+
+  readline@1.3.0:
+    resolution:
+      {
+        integrity: sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg==,
+      }
+
+  recast@0.21.5:
+    resolution:
+      {
+        integrity: sha512-hjMmLaUXAm1hIuTqOdeYObMslq/q+Xff6QE3Y2P+uoHAg2nmVlLBps2hzh1UJDdMtDTMXOFewK6ky51JQIeECg==,
+      }
+    engines: { node: ">= 4" }
 
   recast@0.23.11:
     resolution:
@@ -4590,6 +7613,25 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  regenerate-unicode-properties@10.2.2:
+    resolution:
+      {
+        integrity: sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==,
+      }
+    engines: { node: ">=4" }
+
+  regenerate@1.4.2:
+    resolution:
+      {
+        integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==,
+      }
+
+  regenerator-runtime@0.13.11:
+    resolution:
+      {
+        integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==,
+      }
+
   regexp.prototype.flags@1.5.4:
     resolution:
       {
@@ -4603,6 +7645,26 @@ packages:
         integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==,
       }
     engines: { node: ">=8" }
+
+  regexpu-core@6.4.0:
+    resolution:
+      {
+        integrity: sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==,
+      }
+    engines: { node: ">=4" }
+
+  regjsgen@0.8.0:
+    resolution:
+      {
+        integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==,
+      }
+
+  regjsparser@0.13.2:
+    resolution:
+      {
+        integrity: sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==,
+      }
+    hasBin: true
 
   require-directory@2.1.1:
     resolution:
@@ -4630,6 +7692,13 @@ packages:
         integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==,
       }
 
+  resolve-from@3.0.0:
+    resolution:
+      {
+        integrity: sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==,
+      }
+    engines: { node: ">=4" }
+
   resolve-from@4.0.0:
     resolution:
       {
@@ -4651,6 +7720,21 @@ packages:
     engines: { node: ">= 0.4" }
     hasBin: true
 
+  resolve@1.22.12:
+    resolution:
+      {
+        integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==,
+      }
+    engines: { node: ">= 0.4" }
+    hasBin: true
+
+  restore-cursor@3.1.0:
+    resolution:
+      {
+        integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==,
+      }
+    engines: { node: ">=8" }
+
   restore-cursor@5.1.0:
     resolution:
       {
@@ -4670,6 +7754,14 @@ packages:
       {
         integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
       }
+
+  rimraf@2.6.3:
+    resolution:
+      {
+        integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==,
+      }
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
 
   rimraf@2.7.1:
     resolution:
@@ -4721,6 +7813,18 @@ packages:
       }
     engines: { node: ">=0.4" }
 
+  safe-buffer@5.1.2:
+    resolution:
+      {
+        integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==,
+      }
+
+  safe-buffer@5.2.1:
+    resolution:
+      {
+        integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
+      }
+
   safe-push-apply@1.0.0:
     resolution:
       {
@@ -4760,6 +7864,19 @@ packages:
         integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==,
       }
 
+  scheduler@0.24.0-canary-efb381bbf-20230505:
+    resolution:
+      {
+        integrity: sha512-ABvovCDe/k9IluqSh4/ISoq8tIJnW8euVAWYt5j/bg6dRnqwQwiGO1F/V4AyK96NGF/FB04FhOUDuWj8IKfABA==,
+      }
+
+  semver@5.7.2:
+    resolution:
+      {
+        integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==,
+      }
+    hasBin: true
+
   semver@6.3.1:
     resolution:
       {
@@ -4782,6 +7899,27 @@ packages:
       }
     engines: { node: ">=10" }
     hasBin: true
+
+  send@0.19.2:
+    resolution:
+      {
+        integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==,
+      }
+    engines: { node: ">= 0.8.0" }
+
+  serialize-error@2.1.0:
+    resolution:
+      {
+        integrity: sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  serve-static@1.16.3:
+    resolution:
+      {
+        integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==,
+      }
+    engines: { node: ">= 0.8.0" }
 
   set-blocking@2.0.0:
     resolution:
@@ -4810,6 +7948,19 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  setprototypeof@1.2.0:
+    resolution:
+      {
+        integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==,
+      }
+
+  shallow-clone@3.0.1:
+    resolution:
+      {
+        integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==,
+      }
+    engines: { node: ">=8" }
+
   shebang-command@2.0.0:
     resolution:
       {
@@ -4823,6 +7974,13 @@ packages:
         integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
       }
     engines: { node: ">=8" }
+
+  shell-quote@1.10.0:
+    resolution:
+      {
+        integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==,
+      }
+    engines: { node: ">= 0.4" }
 
   side-channel-list@1.0.0:
     resolution:
@@ -4858,6 +8016,12 @@ packages:
         integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
       }
 
+  signal-exit@3.0.7:
+    resolution:
+      {
+        integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==,
+      }
+
   signal-exit@4.1.0:
     resolution:
       {
@@ -4865,12 +8029,25 @@ packages:
       }
     engines: { node: ">=14" }
 
+  sisteransi@1.0.5:
+    resolution:
+      {
+        integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==,
+      }
+
   slash@3.0.0:
     resolution:
       {
         integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==,
       }
     engines: { node: ">=8" }
+
+  slice-ansi@2.1.0:
+    resolution:
+      {
+        integrity: sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==,
+      }
+    engines: { node: ">=6" }
 
   slice-ansi@5.0.0:
     resolution:
@@ -4900,6 +8077,19 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  source-map-support@0.5.21:
+    resolution:
+      {
+        integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==,
+      }
+
+  source-map@0.5.7:
+    resolution:
+      {
+        integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==,
+      }
+    engines: { node: ">=0.10.0" }
+
   source-map@0.6.1:
     resolution:
       {
@@ -4907,11 +8097,25 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  source-map@0.7.6:
+    resolution:
+      {
+        integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==,
+      }
+    engines: { node: ">= 12" }
+
   sprintf-js@1.0.3:
     resolution:
       {
         integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==,
       }
+
+  stack-utils@2.0.6:
+    resolution:
+      {
+        integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==,
+      }
+    engines: { node: ">=10" }
 
   stackback@0.0.2:
     resolution:
@@ -4919,10 +8123,37 @@ packages:
         integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
       }
 
+  stackframe@1.3.4:
+    resolution:
+      {
+        integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==,
+      }
+
+  stacktrace-parser@0.1.11:
+    resolution:
+      {
+        integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==,
+      }
+    engines: { node: ">=6" }
+
+  statuses@1.5.0:
+    resolution:
+      {
+        integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==,
+      }
+    engines: { node: ">= 0.6" }
+
   statuses@2.0.1:
     resolution:
       {
         integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==,
+      }
+    engines: { node: ">= 0.8" }
+
+  statuses@2.0.2:
+    resolution:
+      {
+        integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==,
       }
     engines: { node: ">= 0.8" }
 
@@ -5006,6 +8237,25 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  string_decoder@1.1.1:
+    resolution:
+      {
+        integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==,
+      }
+
+  string_decoder@1.3.0:
+    resolution:
+      {
+        integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==,
+      }
+
+  strip-ansi@5.2.0:
+    resolution:
+      {
+        integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==,
+      }
+    engines: { node: ">=6" }
+
   strip-ansi@6.0.1:
     resolution:
       {
@@ -5026,6 +8276,13 @@ packages:
         integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==,
       }
     engines: { node: ">=4" }
+
+  strip-final-newline@2.0.0:
+    resolution:
+      {
+        integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==,
+      }
+    engines: { node: ">=6" }
 
   strip-final-newline@3.0.0:
     resolution:
@@ -5053,6 +8310,19 @@ packages:
       {
         integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==,
       }
+
+  strnum@1.1.2:
+    resolution:
+      {
+        integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==,
+      }
+
+  sudo-prompt@9.2.1:
+    resolution:
+      {
+        integrity: sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==,
+      }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   supports-color@7.2.0:
     resolution:
@@ -5183,10 +8453,37 @@ packages:
       }
     engines: { node: ^14.18.0 || >=16.0.0 }
 
+  temp@0.8.4:
+    resolution:
+      {
+        integrity: sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==,
+      }
+    engines: { node: ">=6.0.0" }
+
+  terser@5.49.0:
+    resolution:
+      {
+        integrity: sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==,
+      }
+    engines: { node: ">=10" }
+    hasBin: true
+
   text-table@0.2.0:
     resolution:
       {
         integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==,
+      }
+
+  throat@5.0.0:
+    resolution:
+      {
+        integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==,
+      }
+
+  through2@2.0.5:
+    resolution:
+      {
+        integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==,
       }
 
   tiny-invariant@1.3.3:
@@ -5262,12 +8559,25 @@ packages:
       }
     hasBin: true
 
+  tmpl@1.0.5:
+    resolution:
+      {
+        integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==,
+      }
+
   to-regex-range@5.0.1:
     resolution:
       {
         integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
       }
     engines: { node: ">=8.0" }
+
+  toidentifier@1.0.1:
+    resolution:
+      {
+        integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==,
+      }
+    engines: { node: ">=0.6" }
 
   tough-cookie@4.1.4:
     resolution:
@@ -5282,6 +8592,12 @@ packages:
         integrity: sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==,
       }
     engines: { node: ">=16" }
+
+  tr46@0.0.3:
+    resolution:
+      {
+        integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==,
+      }
 
   tr46@5.0.0:
     resolution:
@@ -5334,6 +8650,13 @@ packages:
       }
     engines: { node: ">= 0.8.0" }
 
+  type-detect@4.0.8:
+    resolution:
+      {
+        integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==,
+      }
+    engines: { node: ">=4" }
+
   type-fest@0.20.2:
     resolution:
       {
@@ -5347,6 +8670,13 @@ packages:
         integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==,
       }
     engines: { node: ">=10" }
+
+  type-fest@0.7.1:
+    resolution:
+      {
+        integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==,
+      }
+    engines: { node: ">=8" }
 
   type-fest@2.19.0:
     resolution:
@@ -5430,6 +8760,15 @@ packages:
         integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==,
       }
 
+  uglify-es@3.3.9:
+    resolution:
+      {
+        integrity: sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==,
+      }
+    engines: { node: ">=0.8.0" }
+    deprecated: support for ECMAScript is superseded by `uglify-js` as of v3.13.0
+    hasBin: true
+
   unbox-primitive@1.1.0:
     resolution:
       {
@@ -5442,6 +8781,41 @@ packages:
       {
         integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==,
       }
+
+  unicode-canonical-property-names-ecmascript@2.0.1:
+    resolution:
+      {
+        integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==,
+      }
+    engines: { node: ">=4" }
+
+  unicode-match-property-ecmascript@2.0.0:
+    resolution:
+      {
+        integrity: sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==,
+      }
+    engines: { node: ">=4" }
+
+  unicode-match-property-value-ecmascript@2.2.1:
+    resolution:
+      {
+        integrity: sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==,
+      }
+    engines: { node: ">=4" }
+
+  unicode-property-aliases-ecmascript@2.2.0:
+    resolution:
+      {
+        integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==,
+      }
+    engines: { node: ">=4" }
+
+  universalify@0.1.2:
+    resolution:
+      {
+        integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==,
+      }
+    engines: { node: ">= 4.0.0" }
 
   universalify@0.2.0:
     resolution:
@@ -5457,12 +8831,28 @@ packages:
       }
     engines: { node: ">= 10.0.0" }
 
+  unpipe@1.0.0:
+    resolution:
+      {
+        integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==,
+      }
+    engines: { node: ">= 0.8" }
+
   unplugin@1.16.1:
     resolution:
       {
         integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==,
       }
     engines: { node: ">=14.0.0" }
+
+  update-browserslist-db@1.2.3:
+    resolution:
+      {
+        integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==,
+      }
+    hasBin: true
+    peerDependencies:
+      browserslist: ">= 4.21.0"
 
   uri-js@4.4.1:
     resolution:
@@ -5476,6 +8866,14 @@ packages:
         integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==,
       }
 
+  use-sync-external-store@1.6.0:
+    resolution:
+      {
+        integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==,
+      }
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution:
       {
@@ -5487,6 +8885,13 @@ packages:
       {
         integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==,
       }
+
+  utils-merge@1.0.1:
+    resolution:
+      {
+        integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==,
+      }
+    engines: { node: ">= 0.4.0" }
 
   uuid@11.0.5:
     resolution:
@@ -5508,6 +8913,13 @@ packages:
       {
         integrity: sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==,
       }
+
+  vary@1.1.2:
+    resolution:
+      {
+        integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==,
+      }
+    engines: { node: ">= 0.8" }
 
   vite-node@3.2.4:
     resolution:
@@ -5614,6 +9026,12 @@ packages:
       jsdom:
         optional: true
 
+  vlq@1.0.1:
+    resolution:
+      {
+        integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==,
+      }
+
   vscode-uri@3.0.8:
     resolution:
       {
@@ -5626,6 +9044,24 @@ packages:
         integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==,
       }
     engines: { node: ">=18" }
+
+  walker@1.0.8:
+    resolution:
+      {
+        integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==,
+      }
+
+  wcwidth@1.0.1:
+    resolution:
+      {
+        integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==,
+      }
+
+  webidl-conversions@3.0.1:
+    resolution:
+      {
+        integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==,
+      }
 
   webidl-conversions@7.0.0:
     resolution:
@@ -5648,6 +9084,12 @@ packages:
     engines: { node: ">=18" }
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
+  whatwg-fetch@3.6.20:
+    resolution:
+      {
+        integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==,
+      }
+
   whatwg-mimetype@4.0.0:
     resolution:
       {
@@ -5661,6 +9103,12 @@ packages:
         integrity: sha512-jlf/foYIKywAt3x/XWKZ/3rz8OSJPiWktjmk891alJUEjiVxKX9LEO92qH3hv4aJ0mN3MWPvGMCy8jQi95xK4w==,
       }
     engines: { node: ">=18" }
+
+  whatwg-url@5.0.0:
+    resolution:
+      {
+        integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==,
+      }
 
   which-boxed-primitive@1.1.1:
     resolution:
@@ -5746,6 +9194,41 @@ packages:
         integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
       }
 
+  write-file-atomic@2.4.3:
+    resolution:
+      {
+        integrity: sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==,
+      }
+
+  ws@6.2.6:
+    resolution:
+      {
+        integrity: sha512-XTrf1gv7kXoVf1hbC3PAyAiPgR8Wz1blcrYIjEsUmr08BLksT41R8KbjmS9408C2ERx7v1JDLD/BkpLEttjfKA==,
+      }
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@7.5.13:
+    resolution:
+      {
+        integrity: sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==,
+      }
+    engines: { node: ">=8.3.0" }
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.18.0:
     resolution:
       {
@@ -5774,6 +9257,13 @@ packages:
         integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==,
       }
 
+  xtend@4.0.2:
+    resolution:
+      {
+        integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==,
+      }
+    engines: { node: ">=0.4" }
+
   y18n@4.0.3:
     resolution:
       {
@@ -5786,6 +9276,12 @@ packages:
         integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==,
       }
     engines: { node: ">=10" }
+
+  yallist@3.1.1:
+    resolution:
+      {
+        integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==,
+      }
 
   yallist@4.0.0:
     resolution:
@@ -5859,26 +9355,996 @@ packages:
 snapshots:
   "@adobe/css-tools@4.4.1": {}
 
+  "@amazon-devices/keplerscript-appstore-iap-lib@2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))":
+    dependencies:
+      "@amazon-devices/keplerscript-turbomodule-api": 1.2.5(@babel/preset-env@7.29.7(@babel/core@7.29.7))
+      "@amazon-devices/react-native-kepler": 2.0.9000000000(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react-native@0.72.0(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-native: 0.72.0(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react@18.3.1)
+      react-native-uuid: 2.0.4
+    transitivePeerDependencies:
+      - "@babel/core"
+      - "@babel/preset-env"
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  "@amazon-devices/keplerscript-turbomodule-api@1.2.5(@babel/preset-env@7.29.7(@babel/core@7.29.7))":
+    dependencies:
+      "@babel/parser": 7.28.4
+      flow-parser: 0.206.0
+      invariant: 2.2.4
+      jscodeshift: 0.14.0(@babel/preset-env@7.29.7(@babel/core@7.29.7))
+      nullthrows: 1.1.1
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - "@babel/preset-env"
+      - supports-color
+
+  "@amazon-devices/react-native-kepler@2.0.9000000000(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react-native@0.72.0(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react@18.2.0))(react@18.2.0)":
+    dependencies:
+      "@babel/traverse": 7.23.2
+      "@jest/create-cache-key-function": 29.7.0
+      "@react-native-community/cli": 11.4.1(@babel/core@7.29.7)
+      "@react-native-community/cli-platform-android": 11.4.1
+      "@react-native-community/cli-platform-ios": 11.4.1
+      "@react-native/assets-registry": 0.72.0
+      "@react-native/codegen": 0.72.8(@babel/preset-env@7.29.7(@babel/core@7.29.7))
+      "@react-native/gradle-plugin": 0.72.11
+      "@react-native/js-polyfills": 0.72.1
+      "@react-native/normalize-colors": 0.72.0
+      "@react-native/virtualized-lists": 0.72.8(react-native@0.72.0(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react@18.2.0))
+      abort-controller: 3.0.0
+      anser: 1.4.10
+      base64-js: 1.5.1
+      deprecated-react-native-prop-types: 4.1.0
+      event-target-shim: 5.0.1
+      flow-enums-runtime: 0.0.5
+      invariant: 2.2.4
+      jest-environment-node: 29.7.0
+      jsc-android: 250231.0.0
+      memoize-one: 5.2.1
+      metro-runtime: 0.76.5
+      metro-source-map: 0.76.5
+      mkdirp: 0.5.6
+      nullthrows: 1.1.1
+      pretty-format: 26.6.2
+      promise: 8.3.0
+      react: 18.2.0
+      react-devtools-core: 4.28.5
+      react-native: 0.72.0(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react@18.3.1)
+      react-refresh: 0.4.3
+      react-shallow-renderer: 16.15.0(react@18.2.0)
+      regenerator-runtime: 0.13.11
+      scheduler: 0.24.0-canary-efb381bbf-20230505
+      stacktrace-parser: 0.1.11
+      use-sync-external-store: 1.6.0(react@18.2.0)
+      whatwg-fetch: 3.6.20
+      ws: 6.2.6
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - "@babel/core"
+      - "@babel/preset-env"
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
   "@babel/code-frame@7.26.2":
     dependencies:
       "@babel/helper-validator-identifier": 7.27.1
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  "@babel/code-frame@7.29.7":
+    dependencies:
+      "@babel/helper-validator-identifier": 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  "@babel/compat-data@7.29.7": {}
+
+  "@babel/core@7.29.7":
+    dependencies:
+      "@babel/code-frame": 7.29.7
+      "@babel/generator": 7.29.7
+      "@babel/helper-compilation-targets": 7.29.7
+      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7)
+      "@babel/helpers": 7.29.7
+      "@babel/parser": 7.29.7
+      "@babel/template": 7.29.7
+      "@babel/traverse": 7.29.7
+      "@babel/types": 7.29.7
+      "@jridgewell/remapping": 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/generator@7.29.7":
+    dependencies:
+      "@babel/parser": 7.29.7
+      "@babel/types": 7.29.7
+      "@jridgewell/gen-mapping": 0.3.13
+      "@jridgewell/trace-mapping": 0.3.31
+      jsesc: 3.1.0
+
+  "@babel/helper-annotate-as-pure@7.29.7":
+    dependencies:
+      "@babel/types": 7.29.7
+
+  "@babel/helper-compilation-targets@7.29.7":
+    dependencies:
+      "@babel/compat-data": 7.29.7
+      "@babel/helper-validator-option": 7.29.7
+      browserslist: 4.28.7
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  "@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-annotate-as-pure": 7.29.7
+      "@babel/helper-member-expression-to-functions": 7.29.7
+      "@babel/helper-optimise-call-expression": 7.29.7
+      "@babel/helper-replace-supers": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
+      "@babel/traverse": 7.29.7
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-annotate-as-pure": 7.29.7
+      regexpu-core: 6.4.0
+      semver: 6.3.1
+
+  "@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-compilation-targets": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      debug: 4.4.3
+      lodash.debounce: 4.0.8
+      resolve: 1.22.12
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/helper-environment-visitor@7.24.7":
+    dependencies:
+      "@babel/types": 7.28.4
+
+  "@babel/helper-function-name@7.24.7":
+    dependencies:
+      "@babel/template": 7.29.7
+      "@babel/types": 7.28.4
+
+  "@babel/helper-globals@7.29.7": {}
+
+  "@babel/helper-hoist-variables@7.24.7":
+    dependencies:
+      "@babel/types": 7.28.4
+
+  "@babel/helper-member-expression-to-functions@7.29.7":
+    dependencies:
+      "@babel/traverse": 7.29.7
+      "@babel/types": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/helper-module-imports@7.29.7":
+    dependencies:
+      "@babel/traverse": 7.29.7
+      "@babel/types": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-module-imports": 7.29.7
+      "@babel/helper-validator-identifier": 7.29.7
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/helper-optimise-call-expression@7.29.7":
+    dependencies:
+      "@babel/types": 7.29.7
+
+  "@babel/helper-plugin-utils@7.29.7": {}
+
+  "@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-annotate-as-pure": 7.29.7
+      "@babel/helper-wrap-function": 7.29.7
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-member-expression-to-functions": 7.29.7
+      "@babel/helper-optimise-call-expression": 7.29.7
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/helper-skip-transparent-expression-wrappers@7.29.7":
+    dependencies:
+      "@babel/traverse": 7.29.7
+      "@babel/types": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/helper-split-export-declaration@7.24.7":
+    dependencies:
+      "@babel/types": 7.28.4
+
   "@babel/helper-string-parser@7.27.1": {}
 
+  "@babel/helper-string-parser@7.29.7": {}
+
   "@babel/helper-validator-identifier@7.27.1": {}
+
+  "@babel/helper-validator-identifier@7.29.7": {}
+
+  "@babel/helper-validator-option@7.29.7": {}
+
+  "@babel/helper-wrap-function@7.29.7":
+    dependencies:
+      "@babel/template": 7.29.7
+      "@babel/traverse": 7.29.7
+      "@babel/types": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/helpers@7.29.7":
+    dependencies:
+      "@babel/template": 7.29.7
+      "@babel/types": 7.29.7
 
   "@babel/parser@7.28.4":
     dependencies:
       "@babel/types": 7.28.4
 
+  "@babel/parser@7.29.7":
+    dependencies:
+      "@babel/types": 7.29.7
+
+  "@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
+      "@babel/plugin-transform-optional-chaining": 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-environment-visitor": 7.24.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-remap-async-to-generator": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-syntax-async-generators": 7.8.4(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-plugin-utils": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-proposal-export-default-from@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/plugin-syntax-nullish-coalescing-operator": 7.8.3(@babel/core@7.29.7)
+
+  "@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/plugin-syntax-numeric-separator": 7.10.4(@babel/core@7.29.7)
+
+  "@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/compat-data": 7.29.7
+      "@babel/core": 7.29.7
+      "@babel/helper-compilation-targets": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/plugin-syntax-object-rest-spread": 7.8.3(@babel/core@7.29.7)
+      "@babel/plugin-transform-parameters": 7.29.7(@babel/core@7.29.7)
+
+  "@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/plugin-syntax-optional-catch-binding": 7.8.3(@babel/core@7.29.7)
+
+  "@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
+      "@babel/plugin-syntax-optional-chaining": 7.8.3(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+
+  "@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-syntax-export-default-from@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-syntax-flow@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-arrow-functions@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-remap-async-to-generator": 7.29.7(@babel/core@7.29.7)
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-async-to-generator@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-module-imports": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-remap-async-to-generator": 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-block-scoped-functions@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-plugin-utils": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-class-static-block@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-plugin-utils": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-classes@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-annotate-as-pure": 7.29.7
+      "@babel/helper-compilation-targets": 7.29.7
+      "@babel/helper-globals": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-replace-supers": 7.29.7(@babel/core@7.29.7)
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-computed-properties@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/template": 7.29.7
+
+  "@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-dotall-regex@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-duplicate-keys@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-dynamic-import@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/plugin-transform-destructuring": 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-exponentiation-operator@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-flow-strip-types@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/plugin-syntax-flow": 7.29.7(@babel/core@7.29.7)
+
+  "@babel/plugin-transform-for-of@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-function-name@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-compilation-targets": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-json-strings@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-literals@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-member-expression-literals@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-modules-amd@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-plugin-utils": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-plugin-utils": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-modules-systemjs@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-validator-identifier": 7.29.7
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-modules-umd@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-plugin-utils": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-new-target@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-numeric-separator@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-object-rest-spread@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-compilation-targets": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/plugin-transform-destructuring": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-parameters": 7.29.7(@babel/core@7.29.7)
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-object-super@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-replace-supers": 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-parameters@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-plugin-utils": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-private-property-in-object@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-annotate-as-pure": 7.29.7
+      "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-plugin-utils": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-property-literals@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-react-display-name@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-react-jsx@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-annotate-as-pure": 7.29.7
+      "@babel/helper-module-imports": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/plugin-syntax-jsx": 7.29.7(@babel/core@7.29.7)
+      "@babel/types": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-regenerator@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-regexp-modifiers@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-reserved-words@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-module-imports": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.7)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-shorthand-properties@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-spread@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-sticky-regex@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-template-literals@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-typeof-symbol@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-annotate-as-pure": 7.29.7
+      "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
+      "@babel/plugin-syntax-typescript": 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-unicode-escapes@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-unicode-property-regex@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-unicode-sets-regex@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/preset-env@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/compat-data": 7.29.7
+      "@babel/core": 7.29.7
+      "@babel/helper-compilation-targets": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-validator-option": 7.29.7
+      "@babel/plugin-bugfix-firefox-class-in-computed-class-key": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-bugfix-safari-class-field-initializer-scope": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-proposal-private-property-in-object": 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)
+      "@babel/plugin-syntax-import-assertions": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-syntax-import-attributes": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-syntax-unicode-sets-regex": 7.18.6(@babel/core@7.29.7)
+      "@babel/plugin-transform-arrow-functions": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-async-generator-functions": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-async-to-generator": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-block-scoped-functions": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-block-scoping": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-class-properties": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-class-static-block": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-classes": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-computed-properties": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-destructuring": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-dotall-regex": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-duplicate-keys": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-duplicate-named-capturing-groups-regex": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-dynamic-import": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-explicit-resource-management": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-exponentiation-operator": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-export-namespace-from": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-for-of": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-function-name": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-json-strings": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-literals": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-logical-assignment-operators": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-member-expression-literals": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-modules-amd": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-modules-commonjs": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-modules-systemjs": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-modules-umd": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-named-capturing-groups-regex": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-new-target": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-nullish-coalescing-operator": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-numeric-separator": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-object-rest-spread": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-object-super": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-optional-catch-binding": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-optional-chaining": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-parameters": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-private-methods": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-private-property-in-object": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-property-literals": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-regenerator": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-regexp-modifiers": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-reserved-words": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-shorthand-properties": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-spread": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-sticky-regex": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-template-literals": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-typeof-symbol": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-unicode-escapes": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-unicode-property-regex": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-unicode-regex": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-unicode-sets-regex": 7.29.7(@babel/core@7.29.7)
+      "@babel/preset-modules": 0.1.6-no-external-plugins(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.7)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7)
+      core-js-compat: 3.49.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/preset-flow@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-validator-option": 7.29.7
+      "@babel/plugin-transform-flow-strip-types": 7.29.7(@babel/core@7.29.7)
+
+  "@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/types": 7.28.4
+      esutils: 2.0.3
+
+  "@babel/preset-typescript@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-validator-option": 7.29.7
+      "@babel/plugin-syntax-jsx": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-modules-commonjs": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-typescript": 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/register@7.29.7(@babel/core@7.29.7)":
+    dependencies:
+      "@babel/core": 7.29.7
+      clone-deep: 4.0.1
+      find-cache-dir: 2.1.0
+      make-dir: 2.1.0
+      pirates: 4.0.7
+      source-map-support: 0.5.21
+
   "@babel/runtime@7.28.6": {}
+
+  "@babel/template@7.29.7":
+    dependencies:
+      "@babel/code-frame": 7.29.7
+      "@babel/parser": 7.29.7
+      "@babel/types": 7.29.7
+
+  "@babel/traverse@7.23.2":
+    dependencies:
+      "@babel/code-frame": 7.26.2
+      "@babel/generator": 7.29.7
+      "@babel/helper-environment-visitor": 7.24.7
+      "@babel/helper-function-name": 7.24.7
+      "@babel/helper-hoist-variables": 7.24.7
+      "@babel/helper-split-export-declaration": 7.24.7
+      "@babel/parser": 7.28.4
+      "@babel/types": 7.28.4
+      debug: 4.4.3
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/traverse@7.29.7":
+    dependencies:
+      "@babel/code-frame": 7.29.7
+      "@babel/generator": 7.29.7
+      "@babel/helper-globals": 7.29.7
+      "@babel/parser": 7.29.7
+      "@babel/template": 7.29.7
+      "@babel/types": 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   "@babel/types@7.28.4":
     dependencies:
       "@babel/helper-string-parser": 7.27.1
       "@babel/helper-validator-identifier": 7.27.1
+
+  "@babel/types@7.29.7":
+    dependencies:
+      "@babel/helper-string-parser": 7.29.7
+      "@babel/helper-validator-identifier": 7.29.7
 
   "@bundled-es-modules/cookie@2.0.1":
     dependencies:
@@ -6013,6 +10479,12 @@ snapshots:
       "@shikijs/types": 1.26.1
       "@shikijs/vscode-textmate": 10.0.1
 
+  "@hapi/hoek@9.3.0": {}
+
+  "@hapi/topo@5.1.0":
+    dependencies:
+      "@hapi/hoek": 9.3.0
+
   "@humanwhocodes/config-array@0.13.0":
     dependencies:
       "@humanwhocodes/object-schema": 2.0.3
@@ -6067,6 +10539,60 @@ snapshots:
     dependencies:
       "@isaacs/balanced-match": 4.0.1
 
+  "@jest/create-cache-key-function@29.7.0":
+    dependencies:
+      "@jest/types": 29.6.3
+
+  "@jest/environment@29.7.0":
+    dependencies:
+      "@jest/fake-timers": 29.7.0
+      "@jest/types": 29.6.3
+      "@types/node": 22.10.5
+      jest-mock: 29.7.0
+
+  "@jest/fake-timers@29.7.0":
+    dependencies:
+      "@jest/types": 29.6.3
+      "@sinonjs/fake-timers": 10.3.0
+      "@types/node": 22.10.5
+      jest-message-util: 29.7.0
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
+
+  "@jest/schemas@29.6.3":
+    dependencies:
+      "@sinclair/typebox": 0.27.12
+
+  "@jest/types@26.6.2":
+    dependencies:
+      "@types/istanbul-lib-coverage": 2.0.6
+      "@types/istanbul-reports": 3.0.4
+      "@types/node": 22.10.5
+      "@types/yargs": 15.0.20
+      chalk: 4.1.2
+
+  "@jest/types@27.5.1":
+    dependencies:
+      "@types/istanbul-lib-coverage": 2.0.6
+      "@types/istanbul-reports": 3.0.4
+      "@types/node": 22.10.5
+      "@types/yargs": 16.0.11
+      chalk: 4.1.2
+
+  "@jest/types@29.6.3":
+    dependencies:
+      "@jest/schemas": 29.6.3
+      "@types/istanbul-lib-coverage": 2.0.6
+      "@types/istanbul-reports": 3.0.4
+      "@types/node": 22.10.5
+      "@types/yargs": 17.0.35
+      chalk: 4.1.2
+
+  "@jridgewell/gen-mapping@0.3.13":
+    dependencies:
+      "@jridgewell/sourcemap-codec": 1.5.0
+      "@jridgewell/trace-mapping": 0.3.31
+
   "@jridgewell/gen-mapping@0.3.8":
     dependencies:
       "@jridgewell/set-array": 1.2.1
@@ -6082,9 +10608,19 @@ snapshots:
 
   "@jridgewell/set-array@1.2.1": {}
 
+  "@jridgewell/source-map@0.3.11":
+    dependencies:
+      "@jridgewell/gen-mapping": 0.3.8
+      "@jridgewell/trace-mapping": 0.3.25
+
   "@jridgewell/sourcemap-codec@1.5.0": {}
 
   "@jridgewell/trace-mapping@0.3.25":
+    dependencies:
+      "@jridgewell/resolve-uri": 3.1.2
+      "@jridgewell/sourcemap-codec": 1.5.0
+
+  "@jridgewell/trace-mapping@0.3.31":
     dependencies:
       "@jridgewell/resolve-uri": 3.1.2
       "@jridgewell/sourcemap-codec": 1.5.0
@@ -6163,6 +10699,353 @@ snapshots:
   "@paddle/paddle-js@1.6.4": {}
 
   "@pkgr/core@0.1.1": {}
+
+  "@react-native-community/cli-clean@11.3.2":
+    dependencies:
+      "@react-native-community/cli-tools": 11.3.2
+      chalk: 4.1.2
+      execa: 5.1.1
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - encoding
+
+  "@react-native-community/cli-clean@11.4.1":
+    dependencies:
+      "@react-native-community/cli-tools": 11.4.1
+      chalk: 4.1.2
+      execa: 5.1.1
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - encoding
+
+  "@react-native-community/cli-config@11.3.2":
+    dependencies:
+      "@react-native-community/cli-tools": 11.3.2
+      chalk: 4.1.2
+      cosmiconfig: 5.2.1
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      joi: 17.13.4
+    transitivePeerDependencies:
+      - encoding
+
+  "@react-native-community/cli-config@11.4.1":
+    dependencies:
+      "@react-native-community/cli-tools": 11.4.1
+      chalk: 4.1.2
+      cosmiconfig: 5.2.1
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      joi: 17.13.4
+    transitivePeerDependencies:
+      - encoding
+
+  "@react-native-community/cli-debugger-ui@11.3.2":
+    dependencies:
+      serve-static: 1.16.3
+    transitivePeerDependencies:
+      - supports-color
+
+  "@react-native-community/cli-debugger-ui@11.4.1":
+    dependencies:
+      serve-static: 1.16.3
+    transitivePeerDependencies:
+      - supports-color
+
+  "@react-native-community/cli-doctor@11.3.2":
+    dependencies:
+      "@react-native-community/cli-config": 11.3.2
+      "@react-native-community/cli-platform-android": 11.3.2
+      "@react-native-community/cli-platform-ios": 11.3.2
+      "@react-native-community/cli-tools": 11.3.2
+      chalk: 4.1.2
+      command-exists: 1.2.9
+      envinfo: 7.21.0
+      execa: 5.1.1
+      hermes-profile-transformer: 0.0.6
+      ip: 1.1.9
+      node-stream-zip: 1.16.0
+      ora: 5.4.1
+      prompts: 2.4.2
+      semver: 6.3.1
+      strip-ansi: 5.2.0
+      sudo-prompt: 9.2.1
+      wcwidth: 1.0.1
+      yaml: 2.6.1
+    transitivePeerDependencies:
+      - encoding
+
+  "@react-native-community/cli-doctor@11.4.1":
+    dependencies:
+      "@react-native-community/cli-config": 11.4.1
+      "@react-native-community/cli-platform-android": 11.4.1
+      "@react-native-community/cli-platform-ios": 11.4.1
+      "@react-native-community/cli-tools": 11.4.1
+      chalk: 4.1.2
+      command-exists: 1.2.9
+      envinfo: 7.21.0
+      execa: 5.1.1
+      hermes-profile-transformer: 0.0.6
+      node-stream-zip: 1.16.0
+      ora: 5.4.1
+      prompts: 2.4.2
+      semver: 7.7.1
+      strip-ansi: 5.2.0
+      sudo-prompt: 9.2.1
+      wcwidth: 1.0.1
+      yaml: 2.6.1
+    transitivePeerDependencies:
+      - encoding
+
+  "@react-native-community/cli-hermes@11.3.2":
+    dependencies:
+      "@react-native-community/cli-platform-android": 11.3.2
+      "@react-native-community/cli-tools": 11.3.2
+      chalk: 4.1.2
+      hermes-profile-transformer: 0.0.6
+      ip: 1.1.9
+    transitivePeerDependencies:
+      - encoding
+
+  "@react-native-community/cli-hermes@11.4.1":
+    dependencies:
+      "@react-native-community/cli-platform-android": 11.4.1
+      "@react-native-community/cli-tools": 11.4.1
+      chalk: 4.1.2
+      hermes-profile-transformer: 0.0.6
+    transitivePeerDependencies:
+      - encoding
+
+  "@react-native-community/cli-platform-android@11.3.2":
+    dependencies:
+      "@react-native-community/cli-tools": 11.3.2
+      chalk: 4.1.2
+      execa: 5.1.1
+      glob: 7.2.3
+      logkitty: 0.7.1
+    transitivePeerDependencies:
+      - encoding
+
+  "@react-native-community/cli-platform-android@11.4.1":
+    dependencies:
+      "@react-native-community/cli-tools": 11.4.1
+      chalk: 4.1.2
+      execa: 5.1.1
+      glob: 7.2.3
+      logkitty: 0.7.1
+    transitivePeerDependencies:
+      - encoding
+
+  "@react-native-community/cli-platform-ios@11.3.2":
+    dependencies:
+      "@react-native-community/cli-tools": 11.3.2
+      chalk: 4.1.2
+      execa: 5.1.1
+      fast-xml-parser: 4.5.7
+      glob: 7.2.3
+      ora: 5.4.1
+    transitivePeerDependencies:
+      - encoding
+
+  "@react-native-community/cli-platform-ios@11.4.1":
+    dependencies:
+      "@react-native-community/cli-tools": 11.4.1
+      chalk: 4.1.2
+      execa: 5.1.1
+      fast-xml-parser: 4.5.7
+      glob: 7.2.3
+      ora: 5.4.1
+    transitivePeerDependencies:
+      - encoding
+
+  "@react-native-community/cli-plugin-metro@11.3.2(@babel/core@7.29.7)":
+    dependencies:
+      "@react-native-community/cli-server-api": 11.3.2
+      "@react-native-community/cli-tools": 11.3.2
+      chalk: 4.1.2
+      execa: 5.1.1
+      metro: 0.76.5
+      metro-config: 0.76.5
+      metro-core: 0.76.5
+      metro-react-native-babel-transformer: 0.76.5(@babel/core@7.29.7)
+      metro-resolver: 0.76.5
+      metro-runtime: 0.76.5
+      readline: 1.3.0
+    transitivePeerDependencies:
+      - "@babel/core"
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  "@react-native-community/cli-plugin-metro@11.4.1(@babel/core@7.29.7)":
+    dependencies:
+      "@react-native-community/cli-server-api": 11.4.1
+      "@react-native-community/cli-tools": 11.4.1
+      chalk: 4.1.2
+      execa: 5.1.1
+      metro: 0.76.9
+      metro-config: 0.76.9
+      metro-core: 0.76.9
+      metro-react-native-babel-transformer: 0.76.9(@babel/core@7.29.7)
+      metro-resolver: 0.76.9
+      metro-runtime: 0.76.9
+      readline: 1.3.0
+    transitivePeerDependencies:
+      - "@babel/core"
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  "@react-native-community/cli-server-api@11.3.2":
+    dependencies:
+      "@react-native-community/cli-debugger-ui": 11.3.2
+      "@react-native-community/cli-tools": 11.3.2
+      compression: 1.8.1
+      connect: 3.7.0
+      errorhandler: 1.5.2
+      nocache: 3.0.4
+      pretty-format: 26.6.2
+      serve-static: 1.16.3
+      ws: 7.5.13
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  "@react-native-community/cli-server-api@11.4.1":
+    dependencies:
+      "@react-native-community/cli-debugger-ui": 11.4.1
+      "@react-native-community/cli-tools": 11.4.1
+      compression: 1.8.1
+      connect: 3.7.0
+      errorhandler: 1.5.2
+      nocache: 3.0.4
+      pretty-format: 26.6.2
+      serve-static: 1.16.3
+      ws: 7.5.13
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  "@react-native-community/cli-tools@11.3.2":
+    dependencies:
+      appdirsjs: 1.2.7
+      chalk: 4.1.2
+      find-up: 5.0.0
+      mime: 2.6.0
+      node-fetch: 2.7.0
+      open: 6.4.0
+      ora: 5.4.1
+      semver: 6.3.1
+      shell-quote: 1.10.0
+    transitivePeerDependencies:
+      - encoding
+
+  "@react-native-community/cli-tools@11.4.1":
+    dependencies:
+      appdirsjs: 1.2.7
+      chalk: 4.1.2
+      find-up: 5.0.0
+      mime: 2.6.0
+      node-fetch: 2.7.0
+      open: 6.4.0
+      ora: 5.4.1
+      semver: 7.7.1
+      shell-quote: 1.10.0
+    transitivePeerDependencies:
+      - encoding
+
+  "@react-native-community/cli-types@11.3.2":
+    dependencies:
+      joi: 17.13.4
+
+  "@react-native-community/cli-types@11.4.1":
+    dependencies:
+      joi: 17.13.4
+
+  "@react-native-community/cli@11.3.2(@babel/core@7.29.7)":
+    dependencies:
+      "@react-native-community/cli-clean": 11.3.2
+      "@react-native-community/cli-config": 11.3.2
+      "@react-native-community/cli-debugger-ui": 11.3.2
+      "@react-native-community/cli-doctor": 11.3.2
+      "@react-native-community/cli-hermes": 11.3.2
+      "@react-native-community/cli-plugin-metro": 11.3.2(@babel/core@7.29.7)
+      "@react-native-community/cli-server-api": 11.3.2
+      "@react-native-community/cli-tools": 11.3.2
+      "@react-native-community/cli-types": 11.3.2
+      chalk: 4.1.2
+      commander: 9.5.0
+      execa: 5.1.1
+      find-up: 4.1.0
+      fs-extra: 8.1.0
+      graceful-fs: 4.2.11
+      prompts: 2.4.2
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - "@babel/core"
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  "@react-native-community/cli@11.4.1(@babel/core@7.29.7)":
+    dependencies:
+      "@react-native-community/cli-clean": 11.4.1
+      "@react-native-community/cli-config": 11.4.1
+      "@react-native-community/cli-debugger-ui": 11.4.1
+      "@react-native-community/cli-doctor": 11.4.1
+      "@react-native-community/cli-hermes": 11.4.1
+      "@react-native-community/cli-plugin-metro": 11.4.1(@babel/core@7.29.7)
+      "@react-native-community/cli-server-api": 11.4.1
+      "@react-native-community/cli-tools": 11.4.1
+      "@react-native-community/cli-types": 11.4.1
+      chalk: 4.1.2
+      commander: 9.5.0
+      execa: 5.1.1
+      find-up: 4.1.0
+      fs-extra: 8.1.0
+      graceful-fs: 4.2.11
+      prompts: 2.4.2
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - "@babel/core"
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  "@react-native/assets-registry@0.72.0": {}
+
+  "@react-native/codegen@0.72.8(@babel/preset-env@7.29.7(@babel/core@7.29.7))":
+    dependencies:
+      "@babel/parser": 7.28.4
+      "@babel/preset-env": 7.29.7(@babel/core@7.29.7)
+      flow-parser: 0.206.0
+      glob: 7.2.3
+      invariant: 2.2.4
+      jscodeshift: 0.14.0(@babel/preset-env@7.29.7(@babel/core@7.29.7))
+      mkdirp: 0.5.6
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  "@react-native/gradle-plugin@0.72.11": {}
+
+  "@react-native/js-polyfills@0.72.1": {}
+
+  "@react-native/normalize-colors@0.72.0": {}
+
+  "@react-native/virtualized-lists@0.72.8(react-native@0.72.0(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react@18.2.0))":
+    dependencies:
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      react-native: 0.72.0(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react@18.3.1)
 
   "@revenuecat/purchases-ui-js@4.8.11(svelte@5.46.4)":
     dependencies:
@@ -6288,6 +11171,24 @@ snapshots:
 
   "@shikijs/vscode-textmate@10.0.1": {}
 
+  "@sideway/address@4.1.5":
+    dependencies:
+      "@hapi/hoek": 9.3.0
+
+  "@sideway/formula@3.0.1": {}
+
+  "@sideway/pinpoint@2.0.0": {}
+
+  "@sinclair/typebox@0.27.12": {}
+
+  "@sinonjs/commons@3.0.1":
+    dependencies:
+      type-detect: 4.0.8
+
+  "@sinonjs/fake-timers@10.3.0":
+    dependencies:
+      "@sinonjs/commons": 3.0.1
+
   "@storybook/addon-actions@8.6.15(storybook@8.6.15(prettier@3.4.2))":
     dependencies:
       "@storybook/global": 5.0.0
@@ -6374,11 +11275,11 @@ snapshots:
       storybook: 8.6.15(prettier@3.4.2)
       ts-dedent: 2.2.0
 
-  "@storybook/addon-svelte-csf@5.0.8(@storybook/svelte@8.6.15(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4))(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1)))(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))":
+  "@storybook/addon-svelte-csf@5.0.8(@storybook/svelte@8.6.15(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4))(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)))(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))":
     dependencies:
       "@storybook/csf": 0.1.13
       "@storybook/svelte": 8.6.15(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4)
-      "@sveltejs/vite-plugin-svelte": 6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))
+      "@sveltejs/vite-plugin-svelte": 6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))
       dedent: 1.5.3
       es-toolkit: 1.31.0
       esrap: 1.3.2
@@ -6386,7 +11287,7 @@ snapshots:
       storybook: 8.6.15(prettier@3.4.2)
       svelte: 5.46.4
       svelte-ast-print: 0.4.2(svelte@5.46.4)
-      vite: 6.4.1(@types/node@22.10.5)(yaml@2.6.1)
+      vite: 6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)
       zimmerframe: 1.1.2
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -6414,13 +11315,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  "@storybook/builder-vite@8.6.15(storybook@8.6.15(prettier@3.4.2))(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))":
+  "@storybook/builder-vite@8.6.15(storybook@8.6.15(prettier@3.4.2))(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))":
     dependencies:
       "@storybook/csf-plugin": 8.6.15(storybook@8.6.15(prettier@3.4.2))
       browser-assert: 1.2.1
       storybook: 8.6.15(prettier@3.4.2)
       ts-dedent: 2.2.0
-      vite: 6.4.1(@types/node@22.10.5)(yaml@2.6.1)
+      vite: 6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)
 
   "@storybook/components@8.6.15(storybook@8.6.15(prettier@3.4.2))":
     dependencies:
@@ -6487,20 +11388,20 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.6.15(prettier@3.4.2)
 
-  "@storybook/svelte-vite@8.6.15(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1)))(postcss-load-config@3.1.4(postcss@8.5.3))(postcss@8.5.3)(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))":
+  "@storybook/svelte-vite@8.6.15(@babel/core@7.29.7)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)))(postcss-load-config@3.1.4(postcss@8.5.3))(postcss@8.5.3)(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))":
     dependencies:
-      "@storybook/builder-vite": 8.6.15(storybook@8.6.15(prettier@3.4.2))(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))
+      "@storybook/builder-vite": 8.6.15(storybook@8.6.15(prettier@3.4.2))(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))
       "@storybook/svelte": 8.6.15(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4)
-      "@sveltejs/vite-plugin-svelte": 6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))
+      "@sveltejs/vite-plugin-svelte": 6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))
       magic-string: 0.30.17
       storybook: 8.6.15(prettier@3.4.2)
       svelte: 5.46.4
-      svelte-preprocess: 5.1.4(postcss-load-config@3.1.4(postcss@8.5.3))(postcss@8.5.3)(svelte@5.46.4)(typescript@5.8.2)
+      svelte-preprocess: 5.1.4(@babel/core@7.29.7)(postcss-load-config@3.1.4(postcss@8.5.3))(postcss@8.5.3)(svelte@5.46.4)(typescript@5.8.2)
       svelte2tsx: 0.7.35(svelte@5.46.4)(typescript@5.8.2)
       sveltedoc-parser: 4.2.1
       ts-dedent: 2.2.0
       typescript: 5.8.2
-      vite: 6.4.1(@types/node@22.10.5)(yaml@2.6.1)
+      vite: 6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - "@babel/core"
       - coffeescript
@@ -6529,15 +11430,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@storybook/sveltekit@8.6.15(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1)))(postcss-load-config@3.1.4(postcss@8.5.3))(postcss@8.5.3)(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))":
+  "@storybook/sveltekit@8.6.15(@babel/core@7.29.7)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)))(postcss-load-config@3.1.4(postcss@8.5.3))(postcss@8.5.3)(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))":
     dependencies:
       "@storybook/addon-actions": 8.6.15(storybook@8.6.15(prettier@3.4.2))
-      "@storybook/builder-vite": 8.6.15(storybook@8.6.15(prettier@3.4.2))(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))
+      "@storybook/builder-vite": 8.6.15(storybook@8.6.15(prettier@3.4.2))(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))
       "@storybook/svelte": 8.6.15(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4)
-      "@storybook/svelte-vite": 8.6.15(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1)))(postcss-load-config@3.1.4(postcss@8.5.3))(postcss@8.5.3)(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))
+      "@storybook/svelte-vite": 8.6.15(@babel/core@7.29.7)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)))(postcss-load-config@3.1.4(postcss@8.5.3))(postcss@8.5.3)(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))
       storybook: 8.6.15(prettier@3.4.2)
       svelte: 5.46.4
-      vite: 6.4.1(@types/node@22.10.5)(yaml@2.6.1)
+      vite: 6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - "@babel/core"
       - "@sveltejs/vite-plugin-svelte"
@@ -6572,24 +11473,24 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  "@sveltejs/vite-plugin-svelte-inspector@5.0.1(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1)))(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))":
+  "@sveltejs/vite-plugin-svelte-inspector@5.0.1(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)))(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))":
     dependencies:
-      "@sveltejs/vite-plugin-svelte": 6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))
+      "@sveltejs/vite-plugin-svelte": 6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))
       debug: 4.4.3
       svelte: 5.46.4
-      vite: 6.4.1(@types/node@22.10.5)(yaml@2.6.1)
+      vite: 6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))":
+  "@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))":
     dependencies:
-      "@sveltejs/vite-plugin-svelte-inspector": 5.0.1(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1)))(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))
+      "@sveltejs/vite-plugin-svelte-inspector": 5.0.1(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)))(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))
       debug: 4.4.3
       deepmerge: 4.3.1
       magic-string: 0.30.17
       svelte: 5.46.4
-      vite: 6.4.1(@types/node@22.10.5)(yaml@2.6.1)
-      vitefu: 1.1.1(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))
+      vite: 6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)
+      vitefu: 1.1.1(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -6624,13 +11525,13 @@ snapshots:
       lodash: 4.17.23
       redent: 3.0.0
 
-  "@testing-library/svelte@5.2.7(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))(vitest@3.2.4(@types/node@22.10.5)(jsdom@25.0.1)(msw@2.7.0(@types/node@22.10.5)(typescript@5.8.2))(yaml@2.6.1))":
+  "@testing-library/svelte@5.2.7(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))(vitest@3.2.4(@types/node@22.10.5)(jsdom@25.0.1)(msw@2.7.0(@types/node@22.10.5)(typescript@5.8.2))(terser@5.49.0)(yaml@2.6.1))":
     dependencies:
       "@testing-library/dom": 10.4.0
       svelte: 5.46.4
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.10.5)(yaml@2.6.1)
-      vitest: 3.2.4(@types/node@22.10.5)(jsdom@25.0.1)(msw@2.7.0(@types/node@22.10.5)(typescript@5.8.2))(yaml@2.6.1)
+      vite: 6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)
+      vitest: 3.2.4(@types/node@22.10.5)(jsdom@25.0.1)(msw@2.7.0(@types/node@22.10.5)(typescript@5.8.2))(terser@5.49.0)(yaml@2.6.1)
 
   "@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)":
     dependencies:
@@ -6656,6 +11557,16 @@ snapshots:
     dependencies:
       "@types/unist": 3.0.3
 
+  "@types/istanbul-lib-coverage@2.0.6": {}
+
+  "@types/istanbul-lib-report@3.0.3":
+    dependencies:
+      "@types/istanbul-lib-coverage": 2.0.6
+
+  "@types/istanbul-reports@3.0.4":
+    dependencies:
+      "@types/istanbul-lib-report": 3.0.3
+
   "@types/json-schema@7.0.15": {}
 
   "@types/json5@0.0.29": {}
@@ -6674,6 +11585,8 @@ snapshots:
 
   "@types/semver@7.5.8": {}
 
+  "@types/stack-utils@2.0.3": {}
+
   "@types/statuses@2.0.5": {}
 
   "@types/tough-cookie@4.0.5": {}
@@ -6683,6 +11596,20 @@ snapshots:
   "@types/uuid@10.0.0": {}
 
   "@types/uuid@9.0.8": {}
+
+  "@types/yargs-parser@21.0.3": {}
+
+  "@types/yargs@15.0.20":
+    dependencies:
+      "@types/yargs-parser": 21.0.3
+
+  "@types/yargs@16.0.11":
+    dependencies:
+      "@types/yargs-parser": 21.0.3
+
+  "@types/yargs@17.0.35":
+    dependencies:
+      "@types/yargs-parser": 21.0.3
 
   "@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@8.19.1(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)":
     dependencies:
@@ -6864,14 +11791,14 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  "@vitest/mocker@3.2.4(msw@2.7.0(@types/node@22.10.5)(typescript@5.8.2))(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))":
+  "@vitest/mocker@3.2.4(msw@2.7.0(@types/node@22.10.5)(typescript@5.8.2))(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))":
     dependencies:
       "@vitest/spy": 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.7.0(@types/node@22.10.5)(typescript@5.8.2)
-      vite: 6.4.1(@types/node@22.10.5)(yaml@2.6.1)
+      vite: 6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)
 
   "@vitest/pretty-format@2.0.5":
     dependencies:
@@ -6969,6 +11896,15 @@ snapshots:
 
   "@vue/shared@3.5.21": {}
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -7008,6 +11944,8 @@ snapshots:
 
   alien-signals@0.4.14: {}
 
+  anser@1.4.10: {}
+
   ansi-colors@4.1.3: {}
 
   ansi-escapes@4.3.2:
@@ -7018,9 +11956,21 @@ snapshots:
     dependencies:
       environment: 1.1.0
 
+  ansi-fragments@0.2.1:
+    dependencies:
+      colorette: 1.4.0
+      slice-ansi: 2.1.0
+      strip-ansi: 5.2.0
+
+  ansi-regex@4.1.1: {}
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.1.0: {}
+
+  ansi-styles@3.2.1:
+    dependencies:
+      color-convert: 1.9.3
 
   ansi-styles@4.3.0:
     dependencies:
@@ -7029,6 +11979,13 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.1: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
+
+  appdirsjs@1.2.7: {}
 
   argparse@1.0.10:
     dependencies:
@@ -7091,11 +12048,23 @@ snapshots:
       get-intrinsic: 1.2.7
       is-array-buffer: 3.0.5
 
+  asap@2.0.6: {}
+
   assertion-error@2.0.1: {}
+
+  ast-types@0.15.2:
+    dependencies:
+      tslib: 2.8.1
 
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
+
+  astral-regex@1.0.0: {}
+
+  async-limiter@1.0.1: {}
+
+  async@3.2.6: {}
 
   asynckit@0.4.0: {}
 
@@ -7105,11 +12074,98 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  babel-core@7.0.0-bridge.0(@babel/core@7.29.7):
+    dependencies:
+      "@babel/core": 7.29.7
+
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7):
+    dependencies:
+      "@babel/compat-data": 7.29.7
+      "@babel/core": 7.29.7
+      "@babel/helper-define-polyfill-provider": 0.6.8(@babel/core@7.29.7)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.7):
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-define-polyfill-provider": 0.6.8(@babel/core@7.29.7)
+      core-js-compat: 3.49.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.7):
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-define-polyfill-provider": 0.6.8(@babel/core@7.29.7)
+      core-js-compat: 3.49.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.7):
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/helper-define-polyfill-provider": 0.6.8(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0: {}
+
+  babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.29.7):
+    dependencies:
+      "@babel/plugin-syntax-flow": 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - "@babel/core"
+
+  babel-preset-fbjs@3.4.0(@babel/core@7.29.7):
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/plugin-proposal-class-properties": 7.18.6(@babel/core@7.29.7)
+      "@babel/plugin-proposal-object-rest-spread": 7.20.7(@babel/core@7.29.7)
+      "@babel/plugin-syntax-class-properties": 7.12.13(@babel/core@7.29.7)
+      "@babel/plugin-syntax-flow": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-syntax-jsx": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-syntax-object-rest-spread": 7.8.3(@babel/core@7.29.7)
+      "@babel/plugin-transform-arrow-functions": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-block-scoped-functions": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-block-scoping": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-classes": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-computed-properties": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-destructuring": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-flow-strip-types": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-for-of": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-function-name": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-literals": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-member-expression-literals": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-modules-commonjs": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-object-super": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-parameters": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-property-literals": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-react-display-name": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-react-jsx": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-shorthand-properties": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-spread": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-template-literals": 7.29.7(@babel/core@7.29.7)
+      babel-plugin-syntax-trailing-function-commas: 7.0.0-beta.0
+    transitivePeerDependencies:
+      - supports-color
+
   balanced-match@1.0.2: {}
+
+  base64-js@1.5.1: {}
+
+  baseline-browser-mapping@2.11.5: {}
 
   better-opn@3.0.2:
     dependencies:
       open: 8.4.2
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   brace-expansion@1.1.11:
     dependencies:
@@ -7126,13 +12182,34 @@ snapshots:
 
   browser-assert@1.2.1: {}
 
+  browserslist@4.28.7:
+    dependencies:
+      baseline-browser-mapping: 2.11.5
+      caniuse-lite: 1.0.30001806
+      electron-to-chromium: 1.5.396
+      node-releases: 2.0.51
+      update-browserslist-db: 1.2.3(browserslist@4.28.7)
+
+  bser@2.1.1:
+    dependencies:
+      node-int64: 0.4.0
+
   buffer-crc32@1.0.0: {}
+
+  buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   builtin-modules@3.3.0: {}
 
   builtins@5.1.0:
     dependencies:
       semver: 7.7.1
+
+  bytes@3.1.2: {}
 
   cac@6.7.14: {}
 
@@ -7153,9 +12230,23 @@ snapshots:
       call-bind-apply-helpers: 1.0.1
       get-intrinsic: 1.2.7
 
+  caller-callsite@2.0.0:
+    dependencies:
+      callsites: 2.0.0
+
+  caller-path@2.0.0:
+    dependencies:
+      caller-callsite: 2.0.0
+
+  callsites@2.0.0: {}
+
   callsites@3.1.0: {}
 
   camelcase@5.3.1: {}
+
+  camelcase@6.3.0: {}
+
+  caniuse-lite@1.0.30001806: {}
 
   chai@5.2.0:
     dependencies:
@@ -7185,9 +12276,19 @@ snapshots:
 
   chromatic@11.22.0: {}
 
+  ci-info@2.0.0: {}
+
+  ci-info@3.9.0: {}
+
+  cli-cursor@3.1.0:
+    dependencies:
+      restore-cursor: 3.1.0
+
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
+
+  cli-spinners@2.9.2: {}
 
   cli-truncate@4.0.0:
     dependencies:
@@ -7208,13 +12309,29 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clone-deep@4.0.1:
+    dependencies:
+      is-plain-object: 2.0.4
+      kind-of: 6.0.3
+      shallow-clone: 3.0.1
+
+  clone@1.0.4: {}
+
   clsx@2.1.1: {}
+
+  color-convert@1.9.3:
+    dependencies:
+      color-name: 1.1.3
 
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
+  color-name@1.1.3: {}
+
   color-name@1.1.4: {}
+
+  colorette@1.4.0: {}
 
   colorette@2.0.20: {}
 
@@ -7222,9 +12339,35 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  command-exists@1.2.9: {}
+
   commander@12.1.0: {}
 
+  commander@2.13.0: {}
+
+  commander@2.20.3: {}
+
+  commander@9.5.0: {}
+
+  commondir@1.0.1: {}
+
   compare-versions@6.1.1: {}
+
+  compressible@2.0.18:
+    dependencies:
+      mime-db: 1.52.0
+
+  compression@1.8.1:
+    dependencies:
+      bytes: 3.1.2
+      compressible: 2.0.18
+      debug: 2.6.9
+      negotiator: 0.6.4
+      on-headers: 1.1.0
+      safe-buffer: 5.2.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   concat-map@0.0.1: {}
 
@@ -7232,7 +12375,31 @@ snapshots:
 
   confbox@0.2.2: {}
 
+  connect@3.7.0:
+    dependencies:
+      debug: 2.6.9
+      finalhandler: 1.1.2
+      parseurl: 1.3.3
+      utils-merge: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  convert-source-map@2.0.0: {}
+
   cookie@0.7.2: {}
+
+  core-js-compat@3.49.0:
+    dependencies:
+      browserslist: 4.28.7
+
+  core-util-is@1.0.3: {}
+
+  cosmiconfig@5.2.1:
+    dependencies:
+      import-fresh: 2.0.0
+      is-directory: 0.3.1
+      js-yaml: 3.15.0
+      parse-json: 4.0.0
 
   cross-spawn@7.0.6:
     dependencies:
@@ -7273,7 +12440,13 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  dayjs@1.11.21: {}
+
   de-indent@1.0.2: {}
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
 
   debug@3.2.7:
     dependencies:
@@ -7297,6 +12470,10 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  defaults@1.0.4:
+    dependencies:
+      clone: 1.0.4
+
   define-data-property@1.1.4:
     dependencies:
       es-define-property: 1.0.1
@@ -7313,7 +12490,19 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  denodeify@1.2.1: {}
+
+  depd@2.0.0: {}
+
+  deprecated-react-native-prop-types@4.1.0:
+    dependencies:
+      "@react-native/normalize-colors": 0.72.0
+      invariant: 2.2.4
+      prop-types: 15.8.1
+
   dequal@2.0.3: {}
+
+  destroy@1.2.0: {}
 
   detect-indent@6.1.0: {}
 
@@ -7365,9 +12554,17 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  ee-first@1.1.1: {}
+
+  electron-to-chromium@1.5.396: {}
+
   emoji-regex@10.4.0: {}
 
   emoji-regex@8.0.0: {}
+
+  encodeurl@1.0.2: {}
+
+  encodeurl@2.0.0: {}
 
   enquirer@2.4.1:
     dependencies:
@@ -7378,7 +12575,22 @@ snapshots:
 
   entities@4.5.0: {}
 
+  envinfo@7.21.0: {}
+
   environment@1.1.0: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
+
+  error-stack-parser@2.1.4:
+    dependencies:
+      stackframe: 1.3.4
+
+  errorhandler@1.5.2:
+    dependencies:
+      accepts: 1.3.8
+      escape-html: 1.0.3
 
   es-abstract@1.23.9:
     dependencies:
@@ -7501,6 +12713,10 @@ snapshots:
       "@esbuild/win32-x64": 0.25.1
 
   escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
+
+  escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -7793,7 +13009,23 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
+  event-target-shim@5.0.1: {}
+
   eventemitter3@5.0.1: {}
+
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
 
   execa@8.0.1:
     dependencies:
@@ -7827,9 +13059,17 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-xml-parser@4.5.7:
+    dependencies:
+      strnum: 1.1.2
+
   fastq@1.18.0:
     dependencies:
       reusify: 1.0.4
+
+  fb-watchman@2.0.2:
+    dependencies:
+      bser: 2.1.1
 
   fdir@6.4.5(picomatch@4.0.3):
     optionalDependencies:
@@ -7842,6 +13082,28 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@1.1.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      on-finished: 2.3.0
+      parseurl: 1.3.3
+      statuses: 1.5.0
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  find-cache-dir@2.1.0:
+    dependencies:
+      commondir: 1.0.1
+      make-dir: 2.1.0
+      pkg-dir: 3.0.0
+
+  find-up@3.0.0:
+    dependencies:
+      locate-path: 3.0.0
 
   find-up@4.1.0:
     dependencies:
@@ -7861,6 +13123,10 @@ snapshots:
 
   flatted@3.3.2: {}
 
+  flow-enums-runtime@0.0.5: {}
+
+  flow-parser@0.206.0: {}
+
   for-each@0.3.3:
     dependencies:
       is-callable: 1.2.7
@@ -7873,11 +13139,19 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  fresh@0.5.2: {}
+
   fs-extra@11.3.2:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
       universalify: 2.0.1
+
+  fs-extra@8.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
 
   fs.realpath@1.0.0: {}
 
@@ -7898,6 +13172,8 @@ snapshots:
   functional-red-black-tree@1.0.1: {}
 
   functions-have-names@1.2.3: {}
+
+  gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
@@ -7920,6 +13196,8 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.0.0
+
+  get-stream@6.0.1: {}
 
   get-stream@8.0.1: {}
 
@@ -7949,6 +13227,8 @@ snapshots:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
+
+  globals@11.12.0: {}
 
   globals@13.24.0:
     dependencies:
@@ -8004,6 +13284,22 @@ snapshots:
 
   headers-polyfill@4.0.3: {}
 
+  hermes-estree@0.12.0: {}
+
+  hermes-estree@0.8.0: {}
+
+  hermes-parser@0.12.0:
+    dependencies:
+      hermes-estree: 0.12.0
+
+  hermes-parser@0.8.0:
+    dependencies:
+      hermes-estree: 0.8.0
+
+  hermes-profile-transformer@0.0.6:
+    dependencies:
+      source-map: 0.7.6
+
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
@@ -8014,6 +13310,14 @@ snapshots:
       domhandler: 3.3.0
       domutils: 2.8.0
       entities: 2.2.0
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -8031,6 +13335,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  human-signals@2.1.0: {}
+
   human-signals@5.0.0: {}
 
   husky@9.1.7: {}
@@ -8039,9 +13345,20 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@4.0.6: {}
 
   ignore@5.3.2: {}
+
+  image-size@1.2.1:
+    dependencies:
+      queue: 6.0.2
+
+  import-fresh@2.0.0:
+    dependencies:
+      caller-path: 2.0.0
+      resolve-from: 3.0.0
 
   import-fresh@3.3.0:
     dependencies:
@@ -8067,6 +13384,12 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
+  invariant@2.2.4:
+    dependencies:
+      loose-envify: 1.4.0
+
+  ip@1.1.9: {}
+
   is-arguments@1.2.0:
     dependencies:
       call-bound: 1.0.3
@@ -8077,6 +13400,8 @@ snapshots:
       call-bind: 1.0.8
       call-bound: 1.0.3
       get-intrinsic: 1.2.7
+
+  is-arrayish@0.2.1: {}
 
   is-async-function@2.1.0:
     dependencies:
@@ -8115,6 +13440,8 @@ snapshots:
       call-bound: 1.0.3
       has-tostringtag: 1.0.2
 
+  is-directory@0.3.1: {}
+
   is-docker@2.2.1: {}
 
   is-extglob@2.1.1: {}
@@ -8122,6 +13449,8 @@ snapshots:
   is-finalizationregistry@1.1.1:
     dependencies:
       call-bound: 1.0.3
+
+  is-fullwidth-code-point@2.0.0: {}
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -8142,6 +13471,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-interactive@1.0.0: {}
+
   is-map@2.0.3: {}
 
   is-node-process@1.2.0: {}
@@ -8154,6 +13485,10 @@ snapshots:
   is-number@7.0.0: {}
 
   is-path-inside@3.0.3: {}
+
+  is-plain-object@2.0.4:
+    dependencies:
+      isobject: 3.0.1
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -8174,6 +13509,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.3
 
+  is-stream@2.0.1: {}
+
   is-stream@3.0.0: {}
 
   is-string@1.1.1:
@@ -8191,6 +13528,8 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.18
 
+  is-unicode-supported@0.1.0: {}
+
   is-weakmap@2.0.2: {}
 
   is-weakref@1.1.0:
@@ -8202,23 +13541,135 @@ snapshots:
       call-bound: 1.0.3
       get-intrinsic: 1.2.7
 
+  is-wsl@1.1.0: {}
+
   is-wsl@2.2.0:
     dependencies:
       is-docker: 2.2.1
+
+  isarray@1.0.0: {}
 
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 
+  isobject@3.0.1: {}
+
+  jest-environment-node@29.7.0:
+    dependencies:
+      "@jest/environment": 29.7.0
+      "@jest/fake-timers": 29.7.0
+      "@jest/types": 29.6.3
+      "@types/node": 22.10.5
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
+
+  jest-get-type@29.6.3: {}
+
+  jest-message-util@29.7.0:
+    dependencies:
+      "@babel/code-frame": 7.26.2
+      "@jest/types": 29.6.3
+      "@types/stack-utils": 2.0.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+
+  jest-mock@29.7.0:
+    dependencies:
+      "@jest/types": 29.6.3
+      "@types/node": 22.10.5
+      jest-util: 29.7.0
+
+  jest-regex-util@27.5.1: {}
+
+  jest-util@27.5.1:
+    dependencies:
+      "@jest/types": 27.5.1
+      "@types/node": 22.10.5
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      graceful-fs: 4.2.11
+      picomatch: 2.3.1
+
+  jest-util@29.7.0:
+    dependencies:
+      "@jest/types": 29.6.3
+      "@types/node": 22.10.5
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      graceful-fs: 4.2.11
+      picomatch: 2.3.1
+
+  jest-validate@29.7.0:
+    dependencies:
+      "@jest/types": 29.6.3
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      jest-get-type: 29.6.3
+      leven: 3.1.0
+      pretty-format: 29.7.0
+
+  jest-worker@27.5.1:
+    dependencies:
+      "@types/node": 22.10.5
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
   jju@1.4.0: {}
+
+  joi@17.13.4:
+    dependencies:
+      "@hapi/hoek": 9.3.0
+      "@hapi/topo": 5.1.0
+      "@sideway/address": 4.1.5
+      "@sideway/formula": 3.0.1
+      "@sideway/pinpoint": 2.0.0
 
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
 
+  js-yaml@3.15.0:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsc-android@250231.0.0: {}
+
+  jsc-safe-url@0.2.4: {}
+
+  jscodeshift@0.14.0(@babel/preset-env@7.29.7(@babel/core@7.29.7)):
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/parser": 7.28.4
+      "@babel/plugin-proposal-class-properties": 7.18.6(@babel/core@7.29.7)
+      "@babel/plugin-proposal-nullish-coalescing-operator": 7.18.6(@babel/core@7.29.7)
+      "@babel/plugin-proposal-optional-chaining": 7.21.0(@babel/core@7.29.7)
+      "@babel/plugin-transform-modules-commonjs": 7.29.7(@babel/core@7.29.7)
+      "@babel/preset-env": 7.29.7(@babel/core@7.29.7)
+      "@babel/preset-flow": 7.29.7(@babel/core@7.29.7)
+      "@babel/preset-typescript": 7.29.7(@babel/core@7.29.7)
+      "@babel/register": 7.29.7(@babel/core@7.29.7)
+      babel-core: 7.0.0-bridge.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      flow-parser: 0.206.0
+      graceful-fs: 4.2.11
+      micromatch: 4.0.8
+      neo-async: 2.6.2
+      node-dir: 0.1.17
+      recast: 0.21.5
+      temp: 0.8.4
+      write-file-atomic: 2.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   jsdoc-type-pratt-parser@4.1.0: {}
 
@@ -8250,7 +13701,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  jsesc@3.1.0: {}
+
   json-buffer@3.0.1: {}
+
+  json-parse-better-errors@1.0.2: {}
 
   json-schema-traverse@0.4.1: {}
 
@@ -8262,6 +13717,12 @@ snapshots:
     dependencies:
       minimist: 1.2.8
 
+  json5@2.2.3: {}
+
+  jsonfile@4.0.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
   jsonfile@6.2.0:
     dependencies:
       universalify: 2.0.1
@@ -8272,9 +13733,15 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  kind-of@6.0.3: {}
+
+  kleur@3.0.3: {}
+
   known-css-properties@0.35.0: {}
 
   kolorist@1.8.0: {}
+
+  leven@3.1.0: {}
 
   levn@0.4.1:
     dependencies:
@@ -8321,6 +13788,11 @@ snapshots:
 
   locate-character@3.0.0: {}
 
+  locate-path@3.0.0:
+    dependencies:
+      p-locate: 3.0.0
+      path-exists: 3.0.0
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -8329,9 +13801,18 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.debounce@4.0.8: {}
+
   lodash.merge@4.6.2: {}
 
+  lodash.throttle@4.1.1: {}
+
   lodash@4.17.23: {}
+
+  log-symbols@4.1.0:
+    dependencies:
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
 
   log-update@6.1.0:
     dependencies:
@@ -8340,6 +13821,12 @@ snapshots:
       slice-ansi: 7.1.0
       strip-ansi: 7.1.0
       wrap-ansi: 9.0.0
+
+  logkitty@0.7.1:
+    dependencies:
+      ansi-fragments: 0.2.1
+      dayjs: 1.11.21
+      yargs: 15.4.1
 
   loose-envify@1.4.0:
     dependencies:
@@ -8350,6 +13837,10 @@ snapshots:
   lower-case@2.0.2:
     dependencies:
       tslib: 2.8.1
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   lru-cache@6.0.0:
     dependencies:
@@ -8362,6 +13853,15 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       "@jridgewell/sourcemap-codec": 1.5.0
+
+  make-dir@2.1.0:
+    dependencies:
+      pify: 4.0.1
+      semver: 5.7.2
+
+  makeerror@1.0.12:
+    dependencies:
+      tmpl: 1.0.5
 
   map-or-similar@1.5.0: {}
 
@@ -8378,6 +13878,8 @@ snapshots:
 
   mdurl@2.0.0: {}
 
+  memoize-one@5.2.1: {}
+
   memoizerific@1.11.3:
     dependencies:
       map-or-similar: 1.5.0
@@ -8385,6 +13887,500 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  metro-babel-transformer@0.76.5:
+    dependencies:
+      "@babel/core": 7.29.7
+      hermes-parser: 0.8.0
+      metro-source-map: 0.76.5
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-babel-transformer@0.76.9:
+    dependencies:
+      "@babel/core": 7.29.7
+      hermes-parser: 0.12.0
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-cache-key@0.76.5: {}
+
+  metro-cache-key@0.76.9: {}
+
+  metro-cache@0.76.5:
+    dependencies:
+      metro-core: 0.76.5
+      rimraf: 3.0.2
+
+  metro-cache@0.76.9:
+    dependencies:
+      metro-core: 0.76.9
+      rimraf: 3.0.2
+
+  metro-config@0.76.5:
+    dependencies:
+      cosmiconfig: 5.2.1
+      jest-validate: 29.7.0
+      metro: 0.76.5
+      metro-cache: 0.76.5
+      metro-core: 0.76.5
+      metro-runtime: 0.76.5
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  metro-config@0.76.9:
+    dependencies:
+      connect: 3.7.0
+      cosmiconfig: 5.2.1
+      jest-validate: 29.7.0
+      metro: 0.76.9
+      metro-cache: 0.76.9
+      metro-core: 0.76.9
+      metro-runtime: 0.76.9
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  metro-core@0.76.5:
+    dependencies:
+      lodash.throttle: 4.1.1
+      metro-resolver: 0.76.5
+
+  metro-core@0.76.9:
+    dependencies:
+      lodash.throttle: 4.1.1
+      metro-resolver: 0.76.9
+
+  metro-file-map@0.76.5:
+    dependencies:
+      anymatch: 3.1.3
+      debug: 2.6.9
+      fb-watchman: 2.0.2
+      graceful-fs: 4.2.11
+      invariant: 2.2.4
+      jest-regex-util: 27.5.1
+      jest-util: 27.5.1
+      jest-worker: 27.5.1
+      micromatch: 4.0.8
+      node-abort-controller: 3.1.1
+      nullthrows: 1.1.1
+      walker: 1.0.8
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-file-map@0.76.9:
+    dependencies:
+      anymatch: 3.1.3
+      debug: 2.6.9
+      fb-watchman: 2.0.2
+      graceful-fs: 4.2.11
+      invariant: 2.2.4
+      jest-regex-util: 27.5.1
+      jest-util: 27.5.1
+      jest-worker: 27.5.1
+      micromatch: 4.0.8
+      node-abort-controller: 3.1.1
+      nullthrows: 1.1.1
+      walker: 1.0.8
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-inspector-proxy@0.76.5:
+    dependencies:
+      connect: 3.7.0
+      debug: 2.6.9
+      node-fetch: 2.7.0
+      ws: 7.5.13
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  metro-inspector-proxy@0.76.9:
+    dependencies:
+      connect: 3.7.0
+      debug: 2.6.9
+      node-fetch: 2.7.0
+      ws: 7.5.13
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  metro-minify-terser@0.76.5:
+    dependencies:
+      terser: 5.49.0
+
+  metro-minify-terser@0.76.9:
+    dependencies:
+      terser: 5.49.0
+
+  metro-minify-uglify@0.76.5:
+    dependencies:
+      uglify-es: 3.3.9
+
+  metro-minify-uglify@0.76.9:
+    dependencies:
+      uglify-es: 3.3.9
+
+  metro-react-native-babel-preset@0.76.5(@babel/core@7.29.7):
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/plugin-proposal-async-generator-functions": 7.20.7(@babel/core@7.29.7)
+      "@babel/plugin-proposal-class-properties": 7.18.6(@babel/core@7.29.7)
+      "@babel/plugin-proposal-export-default-from": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-proposal-nullish-coalescing-operator": 7.18.6(@babel/core@7.29.7)
+      "@babel/plugin-proposal-numeric-separator": 7.18.6(@babel/core@7.29.7)
+      "@babel/plugin-proposal-object-rest-spread": 7.20.7(@babel/core@7.29.7)
+      "@babel/plugin-proposal-optional-catch-binding": 7.18.6(@babel/core@7.29.7)
+      "@babel/plugin-proposal-optional-chaining": 7.21.0(@babel/core@7.29.7)
+      "@babel/plugin-syntax-dynamic-import": 7.8.3(@babel/core@7.29.7)
+      "@babel/plugin-syntax-export-default-from": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-syntax-flow": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-syntax-nullish-coalescing-operator": 7.8.3(@babel/core@7.29.7)
+      "@babel/plugin-syntax-optional-chaining": 7.8.3(@babel/core@7.29.7)
+      "@babel/plugin-transform-arrow-functions": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-async-to-generator": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-block-scoping": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-classes": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-computed-properties": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-destructuring": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-flow-strip-types": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-function-name": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-literals": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-modules-commonjs": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-named-capturing-groups-regex": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-parameters": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-react-display-name": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-react-jsx": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-react-jsx-self": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-react-jsx-source": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-runtime": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-shorthand-properties": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-spread": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-sticky-regex": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-typescript": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-unicode-regex": 7.29.7(@babel/core@7.29.7)
+      "@babel/template": 7.29.7
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.7)
+      react-refresh: 0.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-react-native-babel-preset@0.76.9(@babel/core@7.29.7):
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/plugin-proposal-async-generator-functions": 7.20.7(@babel/core@7.29.7)
+      "@babel/plugin-proposal-class-properties": 7.18.6(@babel/core@7.29.7)
+      "@babel/plugin-proposal-export-default-from": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-proposal-nullish-coalescing-operator": 7.18.6(@babel/core@7.29.7)
+      "@babel/plugin-proposal-numeric-separator": 7.18.6(@babel/core@7.29.7)
+      "@babel/plugin-proposal-object-rest-spread": 7.20.7(@babel/core@7.29.7)
+      "@babel/plugin-proposal-optional-catch-binding": 7.18.6(@babel/core@7.29.7)
+      "@babel/plugin-proposal-optional-chaining": 7.21.0(@babel/core@7.29.7)
+      "@babel/plugin-syntax-dynamic-import": 7.8.3(@babel/core@7.29.7)
+      "@babel/plugin-syntax-export-default-from": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-syntax-flow": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-syntax-nullish-coalescing-operator": 7.8.3(@babel/core@7.29.7)
+      "@babel/plugin-syntax-optional-chaining": 7.8.3(@babel/core@7.29.7)
+      "@babel/plugin-transform-arrow-functions": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-async-to-generator": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-block-scoping": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-classes": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-computed-properties": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-destructuring": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-flow-strip-types": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-function-name": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-literals": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-modules-commonjs": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-named-capturing-groups-regex": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-parameters": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-react-display-name": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-react-jsx": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-react-jsx-self": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-react-jsx-source": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-runtime": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-shorthand-properties": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-spread": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-sticky-regex": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-typescript": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-unicode-regex": 7.29.7(@babel/core@7.29.7)
+      "@babel/template": 7.29.7
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.7)
+      react-refresh: 0.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-react-native-babel-transformer@0.76.5(@babel/core@7.29.7):
+    dependencies:
+      "@babel/core": 7.29.7
+      babel-preset-fbjs: 3.4.0(@babel/core@7.29.7)
+      hermes-parser: 0.8.0
+      metro-babel-transformer: 0.76.5
+      metro-react-native-babel-preset: 0.76.5(@babel/core@7.29.7)
+      metro-source-map: 0.76.5
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-react-native-babel-transformer@0.76.9(@babel/core@7.29.7):
+    dependencies:
+      "@babel/core": 7.29.7
+      babel-preset-fbjs: 3.4.0(@babel/core@7.29.7)
+      hermes-parser: 0.12.0
+      metro-react-native-babel-preset: 0.76.9(@babel/core@7.29.7)
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-resolver@0.76.5: {}
+
+  metro-resolver@0.76.9: {}
+
+  metro-runtime@0.76.5:
+    dependencies:
+      "@babel/runtime": 7.28.6
+      react-refresh: 0.4.3
+
+  metro-runtime@0.76.9:
+    dependencies:
+      "@babel/runtime": 7.28.6
+      react-refresh: 0.4.3
+
+  metro-source-map@0.76.5:
+    dependencies:
+      "@babel/traverse": 7.23.2
+      "@babel/types": 7.28.4
+      invariant: 2.2.4
+      metro-symbolicate: 0.76.5
+      nullthrows: 1.1.1
+      ob1: 0.76.5
+      source-map: 0.5.7
+      vlq: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-source-map@0.76.9:
+    dependencies:
+      "@babel/traverse": 7.23.2
+      "@babel/types": 7.28.4
+      invariant: 2.2.4
+      metro-symbolicate: 0.76.9
+      nullthrows: 1.1.1
+      ob1: 0.76.9
+      source-map: 0.5.7
+      vlq: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-symbolicate@0.76.5:
+    dependencies:
+      invariant: 2.2.4
+      metro-source-map: 0.76.5
+      nullthrows: 1.1.1
+      source-map: 0.5.7
+      through2: 2.0.5
+      vlq: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-symbolicate@0.76.9:
+    dependencies:
+      invariant: 2.2.4
+      metro-source-map: 0.76.9
+      nullthrows: 1.1.1
+      source-map: 0.5.7
+      through2: 2.0.5
+      vlq: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-transform-plugins@0.76.5:
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/generator": 7.29.7
+      "@babel/template": 7.29.7
+      "@babel/traverse": 7.29.7
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-transform-plugins@0.76.9:
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/generator": 7.29.7
+      "@babel/template": 7.29.7
+      "@babel/traverse": 7.23.2
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-transform-worker@0.76.5:
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/generator": 7.29.7
+      "@babel/parser": 7.28.4
+      "@babel/types": 7.28.4
+      babel-preset-fbjs: 3.4.0(@babel/core@7.29.7)
+      metro: 0.76.5
+      metro-babel-transformer: 0.76.5
+      metro-cache: 0.76.5
+      metro-cache-key: 0.76.5
+      metro-source-map: 0.76.5
+      metro-transform-plugins: 0.76.5
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  metro-transform-worker@0.76.9:
+    dependencies:
+      "@babel/core": 7.29.7
+      "@babel/generator": 7.29.7
+      "@babel/parser": 7.28.4
+      "@babel/types": 7.28.4
+      babel-preset-fbjs: 3.4.0(@babel/core@7.29.7)
+      metro: 0.76.9
+      metro-babel-transformer: 0.76.9
+      metro-cache: 0.76.9
+      metro-cache-key: 0.76.9
+      metro-minify-terser: 0.76.9
+      metro-source-map: 0.76.9
+      metro-transform-plugins: 0.76.9
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  metro@0.76.5:
+    dependencies:
+      "@babel/code-frame": 7.26.2
+      "@babel/core": 7.29.7
+      "@babel/generator": 7.29.7
+      "@babel/parser": 7.28.4
+      "@babel/template": 7.29.7
+      "@babel/traverse": 7.29.7
+      "@babel/types": 7.28.4
+      accepts: 1.3.8
+      async: 3.2.6
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 2.6.9
+      denodeify: 1.2.1
+      error-stack-parser: 2.1.4
+      graceful-fs: 4.2.11
+      hermes-parser: 0.8.0
+      image-size: 1.2.1
+      invariant: 2.2.4
+      jest-worker: 27.5.1
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.76.5
+      metro-cache: 0.76.5
+      metro-cache-key: 0.76.5
+      metro-config: 0.76.5
+      metro-core: 0.76.5
+      metro-file-map: 0.76.5
+      metro-inspector-proxy: 0.76.5
+      metro-minify-terser: 0.76.5
+      metro-minify-uglify: 0.76.5
+      metro-react-native-babel-preset: 0.76.5(@babel/core@7.29.7)
+      metro-resolver: 0.76.5
+      metro-runtime: 0.76.5
+      metro-source-map: 0.76.5
+      metro-symbolicate: 0.76.5
+      metro-transform-plugins: 0.76.5
+      metro-transform-worker: 0.76.5
+      mime-types: 2.1.35
+      node-fetch: 2.7.0
+      nullthrows: 1.1.1
+      rimraf: 3.0.2
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      strip-ansi: 6.0.1
+      throat: 5.0.0
+      ws: 7.5.13
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  metro@0.76.9:
+    dependencies:
+      "@babel/code-frame": 7.26.2
+      "@babel/core": 7.29.7
+      "@babel/generator": 7.29.7
+      "@babel/parser": 7.28.4
+      "@babel/template": 7.29.7
+      "@babel/traverse": 7.23.2
+      "@babel/types": 7.28.4
+      accepts: 1.3.8
+      async: 3.2.6
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 2.6.9
+      denodeify: 1.2.1
+      error-stack-parser: 2.1.4
+      graceful-fs: 4.2.11
+      hermes-parser: 0.12.0
+      image-size: 1.2.1
+      invariant: 2.2.4
+      jest-worker: 27.5.1
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.76.9
+      metro-cache: 0.76.9
+      metro-cache-key: 0.76.9
+      metro-config: 0.76.9
+      metro-core: 0.76.9
+      metro-file-map: 0.76.9
+      metro-inspector-proxy: 0.76.9
+      metro-minify-uglify: 0.76.9
+      metro-react-native-babel-preset: 0.76.9(@babel/core@7.29.7)
+      metro-resolver: 0.76.9
+      metro-runtime: 0.76.9
+      metro-source-map: 0.76.9
+      metro-symbolicate: 0.76.9
+      metro-transform-plugins: 0.76.9
+      metro-transform-worker: 0.76.9
+      mime-types: 2.1.35
+      node-fetch: 2.7.0
+      nullthrows: 1.1.1
+      rimraf: 3.0.2
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      strip-ansi: 6.0.1
+      throat: 5.0.0
+      ws: 7.5.13
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
 
   micromatch@4.0.8:
     dependencies:
@@ -8396,6 +14392,12 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime@1.6.0: {}
+
+  mime@2.6.0: {}
+
+  mimic-fn@2.1.0: {}
 
   mimic-fn@4.0.0: {}
 
@@ -8434,6 +14436,8 @@ snapshots:
 
   mri@1.2.0: {}
 
+  ms@2.0.0: {}
+
   ms@2.1.3: {}
 
   msw@2.7.0(@types/node@22.10.5)(typescript@5.8.2):
@@ -8469,16 +14473,54 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@0.6.3: {}
+
+  negotiator@0.6.4: {}
+
+  neo-async@2.6.2: {}
+
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
       tslib: 2.8.1
 
+  nocache@3.0.4: {}
+
+  node-abort-controller@3.1.1: {}
+
+  node-dir@0.1.17:
+    dependencies:
+      minimatch: 3.1.2
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-int64@0.4.0: {}
+
+  node-releases@2.0.51: {}
+
+  node-stream-zip@1.16.0: {}
+
+  normalize-path@3.0.0: {}
+
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
 
+  nullthrows@1.1.1: {}
+
   nwsapi@2.2.16: {}
+
+  ob1@0.76.5: {}
+
+  ob1@0.76.9: {}
+
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.3: {}
 
@@ -8513,9 +14555,23 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.0.0
 
+  on-finished@2.3.0:
+    dependencies:
+      ee-first: 1.1.1
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  on-headers@1.1.0: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
 
   onetime@6.0.0:
     dependencies:
@@ -8524,6 +14580,10 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  open@6.4.0:
+    dependencies:
+      is-wsl: 1.1.0
 
   open@8.4.2:
     dependencies:
@@ -8539,6 +14599,18 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  ora@5.4.1:
+    dependencies:
+      bl: 4.1.0
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-spinners: 2.9.2
+      is-interactive: 1.0.0
+      is-unicode-supported: 0.1.0
+      log-symbols: 4.1.0
+      strip-ansi: 6.0.1
+      wcwidth: 1.0.1
 
   outvariant@1.4.3: {}
 
@@ -8556,6 +14628,10 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-locate@3.0.0:
+    dependencies:
+      p-limit: 2.3.0
+
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
@@ -8570,9 +14646,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-json@4.0.0:
+    dependencies:
+      error-ex: 1.3.4
+      json-parse-better-errors: 1.0.2
+
   parse5@7.2.1:
     dependencies:
       entities: 4.5.0
+
+  parseurl@1.3.3: {}
 
   pascal-case@3.1.2:
     dependencies:
@@ -8580,6 +14663,8 @@ snapshots:
       tslib: 2.8.1
 
   path-browserify@1.0.1: {}
+
+  path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
 
@@ -8606,6 +14691,14 @@ snapshots:
   picomatch@4.0.3: {}
 
   pidtree@0.6.0: {}
+
+  pify@4.0.1: {}
+
+  pirates@4.0.7: {}
+
+  pkg-dir@3.0.0:
+    dependencies:
+      find-up: 3.0.0
 
   pkg-types@1.3.1:
     dependencies:
@@ -8666,15 +14759,45 @@ snapshots:
 
   prettier@3.4.2: {}
 
+  pretty-format@26.6.2:
+    dependencies:
+      "@jest/types": 26.6.2
+      ansi-regex: 5.0.1
+      ansi-styles: 4.3.0
+      react-is: 17.0.2
+
   pretty-format@27.5.1:
     dependencies:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  pretty-format@29.7.0:
+    dependencies:
+      "@jest/schemas": 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
+  process-nextick-args@2.0.1: {}
+
   process@0.11.10: {}
 
   progress@2.0.3: {}
+
+  promise@8.3.0:
+    dependencies:
+      asap: 2.0.6
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
+
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
 
   psl@1.15.0:
     dependencies:
@@ -8696,19 +14819,123 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  queue@6.0.2:
+    dependencies:
+      inherits: 2.0.4
+
+  range-parser@1.2.1: {}
+
+  react-devtools-core@4.28.5:
+    dependencies:
+      shell-quote: 1.10.0
+      ws: 7.5.13
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-is@16.13.1: {}
+
   react-is@17.0.2: {}
+
+  react-is@18.3.1: {}
+
+  react-native-uuid@2.0.4: {}
+
+  react-native@0.72.0(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react@18.3.1):
+    dependencies:
+      "@jest/create-cache-key-function": 29.7.0
+      "@react-native-community/cli": 11.3.2(@babel/core@7.29.7)
+      "@react-native-community/cli-platform-android": 11.3.2
+      "@react-native-community/cli-platform-ios": 11.3.2
+      "@react-native/assets-registry": 0.72.0
+      "@react-native/codegen": 0.72.8(@babel/preset-env@7.29.7(@babel/core@7.29.7))
+      "@react-native/gradle-plugin": 0.72.11
+      "@react-native/js-polyfills": 0.72.1
+      "@react-native/normalize-colors": 0.72.0
+      "@react-native/virtualized-lists": 0.72.8(react-native@0.72.0(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react@18.2.0))
+      abort-controller: 3.0.0
+      anser: 1.4.10
+      base64-js: 1.5.1
+      deprecated-react-native-prop-types: 4.1.0
+      event-target-shim: 5.0.1
+      flow-enums-runtime: 0.0.5
+      invariant: 2.2.4
+      jest-environment-node: 29.7.0
+      jsc-android: 250231.0.0
+      memoize-one: 5.2.1
+      metro-runtime: 0.76.5
+      metro-source-map: 0.76.5
+      mkdirp: 0.5.6
+      nullthrows: 1.1.1
+      pretty-format: 26.6.2
+      promise: 8.3.0
+      react: 18.3.1
+      react-devtools-core: 4.28.5
+      react-refresh: 0.4.3
+      react-shallow-renderer: 16.15.0(react@18.2.0)
+      regenerator-runtime: 0.13.11
+      scheduler: 0.24.0-canary-efb381bbf-20230505
+      stacktrace-parser: 0.1.11
+      use-sync-external-store: 1.6.0(react@18.2.0)
+      whatwg-fetch: 3.6.20
+      ws: 6.2.6
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - "@babel/core"
+      - "@babel/preset-env"
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  react-refresh@0.4.3: {}
+
+  react-shallow-renderer@16.15.0(react@18.2.0):
+    dependencies:
+      object-assign: 4.1.1
+      react: 18.2.0
+      react-is: 17.0.2
+
+  react@18.2.0:
+    dependencies:
+      loose-envify: 1.4.0
 
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   readdirp@4.0.2: {}
+
+  readline@1.3.0: {}
+
+  recast@0.21.5:
+    dependencies:
+      ast-types: 0.15.2
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tslib: 2.8.1
 
   recast@0.23.11:
     dependencies:
@@ -8734,6 +14961,14 @@ snapshots:
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
 
+  regenerate-unicode-properties@10.2.2:
+    dependencies:
+      regenerate: 1.4.2
+
+  regenerate@1.4.2: {}
+
+  regenerator-runtime@0.13.11: {}
+
   regexp.prototype.flags@1.5.4:
     dependencies:
       call-bind: 1.0.8
@@ -8745,6 +14980,21 @@ snapshots:
 
   regexpp@3.2.0: {}
 
+  regexpu-core@6.4.0:
+    dependencies:
+      regenerate: 1.4.2
+      regenerate-unicode-properties: 10.2.2
+      regjsgen: 0.8.0
+      regjsparser: 0.13.2
+      unicode-match-property-ecmascript: 2.0.0
+      unicode-match-property-value-ecmascript: 2.2.1
+
+  regjsgen@0.8.0: {}
+
+  regjsparser@0.13.2:
+    dependencies:
+      jsesc: 3.1.0
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -8752,6 +15002,8 @@ snapshots:
   require-main-filename@2.0.0: {}
 
   requires-port@1.0.0: {}
+
+  resolve-from@3.0.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -8763,6 +15015,18 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  restore-cursor@3.1.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
@@ -8771,6 +15035,10 @@ snapshots:
   reusify@1.0.4: {}
 
   rfdc@1.4.1: {}
+
+  rimraf@2.6.3:
+    dependencies:
+      glob: 7.2.3
 
   rimraf@2.7.1:
     dependencies:
@@ -8824,6 +15092,10 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.1.2: {}
+
+  safe-buffer@5.2.1: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -8852,6 +15124,12 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  scheduler@0.24.0-canary-efb381bbf-20230505:
+    dependencies:
+      loose-envify: 1.4.0
+
+  semver@5.7.2: {}
+
   semver@6.3.1: {}
 
   semver@7.5.4:
@@ -8859,6 +15137,35 @@ snapshots:
       lru-cache: 6.0.0
 
   semver@7.7.1: {}
+
+  send@0.19.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serialize-error@2.1.0: {}
+
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
 
   set-blocking@2.0.0: {}
 
@@ -8884,11 +15191,19 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.0.0
 
+  setprototypeof@1.2.0: {}
+
+  shallow-clone@3.0.1:
+    dependencies:
+      kind-of: 6.0.3
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.10.0: {}
 
   side-channel-list@1.0.0:
     dependencies:
@@ -8920,9 +15235,19 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7: {}
+
   signal-exit@4.1.0: {}
 
+  sisteransi@1.0.5: {}
+
   slash@3.0.0: {}
+
+  slice-ansi@2.1.0:
+    dependencies:
+      ansi-styles: 3.2.1
+      astral-regex: 1.0.0
+      is-fullwidth-code-point: 2.0.0
 
   slice-ansi@5.0.0:
     dependencies:
@@ -8943,13 +15268,36 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.5.7: {}
+
   source-map@0.6.1: {}
+
+  source-map@0.7.6: {}
 
   sprintf-js@1.0.3: {}
 
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
   stackback@0.0.2: {}
 
+  stackframe@1.3.4: {}
+
+  stacktrace-parser@0.1.11:
+    dependencies:
+      type-fest: 0.7.1
+
+  statuses@1.5.0: {}
+
   statuses@2.0.1: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.9.0: {}
 
@@ -9012,6 +15360,18 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.0.0
 
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-ansi@5.2.0:
+    dependencies:
+      ansi-regex: 4.1.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -9021,6 +15381,8 @@ snapshots:
       ansi-regex: 6.1.0
 
   strip-bom@3.0.0: {}
+
+  strip-final-newline@2.0.0: {}
 
   strip-final-newline@3.0.0: {}
 
@@ -9033,6 +15395,10 @@ snapshots:
   strip-literal@3.0.0:
     dependencies:
       js-tokens: 9.0.1
+
+  strnum@1.1.2: {}
+
+  sudo-prompt@9.2.1: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -9072,7 +15438,7 @@ snapshots:
     optionalDependencies:
       svelte: 5.46.4
 
-  svelte-preprocess@5.1.4(postcss-load-config@3.1.4(postcss@8.5.3))(postcss@8.5.3)(svelte@5.46.4)(typescript@5.8.2):
+  svelte-preprocess@5.1.4(@babel/core@7.29.7)(postcss-load-config@3.1.4(postcss@8.5.3))(postcss@8.5.3)(svelte@5.46.4)(typescript@5.8.2):
     dependencies:
       "@types/pug": 2.0.10
       detect-indent: 6.1.0
@@ -9081,6 +15447,7 @@ snapshots:
       strip-indent: 3.0.0
       svelte: 5.46.4
     optionalDependencies:
+      "@babel/core": 7.29.7
       postcss: 8.5.3
       postcss-load-config: 3.1.4(postcss@8.5.3)
       typescript: 5.8.2
@@ -9125,7 +15492,25 @@ snapshots:
       "@pkgr/core": 0.1.1
       tslib: 2.8.1
 
+  temp@0.8.4:
+    dependencies:
+      rimraf: 2.6.3
+
+  terser@5.49.0:
+    dependencies:
+      "@jridgewell/source-map": 0.3.11
+      acorn: 8.15.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
+
   text-table@0.2.0: {}
+
+  throat@5.0.0: {}
+
+  through2@2.0.5:
+    dependencies:
+      readable-stream: 2.3.8
+      xtend: 4.0.2
 
   tiny-invariant@1.3.3: {}
 
@@ -9154,9 +15539,13 @@ snapshots:
     dependencies:
       tldts-core: 6.1.71
 
+  tmpl@1.0.5: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  toidentifier@1.0.1: {}
 
   tough-cookie@4.1.4:
     dependencies:
@@ -9168,6 +15557,8 @@ snapshots:
   tough-cookie@5.0.0:
     dependencies:
       tldts: 6.1.71
+
+  tr46@0.0.3: {}
 
   tr46@5.0.0:
     dependencies:
@@ -9196,9 +15587,13 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-detect@4.0.8: {}
+
   type-fest@0.20.2: {}
 
   type-fest@0.21.3: {}
+
+  type-fest@0.7.1: {}
 
   type-fest@2.19.0: {}
 
@@ -9262,6 +15657,11 @@ snapshots:
 
   ufo@1.6.1: {}
 
+  uglify-es@3.3.9:
+    dependencies:
+      commander: 2.13.0
+      source-map: 0.6.1
+
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.3
@@ -9271,14 +15671,35 @@ snapshots:
 
   undici-types@6.20.0: {}
 
+  unicode-canonical-property-names-ecmascript@2.0.1: {}
+
+  unicode-match-property-ecmascript@2.0.0:
+    dependencies:
+      unicode-canonical-property-names-ecmascript: 2.0.1
+      unicode-property-aliases-ecmascript: 2.2.0
+
+  unicode-match-property-value-ecmascript@2.2.1: {}
+
+  unicode-property-aliases-ecmascript@2.2.0: {}
+
+  universalify@0.1.2: {}
+
   universalify@0.2.0: {}
 
   universalify@2.0.1: {}
+
+  unpipe@1.0.0: {}
 
   unplugin@1.16.1:
     dependencies:
       acorn: 8.15.0
       webpack-virtual-modules: 0.6.2
+
+  update-browserslist-db@1.2.3(browserslist@4.28.7):
+    dependencies:
+      browserslist: 4.28.7
+      escalade: 3.2.0
+      picocolors: 1.1.1
 
   uri-js@4.4.1:
     dependencies:
@@ -9288,6 +15709,10 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  use-sync-external-store@1.6.0(react@18.2.0):
+    dependencies:
+      react: 18.2.0
 
   util-deprecate@1.0.2: {}
 
@@ -9299,19 +15724,23 @@ snapshots:
       is-typed-array: 1.1.15
       which-typed-array: 1.1.18
 
+  utils-merge@1.0.1: {}
+
   uuid@11.0.5: {}
 
   uuid@9.0.1: {}
 
   v8-compile-cache@2.4.0: {}
 
-  vite-node@3.2.4(@types/node@22.10.5)(yaml@2.6.1):
+  vary@1.1.2: {}
+
+  vite-node@3.2.4(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.1(@types/node@22.10.5)(yaml@2.6.1)
+      vite: 6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - "@types/node"
       - jiti
@@ -9326,7 +15755,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-dts@4.5.4(@types/node@22.10.5)(rollup@4.41.1)(typescript@5.8.2)(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1)):
+  vite-plugin-dts@4.5.4(@types/node@22.10.5)(rollup@4.41.1)(typescript@5.8.2)(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)):
     dependencies:
       "@microsoft/api-extractor": 7.52.13(@types/node@22.10.5)
       "@rollup/pluginutils": 5.1.4(rollup@4.41.1)
@@ -9339,13 +15768,13 @@ snapshots:
       magic-string: 0.30.17
       typescript: 5.8.2
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.10.5)(yaml@2.6.1)
+      vite: 6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - "@types/node"
       - rollup
       - supports-color
 
-  vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1):
+  vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1):
     dependencies:
       esbuild: 0.25.1
       fdir: 6.4.5(picomatch@4.0.3)
@@ -9356,17 +15785,18 @@ snapshots:
     optionalDependencies:
       "@types/node": 22.10.5
       fsevents: 2.3.3
+      terser: 5.49.0
       yaml: 2.6.1
 
-  vitefu@1.1.1(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1)):
+  vitefu@1.1.1(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)):
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.10.5)(yaml@2.6.1)
+      vite: 6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)
 
-  vitest@3.2.4(@types/node@22.10.5)(jsdom@25.0.1)(msw@2.7.0(@types/node@22.10.5)(typescript@5.8.2))(yaml@2.6.1):
+  vitest@3.2.4(@types/node@22.10.5)(jsdom@25.0.1)(msw@2.7.0(@types/node@22.10.5)(typescript@5.8.2))(terser@5.49.0)(yaml@2.6.1):
     dependencies:
       "@types/chai": 5.2.2
       "@vitest/expect": 3.2.4
-      "@vitest/mocker": 3.2.4(msw@2.7.0(@types/node@22.10.5)(typescript@5.8.2))(vite@6.4.1(@types/node@22.10.5)(yaml@2.6.1))
+      "@vitest/mocker": 3.2.4(msw@2.7.0(@types/node@22.10.5)(typescript@5.8.2))(vite@6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1))
       "@vitest/pretty-format": 3.2.4
       "@vitest/runner": 3.2.4
       "@vitest/snapshot": 3.2.4
@@ -9384,8 +15814,8 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.1(@types/node@22.10.5)(yaml@2.6.1)
-      vite-node: 3.2.4(@types/node@22.10.5)(yaml@2.6.1)
+      vite: 6.4.1(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)
+      vite-node: 3.2.4(@types/node@22.10.5)(terser@5.49.0)(yaml@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       "@types/node": 22.10.5
@@ -9404,11 +15834,23 @@ snapshots:
       - tsx
       - yaml
 
+  vlq@1.0.1: {}
+
   vscode-uri@3.0.8: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+
+  walker@1.0.8:
+    dependencies:
+      makeerror: 1.0.12
+
+  wcwidth@1.0.1:
+    dependencies:
+      defaults: 1.0.4
+
+  webidl-conversions@3.0.1: {}
 
   webidl-conversions@7.0.0: {}
 
@@ -9418,12 +15860,19 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
 
+  whatwg-fetch@3.6.20: {}
+
   whatwg-mimetype@4.0.0: {}
 
   whatwg-url@14.1.0:
     dependencies:
       tr46: 5.0.0
       webidl-conversions: 7.0.0
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -9498,15 +15947,31 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  write-file-atomic@2.4.3:
+    dependencies:
+      graceful-fs: 4.2.11
+      imurmurhash: 0.1.4
+      signal-exit: 3.0.7
+
+  ws@6.2.6:
+    dependencies:
+      async-limiter: 1.0.1
+
+  ws@7.5.13: {}
+
   ws@8.18.0: {}
 
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
 
+  xtend@4.0.2: {}
+
   y18n@4.0.3: {}
 
   y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
 
   yallist@4.0.0: {}
 

--- a/src/amazon-vega/amazon-vega-billing-wrapper.ts
+++ b/src/amazon-vega/amazon-vega-billing-wrapper.ts
@@ -1,0 +1,36 @@
+import { ErrorCode, PurchasesError } from "../entities/errors";
+import {
+  type AmazonVegaSdk,
+  type AmazonVegaSdkLoader,
+  loadAmazonVegaSdk,
+} from "./amazon-vega-sdk-loader";
+
+/**
+ * Amazon billing wrapper. Handles processing of various functions for the Amazon Store
+ * when running on the Vega OS.
+ * @internal
+ */
+export class AmazonVegaBillingWrapper {
+  constructor(
+    private readonly amazonVegaSdkLoader: AmazonVegaSdkLoader = {
+      load: loadAmazonVegaSdk,
+    },
+  ) {}
+
+  // @ts-expect-error TS6133: This will be consumed by future functions in this class, like getProducts() and purchase().
+  private async getAmazonIapSdk(): Promise<AmazonVegaSdk> {
+    try {
+      return await this.amazonVegaSdkLoader.load();
+    } catch (error) {
+      if (error instanceof PurchasesError) {
+        throw error;
+      }
+
+      throw new PurchasesError(
+        ErrorCode.ConfigurationError,
+        "Amazon Vega IAP SDK is unavailable. Install @amazon-devices/keplerscript-appstore-iap-lib to use an Amazon API key.",
+        error instanceof Error ? error.message : undefined,
+      );
+    }
+  }
+}

--- a/src/amazon-vega/amazon-vega-sdk-loader.ts
+++ b/src/amazon-vega/amazon-vega-sdk-loader.ts
@@ -1,0 +1,44 @@
+import type * as AmazonVegaSdkModule from "@amazon-devices/keplerscript-appstore-iap-lib";
+
+/**
+ * The Vega SDK should only be available when configured with an Amazon API Key.
+ * This loader manages importing the SDK at runtime so web and other store
+ * configurations never resolve it.
+ * @internal
+ */
+export type AmazonVegaSdk = typeof AmazonVegaSdkModule;
+
+type AmazonVegaSdkImporter = () => Promise<AmazonVegaSdk>;
+
+const importAmazonVegaSdk: AmazonVegaSdkImporter = async () =>
+  await import("@amazon-devices/keplerscript-appstore-iap-lib");
+
+/** @internal */
+export interface AmazonVegaSdkLoader {
+  load(): Promise<AmazonVegaSdk>;
+}
+
+/** @internal */
+export function createAmazonVegaSdkLoader(
+  importer: AmazonVegaSdkImporter = importAmazonVegaSdk,
+): AmazonVegaSdkLoader {
+  let sdkPromise: Promise<AmazonVegaSdk> | undefined;
+
+  return {
+    load(): Promise<AmazonVegaSdk> {
+      sdkPromise ??= importer();
+      return sdkPromise;
+    },
+  };
+}
+
+const amazonVegaSdkLoader = createAmazonVegaSdkLoader();
+
+/**
+ * Starts loading the Vega SDK and returns the cached loading promise.
+ * Future Amazon purchase handling can await this same promise.
+ * @internal
+ */
+export function loadAmazonVegaSdk(): Promise<AmazonVegaSdk> {
+  return amazonVegaSdkLoader.load();
+}

--- a/src/amazon-vega/amazon-vega-sdk.d.ts
+++ b/src/amazon-vega/amazon-vega-sdk.d.ts
@@ -1,0 +1,1 @@
+declare module "@amazon-devices/keplerscript-appstore-iap-lib";

--- a/src/helpers/api-key-helper.ts
+++ b/src/helpers/api-key-helper.ts
@@ -2,6 +2,7 @@ const rc_api_key_regex = /^rcb_[a-zA-Z0-9_.-]+$/;
 const paddle_api_key_regex = /^pdl_[a-zA-Z0-9_.-]+$/;
 const rc_simulated_store_api_key_regex = /^test_[a-zA-Z0-9_.-]+$/;
 const stripe_api_key_regex = /^strp_[a-zA-Z0-9_.-]+$/;
+const amazon_api_key_regex = /^amzn_[a-zA-Z0-9_.-]+$/;
 
 export function isWebBillingSandboxApiKey(apiKey: string): boolean {
   return apiKey ? apiKey.startsWith("rcb_sb_") : false;
@@ -17,6 +18,10 @@ export function isPaddleApiKey(apiKey: string): boolean {
 
 export function isStripeApiKey(apiKey: string): boolean {
   return apiKey ? stripe_api_key_regex.test(apiKey) : false;
+}
+
+export function isAmazonApiKey(apiKey: string): boolean {
+  return apiKey ? amazon_api_key_regex.test(apiKey) : false;
 }
 
 export function isSimulatedStoreApiKey(apiKey: string): boolean {

--- a/src/helpers/configuration-validators.ts
+++ b/src/helpers/configuration-validators.ts
@@ -1,6 +1,7 @@
 import { ErrorCode, PurchasesError } from "../entities/errors";
 import { SDK_HEADERS } from "../networking/http-client";
 import {
+  isAmazonApiKey,
   isPaddleApiKey,
   isSimulatedStoreApiKey,
   isStripeApiKey,
@@ -12,7 +13,8 @@ export function validateApiKey(apiKey: string) {
     isWebBillingApiKey(apiKey) ||
     isSimulatedStoreApiKey(apiKey) ||
     isPaddleApiKey(apiKey) ||
-    isStripeApiKey(apiKey);
+    isStripeApiKey(apiKey) ||
+    isAmazonApiKey(apiKey);
 
   if (!isValidApiKey) {
     throw new PurchasesError(

--- a/src/tests/amazon-vega/amazon-vega-billing-wrapper.test.ts
+++ b/src/tests/amazon-vega/amazon-vega-billing-wrapper.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test, vi } from "vitest";
+import { AmazonVegaBillingWrapper } from "../../amazon-vega/amazon-vega-billing-wrapper";
+import type {
+  AmazonVegaSdk,
+  AmazonVegaSdkLoader,
+} from "../../amazon-vega/amazon-vega-sdk-loader";
+import { ErrorCode, PurchasesError } from "../../entities/errors";
+
+type AmazonIapSdkGetter = {
+  getAmazonIapSdk(): Promise<AmazonVegaSdk>;
+};
+
+function getAmazonIapSdk(
+  wrapper: AmazonVegaBillingWrapper,
+): Promise<AmazonVegaSdk> {
+  return (wrapper as unknown as AmazonIapSdkGetter).getAmazonIapSdk();
+}
+
+describe("AmazonVegaBillingWrapper", () => {
+  test("returns the Amazon SDK from its loader", async () => {
+    const sdk = {} as AmazonVegaSdk;
+    const loader: AmazonVegaSdkLoader = {
+      load: vi.fn(() => Promise.resolve(sdk)),
+    };
+    const wrapper = new AmazonVegaBillingWrapper(loader);
+
+    await expect(getAmazonIapSdk(wrapper)).resolves.toBe(sdk);
+    expect(loader.load).toHaveBeenCalledOnce();
+  });
+
+  test("converts an SDK loading failure into a configuration error", async () => {
+    const underlyingError = new Error("Cannot find package");
+    const loader: AmazonVegaSdkLoader = {
+      load: vi.fn(() => Promise.reject(underlyingError)),
+    };
+    const wrapper = new AmazonVegaBillingWrapper(loader);
+
+    await expect(getAmazonIapSdk(wrapper)).rejects.toMatchObject({
+      errorCode: ErrorCode.ConfigurationError,
+      message:
+        "Amazon Vega IAP SDK is unavailable. Install @amazon-devices/keplerscript-appstore-iap-lib to use an Amazon API key.",
+      underlyingErrorMessage: "Cannot find package",
+    });
+  });
+
+  test("preserves a typed loader error", async () => {
+    const loaderError = new PurchasesError(
+      ErrorCode.ConfigurationError,
+      "The Amazon SDK is incompatible",
+    );
+    const loader: AmazonVegaSdkLoader = {
+      load: vi.fn(() => Promise.reject(loaderError)),
+    };
+    const wrapper = new AmazonVegaBillingWrapper(loader);
+
+    await expect(getAmazonIapSdk(wrapper)).rejects.toBe(loaderError);
+  });
+
+  test("omits an underlying error message for non-Error loading failures", async () => {
+    const loader: AmazonVegaSdkLoader = {
+      load: vi.fn(() => Promise.reject("SDK unavailable")),
+    };
+    const wrapper = new AmazonVegaBillingWrapper(loader);
+
+    await expect(getAmazonIapSdk(wrapper)).rejects.toMatchObject({
+      errorCode: ErrorCode.ConfigurationError,
+      underlyingErrorMessage: undefined,
+    });
+  });
+});

--- a/src/tests/amazon-vega/amazon-vega-sdk-loader.test.ts
+++ b/src/tests/amazon-vega/amazon-vega-sdk-loader.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  createAmazonVegaSdkLoader,
+  type AmazonVegaSdk,
+} from "../../amazon-vega/amazon-vega-sdk-loader";
+
+describe("AmazonVegaSdkLoader", () => {
+  test("does not import the Amazon SDK until it is loaded", () => {
+    const importer = vi.fn();
+
+    createAmazonVegaSdkLoader(importer);
+
+    expect(importer).not.toHaveBeenCalled();
+  });
+
+  test("loads the Amazon SDK once and returns the cached promise", async () => {
+    const sdk = {} as AmazonVegaSdk;
+    const importer = vi.fn(() => Promise.resolve(sdk));
+    const loader = createAmazonVegaSdkLoader(importer);
+
+    const firstLoad = loader.load();
+    const secondLoad = loader.load();
+
+    expect(importer).toHaveBeenCalledOnce();
+    expect(secondLoad).toBe(firstLoad);
+    await expect(firstLoad).resolves.toBe(sdk);
+  });
+
+  test("caches an Amazon SDK loading failure", async () => {
+    const error = new Error("Amazon Vega IAP is unavailable");
+    const importer = vi.fn(() => Promise.reject(error));
+    const loader = createAmazonVegaSdkLoader(importer);
+
+    const firstLoad = loader.load();
+    const secondLoad = loader.load();
+
+    expect(importer).toHaveBeenCalledOnce();
+    expect(secondLoad).toBe(firstLoad);
+    await expect(firstLoad).rejects.toBe(error);
+  });
+});

--- a/src/tests/helpers/api-key-helper.test.ts
+++ b/src/tests/helpers/api-key-helper.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+import { isAmazonApiKey } from "../../helpers/api-key-helper";
+
+describe("isAmazonApiKey", () => {
+  test.each([
+    "amzn_key",
+    "amzn_key.with-dashes_and_underscores",
+    "amzn_1234567890",
+  ])("returns true for a valid Amazon API key: %s", (apiKey) => {
+    expect(isAmazonApiKey(apiKey)).toBe(true);
+  });
+
+  test.each([
+    "",
+    "amzn_",
+    "amzn_key with spaces",
+    "amzn_key/with/slashes",
+    "amzn_key!",
+    "goog_valid_key",
+    "appl_valid_key",
+    "galx_valid_key",
+    "test_valid_key",
+    "pdl_valid_key",
+    "rcb_valid_key",
+    "AMZN_valid_key",
+  ])("returns false for an invalid Amazon API key: %s", (apiKey) => {
+    expect(isAmazonApiKey(apiKey)).toBe(false);
+  });
+});

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -206,6 +206,24 @@ describe("Purchases.configure()", () => {
     ).not.toThrow();
   });
 
+  test("throws error if given invalid Amazon API key", () => {
+    expect(() =>
+      Purchases.configure({
+        apiKey: "amzn_test invalidchar",
+        appUserId: testUserId,
+      }),
+    ).toThrowError(PurchasesError);
+  });
+
+  test("does not throw error if given valid Amazon API key", () => {
+    expect(() =>
+      Purchases.configure({
+        apiKey: "amzn_valid_key",
+        appUserId: testUserId,
+      }),
+    ).not.toThrow();
+  });
+
   test("does not throw error if given valid web billing api key", () => {
     expect(() =>
       Purchases.configure({

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,6 +14,12 @@ export default defineConfig({
       name: "Purchases",
       fileName: (format) => `Purchases.${format}.js`,
     },
+    rollupOptions: {
+      external: [
+        "@amazon-devices/keplerscript-appstore-iap-lib",
+        "@amazon-devices/react-native-kepler",
+      ],
+    },
   },
   plugins: [
     dts({


### PR DESCRIPTION
## Description
This PR is part 2/X of a stack for adding Amazon Vega support to the `purchases-js` SDK. It introduces the ability for the SDK to lazily import the Vega SDK so that all users of the purchases-js SDK don't need to import it.

Vega apps will need to manually declare a dependency on the Vega SDK themselves, and then we'll load it up when needed. This PR doesn't actually load the Vega SDK, but instead we'll ensure that it's loaded when it is required, like when fetching products, making a purchase, or syncing purchases.

Specifically, this PR:
- Adds an optional peer dependency on @amazon-devices/keplerscript-appstore-iap-lib.
- Externalizes Amazon Vega dependencies from the library bundle.
- Adds a cached, lazy Amazon Vega SDK loader.
- Adds `AmazonVegaBillingWrapper` with a private SDK accessor that maps SDK-loading failures to typed `PurchasesError` instances.
- Adds unit test coverage for lazy loading, caching, loader failures, and typed error conversion.
