### PR TITLE
fix: align normalized prices with native SDKs

### DIFF
--- a/src/entities/offerings.ts
+++ b/src/entities/offerings.ts
@@ -17,11 +17,8 @@ import {
   formatPrice,
 } from "../helpers/price-labels";
 import { Logger } from "../helpers/logger";
-import {
-  parseISODuration,
-  type Period,
-  PeriodUnit,
-} from "../helpers/duration-helper";
+import { parseISODuration, type Period } from "../helpers/duration-helper";
+import { getPricePerPeriodFactors } from "../helpers/price-conversion-helper";
 import type { PaywallData, UIConfig } from "@revenuecat/purchases-ui-js";
 
 /**
@@ -557,11 +554,11 @@ const toPricingPhase = (optionPhase: PricingPhaseResponse): PricingPhase => {
   let pricePerYear: Price | null = null;
 
   if (price !== null && period !== null) {
-    const factor = getPriceConversionFactor(period);
+    const priceFactors = getPricePerPeriodFactors(period);
     const conversionFromMicrosToCents = 10000;
 
     const weeklyAmountMicros = floorMicrosToCurrencyUnit(
-      price.amountMicros * factor.toWeek,
+      price.amountMicros * priceFactors.perWeek,
       price.currency,
     );
     pricePerWeek = {
@@ -572,7 +569,7 @@ const toPricingPhase = (optionPhase: PricingPhaseResponse): PricingPhase => {
     };
 
     const monthlyAmountMicros = floorMicrosToCurrencyUnit(
-      price.amountMicros * factor.toMonth,
+      price.amountMicros * priceFactors.perMonth,
       price.currency,
     );
     pricePerMonth = {
@@ -583,7 +580,7 @@ const toPricingPhase = (optionPhase: PricingPhaseResponse): PricingPhase => {
     };
 
     const yearlyAmountMicros = floorMicrosToCurrencyUnit(
-      price.amountMicros * factor.toYear,
+      price.amountMicros * priceFactors.perYear,
       price.currency,
     );
     pricePerYear = {
@@ -650,44 +647,6 @@ const toDiscountPhase = (
         : null,
   };
 };
-
-function getPriceConversionFactor(period: Period): {
-  toWeek: number;
-  toMonth: number;
-  toYear: number;
-} {
-  const { number, unit } = period;
-
-  const DAYS_PER_WEEK = 7;
-  const DAYS_PER_MONTH = 30.0;
-  const DAYS_PER_YEAR = 365.0;
-
-  let daysInPeriod: number;
-
-  switch (unit) {
-    case PeriodUnit.Day:
-      daysInPeriod = number;
-      break;
-    case PeriodUnit.Week:
-      daysInPeriod = number * DAYS_PER_WEEK;
-      break;
-    case PeriodUnit.Month:
-      daysInPeriod = number * DAYS_PER_MONTH;
-      break;
-    case PeriodUnit.Year:
-      daysInPeriod = number * DAYS_PER_YEAR;
-      break;
-    default:
-      daysInPeriod = 0;
-      Logger.errorLog(`Unknown period unit: ${unit}`);
-  }
-
-  const toWeek = daysInPeriod > 0 ? DAYS_PER_WEEK / daysInPeriod : 0;
-  const toMonth = daysInPeriod > 0 ? DAYS_PER_MONTH / daysInPeriod : 0;
-  const toYear = daysInPeriod > 0 ? DAYS_PER_YEAR / daysInPeriod : 0;
-
-  return { toWeek, toMonth, toYear };
-}
 
 const toSubscriptionOption = (
   option: SubscriptionOptionResponse,

--- a/src/helpers/paywall-price-helpers.ts
+++ b/src/helpers/paywall-price-helpers.ts
@@ -1,14 +1,7 @@
 import { type Price } from "../entities/offerings";
 import { type Translator } from "../ui/localization/translator";
-import { PeriodUnit, type Period } from "./duration-helper";
-import {
-  DAYS_PER_MONTH,
-  DAYS_PER_WEEK,
-  DAYS_PER_YEAR,
-  MONTHS_PER_YEAR,
-  WEEKS_PER_MONTH,
-  WEEKS_PER_YEAR,
-} from "./paywall-period-helpers";
+import { type Period } from "./duration-helper";
+import { getPricePerPeriodFactors } from "./price-conversion-helper";
 import { floorMicrosToCurrencyUnit } from "./price-labels";
 
 function formatFlooredPrice(
@@ -20,181 +13,6 @@ function formatFlooredPrice(
     floorMicrosToCurrencyUnit(micros, currency),
     currency,
   );
-}
-
-function getPricePeDay(
-  price: Price,
-  period: Period | null,
-  translator: Translator,
-) {
-  const fallback = translator.formatPrice(price.amountMicros, price.currency);
-
-  if (!period) {
-    return fallback;
-  }
-
-  if (period.unit === PeriodUnit.Year) {
-    return formatFlooredPrice(
-      price.amountMicros / DAYS_PER_YEAR / period.number,
-      price.currency,
-      translator,
-    );
-  }
-  if (period.unit === PeriodUnit.Month) {
-    return formatFlooredPrice(
-      price.amountMicros / DAYS_PER_MONTH / period.number,
-      price.currency,
-      translator,
-    );
-  }
-  if (period.unit === PeriodUnit.Week) {
-    return formatFlooredPrice(
-      price.amountMicros / DAYS_PER_WEEK / period.number,
-      price.currency,
-      translator,
-    );
-  }
-  if (period.unit === PeriodUnit.Day) {
-    return formatFlooredPrice(
-      price.amountMicros / period.number,
-      price.currency,
-      translator,
-    );
-  }
-
-  return fallback;
-}
-
-function getPricePerWeek(
-  price: Price,
-  period: Period | null,
-  translator: Translator,
-) {
-  const fallback = translator.formatPrice(price.amountMicros, price.currency);
-
-  if (!period) {
-    return fallback;
-  }
-
-  if (period.unit === PeriodUnit.Year) {
-    return formatFlooredPrice(
-      price.amountMicros / WEEKS_PER_YEAR / period.number,
-      price.currency,
-      translator,
-    );
-  }
-  if (period.unit === PeriodUnit.Month) {
-    return formatFlooredPrice(
-      price.amountMicros / WEEKS_PER_MONTH / period.number,
-      price.currency,
-      translator,
-    );
-  }
-  if (period.unit === PeriodUnit.Week) {
-    return formatFlooredPrice(
-      price.amountMicros / period.number,
-      price.currency,
-      translator,
-    );
-  }
-  if (period.unit === PeriodUnit.Day) {
-    return formatFlooredPrice(
-      (price.amountMicros * DAYS_PER_WEEK) / period.number,
-      price.currency,
-      translator,
-    );
-  }
-
-  return fallback;
-}
-
-function getPricePerMonth(
-  price: Price,
-  period: Period | null,
-  translator: Translator,
-) {
-  if (!period) {
-    return translator.formatPrice(price.amountMicros, price.currency);
-  }
-
-  if (period.unit === PeriodUnit.Year) {
-    return formatFlooredPrice(
-      price.amountMicros / MONTHS_PER_YEAR,
-      price.currency,
-      translator,
-    );
-  }
-  if (period.unit === PeriodUnit.Month) {
-    return formatFlooredPrice(
-      price.amountMicros / period.number,
-      price.currency,
-      translator,
-    );
-  }
-  if (period.unit === PeriodUnit.Week) {
-    return formatFlooredPrice(
-      (price.amountMicros * WEEKS_PER_MONTH) / period.number,
-      price.currency,
-      translator,
-    );
-  }
-  if (period.unit === PeriodUnit.Day) {
-    return formatFlooredPrice(
-      (price.amountMicros * DAYS_PER_MONTH) / period.number,
-      price.currency,
-      translator,
-    );
-  }
-
-  // Fallback: treat as monthly if unit is unrecognized
-  return formatFlooredPrice(
-    price.amountMicros / (period.number || 1),
-    price.currency,
-    translator,
-  );
-}
-
-function getPricePerYear(
-  price: Price,
-  period: Period | null,
-  translator: Translator,
-) {
-  const fallback = translator.formatPrice(price.amountMicros, price.currency);
-
-  if (!period) {
-    return fallback;
-  }
-
-  if (period.unit === PeriodUnit.Year) {
-    return formatFlooredPrice(
-      price.amountMicros / period.number,
-      price.currency,
-      translator,
-    );
-  }
-  if (period.unit === PeriodUnit.Month) {
-    return formatFlooredPrice(
-      (price.amountMicros * MONTHS_PER_YEAR) / period.number,
-      price.currency,
-      translator,
-    );
-  }
-  if (period.unit === PeriodUnit.Week) {
-    return formatFlooredPrice(
-      (price.amountMicros * WEEKS_PER_YEAR) / period.number,
-      price.currency,
-      translator,
-    );
-  }
-  if (period.unit === PeriodUnit.Day) {
-    return formatFlooredPrice(
-      (price.amountMicros * DAYS_PER_YEAR) / period.number,
-      price.currency,
-      translator,
-    );
-  }
-
-  return fallback;
 }
 
 interface PriceVariables {
@@ -209,10 +27,40 @@ export function getPriceVariables(
   period: Period | null,
   translator: Translator,
 ): PriceVariables {
+  if (period === null) {
+    const priceString = translator.formatPrice(
+      price.amountMicros,
+      price.currency,
+    );
+    return {
+      pricePerDay: priceString,
+      pricePerWeek: priceString,
+      pricePerMonth: priceString,
+      pricePerYear: priceString,
+    };
+  }
+
+  const priceFactors = getPricePerPeriodFactors(period);
   return {
-    pricePerDay: getPricePeDay(price, period, translator),
-    pricePerWeek: getPricePerWeek(price, period, translator),
-    pricePerMonth: getPricePerMonth(price, period, translator),
-    pricePerYear: getPricePerYear(price, period, translator),
+    pricePerDay: formatFlooredPrice(
+      price.amountMicros * priceFactors.perDay,
+      price.currency,
+      translator,
+    ),
+    pricePerWeek: formatFlooredPrice(
+      price.amountMicros * priceFactors.perWeek,
+      price.currency,
+      translator,
+    ),
+    pricePerMonth: formatFlooredPrice(
+      price.amountMicros * priceFactors.perMonth,
+      price.currency,
+      translator,
+    ),
+    pricePerYear: formatFlooredPrice(
+      price.amountMicros * priceFactors.perYear,
+      price.currency,
+      translator,
+    ),
   };
 }

--- a/src/helpers/paywall-variables-helpers.ts
+++ b/src/helpers/paywall-variables-helpers.ts
@@ -11,15 +11,9 @@ import {
   Translator,
   type CustomTranslations,
 } from "../ui/localization/translator";
-import { PeriodUnit } from "./duration-helper";
-
 import { LocalizationKeys } from "../ui/localization/supportedLanguages";
-import {
-  DAYS_PER_MONTH,
-  getPeriodVariables,
-  MONTHS_PER_YEAR,
-  WEEKS_PER_MONTH,
-} from "./paywall-period-helpers";
+import { getPeriodVariables } from "./paywall-period-helpers";
+import { getPricePerPeriodFactors } from "./price-conversion-helper";
 import { getPriceVariables } from "./paywall-price-helpers";
 import {
   setNonSubscriptionOfferVariables,
@@ -53,7 +47,6 @@ export function buildVariablesPerPackage(
   return parseOfferingIntoVariables(offering, translator);
 }
 
-// Helper function to get monthly equivalent price for any package
 function getPackageMonthlyPrice(pkg: Package): number {
   const price = pkg.webBillingProduct.price;
   const purchaseOption = getDefaultPurchaseOption(pkg);
@@ -65,18 +58,7 @@ function getPackageMonthlyPrice(pkg: Package): number {
     return price.amountMicros;
   }
 
-  switch (period.unit) {
-    case PeriodUnit.Year:
-      return price.amountMicros / MONTHS_PER_YEAR;
-    case PeriodUnit.Month:
-      return price.amountMicros / period.number;
-    case PeriodUnit.Week:
-      return (price.amountMicros * WEEKS_PER_MONTH) / period.number;
-    case PeriodUnit.Day:
-      return (price.amountMicros * DAYS_PER_MONTH) / period.number;
-    default:
-      return price.amountMicros / (period.number || 1);
-  }
+  return price.amountMicros * getPricePerPeriodFactors(period).perMonth;
 }
 
 function getDefaultPurchaseOption(

--- a/src/helpers/price-conversion-helper.ts
+++ b/src/helpers/price-conversion-helper.ts
@@ -1,0 +1,57 @@
+import { type Period, PeriodUnit } from "./duration-helper";
+import { Logger } from "./logger";
+
+const DAYS_PER_WEEK = 7;
+const DAYS_PER_MONTH = 30;
+const DAYS_PER_YEAR = 365;
+const MONTHS_PER_YEAR = 12;
+const WEEKS_PER_YEAR = DAYS_PER_YEAR / DAYS_PER_WEEK;
+const WEEKS_PER_MONTH = WEEKS_PER_YEAR / MONTHS_PER_YEAR;
+
+interface PricePerPeriodFactors {
+  perDay: number;
+  perWeek: number;
+  perMonth: number;
+  perYear: number;
+}
+
+/** Returns multipliers for expressing a period's total price per day, week, month, and year. */
+export function getPricePerPeriodFactors(
+  period: Period,
+): PricePerPeriodFactors {
+  const perUnit = period.number > 0 ? 1 / period.number : 0;
+
+  switch (period.unit) {
+    case PeriodUnit.Day:
+      return {
+        perDay: perUnit,
+        perWeek: DAYS_PER_WEEK * perUnit,
+        perMonth: DAYS_PER_MONTH * perUnit,
+        perYear: DAYS_PER_YEAR * perUnit,
+      };
+    case PeriodUnit.Week:
+      return {
+        perDay: perUnit / DAYS_PER_WEEK,
+        perWeek: perUnit,
+        perMonth: WEEKS_PER_MONTH * perUnit,
+        perYear: WEEKS_PER_YEAR * perUnit,
+      };
+    case PeriodUnit.Month:
+      return {
+        perDay: perUnit / DAYS_PER_MONTH,
+        perWeek: perUnit / WEEKS_PER_MONTH,
+        perMonth: perUnit,
+        perYear: MONTHS_PER_YEAR * perUnit,
+      };
+    case PeriodUnit.Year:
+      return {
+        perDay: perUnit / DAYS_PER_YEAR,
+        perWeek: perUnit / WEEKS_PER_YEAR,
+        perMonth: perUnit / MONTHS_PER_YEAR,
+        perYear: perUnit,
+      };
+    default:
+      Logger.errorLog(`Unknown period unit: ${period.unit}`);
+      return { perDay: 0, perWeek: 0, perMonth: 0, perYear: 0 };
+  }
+}

