### PR TITLE
[WEB-4548] Use product_id over sub_id for product changes

### DIFF
--- a/examples/webbilling-demo/README.md
+++ b/examples/webbilling-demo/README.md
@@ -49,8 +49,9 @@ It uses a small token server to serve as a backend: it holds a **secret** API ke
 2. Start the token server: `pnpm run token-server`
 3. In another terminal, start the demo: `pnpm run dev` (Vite proxies `/api` → the token server)
 4. Open `/upgrade/<app_user_id>` for a customer with an active Web Billing subscription
-5. Pick the target package from the current offering and enter the RevenueCat subscription public id (`sub…`)
-6. Click **Open upgrade checkout**. The SDK starts a checkout session, shows from→to / pricing / PM on file, then confirms on CTA.
+5. Pick the target package from the current offering.
+6. Optionally, pick a source product from `customerInfo.activeSubscriptions` (required if the user has more than one active Web Billing subscription - otherwise it's inferred).
+7. Click **Open upgrade checkout**. The SDK starts a checkout session, shows from→to / pricing / PM on file, then confirms on CTA.
 
 ### Payment Methods
 

--- a/examples/webbilling-demo/src/pages/upgrade/index.tsx
+++ b/examples/webbilling-demo/src/pages/upgrade/index.tsx
@@ -8,23 +8,34 @@ import { usePurchasesLoaderData } from "../../util/PurchasesLoader";
  *
  * Fetches a short-lived subscriber access token from the demo token server,
  * then calls Purchases.purchase with productChangeInfo to mount the upgrade
- * checkout UI (start → confirm). Target product is taken from the selected
- * package (same shape a paywall would use).
+ * checkout UI (start → confirm). Source product comes from CustomerInfo;
+ * target product is taken from the selected package.
  */
 const UpgradePage: React.FC = () => {
   const { purchases, customerInfo, offering } = usePurchasesLoaderData();
+  // Product changes only apply to Web Billing; activeSubscriptions mixes stores.
+  const activeWebBillingProductIds = Object.values(
+    customerInfo.subscriptionsByProductIdentifier,
+  )
+    .filter(
+      (subscription) =>
+        subscription.store === "rc_billing" &&
+        customerInfo.activeSubscriptions.has(subscription.productIdentifier),
+    )
+    .map((subscription) => subscription.productIdentifier);
   const [selectedPackageId, setSelectedPackageId] = useState("");
-  const [subscriptionId, setSubscriptionId] = useState("");
+  const [fromProductIdentifier, setFromProductIdentifier] = useState(
+    () => activeWebBillingProductIds[0] ?? "",
+  );
   const [inProgress, setInProgress] = useState(false);
   const [result, setResult] = useState<PurchaseResult | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const activeProductIds = Array.from(customerInfo.activeSubscriptions);
   const packages: Package[] = offering?.availablePackages ?? [];
   const selectedPackage =
     packages.find((pkg) => pkg.identifier === selectedPackageId) ?? null;
 
-  const canConfirm = Boolean(selectedPackage) && Boolean(subscriptionId);
+  const canConfirm = Boolean(selectedPackage);
 
   const openUpgradeCheckout = async () => {
     if (!selectedPackage) {
@@ -54,7 +65,7 @@ const UpgradePage: React.FC = () => {
         rcPackage: selectedPackage,
         // @ts-expect-error productChangeInfo is marked as internal for now
         productChangeInfo: {
-          subscriptionId,
+          ...(fromProductIdentifier ? { fromProductIdentifier } : {}),
           subscriberToken,
         },
       });
@@ -86,10 +97,21 @@ const UpgradePage: React.FC = () => {
           Current user: <code>{purchases.getAppUserId()}</code>
         </p>
         <p>
-          Active subscription product(s):{" "}
-          <code>
-            {activeProductIds.length > 0 ? activeProductIds.join(", ") : "none"}
-          </code>
+          <label>
+            Change from product:{" "}
+            <select
+              value={fromProductIdentifier}
+              onChange={(event) => setFromProductIdentifier(event.target.value)}
+              style={{ width: "320px" }}
+            >
+              <option value="">Infer</option>
+              {activeWebBillingProductIds.map((productId) => (
+                <option key={productId} value={productId}>
+                  {productId}
+                </option>
+              ))}
+            </select>
+          </label>
         </p>
 
         <p>
@@ -107,19 +129,6 @@ const UpgradePage: React.FC = () => {
                 </option>
               ))}
             </select>
-          </label>
-        </p>
-
-        <p>
-          <label>
-            Subscription id (<code>sub…</code>):{" "}
-            <input
-              type="text"
-              value={subscriptionId}
-              placeholder="sub…"
-              onChange={(event) => setSubscriptionId(event.target.value)}
-              style={{ width: "300px" }}
-            />
           </label>
         </p>
 
@@ -153,12 +162,8 @@ const UpgradePage: React.FC = () => {
         )}
 
         <div className="notice">
-          Requires the token server (<code>npm run token-server</code>), a
-          configured product change path to the selected package's product, and
-          the RevenueCat subscription public id (<code>sub…</code>). Uses{" "}
-          <code>purchases.purchase</code> with <code>rcPackage</code> +{" "}
-          <code>productChangeInfo</code> (target product defaults from the
-          package).
+          Requires the token server (<code>npm run token-server</code>) and a
+          configured product change path to the selected package's product.
         </div>
       </div>
     </>

--- a/src/entities/product-change-params.ts
+++ b/src/entities/product-change-params.ts
@@ -5,13 +5,18 @@
  */
 export interface ProductChangeInfo {
   /**
-   * RevenueCat subscription public id (`sub…`) of the subscription to change.
+   * Product identifier of the Web Billing subscription to change.
    *
-   * Typically obtained by your backend via the
-   * [Developer API](https://www.revenuecat.com/docs/api-v2)
-   * customer subscriptions list and passed to the client with the token.
+   * Obtainable from {@link CustomerInfo.activeSubscriptions} or
+   * {@link CustomerInfo.subscriptionsByProductIdentifier} via
+   * {@link Purchases.getCustomerInfo}.
+   *
+   * When omitted, the source will be inferred on the assumption that the app
+   * user has exactly one active Web Billing subscription.
+   * However if it is possible for an app user to have zero or multiple
+   * active Web Billing subscriptions then this field is required.
    */
-  subscriptionId: string;
+  fromProductIdentifier?: string;
   /**
    * Optional short-lived subscriber access token override for this call.
    * Falls back to {@link PurchasesConfig.subscriberToken} when omitted.

--- a/src/helpers/product-change-operation-helper.ts
+++ b/src/helpers/product-change-operation-helper.ts
@@ -15,13 +15,13 @@ export class ProductChangeOperationHelper {
 
   async start(
     newProductId: string,
-    subscriptionId: string,
+    fromProductIdentifier: string | undefined,
     subscriberToken: string,
   ): Promise<SubscriptionChangeCheckoutStartResponse> {
     try {
       const response = await this.backend.postSubscriptionChangeCheckoutStart(
         newProductId,
-        subscriptionId,
+        fromProductIdentifier,
         subscriberToken,
       );
       this.operationSessionId = response.operation_session_id;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2203,20 +2203,12 @@ export class Purchases {
       );
     }
 
-    const { subscriptionId } = productChangeInfo;
+    const fromProductIdentifier =
+      productChangeInfo.fromProductIdentifier || undefined;
     const subscriberToken =
       productChangeInfo.subscriberToken ?? this._subscriberToken ?? undefined;
     const { rcPackage, htmlTarget } = params;
     const newProductId = rcPackage.webBillingProduct.identifier;
-
-    if (!subscriptionId) {
-      throw new PurchasesError(
-        ErrorCode.PurchaseInvalidError,
-        "subscriptionId is required.",
-        "Pass the RevenueCat subscription public id (sub…) for the " +
-          "subscription to change via productChangeInfo.subscriptionId.",
-      );
-    }
 
     if (!subscriberToken) {
       throw new PurchasesError(
@@ -2285,7 +2277,7 @@ export class Purchases {
         target: certainHTMLTarget,
         props: {
           newProductId,
-          subscriptionId,
+          fromProductIdentifier,
           subscriberToken,
           brandingInfo: this._brandingInfo,
           isInElement,

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -466,23 +466,27 @@ export class Backend {
 
   async postSubscriptionChangeCheckoutStart(
     newProductId: string,
-    subscriptionId: string,
+    fromProductIdentifier: string | undefined,
     subscriberToken: string,
   ): Promise<SubscriptionChangeCheckoutStartResponse> {
     type RequestBody = {
       new_product_id: string;
-      subscription_id: string;
+      from_product_id?: string;
     };
+
+    const body: RequestBody = {
+      new_product_id: newProductId,
+    };
+    if (fromProductIdentifier) {
+      body.from_product_id = fromProductIdentifier;
+    }
 
     return await performRequest<
       RequestBody,
       SubscriptionChangeCheckoutStartResponse
     >(new SubscriptionChangeCheckoutStartEndpoint(), {
       apiKey: this.API_KEY,
-      body: {
-        new_product_id: newProductId,
-        subscription_id: subscriptionId,
-      },
+      body,
       headers: { Authorization: `Bearer ${subscriberToken}` },
       httpConfig: this.httpConfig,
     });

--- a/src/stories/pages/upgrade-checkout-ui.stories.svelte
+++ b/src/stories/pages/upgrade-checkout-ui.stories.svelte
@@ -68,7 +68,7 @@
   {@const productChangeOperationHelper = helperForArgs(args)}
   <UpgradeCheckoutUi
     newProductId={args.startData?.to_product.product_id ?? "premium_monthly"}
-    subscriptionId="sub_story_123"
+    fromProductIdentifier="premium_monthly"
     subscriberToken="subscriber_token_story"
     {brandingInfo}
     isInElement={context.globals.viewport === "embedded"}

--- a/src/tests/change-product.test.ts
+++ b/src/tests/change-product.test.ts
@@ -17,6 +17,7 @@ import { createMonthlyPackageMock } from "./mocks/offering-mock-provider";
 
 const SUBSCRIBER_TOKEN_1 = "eyJhbGciOiJSUzI1NiJ9.subscriber.token.1";
 const SUBSCRIBER_TOKEN_2 = "eyJhbGciOiJSUzI1NiJ9.subscriber.token.2";
+const FROM_PRODUCT_IDENTIFIER = "premium_monthly";
 const packageToBuy = createMonthlyPackageMock();
 
 describe("Purchases.purchase productChangeInfo", () => {
@@ -31,7 +32,7 @@ describe("Purchases.purchase productChangeInfo", () => {
       purchases.purchase({
         rcPackage: packageToBuy,
         productChangeInfo: {
-          subscriptionId: "subabc123",
+          fromProductIdentifier: FROM_PRODUCT_IDENTIFIER,
           subscriberToken: "rcb_test_api_key",
         },
       }),
@@ -42,24 +43,34 @@ describe("Purchases.purchase productChangeInfo", () => {
     );
   });
 
-  test("requires subscriptionId", async () => {
-    const purchases = configurePurchases();
+  test("allows omitting fromProductIdentifier for backend inference", async () => {
+    if (Purchases.isConfigured()) {
+      Purchases.getSharedInstance().close();
+    }
+    const purchases = Purchases.configure({
+      apiKey: testApiKey,
+      appUserId: testUserId,
+      httpConfig: defaultHttpConfig,
+      flags: { rcSource: "rcSource" },
+      subscriberToken: SUBSCRIBER_TOKEN_1,
+    });
 
-    await expectPromiseToError(
-      purchases.purchase({
-        rcPackage: packageToBuy,
-        productChangeInfo: {
-          subscriptionId: "",
-          subscriberToken: SUBSCRIBER_TOKEN_1,
-        },
-      }),
-      new PurchasesError(
-        ErrorCode.PurchaseInvalidError,
-        "subscriptionId is required.",
-        "Pass the RevenueCat subscription public id (sub…) for the " +
-          "subscription to change via productChangeInfo.subscriptionId.",
-      ),
-    );
+    const startSpy = vi
+      .spyOn(ProductChangeOperationHelper.prototype, "start")
+      .mockResolvedValue(subscriptionChangeImmediateWithTax);
+
+    void purchases.purchase({
+      rcPackage: packageToBuy,
+      productChangeInfo: {},
+    });
+
+    await vi.waitFor(() => {
+      expect(startSpy).toHaveBeenCalledWith(
+        packageToBuy.webBillingProduct.identifier,
+        undefined,
+        SUBSCRIBER_TOKEN_1,
+      );
+    });
   });
 
   test("requires subscriberToken from configure or productChangeInfo", async () => {
@@ -69,7 +80,7 @@ describe("Purchases.purchase productChangeInfo", () => {
       purchases.purchase({
         rcPackage: packageToBuy,
         productChangeInfo: {
-          subscriptionId: "subabc123",
+          fromProductIdentifier: FROM_PRODUCT_IDENTIFIER,
         },
       }),
       new PurchasesError(
@@ -100,14 +111,14 @@ describe("Purchases.purchase productChangeInfo", () => {
     void purchases.purchase({
       rcPackage: packageToBuy,
       productChangeInfo: {
-        subscriptionId: "subabc123",
+        fromProductIdentifier: FROM_PRODUCT_IDENTIFIER,
       },
     });
 
     await vi.waitFor(() => {
       expect(startSpy).toHaveBeenCalledWith(
         packageToBuy.webBillingProduct.identifier,
-        "subabc123",
+        FROM_PRODUCT_IDENTIFIER,
         SUBSCRIBER_TOKEN_1,
       );
     });
@@ -132,7 +143,7 @@ describe("Purchases.purchase productChangeInfo", () => {
     void purchases.purchase({
       rcPackage: packageToBuy,
       productChangeInfo: {
-        subscriptionId: "subabc123",
+        fromProductIdentifier: FROM_PRODUCT_IDENTIFIER,
         subscriberToken: SUBSCRIBER_TOKEN_2,
       },
     });
@@ -140,7 +151,7 @@ describe("Purchases.purchase productChangeInfo", () => {
     await vi.waitFor(() => {
       expect(startSpy).toHaveBeenCalledWith(
         packageToBuy.webBillingProduct.identifier,
-        "subabc123",
+        FROM_PRODUCT_IDENTIFIER,
         SUBSCRIBER_TOKEN_2,
       );
     });
@@ -150,10 +161,10 @@ describe("Purchases.purchase productChangeInfo", () => {
 describe("product change checkout networking", () => {
   const backend = new Backend("rcb_test_api_key");
 
-  test("start sends subscription_id and maps response", async () => {
+  test("start sends from_product_id and maps response", async () => {
     let requestBody: {
       new_product_id?: string;
-      subscription_id?: string;
+      from_product_id?: string;
     } = {};
     let authHeader: string | null = null;
 
@@ -208,16 +219,73 @@ describe("product change checkout networking", () => {
 
     const response = await backend.postSubscriptionChangeCheckoutStart(
       "annual",
-      "subabc123",
+      FROM_PRODUCT_IDENTIFIER,
       SUBSCRIBER_TOKEN_1,
     );
 
     expect(requestBody).toEqual({
       new_product_id: "annual",
-      subscription_id: "subabc123",
+      from_product_id: FROM_PRODUCT_IDENTIFIER,
     });
     expect(authHeader).toBe(`Bearer ${SUBSCRIBER_TOKEN_1}`);
     expect(response.operation_session_id).toBe("rcbopsess_start");
+  });
+
+  test("start omits from_product_id when not provided", async () => {
+    let requestBody: {
+      new_product_id?: string;
+      from_product_id?: string;
+    } = {};
+
+    server.use(
+      http.post(
+        "http://localhost:8000/rcbilling/v1/subscription/change/checkout/start",
+        async ({ request }) => {
+          requestBody = (await request.json()) as typeof requestBody;
+          return HttpResponse.json(
+            {
+              operation_session_id: "rcbopsess_inferred",
+              change_type: "immediate",
+              from_product: {
+                product_id: "monthly",
+                display_name: "Monthly",
+                price_in_micros: 9990000,
+                currency: "USD",
+              },
+              to_product: {
+                product_id: "annual",
+                display_name: "Annual",
+                price_in_micros: 99990000,
+                currency: "USD",
+              },
+              price_breakdown: {
+                currency: "USD",
+                total_amount_in_micros: 99990000,
+                tax_amount_in_micros: null,
+                total_excluding_tax_in_micros: 99990000,
+                original_amount_in_micros: 99990000,
+              },
+              estimated_renewal_price: null,
+              email: "user@example.com",
+              payment_method: null,
+              billing_address: null,
+            },
+            { status: 201 },
+          );
+        },
+      ),
+    );
+
+    await backend.postSubscriptionChangeCheckoutStart(
+      "annual",
+      undefined,
+      SUBSCRIBER_TOKEN_1,
+    );
+
+    expect(requestBody).toEqual({
+      new_product_id: "annual",
+    });
+    expect(requestBody.from_product_id).toBeUndefined();
   });
 
   test("confirm posts to session confirm endpoint", async () => {

--- a/src/ui/upgrade-checkout-ui.svelte
+++ b/src/ui/upgrade-checkout-ui.svelte
@@ -19,7 +19,7 @@
 
   interface Props {
     newProductId: string;
-    subscriptionId: string;
+    fromProductIdentifier?: string;
     subscriberToken: string;
     brandingInfo: BrandingInfoResponse | null;
     isInElement: boolean;
@@ -32,7 +32,7 @@
 
   const {
     newProductId,
-    subscriptionId,
+    fromProductIdentifier,
     subscriberToken,
     brandingInfo,
     isInElement,
@@ -57,7 +57,7 @@
     try {
       startData = await productChangeOperationHelper.start(
         newProductId,
-        subscriptionId,
+        fromProductIdentifier,
         subscriberToken,
       );
     } catch (e) {


### PR DESCRIPTION
## Motivation / Description

See the ticket: https://linear.app/revenuecat/issue/WEB-4548/sdkkhepri-key-product-change-on-productid-over-subscriptionid

Essentially, we think it makes more sense to key the product change on the product id and not the subscription id. This is feasible because an app user should not be subscribed to the same product more than once (though it's theoretically possible in Stripe billing, so we carve out explicit handling for it).

Additionally, we now infer the source subscription if no source product id is provided - though error if 0 or >1 are found for the app user.

The demo remains built in a pretty client side manner, but the product id can still be fetched from API v2 and handled via a backend if preferred.

https://www.loom.com/share/deccb210702541ba8eef05713311bf9a


## Changes introduced

## Linear ticket (if any)

## Additional comments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking API change for experimental `productChangeInfo` (removes `subscriptionId`) and shifts source resolution to product id plus optional backend inference, which can mis-target changes if callers omit `fromProductIdentifier` when multiple Web Billing subscriptions exist.
> 
> **Overview**
> Product change checkout now identifies the **source** subscription with an optional **`fromProductIdentifier`** (from `CustomerInfo`) instead of a required RevenueCat **`subscriptionId` (`sub…`)**. The change/start API body sends **`from_product_id`** when set and omits it so the backend can infer the source when the user has exactly one active Web Billing subscription.
> 
> **`Purchases.purchase`** with **`productChangeInfo`** no longer validates **`subscriptionId`**; **`subscriberToken`** is still required. **`UpgradeCheckoutUi`**, **`ProductChangeOperationHelper`**, and **`Backend.postSubscriptionChangeCheckoutStart`** are aligned on the new parameter.
> 
> The **webbilling-demo** upgrade page drops the subscription id field, lists active **`rc_billing`** products for “change from,” and documents inference vs explicit selection when multiple subscriptions exist. Tests and Storybook props are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee247b9a17ac14dfc641daceaea6d80dd3296965. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->