### PR TITLE
fix: monthly price calculation for yearly subscriptions

### DIFF
--- a/src/entities/offerings.ts
+++ b/src/entities/offerings.ts
@@ -661,6 +661,7 @@ function getPriceConversionFactor(period: Period): {
   const DAYS_PER_WEEK = 7;
   const DAYS_PER_MONTH = 30.0;
   const DAYS_PER_YEAR = 365.0;
+  const MONTHS_PER_YEAR = 12;
 
   let daysInPeriod: number;
 
@@ -683,7 +684,11 @@ function getPriceConversionFactor(period: Period): {
   }
 
   const toWeek = daysInPeriod > 0 ? DAYS_PER_WEEK / daysInPeriod : 0;
-  const toMonth = daysInPeriod > 0 ? DAYS_PER_MONTH / daysInPeriod : 0;
+  let toMonth = daysInPeriod > 0 ? DAYS_PER_MONTH / daysInPeriod : 0;
+  if (unit === PeriodUnit.Year && number > 0) {
+    // Calendar years contain exactly 12 months.
+    toMonth = 1 / (number * MONTHS_PER_YEAR);
+  }
   const toYear = daysInPeriod > 0 ? DAYS_PER_YEAR / daysInPeriod : 0;
 
   return { toWeek, toMonth, toYear };

--- a/src/tests/entities/offerings.test.ts
+++ b/src/tests/entities/offerings.test.ts
@@ -59,6 +59,31 @@ describe("toPurchaseOptionForProductType", () => {
     });
   });
 
+  test("calculates a yearly subscription's monthly price using twelve months", () => {
+    const result = toPurchaseOptionForProductType(ProductType.Subscription, {
+      ...subscriptionOptionResponse,
+      base: {
+        cycle_count: 1,
+        period_duration: "P1Y",
+        price: {
+          amount_micros: 119_990_000,
+          currency: "USD",
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      base: {
+        pricePerMonth: {
+          amount: 999,
+          amountMicros: 9_990_000,
+          currency: "USD",
+          formattedPrice: "$9.99",
+        },
+      },
+    });
+  });
+
   test("returns null when a subscription option is missing its base phase", () => {
     const result = toPurchaseOptionForProductType(ProductType.Subscription, {
       ...subscriptionOptionResponse,


### PR DESCRIPTION
## Motivation / Description

[PricingPhase.pricePerMonth](https://github.com/RevenueCat/purchases-js/blob/785916e776692ff6ed74a802ba2690fd368599c9/src/entities/offerings.ts#L578-L583) currently converts every subscription period using [day-based arithmetic](https://github.com/RevenueCat/purchases-js/blob/785916e776692ff6ed74a802ba2690fd368599c9/src/entities/offerings.ts#L654-L690).

For a yearly period, that makes the monthly factor `30 / 365` instead of `1 / 12`: a `$119.99` `P1Y` product is exposed as `$9.86/month` rather than `$9.99/month`.

RevenueCat's documented contract and other SDK implementations consistently define a yearly subscription's monthly-equivalent price as its price divided by 12:

- The [paywall pricing-variable table ("Examples for all package types")](https://www.revenuecat.com/docs/tools/paywalls/creating-paywalls/variables#pricing) lists `$5.83` as the `product.price_per_month` value for a `$69.99` annual product (annual price divided by 12).
- The [hybrid SDK contract](https://github.com/RevenueCat/purchases-hybrid-common/blob/1ae6aabdba5baf46551e500705968b262ec2396c/typescript/src/offerings.ts#L109-L115) explicitly documents that an annual price is divided by 12.
- [iOS](https://github.com/RevenueCat/purchases-ios/blob/01fdf642d259dcfa05111d227b8ab793ff54a68e/Tests/UnitTests/Purchasing/StoreKitAbstractions/SubscriptionPeriodTests.swift#L98) and [Android](https://github.com/RevenueCat/purchases-android/blob/1ee82cae6a80ccc49009ecc9dde8115a87be9664/purchases/src/test/java/com/revenuecat/purchases/utils/PriceExtensionsPricePerMonthTest.kt#L27) both convert years to exactly 12 months.
- purchases-js's own [paywall price variables](https://github.com/RevenueCat/purchases-js/blob/785916e776692ff6ed74a802ba2690fd368599c9/src/helpers/paywall-price-helpers.ts#L79-L85) also divide yearly prices by 12.

Additionally, the [web hybrid mapper](https://github.com/RevenueCat/purchases-hybrid-common/blob/1ae6aabdba5baf46551e500705968b262ec2396c/purchases-js-hybrid-mappings/src/mappers/offerings_mapper.ts#L50-L70) forwards this value to hybrid SDKs, so the same annual product can expose a different monthly-equivalent string on Web than on native platforms.

## Changes introduced

- Convert yearly pricing phases to months using 12 calendar months per year.
- Unit test.

## Linear ticket (if any)

N/A (we don't have access to Linear).

## Additional comments

Preserved existing day-based approximations for all other cross-unit conversions. For a more ambitious refactor fixing web/native SDK discrepancies more holistically, see #1014.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized pricing math change with a clear regression test; no auth, billing, or API surface changes beyond corrected displayed monthly equivalents.
> 
> **Overview**
> Fixes **yearly subscription `pricePerMonth`** so it matches RevenueCat’s contract and native SDKs (annual price ÷ 12), instead of the old day-based factor (`30/365`).
> 
> In `getPriceConversionFactor`, when the period unit is **year**, `toMonth` is now `1 / (number × 12)`; week/month/year conversions for other units stay on the existing day-based approximations. A unit test asserts a `$119.99` `P1Y` product exposes **$9.99/month** on the base pricing phase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb809ba1486c1f27b764fcf13bb92b9b6e9a062b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->