### PR TITLE
fix: Extend web billing operation polling timeout

### DIFF
--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -166,7 +166,7 @@ export class PurchaseOperationHelper {
   constructor(
     backend: Backend,
     eventsTracker: IEventsTracker,
-    maxNumberAttempts: number = 10,
+    maxNumberAttempts: number = 30,
   ) {
     this.backend = backend;
     this.eventsTracker = eventsTracker;

--- a/src/paddle/paddle-service.ts
+++ b/src/paddle/paddle-service.ts
@@ -182,7 +182,7 @@ export class PaddleService {
   constructor(
     backend: Backend,
     eventsTracker: IEventsTracker,
-    maxNumberAttempts: number = 10,
+    maxNumberAttempts: number = 30,
   ) {
     this.backend = backend;
     this.eventsTracker = eventsTracker;

--- a/src/tests/helpers/purchase-operation-helper.test.ts
+++ b/src/tests/helpers/purchase-operation-helper.test.ts
@@ -993,7 +993,7 @@ describe("PurchaseOperationHelper", () => {
 
     await vi.runAllTimersAsync();
 
-    expect(callCount).toEqual(10);
+    expect(callCount).toEqual(30);
 
     await pollPromise;
 

--- a/src/tests/paddle/paddle-service.test.ts
+++ b/src/tests/paddle/paddle-service.test.ts
@@ -902,9 +902,11 @@ describe("PaddleService", () => {
     test("rejects after max attempts if status never succeeds", async () => {
       vi.useFakeTimers();
 
+      let callCount = 0;
       server.use(
-        http.get(operationStatusEndpoint, () =>
-          HttpResponse.json(
+        http.get(operationStatusEndpoint, () => {
+          callCount++;
+          return HttpResponse.json(
             {
               operation: {
                 status: CheckoutSessionStatus.InProgress,
@@ -915,8 +917,8 @@ describe("PaddleService", () => {
             {
               status: StatusCodes.OK,
             },
-          ),
-        ),
+          );
+        }),
       );
 
       const purchasePromise = paddleService.purchase({
@@ -935,9 +937,9 @@ describe("PaddleService", () => {
 
       // Advance timers to trigger all polling attempts
       // First attempt happens immediately when eventCallback is called
-      // Then we need to advance 10 more times to trigger attempts 2-11
-      // After 10 attempts, the 11th check (checkCount = 11) will exceed maxNumberAttempts (10) and reject
-      for (let i = 0; i < 10; i++) {
+      // Then we need to advance 30 more times to trigger attempts 2-31
+      // After 30 attempts, the 31st check exceeds maxNumberAttempts and rejects
+      for (let i = 0; i < 30; i++) {
         await vi.advanceTimersByTimeAsync(1000);
       }
 
@@ -945,6 +947,7 @@ describe("PaddleService", () => {
       await vi.runAllTimersAsync();
 
       const error = await rejectionPromise;
+      expect(callCount).toBe(30);
       expect(error).toBeInstanceOf(PurchaseFlowError);
       expect(error).toEqual(
         expect.objectContaining({


### PR DESCRIPTION
## Summary

Web Billing purchases can complete successfully while RevenueCat is still processing the operation session. The SDK previously stopped polling after 10 seconds, which could show an error and a Retry action even though the customer had already been charged.

This change extends the polling window to 30 seconds for both Stripe and Paddle. It also updates the timeout coverage to verify that each provider performs 30 status checks before reporting that the operation did not complete.

## Compatibility

The polling interval and terminal error behavior remain unchanged. Purchases that complete within the existing 10-second window behave as before, while slower operation sessions have an additional 20 seconds to finish.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to longer polling before timeout; interval and success/failure handling are unchanged, with slightly more backend polling on slow completions.
> 
> **Overview**
> Raises the default **operation-session polling limit** from **10** to **30** attempts (still **1s** between checks) in `PurchaseOperationHelper` and `PaddleService`, so Web Billing can wait longer for RevenueCat to finish processing after Stripe/Paddle checkout completes.
> 
> Tests now assert **30** status polls before the same *max attempts* error, including Paddle’s timeout case with an explicit `callCount` check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 123ff32333b141928aae9a9a62c38f889ae61e09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->