### PR TITLE
[WEB-4567] Support subId and/or prodId for subscription changes

### DIFF
--- a/examples/webbilling-demo/README.md
+++ b/examples/webbilling-demo/README.md
@@ -49,8 +49,9 @@ It uses a small token server to serve as a backend: it holds a **secret** API ke
 2. Start the token server: `pnpm run token-server`
 3. In another terminal, start the demo: `pnpm run dev` (Vite proxies `/api` → the token server)
 4. Open `/upgrade/<app_user_id>` for a customer with an active Web Billing subscription
-5. Pick the target package from the current offering and enter the RevenueCat subscription public id (`sub…`)
-6. Click **Open upgrade checkout**. The SDK starts a checkout session, shows from→to / pricing / PM on file, then confirms on CTA.
+5. Optionally pick a source product from active Web Billing subscriptions and/or enter a subscription public id (`sub…`). Either, both (must match), or neither (we infer a single active Web Billing subscription) is allowed. Provide at least one id if the user may have multiple active Web Billing subscriptions.
+6. Pick the target package from the current offering.
+7. Click **Open upgrade checkout**. The SDK starts a checkout session, shows from→to / pricing / PM on file, then confirms on CTA.
 
 ### Payment Methods
 

--- a/examples/webbilling-demo/src/pages/upgrade/index.tsx
+++ b/examples/webbilling-demo/src/pages/upgrade/index.tsx
@@ -8,23 +8,35 @@ import { usePurchasesLoaderData } from "../../util/PurchasesLoader";
  *
  * Fetches a short-lived subscriber access token from the demo token server,
  * then calls Purchases.purchase with productChangeInfo to mount the upgrade
- * checkout UI (start → confirm). Target product is taken from the selected
- * package (same shape a paywall would use).
+ * checkout UI (start → confirm). Source may be a product id, subscription id,
+ * both, or omitted for backend inference; target product is taken from the
+ * selected package.
  */
 const UpgradePage: React.FC = () => {
   const { purchases, customerInfo, offering } = usePurchasesLoaderData();
+  const activeWebBillingProductIds = Object.values(
+    customerInfo.subscriptionsByProductIdentifier,
+  )
+    .filter(
+      (subscription) =>
+        subscription.store === "rc_billing" &&
+        customerInfo.activeSubscriptions.has(subscription.productIdentifier),
+    )
+    .map((subscription) => subscription.productIdentifier);
   const [selectedPackageId, setSelectedPackageId] = useState("");
+  const [productIdentifier, setProductIdentifier] = useState(
+    () => activeWebBillingProductIds[0] ?? "",
+  );
   const [subscriptionId, setSubscriptionId] = useState("");
   const [inProgress, setInProgress] = useState(false);
   const [result, setResult] = useState<PurchaseResult | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const activeProductIds = Array.from(customerInfo.activeSubscriptions);
   const packages: Package[] = offering?.availablePackages ?? [];
   const selectedPackage =
     packages.find((pkg) => pkg.identifier === selectedPackageId) ?? null;
 
-  const canConfirm = Boolean(selectedPackage) && Boolean(subscriptionId);
+  const canConfirm = Boolean(selectedPackage);
 
   const openUpgradeCheckout = async () => {
     if (!selectedPackage) {
@@ -54,7 +66,8 @@ const UpgradePage: React.FC = () => {
         rcPackage: selectedPackage,
         // @ts-expect-error productChangeInfo is marked as internal for now
         productChangeInfo: {
-          subscriptionId,
+          ...(subscriptionId ? { subscriptionId } : {}),
+          ...(productIdentifier ? { productIdentifier } : {}),
           subscriberToken,
         },
       });
@@ -86,10 +99,34 @@ const UpgradePage: React.FC = () => {
           Current user: <code>{purchases.getAppUserId()}</code>
         </p>
         <p>
-          Active subscription product(s):{" "}
-          <code>
-            {activeProductIds.length > 0 ? activeProductIds.join(", ") : "none"}
-          </code>
+          <label>
+            Change from product:{" "}
+            <select
+              value={productIdentifier}
+              onChange={(event) => setProductIdentifier(event.target.value)}
+              style={{ width: "320px" }}
+            >
+              <option value="">Infer / omit</option>
+              {activeWebBillingProductIds.map((productId) => (
+                <option key={productId} value={productId}>
+                  {productId}
+                </option>
+              ))}
+            </select>
+          </label>
+        </p>
+
+        <p>
+          <label>
+            Subscription id (<code>sub…</code>, optional):{" "}
+            <input
+              type="text"
+              value={subscriptionId}
+              placeholder="sub… (optional)"
+              onChange={(event) => setSubscriptionId(event.target.value)}
+              style={{ width: "300px" }}
+            />
+          </label>
         </p>
 
         <p>
@@ -107,19 +144,6 @@ const UpgradePage: React.FC = () => {
                 </option>
               ))}
             </select>
-          </label>
-        </p>
-
-        <p>
-          <label>
-            Subscription id (<code>sub…</code>):{" "}
-            <input
-              type="text"
-              value={subscriptionId}
-              placeholder="sub…"
-              onChange={(event) => setSubscriptionId(event.target.value)}
-              style={{ width: "300px" }}
-            />
           </label>
         </p>
 
@@ -153,12 +177,10 @@ const UpgradePage: React.FC = () => {
         )}
 
         <div className="notice">