--- a/src/tests/entities/offerings.test.ts
+++ b/src/tests/entities/offerings.test.ts
@@ -59,6 +59,77 @@ describe("toPurchaseOptionForProductType", () => {
     });
   });
 
+  test.each([
+    {
+      periodDuration: "P7D",
+      amountMicros: 7_000_000,
+      expectedAmountMicros: {
+        week: 7_000_000,
+        month: 30_000_000,
+        year: 365_000_000,
+      },
+    },
+    {
+      periodDuration: "P2W",
+      amountMicros: 20_000_000,
+      expectedAmountMicros: {
+        week: 10_000_000,
+        month: 43_450_000,
+        year: 521_420_000,
+      },
+    },
+    {
+      periodDuration: "P3M",
+      amountMicros: 44_970_000,
+      expectedAmountMicros: {
+        week: 3_440_000,
+        month: 14_990_000,
+        year: 179_880_000,
+      },
+    },
+    {
+      periodDuration: "P1Y",
+      amountMicros: 119_990_000,
+      expectedAmountMicros: {
+        week: 2_300_000,
+        month: 9_990_000,
+        year: 119_990_000,
+      },
+    },
+    {
+      periodDuration: "P2Y",
+      amountMicros: 239_980_000,
+      expectedAmountMicros: {
+        week: 2_300_000,
+        month: 9_990_000,
+        year: 119_990_000,
+      },
+    },
+  ])(
+    "normalizes a $periodDuration subscription price",
+    ({ periodDuration, amountMicros, expectedAmountMicros }) => {
+      const result = toPurchaseOptionForProductType(ProductType.Subscription, {
+        ...subscriptionOptionResponse,
+        base: {
+          cycle_count: 1,
+          period_duration: periodDuration,
+          price: {
+            amount_micros: amountMicros,
+            currency: "USD",
+          },
+        },
+      });
+
+      expect(result).toMatchObject({
+        base: {
+          pricePerWeek: { amountMicros: expectedAmountMicros.week },
+          pricePerMonth: { amountMicros: expectedAmountMicros.month },
+          pricePerYear: { amountMicros: expectedAmountMicros.year },
+        },
+      });
+    },
+  );
+
   test("returns null when a subscription option is missing its base phase", () => {
     const result = toPurchaseOptionForProductType(ProductType.Subscription, {
       ...subscriptionOptionResponse,

--- a/src/tests/helpers/paywall-price-helper.test.ts
+++ b/src/tests/helpers/paywall-price-helper.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+import { PeriodUnit } from "../../helpers/duration-helper";
+import { getPriceVariables } from "../../helpers/paywall-price-helpers";
+import { englishLocale } from "../../ui/localization/constants";
+import { Translator } from "../../ui/localization/translator";
+import { toPrice } from "../utils/fixtures-utils";
+
+describe("getPriceVariables", () => {
+  test("normalizes multi-year prices", () => {
+    const translator = new Translator({}, englishLocale);
+
+    expect(
+      getPriceVariables(
+        toPrice(239_980_000, "USD"),
+        { unit: PeriodUnit.Year, number: 2 },
+        translator,
+      ),
+    ).toEqual({
+      pricePerDay: "$0.32",
+      pricePerWeek: "$2.30",
+      pricePerMonth: "$9.99",
+      pricePerYear: "$119.99",
+    });
+  });
+});

--- a/src/tests/helpers/paywall-variables-helper.test.ts
+++ b/src/tests/helpers/paywall-variables-helper.test.ts
@@ -148,8 +148,8 @@ describe("getPaywallVariables", () => {
           "product.periodly": "weekly",
           "product.period": "week",
           "product.period_abbreviated": "wk",
-          "product.price_per_year": "€468.00",
-          "product.price_per_month": "€38.97",
+          "product.price_per_year": "€469.28",
+          "product.price_per_month": "€39.10",
           "product.price_per_week": "€9.00",
           "product.price_per_day": "€1.28",
           "product.relative_discount": "",
@@ -224,7 +224,7 @@ describe("getPaywallVariables", () => {
           "product.period_abbreviated": "mo",
           "product.price_per_year": "€360.00",
           "product.price_per_month": "€30.00",
-          "product.price_per_week": "€6.92",
+          "product.price_per_week": "€6.90",
           "product.price_per_day": "€1.00",
           "product.relative_discount": "23%",
           "product.currency_code": "EUR",
@@ -249,10 +249,10 @@ describe("getPaywallVariables", () => {
       }),
     );
   });
-  test("sub_relative_discount is calculated correctly for same-priced packages", () => {
+  test("sub_relative_discount hides differences below 1%", () => {
     /**
      * Monthly: 9€/month
-     * Weekly: 2.08€/week - 9€/month
+     * Weekly: €2.08/week ≈ €9.04/month
      * Trial: 9€/month after trial
      */
     const off = toOffering([
@@ -298,7 +298,7 @@ describe("getPaywallVariables", () => {
   test("sub_relative_discount is calculated correctly for packages with different prices", () => {
     /**
      * Monthly: 3€/month = 88%off
-     * Weekly: 6€/week - 25.98€/month - most expensive
+     * Weekly: €6/week ≈ €26.07/month - most expensive
      * Trial: 9€/month after trial = 65%off
      */
     const expectedValues = ["88%", "", "65%"];
@@ -348,7 +348,7 @@ describe("getPaywallVariables", () => {
     /**
      * Lifetime: €100.00 (non-subscription, should be excluded from comparison)
      * Monthly: €3.00/month = should be 88% off relative to weekly
-     * Weekly: €6.00/week = €25.98/month (most expensive subscription)
+     * Weekly: €6.00/week ≈ €26.07/month (most expensive subscription)
      * Without the fix, lifetime's raw price (100000000 micros) would be treated
      * as the highest, inflating all subscription discounts.
      */
@@ -460,7 +460,7 @@ describe("getPaywallVariables", () => {
         expect.objectContaining({
           "product.offer_price": "$12.00",
           "product.offer_price_per_day": "$0.40",
-          "product.offer_price_per_week": "$2.77",
+          "product.offer_price_per_week": "$2.76",
           "product.offer_price_per_month": "$12.00",
           "product.offer_price_per_year": "$144.00",
           "product.offer_period": "month",
@@ -514,8 +514,8 @@ describe("getPaywallVariables", () => {
           "product.offer_price": "$75.00",
           "product.offer_price_per_day": "$10.71",
           "product.offer_price_per_week": "$75.00",
-          "product.offer_price_per_month": "$324.75",
-          "product.offer_price_per_year": "$3,900.00",
+          "product.offer_price_per_month": "$325.89",
+          "product.offer_price_per_year": "$3,910.71",
           "product.offer_period": "month",
           "product.offer_period_abbreviated": "mo",
           "product.offer_period_with_unit": "2 months",
@@ -681,7 +681,7 @@ describe("getPaywallVariables", () => {
         expect.objectContaining({
           "product.offer_price": "$13.00",
           "product.offer_price_per_day": "$0.43",
-          "product.offer_price_per_week": "$3.00",
+          "product.offer_price_per_week": "$2.99",
           "product.offer_price_per_month": "$13.00",
           "product.offer_price_per_year": "$156.00",
           "product.offer_period": "",

--- a/src/tests/mocks/offering-mock-provider.ts
+++ b/src/tests/mocks/offering-mock-provider.ts
@@ -31,10 +31,10 @@ export function createMonthlyPackageMock(
         formattedPrice: "$3.00",
       },
       pricePerWeek: {
-        amount: 70,
-        amountMicros: 700000,
+        amount: 69,
+        amountMicros: 690000,
         currency: "USD",
-        formattedPrice: "$0.70",
+        formattedPrice: "$0.69",
       },
       pricePerMonth: {
         amount: 300,
@@ -43,10 +43,10 @@ export function createMonthlyPackageMock(
         formattedPrice: "$3.00",
       },
       pricePerYear: {
-        amount: 3650,
-        amountMicros: 36500000,
+        amount: 3600,
+        amountMicros: 36000000,
         currency: "USD",
-        formattedPrice: "$36.50",
+        formattedPrice: "$36.00",
       },
     },
     trial: null,
@@ -120,10 +120,10 @@ export function createMonthlyPackageWithIntroPriceMock(): Package {
         formattedPrice: "$9.99",
       },
       pricePerWeek: {
-        amount: 230,
-        amountMicros: 2300000,
+        amount: 229,
+        amountMicros: 2290000,
         currency: "USD",
-        formattedPrice: "$2.30",
+        formattedPrice: "$2.29",
       },
       pricePerMonth: {
         amount: 999,
@@ -153,10 +153,10 @@ export function createMonthlyPackageWithIntroPriceMock(): Package {
         formattedPrice: "$1.99",
       },
       pricePerWeek: {
-        amount: 46,
-        amountMicros: 460000,
+        amount: 45,
+        amountMicros: 450000,
         currency: "USD",
-        formattedPrice: "$0.46",
+        formattedPrice: "$0.45",
       },
       pricePerMonth: {
         amount: 199,
@@ -227,10 +227,10 @@ export function createMonthlyPackageWithIntroPriceMock(): Package {
         formattedPrice: "$1.99",
       },
       pricePerWeek: {
-        amount: 46,
-        amountMicros: 460000,
+        amount: 45,
+        amountMicros: 450000,
         currency: "USD",
-        formattedPrice: "$0.46",
+        formattedPrice: "$0.45",
       },
       pricePerMonth: {
         amount: 199,
@@ -274,10 +274,10 @@ export function createMonthlyPackageWithTrialAndIntroPriceMock(): Package {
         formattedPrice: "$14.99",
       },
       pricePerWeek: {
-        amount: 346,
-        amountMicros: 3460000,
+        amount: 344,
+        amountMicros: 3440000,
         currency: "USD",
-        formattedPrice: "$3.46",
+        formattedPrice: "$3.44",
       },
       pricePerMonth: {
         amount: 1499,
@@ -318,10 +318,10 @@ export function createMonthlyPackageWithTrialAndIntroPriceMock(): Package {
         formattedPrice: "$4.99",
       },
       pricePerWeek: {
-        amount: 115,
-        amountMicros: 1150000,
+        amount: 114,
+        amountMicros: 1140000,
         currency: "USD",
-        formattedPrice: "$1.15",
+        formattedPrice: "$1.14",
       },
       pricePerMonth: {
         amount: 499,
@@ -403,10 +403,10 @@ export function createMonthlyPackageWithTrialAndIntroPriceMock(): Package {
         formattedPrice: "$4.99",
       },
       pricePerWeek: {
-        amount: 115,
-        amountMicros: 1150000,
+        amount: 114,
+        amountMicros: 1140000,
         currency: "USD",
-        formattedPrice: "$1.15",
+        formattedPrice: "$1.14",
       },
       pricePerMonth: {
         amount: 499,

--- a/src/tests/purchase.offerings.test.ts
+++ b/src/tests/purchase.offerings.test.ts
@@ -39,10 +39,10 @@ describe("getOfferings", () => {
         formattedPrice: "$5.00",
       },
       pricePerWeek: {
-        amount: 116,
-        amountMicros: 1160000,
+        amount: 115,
+        amountMicros: 1150000,
         currency: "USD",
-        formattedPrice: "$1.16",
+        formattedPrice: "$1.15",
       },
       pricePerMonth: {
         amount: 500,
@@ -51,10 +51,10 @@ describe("getOfferings", () => {
         formattedPrice: "$5.00",
       },
       pricePerYear: {
-        amount: 6083,
-        amountMicros: 60830000,
+        amount: 6000,
+        amountMicros: 60000000,
         currency: "USD",
-        formattedPrice: "$60.83",
+        formattedPrice: "$60.00",
       },
     },
     trial: trialPhaseP1W,
@@ -553,8 +553,8 @@ describe("getOfferings", () => {
           formattedPrice: "$1.99",
         },
         pricePerMonth: expect.objectContaining({ amountMicros: 1990000 }),
-        pricePerWeek: expect.objectContaining({ amountMicros: 460000 }),
-        pricePerYear: expect.objectContaining({ amountMicros: 24210000 }),
+        pricePerWeek: expect.objectContaining({ amountMicros: 450000 }),
+        pricePerYear: expect.objectContaining({ amountMicros: 23880000 }),
       };
 
       // Convenience accessors for the intro price phase
@@ -590,8 +590,8 @@ describe("getOfferings", () => {
           formattedPrice: "$4.99",
         },
         pricePerMonth: expect.objectContaining({ amountMicros: 4990000 }),
-        pricePerWeek: expect.objectContaining({ amountMicros: 1160000 }),
-        pricePerYear: expect.objectContaining({ amountMicros: 60710000 }),
+        pricePerWeek: expect.objectContaining({ amountMicros: 1140000 }),
+        pricePerYear: expect.objectContaining({ amountMicros: 59880000 }),
       };
 
       // Convenience accessors for the trial phase
@@ -662,8 +662,8 @@ describe("getOfferings", () => {
           formattedPrice: "$6.99",
         },
         pricePerMonth: expect.objectContaining({ amountMicros: 1160000 }),
-        pricePerWeek: expect.objectContaining({ amountMicros: 270000 }),
-        pricePerYear: expect.objectContaining({ amountMicros: 14170000 }),
+        pricePerWeek: expect.objectContaining({ amountMicros: 260000 }),
+        pricePerYear: expect.objectContaining({ amountMicros: 13980000 }),
       });
     });
 


### PR DESCRIPTION
## Motivation / Description

purchases-js currently calculates normalized price-per-period values using two different conversion models:

- [PricingPhase.pricePer*](https://github.com/RevenueCat/purchases-js/blob/785916e776692ff6ed74a802ba2690fd368599c9/src/entities/offerings.ts#L654-L690) first converts the subscription period to days.
- [Paywall price variables](https://github.com/RevenueCat/purchases-js/blob/785916e776692ff6ed74a802ba2690fd368599c9/src/helpers/paywall-price-helpers.ts#L68-L198) use separate constants such as `4.33` weeks per month and `52` weeks per year.

This can make the public product data and paywall variables disagree with each other and with the iOS and Android SDKs.

For example, these are the resulting USD values after the existing currency-aware flooring:

| Example | Current `PricingPhase` | Current paywall variable | iOS / Android / Web after this change |
| --- | ---: | ---: | ---: |
| `$10.00/week` → monthly | `$42.85` | `$43.30` | `$43.45` |
| `$14.99/month` → weekly | `$3.49` | `$3.46` | `$3.44` |
| `$14.99/month` → yearly | `$182.37` | `$179.88` | `$179.88` |
| `$119.99/year` → monthly | `$9.86` | `$9.99` | `$9.99` |

iOS defines [each conversion directly](https://github.com/RevenueCat/purchases-ios/blob/01fdf642d259dcfa05111d227b8ab793ff54a68e/Sources/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift#L179-L213), with [tests covering the matrix](https://github.com/RevenueCat/purchases-ios/blob/01fdf642d259dcfa05111d227b8ab793ff54a68e/Tests/UnitTests/Purchasing/StoreKitAbstractions/SubscriptionPeriodTests.swift#L57-L144). Android uses the [same logic](https://github.com/RevenueCat/purchases-android/blob/1ee82cae6a80ccc49009ecc9dde8115a87be9664/purchases/src/main/kotlin/com/revenuecat/purchases/models/Period.kt#L18-L132) and tests ([weekly](https://github.com/RevenueCat/purchases-android/blob/1ee82cae6a80ccc49009ecc9dde8115a87be9664/purchases/src/test/java/com/revenuecat/purchases/utils/PriceExtensionsPricePerWeekTest.kt#L18-L28), [monthly](https://github.com/RevenueCat/purchases-android/blob/1ee82cae6a80ccc49009ecc9dde8115a87be9664/purchases/src/test/java/com/revenuecat/purchases/utils/PriceExtensionsPricePerMonthTest.kt#L18-L28), [yearly](https://github.com/RevenueCat/purchases-android/blob/1ee82cae6a80ccc49009ecc9dde8115a87be9664/purchases/src/test/java/com/revenuecat/purchases/utils/PriceExtensionsPricePerYearTest.kt#L18-L30)).

## Changes introduced

- Share one set of price conversion factors for days, weeks, months, and years; aligned with the mobile SDKs.
- Use those factors for:
  - PricingPhase.pricePer*
  - product and offer paywall variables
  - relative-discount monthly comparisons
- Update tests.

## Linear ticket (if any)

N/A (we don't have access to Linear).

## Additional comments

We initially fell into this rabbit hole by noticing our (custom, relying on the RC Flutter SDK's `priceString` and `monthlyPriceString`) was displaying different values on Web vs Android/iOS. It caught our attention because all our prices are supposed to be "charm" prices ($119.99 billed yearly => equivalent to $9.99 monthly) but Web was displaying "weird" equivalents ($9.86 monthly).

We then realized that `purchases-js` was not only inconsistent with the native SDKs, it's also inconsistent with itself (different logic in `PricingPhase` and paywall modules).

This patch is more ambitious than originally intended, but we believe it's also the cleanest and safest way forward.

For the most minimal patch fixing the issue blocking us, see #1013.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-visible subscription price strings and paywall variables change across the Web SDK; logic is centralized and heavily tested but affects pricing presentation and discount comparisons.
> 
> **Overview**
> Unifies **price-per-period normalization** so Web matches iOS/Android and internal callers agree.
> 
> A new **`getPricePerPeriodFactors`** helper in `price-conversion-helper.ts` replaces duplicated conversion logic that used inconsistent constants (e.g. day-based factors in `PricingPhase` vs `4.33` weeks/month in paywall helpers).
> 
> **`PricingPhase.pricePerWeek/Month/Year`**, paywall **`product.price_per_*`** variables, and **relative-discount** monthly comparisons all multiply base price by the same factors. Displayed equivalents change in some cases (e.g. yearly → monthly **$9.99** instead of **$9.86**).
> 
> Tests and mocks were updated for the new normalized values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37c1515d7ecb53e0e9d706c77218fc369f0b604a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->