### PR TITLE
chore: bump purchases-ui-js to 4.8.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@eslint/js": "^9.16.0",
     "@microsoft/api-extractor": "^7.48.0",
     "@paddle/paddle-js": "^1.6.4",
-    "@revenuecat/purchases-ui-js": "4.8.15",
+    "@revenuecat/purchases-ui-js": "4.8.16",
     "@storybook/addon-essentials": "^8.6.15",
     "@storybook/addon-interactions": "^8.6.15",
     "@storybook/addon-links": "^8.6.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^1.6.4
         version: 1.6.4
       "@revenuecat/purchases-ui-js":
-        specifier: 4.8.15
-        version: 4.8.15(svelte@5.46.4)
+        specifier: 4.8.16
+        version: 4.8.16(svelte@5.46.4)
       "@storybook/addon-essentials":
         specifier: ^8.6.15
         version: 8.6.15(@types/react@19.0.10)(storybook@8.6.15(prettier@3.4.2))
@@ -722,10 +722,10 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
 
-  "@revenuecat/purchases-ui-js@4.8.15":
+  "@revenuecat/purchases-ui-js@4.8.16":
     resolution:
       {
-        integrity: sha512-Og2MLTZ5Zz0PlVaDVQl8Um5rREH6j7K9ft0x2eqLNDX1aQRnx75g3ToJs0Tfp6aRfBQ25WQZPap4MdrTobXpOQ==,
+        integrity: sha512-MNAM7H4yaPffzqXgrHY8XXSQM1vdOBRMvspoUSJHdJjNB8oVIyfAXSJKRPfR6W28LvSOE3Z5s6jG6ccfw1adPw==,
       }
     engines: { node: ^22.18 || ^24.11 }
     peerDependencies:
@@ -6164,7 +6164,7 @@ snapshots:
 
   "@pkgr/core@0.1.1": {}
 
-  "@revenuecat/purchases-ui-js@4.8.15(svelte@5.46.4)":
+  "@revenuecat/purchases-ui-js@4.8.16(svelte@5.46.4)":
     dependencies:
       "@revenuecat/workflow-web-components-sdk": 0.1.4
       qrcode: 1.5.4


### PR DESCRIPTION
## Summary
Bumps `@revenuecat/purchases-ui-js` from `4.8.15` → `4.8.16`.

### purchases-ui-js changes included
- [#359](https://github.com/RevenueCat/purchases-ui-js/pull/359) - Fill-height Stack + WebView fill correctly in vertical parents; horizontal parents stretch on the cross axis so row layouts (e.g. Pasta package cards) keep vertically centered content.

## Test plan
- [ ] CI passes
- [ ] Spot-check a fill-height WebView paywall / Pasta-style package row if convenient


Made with [Cursor](https://cursor.com)