-          Requires the token server (<code>npm run token-server</code>), a
-          configured product change path to the selected package's product, and
-          the RevenueCat subscription public id (<code>sub…</code>). Uses{" "}
-          <code>purchases.purchase</code> with <code>rcPackage</code> +{" "}
-          <code>productChangeInfo</code> (target product defaults from the
-          package).
+          Requires the token server (<code>npm run token-server</code>) and a
+          configured product change path to the selected package's product.
+          Source product and/or subscription id are optional; if both are
+          omitted the backend infers a single active Web Billing subscription.
         </div>
       </div>
     </>

--- a/src/entities/product-change-params.ts
+++ b/src/entities/product-change-params.ts
@@ -10,8 +10,30 @@ export interface ProductChangeInfo {
    * Typically obtained by your backend via the
    * [Developer API](https://www.revenuecat.com/docs/api-v2)
    * customer subscriptions list and passed to the client with the token.
+   *
+   * When omitted, the source will be inferred on the assumption that the app
+   * user has exactly one active Web Billing subscription.
+   * However if it is possible for an app user to have zero or multiple
+   * active Web Billing subscriptions then either this field or
+   * {@link productIdentifier} is required.
+   * If both are provided, they must refer to the same subscription.
    */
-  subscriptionId: string;
+  subscriptionId?: string;
+  /**
+   * Product identifier of the Web Billing subscription to change.
+   *
+   * Obtainable from {@link CustomerInfo.activeSubscriptions} or
+   * {@link CustomerInfo.subscriptionsByProductIdentifier} via
+   * {@link Purchases.getCustomerInfo}.
+   *
+   * When omitted, the source will be inferred on the assumption that the app
+   * user has exactly one active Web Billing subscription.
+   * However if it is possible for an app user to have zero or multiple
+   * active Web Billing subscriptions then either this field or
+   * {@link subscriptionId} is required.
+   * If both are provided, they must refer to the same subscription.
+   */
+  productIdentifier?: string;
   /**
    * Optional short-lived subscriber access token override for this call.
    * Falls back to {@link PurchasesConfig.subscriberToken} when omitted.

--- a/src/entities/product-change-params.ts
+++ b/src/entities/product-change-params.ts
@@ -13,7 +13,7 @@ export interface ProductChangeInfo {
    *
    * When omitted, the source will be inferred on the assumption that the app
    * user has exactly one active Web Billing subscription.
-   * However if it is possible for an app user to have zero or multiple
+   * However if it is possible for an app user to have multiple
    * active Web Billing subscriptions then either this field or
    * {@link productIdentifier} is required.
    * If both are provided, they must refer to the same subscription.
@@ -28,7 +28,7 @@ export interface ProductChangeInfo {
    *
    * When omitted, the source will be inferred on the assumption that the app
    * user has exactly one active Web Billing subscription.
-   * However if it is possible for an app user to have zero or multiple
+   * However if it is possible for an app user to multiple
    * active Web Billing subscriptions then either this field or
    * {@link subscriptionId} is required.
    * If both are provided, they must refer to the same subscription.

--- a/src/helpers/product-change-operation-helper.ts
+++ b/src/helpers/product-change-operation-helper.ts
@@ -15,13 +15,15 @@ export class ProductChangeOperationHelper {
 
   async start(
     newProductId: string,
-    subscriptionId: string,
+    subscriptionId: string | undefined,
+    productIdentifier: string | undefined,
     subscriberToken: string,
   ): Promise<SubscriptionChangeCheckoutStartResponse> {
     try {
       const response = await this.backend.postSubscriptionChangeCheckoutStart(
         newProductId,
         subscriptionId,
+        productIdentifier,
         subscriberToken,
       );
       this.operationSessionId = response.operation_session_id;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2203,20 +2203,12 @@ export class Purchases {
       );
     }
 
-    const { subscriptionId } = productChangeInfo;
+    const subscriptionId = productChangeInfo.subscriptionId || undefined;
+    const productIdentifier = productChangeInfo.productIdentifier || undefined;
     const subscriberToken =
       productChangeInfo.subscriberToken ?? this._subscriberToken ?? undefined;
     const { rcPackage, htmlTarget } = params;
     const newProductId = rcPackage.webBillingProduct.identifier;
-
-    if (!subscriptionId) {
-      throw new PurchasesError(
-        ErrorCode.PurchaseInvalidError,
-        "subscriptionId is required.",
-        "Pass the RevenueCat subscription public id (sub…) for the " +
-          "subscription to change via productChangeInfo.subscriptionId.",
-      );
-    }
 
     if (!subscriberToken) {
       throw new PurchasesError(
@@ -2286,6 +2278,7 @@ export class Purchases {
         props: {
           newProductId,
           subscriptionId,
+          productIdentifier,
           subscriberToken,
           brandingInfo: this._brandingInfo,
           isInElement,

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -466,23 +466,32 @@ export class Backend {
 
   async postSubscriptionChangeCheckoutStart(
     newProductId: string,
-    subscriptionId: string,
+    subscriptionId: string | undefined,
+    productIdentifier: string | undefined,
     subscriberToken: string,
   ): Promise<SubscriptionChangeCheckoutStartResponse> {
     type RequestBody = {
       new_product_id: string;
-      subscription_id: string;
+      subscription_id?: string;
+      from_product_id?: string;
     };
+
+    const body: RequestBody = {
+      new_product_id: newProductId,
+    };
+    if (subscriptionId) {
+      body.subscription_id = subscriptionId;
+    }
+    if (productIdentifier) {
+      body.from_product_id = productIdentifier;
+    }
 
     return await performRequest<
       RequestBody,
       SubscriptionChangeCheckoutStartResponse
     >(new SubscriptionChangeCheckoutStartEndpoint(), {
       apiKey: this.API_KEY,
-      body: {
-        new_product_id: newProductId,
-        subscription_id: subscriptionId,
-      },
+      body,
       headers: { Authorization: `Bearer ${subscriberToken}` },
       httpConfig: this.httpConfig,
     });

--- a/src/tests/change-product.test.ts
+++ b/src/tests/change-product.test.ts
@@ -17,6 +17,7 @@ import { createMonthlyPackageMock } from "./mocks/offering-mock-provider";
 
 const SUBSCRIBER_TOKEN_1 = "eyJhbGciOiJSUzI1NiJ9.subscriber.token.1";
 const SUBSCRIBER_TOKEN_2 = "eyJhbGciOiJSUzI1NiJ9.subscriber.token.2";
+const FROM_PRODUCT_IDENTIFIER = "premium_monthly";
 const packageToBuy = createMonthlyPackageMock();
 
 describe("Purchases.purchase productChangeInfo", () => {
@@ -42,24 +43,28 @@ describe("Purchases.purchase productChangeInfo", () => {
     );
   });
 
-  test("requires subscriptionId", async () => {
+  test("allows omitting subscriptionId and productIdentifier for backend inference", async () => {
     const purchases = configurePurchases();
 
-    await expectPromiseToError(
-      purchases.purchase({
-        rcPackage: packageToBuy,
-        productChangeInfo: {
-          subscriptionId: "",
-          subscriberToken: SUBSCRIBER_TOKEN_1,
-        },
-      }),
-      new PurchasesError(
-        ErrorCode.PurchaseInvalidError,
-        "subscriptionId is required.",
-        "Pass the RevenueCat subscription public id (sub…) for the " +
-          "subscription to change via productChangeInfo.subscriptionId.",
-      ),
-    );
+    const startSpy = vi
+      .spyOn(ProductChangeOperationHelper.prototype, "start")
+      .mockResolvedValue(subscriptionChangeImmediateWithTax);
+
+    void purchases.purchase({
+      rcPackage: packageToBuy,
+      productChangeInfo: {
+        subscriberToken: SUBSCRIBER_TOKEN_1,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(startSpy).toHaveBeenCalledWith(
+        packageToBuy.webBillingProduct.identifier,
+        undefined,
+        undefined,
+        SUBSCRIBER_TOKEN_1,
+      );
+    });
   });
 
   test("requires subscriberToken from configure or productChangeInfo", async () => {
@@ -108,6 +113,58 @@ describe("Purchases.purchase productChangeInfo", () => {
       expect(startSpy).toHaveBeenCalledWith(
         packageToBuy.webBillingProduct.identifier,
         "subabc123",
+        undefined,
+        SUBSCRIBER_TOKEN_1,
+      );
+    });
+  });
+
+  test("passes productIdentifier through to start", async () => {
+    const purchases = configurePurchases();
+
+    const startSpy = vi
+      .spyOn(ProductChangeOperationHelper.prototype, "start")
+      .mockResolvedValue(subscriptionChangeImmediateWithTax);
+
+    void purchases.purchase({
+      rcPackage: packageToBuy,
+      productChangeInfo: {
+        productIdentifier: FROM_PRODUCT_IDENTIFIER,
+        subscriberToken: SUBSCRIBER_TOKEN_1,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(startSpy).toHaveBeenCalledWith(
+        packageToBuy.webBillingProduct.identifier,
+        undefined,
+        FROM_PRODUCT_IDENTIFIER,
+        SUBSCRIBER_TOKEN_1,
+      );
+    });
+  });
+
+  test("passes both subscriptionId and productIdentifier through to start", async () => {
+    const purchases = configurePurchases();
+
+    const startSpy = vi
+      .spyOn(ProductChangeOperationHelper.prototype, "start")
+      .mockResolvedValue(subscriptionChangeImmediateWithTax);
+
+    void purchases.purchase({
+      rcPackage: packageToBuy,
+      productChangeInfo: {
+        subscriptionId: "subabc123",
+        productIdentifier: FROM_PRODUCT_IDENTIFIER,
+        subscriberToken: SUBSCRIBER_TOKEN_1,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(startSpy).toHaveBeenCalledWith(
+        packageToBuy.webBillingProduct.identifier,
+        "subabc123",
+        FROM_PRODUCT_IDENTIFIER,
         SUBSCRIBER_TOKEN_1,
       );
     });
@@ -141,6 +198,7 @@ describe("Purchases.purchase productChangeInfo", () => {
       expect(startSpy).toHaveBeenCalledWith(
         packageToBuy.webBillingProduct.identifier,
         "subabc123",
+        undefined,
         SUBSCRIBER_TOKEN_2,
       );
     });
@@ -150,10 +208,48 @@ describe("Purchases.purchase productChangeInfo", () => {
 describe("product change checkout networking", () => {
   const backend = new Backend("rcb_test_api_key");
 
-  test("start sends subscription_id and maps response", async () => {
+  const startSuccessResponse = {
+    operation_session_id: "rcbopsess_start",
+    change_type: "immediate",
+    from_product: {
+      product_id: "monthly",
+      display_name: "Monthly",
+      price_in_micros: 9990000,
+      currency: "USD",
+    },
+    to_product: {
+      product_id: "annual",
+      display_name: "Annual",
+      price_in_micros: 99990000,
+      currency: "USD",
+    },
+    price_breakdown: {
+      currency: "USD",
+      total_amount_in_micros: 99990000,
+      tax_amount_in_micros: null,
+      total_excluding_tax_in_micros: 99990000,
+      original_amount_in_micros: 99990000,
+    },
+    estimated_renewal_price: null,
+    email: "user@example.com",
+    payment_method: {
+      type: "card",
+      last_4: "4242",
+      brand: "visa",
+      exp_month: 12,
+      exp_year: 2030,
+    },
+    billing_address: {
+      country_code: "US",
+      postal_code: "12345",
+    },
+  };
+
+  test("start sends subscription_id only", async () => {
     let requestBody: {
       new_product_id?: string;
       subscription_id?: string;
+      from_product_id?: string;
     } = {};
     let authHeader: string | null = null;
 
@@ -163,45 +259,7 @@ describe("product change checkout networking", () => {
         async ({ request }) => {
           authHeader = request.headers.get("Authorization");
           requestBody = (await request.json()) as typeof requestBody;
-          return HttpResponse.json(
-            {
-              operation_session_id: "rcbopsess_start",
-              change_type: "immediate",
-              from_product: {
-                product_id: "monthly",
-                display_name: "Monthly",
-                price_in_micros: 9990000,
-                currency: "USD",
-              },
-              to_product: {
-                product_id: "annual",
-                display_name: "Annual",
-                price_in_micros: 99990000,
-                currency: "USD",
-              },
-              price_breakdown: {
-                currency: "USD",
-                total_amount_in_micros: 99990000,
-                tax_amount_in_micros: null,
-                total_excluding_tax_in_micros: 99990000,
-                original_amount_in_micros: 99990000,
-              },
-              estimated_renewal_price: null,
-              email: "user@example.com",
-              payment_method: {
-                type: "card",
-                last_4: "4242",
-                brand: "visa",
-                exp_month: 12,
-                exp_year: 2030,
-              },
-              billing_address: {
-                country_code: "US",
-                postal_code: "12345",
-              },
-            },
-            { status: 201 },
-          );
+          return HttpResponse.json(startSuccessResponse, { status: 201 });
         },
       ),
     );
@@ -209,6 +267,7 @@ describe("product change checkout networking", () => {
     const response = await backend.postSubscriptionChangeCheckoutStart(
       "annual",
       "subabc123",
+      undefined,
       SUBSCRIBER_TOKEN_1,
     );
 
@@ -218,6 +277,96 @@ describe("product change checkout networking", () => {
     });
     expect(authHeader).toBe(`Bearer ${SUBSCRIBER_TOKEN_1}`);
     expect(response.operation_session_id).toBe("rcbopsess_start");
+  });
+
+  test("start sends from_product_id only", async () => {
+    let requestBody: {
+      new_product_id?: string;
+      subscription_id?: string;
+      from_product_id?: string;
+    } = {};
+
+    server.use(
+      http.post(
+        "http://localhost:8000/rcbilling/v1/subscription/change/checkout/start",
+        async ({ request }) => {
+          requestBody = (await request.json()) as typeof requestBody;
+          return HttpResponse.json(startSuccessResponse, { status: 201 });
+        },
+      ),
+    );
+
+    await backend.postSubscriptionChangeCheckoutStart(
+      "annual",
+      undefined,
+      FROM_PRODUCT_IDENTIFIER,
+      SUBSCRIBER_TOKEN_1,
+    );
+
+    expect(requestBody).toEqual({
+      new_product_id: "annual",
+      from_product_id: FROM_PRODUCT_IDENTIFIER,
+    });
+  });
+
+  test("start omits both ids for inference", async () => {
+    let requestBody: {
+      new_product_id?: string;
+      subscription_id?: string;
+      from_product_id?: string;
+    } = {};
+
+    server.use(
+      http.post(
+        "http://localhost:8000/rcbilling/v1/subscription/change/checkout/start",
+        async ({ request }) => {
+          requestBody = (await request.json()) as typeof requestBody;
+          return HttpResponse.json(startSuccessResponse, { status: 201 });
+        },
+      ),
+    );
+
+    await backend.postSubscriptionChangeCheckoutStart(
+      "annual",
+      undefined,
+      undefined,
+      SUBSCRIBER_TOKEN_1,
+    );
+
+    expect(requestBody).toEqual({
+      new_product_id: "annual",
+    });
+  });
+
+  test("start sends both subscription_id and from_product_id", async () => {
+    let requestBody: {
+      new_product_id?: string;
+      subscription_id?: string;
+      from_product_id?: string;
+    } = {};
+
+    server.use(
+      http.post(
+        "http://localhost:8000/rcbilling/v1/subscription/change/checkout/start",
+        async ({ request }) => {
+          requestBody = (await request.json()) as typeof requestBody;
+          return HttpResponse.json(startSuccessResponse, { status: 201 });
+        },
+      ),
+    );
+
+    await backend.postSubscriptionChangeCheckoutStart(
+      "annual",
+      "subabc123",
+      FROM_PRODUCT_IDENTIFIER,
+      SUBSCRIBER_TOKEN_1,
+    );
+
+    expect(requestBody).toEqual({
+      new_product_id: "annual",
+      subscription_id: "subabc123",
+      from_product_id: FROM_PRODUCT_IDENTIFIER,
+    });
   });
 
   test("confirm posts to session confirm endpoint", async () => {

--- a/src/ui/upgrade-checkout-ui.svelte
+++ b/src/ui/upgrade-checkout-ui.svelte
@@ -19,7 +19,8 @@
 
   interface Props {
     newProductId: string;
-    subscriptionId: string;
+    subscriptionId?: string;
+    productIdentifier?: string;
     subscriberToken: string;
     brandingInfo: BrandingInfoResponse | null;
     isInElement: boolean;
@@ -33,6 +34,7 @@
   const {
     newProductId,
     subscriptionId,
+    productIdentifier,
     subscriberToken,
     brandingInfo,
     isInElement,
@@ -58,6 +60,7 @@
       startData = await productChangeOperationHelper.start(
         newProductId,
         subscriptionId,
+        productIdentifier,
         subscriberToken,
       );
     } catch (e) {


### PR DESCRIPTION
## Motivation / Description

This PR replaces the previous https://github.com/RevenueCat/purchases-js/pull/1019.

Linked with https://github.com/RevenueCat/khepri/pull/23583.

The goal here is to support subscription changes keyed by either a product ID _or_ a subscription ID.

Generally, we would recommend the subscription ID as it's ultimately the identifier of the subscription that will actually be _changed_. The product ID provided is mapped to a subscription ID, and this isn't necessarily in all possible cases 1:1 (mostly thinking ahead to Stripe support). However in the majority of cases it's likely good enough, eases development for users preferring to use primarily the SDK, and should make support in hybrids easier.

Additionally, this PR also introduces inference if _neither_ is provided, where we use the app_user_id to see if they only have one active relevant subscription - and if so we'll use that.

If both are provided, we just assert that they need to match.

Updates the demo app UI accordingly to support either input.

The video below shows the example demo UI, in which there are inputs for product id and subscription id. Subscription id is currently fetched manually, but we plan to return this alongside the auth token in future which we could then apply in this demo to provide a dropdown similar to what we do with product id. 
The appuser33 app_user_id is subscribed to SubChangesYearlyBasic and the video shows some sample (arbitrary) upgrades/downgrades from that position, given various ids explicitly provided or omitted.

https://github.com/user-attachments/assets/76e8d85c-47a6-4259-8a0b-13f6251e3372


## Changes introduced

## Linear ticket (if any)

## Additional comments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the upgrade flow identifies the source subscription and relies on backend inference when ids are omitted, which can mis-target users with multiple active Web Billing subscriptions if callers omit ids incorrectly.
> 
> **Overview**
> Upgrade checkout no longer **requires** `subscriptionId` in `productChangeInfo`. Callers can pass **`productIdentifier`** (from customer info), **`subscriptionId`**, **both** (must match the same subscription), or **neither** so the backend infers a single active Web Billing subscription.
> 
> The SDK forwards optional ids through `ProductChangeOperationHelper` and `postSubscriptionChangeCheckoutStart`, which now sends `from_product_id` when a product id is set and omits both fields when inference is intended. Client validation that blocked missing `subscriptionId` was removed; **`subscriberToken`** is still required.
> 
> The webbilling demo adds a **change from product** dropdown (active `rc_billing` subs) and treats subscription id as optional, with README steps updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fef92eb08efdf0c3f0a40deb4b314811a2029e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->