### PR TITLE
fix(vega): use store-agnostic invalid API key message

### DIFF
--- a/src/helpers/configuration-validators.ts
+++ b/src/helpers/configuration-validators.ts
@@ -19,7 +19,7 @@ export function validateApiKey(apiKey: string) {
   if (!isValidApiKey) {
     throw new PurchasesError(
       ErrorCode.InvalidCredentialsError,
-      "Invalid API key. Use your Web Billing API key.",
+      "Invalid API key. Use a valid API key obtained from the RevenueCat Dashboard.",
     );
   }
 }


### PR DESCRIPTION
The error message that the SDK uses when an invalid API key is provided to `configure()` states that the developer should provide a Web Billing API key. With the introduction of the Amazon Store to the JS SDK, other API key types may be provided.

This PR updates the error message to use store-agnostic language that applies to both the Amazon Store and Web Billing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to a configuration error string; no validation or auth logic is modified.
> 
> **Overview**
> Updates the `InvalidCredentialsError` message in `validateApiKey` so it no longer tells developers to use a Web Billing API key.
> 
> The new copy points them to a valid key from the RevenueCat Dashboard, covering Amazon and other supported key types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94df14edbc6857f51b750ace17a633ba622f1beb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->