### PR TITLE
WFL-384 | Enable support for multipage paywalls

### DIFF
--- a/examples/webbilling-demo/src/pages/login/index.tsx
+++ b/examples/webbilling-demo/src/pages/login/index.tsx
@@ -11,7 +11,6 @@ const LoginPage: React.FC = () => {
   const [appUserId, setAppUserId] = useState("");
   const [offeringId, setOfferingId] = useState("");
   const [useCustomLogger, setUseCustomLogger] = useState(true);
-  const [enableWorkflows, setEnableWorkflows] = useState(false);
 
   const navigateToAppUserIDPaywall = (
     appUserId?: string,
@@ -30,9 +29,6 @@ const LoginPage: React.FC = () => {
       }
       // Add custom logger preference
       params.append("useCustomLogger", useCustomLogger.toString());
-      if (enableWorkflows) {
-        params.append("enableWorkflows", "true");
-      }
 
       const queryString = params.toString();
       const base = useRCPaywall ? "rc_paywall" : "paywall";
@@ -92,17 +88,6 @@ const LoginPage: React.FC = () => {
             />
             <span className="checkbox-text">
               🏥 Use custom health logger (adds health icon to SDK logs)
-            </span>
-          </label>
-          <label className="checkbox-label">
-            <input
-              type="checkbox"
-              checked={enableWorkflows}
-              onChange={(e) => setEnableWorkflows(e.target.checked)}
-              className="checkbox-input"
-            />
-            <span className="checkbox-text">
-              Enable multipage paywalls (workflows)
             </span>
           </label>
         </div>

--- a/examples/webbilling-demo/src/util/PurchasesLoader.ts
+++ b/examples/webbilling-demo/src/util/PurchasesLoader.ts
@@ -46,8 +46,6 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
   const useCustomLogger = searchParams.get("useCustomLogger") === "true";
   const storeLoadTime =
     (searchParams.get("storeLoadTime") as StoreLoadTime) || undefined;
-  const enableWorkflows =
-    searchParams.get("enableWorkflows") === "true" || false;
 
   if (!appUserId) {
     throw redirect("/");
@@ -68,7 +66,6 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
     autoCollectUTMAsMetadata: !optOutOfAutoUTM,
     hideBackButton: hideCheckoutBackButton,
     ...(storeLoadTime ? { storeLoadTime } : {}),
-    ...(enableWorkflows ? { workflowsEndpointEnabled: true } : {}),
   };
   if (rcSource) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@babel/runtime": "^7.26.10",
     "@eslint/js": "^9.16.0",
     "@microsoft/api-extractor": "^7.48.0",
-    "@revenuecat/purchases-ui-js": "4.8.11",
+    "@revenuecat/purchases-ui-js": "4.8.13",
     "@paddle/paddle-js": "^1.6.4",
     "@storybook/addon-essentials": "^8.6.15",
     "@storybook/addon-interactions": "^8.6.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^1.6.4
         version: 1.6.4
       "@revenuecat/purchases-ui-js":
-        specifier: 4.8.11
-        version: 4.8.11(svelte@5.46.4)
+        specifier: 4.8.13
+        version: 4.8.13(svelte@5.46.4)
       "@storybook/addon-essentials":
         specifier: ^8.6.15
         version: 8.6.15(@types/react@19.0.10)(storybook@8.6.15(prettier@3.4.2))
@@ -722,10 +722,10 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
 
-  "@revenuecat/purchases-ui-js@4.8.11":
+  "@revenuecat/purchases-ui-js@4.8.13":
     resolution:
       {
-        integrity: sha512-7cXXJiswPD8FHryxWcD1qRCmXzbVV0xlv5sqWfc/bFODEFLQVlfQHHoBNbUU9lnSqGTOXLKumVwZmNX6AMZKEw==,
+        integrity: sha512-eRnZKUevJYuclKB1CfNDXvQDw4KFs0CxNtr9dn1I5qh88WMxM8/seW1y9trKRK0v4/1rhrdW/P3UoOlfMWWSAw==,
       }
     engines: { node: ^22.18 || ^24.11 }
     peerDependencies:
@@ -6164,7 +6164,7 @@ snapshots:
 
   "@pkgr/core@0.1.1": {}
 
-  "@revenuecat/purchases-ui-js@4.8.11(svelte@5.46.4)":
+  "@revenuecat/purchases-ui-js@4.8.13(svelte@5.46.4)":
     dependencies:
       "@revenuecat/workflow-web-components-sdk": 0.1.4
       qrcode: 1.5.4

--- a/src/entities/flags-config.ts
+++ b/src/entities/flags-config.ts
@@ -64,15 +64,6 @@ export interface FlagsConfig {
   forceEnableWalletMethods?: boolean;
 
   /**
-   * If set to `true`, the SDK will attempt to fetch and display a workflow
-   * when presenting a paywall, falling back to the standard paywall if none
-   * is found.
-   * @defaultValue false
-   * @internal
-   */
-  workflowsEndpointEnabled?: boolean;
-
-  /**
    * Determines when the store module (e.g. Stripe) is loaded.
    * - `"configuration"`: Preloaded when the SDK is configured (default).
    * - `"purchase_start"`: Loaded on demand when a purchase is started.

--- a/src/main.ts
+++ b/src/main.ts
@@ -623,12 +623,12 @@ export class Purchases {
     }
 
     // Check for a workflow associated with this offering.
-    const workflowsResponse = this._flags.workflowsEndpointEnabled
-      ? await this.backend.getWorkflows(this._appUserId).catch((e) => {
-          Logger.warnLog(`Failed to fetch workflows: ${e}`);
-          return null;
-        })
-      : null;
+    const workflowsResponse = await this.backend
+      .getWorkflows(this._appUserId)
+      .catch((e) => {
+        Logger.warnLog(`Failed to fetch workflows: ${e}`);
+        return null;
+      });
     const matchedWorkflowSummary = workflowsResponse?.workflows?.find(
       (w) => w.offering_id === offering.identifier,
     );

--- a/src/main.ts
+++ b/src/main.ts
@@ -685,7 +685,7 @@ export class Purchases {
 
     // finalLocale and translator are only needed for the standard paywall path.
     // The workflow path resolves its own locale below, against the workflow's
-    // screens (see workflowSelectedLocale).
+    // screens (see finalWorkflowLocale).
     const finalLocale = offering.paywallComponents
       ? calculateLocale(offering.paywallComponents, selectedLocale)
       : selectedLocale;
@@ -965,7 +965,7 @@ export class Purchases {
 
     let workflowNavData: ReturnType<typeof workflowDataToNavData> | undefined;
     let workflowDataResponse: WorkflowData | undefined;
-    let workflowSelectedLocale: string = selectedLocale;
+    let finalWorkflowLocale: string = selectedLocale;
     if (matchedWorkflowSummary) {
       const workflowData = await this.backend
         .getWorkflowById(this._appUserId, matchedWorkflowSummary.id)
@@ -986,10 +986,7 @@ export class Purchases {
         // initial screen is sufficient.
         const initialScreen = navData.pages[navData.initial_page_id];
         if (initialScreen) {
-          workflowSelectedLocale = calculateLocale(
-            initialScreen,
-            selectedLocale,
-          );
+          finalWorkflowLocale = calculateLocale(initialScreen, selectedLocale);
         }
       } else {
         if (workflowData && !navData) {
@@ -1161,7 +1158,7 @@ export class Purchases {
             props: {
               workflow: workflowNavData,
               uiConfig: workflowDataResponse.ui_config as unknown as UIConfig,
-              selectedLocale: workflowSelectedLocale,
+              selectedLocale: finalWorkflowLocale,
               hideBackButtons: paywallParams.hideBackButtons,
               variablesPerPackage,
               walletButtonRender,
@@ -1170,7 +1167,7 @@ export class Purchases {
                 if (pkg) {
                   notifyPurchaseStarted(pkg);
                 }
-                startPurchaseFlow(selectedPackageId, selectedLocale)
+                startPurchaseFlow(selectedPackageId, finalWorkflowLocale)
                   .then(onSuccess)
                   .catch(onError("Error performing purchase"));
               },

--- a/src/main.ts
+++ b/src/main.ts
@@ -683,8 +683,9 @@ export class Purchases {
       ? paywallParams.selectedLocale
       : navigator.language;
 
-    // finalLocale and translator are only needed for the paywall path — the
-    // Workflow component handles locale resolution internally.
+    // finalLocale and translator are only needed for the standard paywall path.
+    // The workflow path resolves its own locale below, against the workflow's
+    // screens (see workflowSelectedLocale).
     const finalLocale = offering.paywallComponents
       ? calculateLocale(offering.paywallComponents, selectedLocale)
       : selectedLocale;
@@ -964,6 +965,7 @@ export class Purchases {
 
     let workflowNavData: ReturnType<typeof workflowDataToNavData> | undefined;
     let workflowDataResponse: WorkflowData | undefined;
+    let workflowSelectedLocale: string = selectedLocale;
     if (matchedWorkflowSummary) {
       const workflowData = await this.backend
         .getWorkflowById(this._appUserId, matchedWorkflowSummary.id)
@@ -977,6 +979,18 @@ export class Purchases {
       if (workflowData && navData) {
         workflowDataResponse = workflowData;
         workflowNavData = navData;
+        // The workflow renderer does exact-key locale lookups only, so resolve
+        // the requested locale to a concrete key the workflow provides (e.g.
+        // "sk" -> "sk_SK"), mirroring what the standard paywall does. All
+        // screens in a workflow share the same locale, so resolving against the
+        // initial screen is sufficient.
+        const initialScreen = navData.pages[navData.initial_page_id];
+        if (initialScreen) {
+          workflowSelectedLocale = calculateLocale(
+            initialScreen,
+            selectedLocale,
+          );
+        }
       } else {
         if (workflowData && !navData) {
           Logger.warnLog(
@@ -1147,7 +1161,8 @@ export class Purchases {
             props: {
               workflow: workflowNavData,
               uiConfig: workflowDataResponse.ui_config as unknown as UIConfig,
-              selectedLocale,
+              selectedLocale: workflowSelectedLocale,
+              hideBackButtons: paywallParams.hideBackButtons,
               variablesPerPackage,
               walletButtonRender,
               onPurchaseClicked: (selectedPackageId: string) => {


### PR DESCRIPTION
## Motivation / Description

Remove the flag we had for testing paywalls returning from the new endpoint and set as the default route, this will allow multipage paywalls to be supported




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default paywall behavior (extra workflow API calls on every present) and core `presentPaywall` routing; failures still fall back with logging, but offerings with workflows-only paywalls depend on that path succeeding.
> 
> **Overview**
> **Multipage paywall workflows are now the default path** when presenting a paywall: the SDK always fetches workflows for the offering and uses a matched workflow when available, with fallback to the standard single-page paywall. The internal `workflowsEndpointEnabled` flag and demo login/query wiring for `enableWorkflows` are removed.
> 
> **Workflow presentation** resolves locale the same way as standard paywalls (e.g. `sk` → `sk_SK`) via the workflow’s initial screen, passes `hideBackButtons` into the workflow UI, and uses that resolved locale for purchases. `@revenuecat/purchases-ui-js` is bumped to **4.8.13**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a880464a38dadd64dd7182592cef699d7f92810c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->