### PR TITLE
fix(paddle): count the next charge date from the intro/trial phase

### DIFF
--- a/src/helpers/locale-helper.ts
+++ b/src/helpers/locale-helper.ts
@@ -1,3 +1,12 @@
+/**
+ * The bare language subtag of a locale, lowercased: `en_US`, `en-US` and `EN`
+ * all become `en`. Mirrors the fallback `Translator` uses to resolve a locale
+ * with a region to its language's translations, so callers that branch on a
+ * language match agree with the strings they will actually get back.
+ */
+export const toLanguageCode = (locale: string): string =>
+  locale.split("_")[0].split("-")[0].toLowerCase();
+
 export const toBcp47Locale = (locale?: string): string | undefined => {
   if (!locale) {
     return locale;

--- a/src/helpers/paywall-offer-helpers.ts
+++ b/src/helpers/paywall-offer-helpers.ts
@@ -10,7 +10,7 @@ import { getNextRenewalDate, type Period } from "./duration-helper";
 import { getPeriodVariables } from "./paywall-period-helpers";
 import { getPriceVariables } from "./paywall-price-helpers";
 
-type OfferPhase = PricingPhase | DiscountPhase;
+export type OfferPhase = PricingPhase | DiscountPhase;
 
 function getOfferCycleCount(offer: OfferPhase): number {
   return offer.cycleCount > 0 ? offer.cycleCount : 1;
@@ -35,7 +35,7 @@ function getOfferPricingPeriod(
   return offer.period;
 }
 
-function getOfferDuration(offer: OfferPhase): Period | null {
+export function getOfferDuration(offer: OfferPhase): Period | null {
   if (offer.period === null) {
     return null;
   }

--- a/src/helpers/price-labels.ts
+++ b/src/helpers/price-labels.ts
@@ -1,8 +1,9 @@
-import { parseISODuration } from "./duration-helper";
+import { parseISODuration, type Period } from "./duration-helper";
 import { type Translator } from "../ui/localization/translator";
 
 import { LocalizationKeys } from "../ui/localization/supportedLanguages";
-import { toBcp47Locale } from "./locale-helper";
+import { englishLocale } from "../ui/localization/constants";
+import { toBcp47Locale, toLanguageCode } from "./locale-helper";
 
 const microsToDollars = (micros: number): number => {
   return micros / 1000000;
@@ -97,4 +98,41 @@ export const getTranslatedPeriodLength = (
     translator.translatePeriod(period.number, period.unit) ||
     `${period.number} ${period.unit}s`
   );
+};
+
+/**
+ * A duration as a customer-facing label ("1 week", "2 weeks", "7 days").
+ *
+ * Takes an already-resolved {@link Period} rather than a pricing phase so the
+ * period-times-cycle-count arithmetic stays in `getOfferDuration`, which is the
+ * one place that also clamps a zero cycle count.
+ *
+ * `collapseSingularInEnglish` drops the leading "1" so a one-unit duration
+ * reads as "week" rather than "1 week". Only pass it where the surrounding copy
+ * reads better that way ("First week for $1.49"); "After week, on Aug 14" does
+ * not, so it defaults off.
+ */
+export const getPeriodDurationLabel = (
+  period: Period | null,
+  translator: Translator,
+  { collapseSingularInEnglish = false } = {},
+): string => {
+  if (!period) return "";
+
+  // This is a customer paper cut that we want to fix, but we run into limitations of the templating translation system.
+  // In order to avoid impact to other locales, we only apply this to the English locale.
+  // Matched on the language subtag, not the whole locale: selectedLocale is
+  // often navigator.language ("en-US") or a paywall locale key ("en_US"), both
+  // of which resolve to the English strings this collapse is written for.
+  if (
+    collapseSingularInEnglish &&
+    period.number === 1 &&
+    toLanguageCode(translator.selectedLocale) === englishLocale
+  ) {
+    return (
+      translator.translatePeriodUnit(period.unit, { noWhitespace: true }) || ""
+    );
+  }
+
+  return translator.translatePeriod(period.number, period.unit) || "";
 };

--- a/src/tests/helpers/price-labels.test.ts
+++ b/src/tests/helpers/price-labels.test.ts
@@ -2,9 +2,16 @@ import { describe, expect, test } from "vitest";
 import {
   floorMicrosToCurrencyUnit,
   formatPrice,
+  getPeriodDurationLabel,
   getTranslatedPeriodFrequency,
 } from "../../helpers/price-labels";
+import { getOfferDuration } from "../../helpers/paywall-offer-helpers";
+import { PeriodUnit } from "../../helpers/duration-helper";
 import { Translator } from "../../ui/localization/translator";
+import {
+  subscriptionOptionWithMultipleWeeksIntroPriceRecurring,
+  subscriptionOptionWithSingleWeekIntroPriceRecurring,
+} from "../../stories/fixtures";
 
 describe("getRenewsLabel", () => {
   const translator: Translator = new Translator();
@@ -78,5 +85,97 @@ describe("formatPrice", () => {
     expect(formatPrice(9990000, "USD", "en-GB")).toEqual("$9.99");
     expect(formatPrice(9990000, "CNY", "en-US")).toEqual("CN¥9.99");
     expect(formatPrice(9990000, "CNY", "zh-CN")).toEqual("¥9.99");
+  });
+});
+
+describe("getPeriodDurationLabel", () => {
+  const translator: Translator = new Translator();
+  const spanishTranslator: Translator = new Translator({}, "es", "en");
+
+  const oneWeek = { number: 1, unit: PeriodUnit.Week };
+  const twoWeeks = { number: 2, unit: PeriodUnit.Week };
+
+  test("pluralises multi-unit durations", () => {
+    expect(getPeriodDurationLabel(twoWeeks, translator)).toEqual("2 weeks");
+  });
+
+  test("keeps the leading 1 by default", () => {
+    expect(getPeriodDurationLabel(oneWeek, translator)).toEqual("1 week");
+  });
+
+  test("drops the leading 1 in English when asked", () => {
+    expect(
+      getPeriodDurationLabel(oneWeek, translator, {
+        collapseSingularInEnglish: true,
+      }),
+    ).toEqual("week");
+  });
+
+  test("keeps the leading 1 outside English even when asked", () => {
+    expect(
+      getPeriodDurationLabel(oneWeek, spanishTranslator, {
+        collapseSingularInEnglish: true,
+      }),
+    ).toEqual("1 semana");
+  });
+
+  test.each(["en-US", "en_US", "en-GB", "EN"])(
+    "collapses for the English variant %s",
+    (locale) => {
+      // selectedLocale is often navigator.language or a paywall locale key, and
+      // Translator resolves those to the English strings, so the collapse has to
+      // match on the language subtag rather than the whole locale.
+      expect(
+        getPeriodDurationLabel(oneWeek, new Translator({}, locale, "en"), {
+          collapseSingularInEnglish: true,
+        }),
+      ).toEqual("week");
+    },
+  );
+
+  test("does not collapse for a non-English regional locale", () => {
+    expect(
+      getPeriodDurationLabel(oneWeek, new Translator({}, "es-MX", "en"), {
+        collapseSingularInEnglish: true,
+      }),
+    ).toEqual("1 semana");
+  });
+
+  test("returns an empty label when there is no period", () => {
+    expect(getPeriodDurationLabel(null, translator)).toEqual("");
+  });
+
+  test("clamps a zero cycle count via getOfferDuration", () => {
+    // cycleCount defaults to 0 in the offerings entity, which must read as one
+    // cycle rather than "0 weeks" — the label and the end date are derived from
+    // the same getOfferDuration result so they cannot disagree.
+    const zeroCycleWeek = {
+      ...subscriptionOptionWithSingleWeekIntroPriceRecurring.introPrice!,
+      cycleCount: 0,
+    };
+    expect(
+      getPeriodDurationLabel(getOfferDuration(zeroCycleWeek), translator),
+    ).toEqual("1 week");
+  });
+
+  test("multiplies the phase period by its cycle count via getOfferDuration", () => {
+    const threeCyclesOfOneWeek = {
+      ...subscriptionOptionWithSingleWeekIntroPriceRecurring.introPrice!,
+      cycleCount: 3,
+    };
+    expect(
+      getPeriodDurationLabel(
+        getOfferDuration(threeCyclesOfOneWeek),
+        translator,
+      ),
+    ).toEqual("3 weeks");
+    expect(
+      getPeriodDurationLabel(
+        getOfferDuration(
+          subscriptionOptionWithMultipleWeeksIntroPriceRecurring.introPrice!,
+        ),
+        translator,
+      ),
+    ).toEqual("2 weeks");
   });
 });

--- a/src/tests/ui/paddle-purchases-ui.test.ts
+++ b/src/tests/ui/paddle-purchases-ui.test.ts
@@ -795,12 +795,14 @@ describe("PaddlePurchasesUI", () => {
         purchaseOption,
         totalAmount = 3,
         recurringTotalAmount = 20,
+        selectedLocale = "en",
       }: {
         purchaseOption: ComponentProps<PaddlePurchasesUI>["purchaseOption"];
         // Paddle reports the same figure for both when there is no offer phase,
         // so tests for the plain case must pass a matching pair.
         totalAmount?: number;
         recurringTotalAmount?: number | null;
+        selectedLocale?: string;
       }) => {
         const paddleServiceMock = createPaddleServiceMock({
           inlineCheckoutEnabled: true,
@@ -823,6 +825,7 @@ describe("PaddlePurchasesUI", () => {
           props: {
             ...baseProps,
             purchaseOption,
+            selectedLocale,
             paddleService: paddleServiceMock,
           },
           context: defaultContext,
@@ -896,6 +899,19 @@ describe("PaddlePurchasesUI", () => {
           await screen.findByText("Due on September 7, 2026"),
         ).toBeInTheDocument();
         expect(await screen.findByText("billed monthly")).toBeInTheDocument();
+      });
+
+      test("formats the date for the region, not just the language", async () => {
+        // Only language-level translations exist, so the translator resolves
+        // en-GB to en. The date still has to follow the region's order.
+        renderWithTotals({
+          purchaseOption: subscriptionOptionWithSingleWeekIntroPriceRecurring,
+          selectedLocale: "en-GB",
+        });
+
+        expect(
+          await screen.findByText("Due on 14 August 2026"),
+        ).toBeInTheDocument();
       });
 
       test("describes a same-length intro that only differs in price", async () => {

--- a/src/tests/ui/paddle-purchases-ui.test.ts
+++ b/src/tests/ui/paddle-purchases-ui.test.ts
@@ -6,6 +6,11 @@ import {
   brandingInfo,
   rcPackage,
   subscriptionOption,
+  subscriptionOptionWithDiscount,
+  subscriptionOptionWithSingleMonthIntroPriceRecurring,
+  subscriptionOptionWithSingleWeekIntroPriceRecurring,
+  subscriptionOptionWithSingleWeekWithTrialAndIntroPriceRecurring,
+  subscriptionOptionWithTrial,
 } from "../../stories/fixtures";
 import { createEventsTrackerMock } from "../mocks/events-tracker-mock-provider";
 import { eventsTrackerContextKey } from "../../ui/constants";
@@ -780,6 +785,177 @@ describe("PaddlePurchasesUI", () => {
       // The subtotal (excl. tax) only renders when the tax breakdown is shown,
       // i.e. when we feed Paddle's calculated totals into the price breakdown.
       expect(await screen.findByText("$8.26")).toBeInTheDocument();
+    });
+
+    describe("order summary next billing date", () => {
+      // Paddle doesn't expose the renewal date through checkout events, so the
+      // summary derives it from the purchase option. It must count from the
+      // intro/trial phase when there is one, not the base period.
+      const renderWithTotals = ({
+        purchaseOption,
+        totalAmount = 3,
+        recurringTotalAmount = 20,
+      }: {
+        purchaseOption: ComponentProps<PaddlePurchasesUI>["purchaseOption"];
+        // Paddle reports the same figure for both when there is no offer phase,
+        // so tests for the plain case must pass a matching pair.
+        totalAmount?: number;
+        recurringTotalAmount?: number | null;
+      }) => {
+        const paddleServiceMock = createPaddleServiceMock({
+          inlineCheckoutEnabled: true,
+        });
+        vi.spyOn(paddleServiceMock, "purchase").mockImplementation((params) => {
+          params.onCheckoutTotals?.({
+            currencyCode: "USD",
+            subtotalAmount: totalAmount,
+            taxAmount: 0,
+            totalAmount,
+            recurringTotalAmount,
+            productName: "Premium",
+            priceName: "Monthly sub",
+          });
+          // Keep the checkout open so the summary stays mounted.
+          return new Promise(() => {});
+        });
+
+        return render(PaddlePurchasesUI, {
+          props: {
+            ...baseProps,
+            purchaseOption,
+            paddleService: paddleServiceMock,
+          },
+          context: defaultContext,
+        });
+      };
+
+      beforeEach(() => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        vi.setSystemTime(new Date("2026-08-07T12:00:00Z"));
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      test("counts from the intro price period, not the base period", async () => {
+        // 1-week intro at $1.49, then $20.00/month. The next charge lands a week
+        // out (Aug 14), not a month out (Sep 7).
+        renderWithTotals({
+          purchaseOption: subscriptionOptionWithSingleWeekIntroPriceRecurring,
+        });
+
+        expect(
+          await screen.findByText("Due on August 14, 2026"),
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByText("Due on September 7, 2026"),
+        ).not.toBeInTheDocument();
+      });
+
+      test("describes the intro window and the price it steps up to", async () => {
+        renderWithTotals({
+          purchaseOption: subscriptionOptionWithSingleWeekIntroPriceRecurring,
+        });
+
+        // Not "billed monthly", which would read as $3.00/month next to the
+        // headline amount while the customer is still in the intro week.
+        expect(
+          await screen.findByText("first week, then $20.00 monthly"),
+        ).toBeInTheDocument();
+        expect(screen.queryByText("billed monthly")).not.toBeInTheDocument();
+      });
+
+      test("shows the recurring price on the product row", async () => {
+        renderWithTotals({
+          purchaseOption: subscriptionOptionWithSingleWeekIntroPriceRecurring,
+        });
+
+        // "/ month" describes the recurring price, so the row pairs it with
+        // $20.00 rather than today's $3.00 intro total.
+        await screen.findByText("Due on August 14, 2026");
+        expect(screen.getAllByText("$20.00").length).toBeGreaterThan(0);
+      });
+
+      test("counts from the trial period when the option has a free trial", async () => {
+        renderWithTotals({ purchaseOption: subscriptionOptionWithTrial });
+
+        expect(
+          await screen.findByText("Due on August 14, 2026"),
+        ).toBeInTheDocument();
+      });
+
+      test("counts from the base period when there is no intro or trial", async () => {
+        // Nothing steps up, so Paddle reports the same figure for both.
+        renderWithTotals({
+          purchaseOption: subscriptionOption,
+          totalAmount: 20,
+        });
+
+        expect(
+          await screen.findByText("Due on September 7, 2026"),
+        ).toBeInTheDocument();
+        expect(await screen.findByText("billed monthly")).toBeInTheDocument();
+      });
+
+      test("describes a same-length intro that only differs in price", async () => {
+        // A first month at $3 against a $20 monthly base: the durations match,
+        // so only the amounts reveal the step-up.
+        renderWithTotals({
+          purchaseOption: subscriptionOptionWithSingleMonthIntroPriceRecurring,
+        });
+
+        expect(
+          await screen.findByText("first month, then $20.00 monthly"),
+        ).toBeInTheDocument();
+        expect(screen.queryByText("billed monthly")).not.toBeInTheDocument();
+      });
+
+      test("still describes the future when a discount supersedes a trial and intro", async () => {
+        // A discount replaces both the trial and the intro price, so there is
+        // no hidden middle phase and the step-up copy is safe to show.
+        renderWithTotals({
+          purchaseOption: {
+            ...subscriptionOptionWithSingleWeekWithTrialAndIntroPriceRecurring,
+            discount: subscriptionOptionWithDiscount.discount,
+          },
+        });
+
+        // 3-month time window discount, so the base price resumes 3 months out.
+        expect(
+          await screen.findByText("Due on November 7, 2026"),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText("first 3 months, then $20.00 monthly"),
+        ).toBeInTheDocument();
+      });
+
+      test("says nothing about the future when a trial precedes a paid intro", async () => {
+        // The sequence is trial -> intro -> base, so Paddle's recurring total is
+        // not what gets charged next. Better silent than confidently wrong.
+        renderWithTotals({
+          purchaseOption:
+            subscriptionOptionWithSingleWeekWithTrialAndIntroPriceRecurring,
+        });
+
+        expect(await screen.findByText("Total due today")).toBeInTheDocument();
+        expect(screen.queryByText(/^Due on /)).not.toBeInTheDocument();
+        expect(screen.getByText("billed monthly")).toBeInTheDocument();
+      });
+
+      test("hides the recurring row when Paddle reports no recurring total", async () => {
+        renderWithTotals({
+          purchaseOption: subscriptionOptionWithSingleWeekIntroPriceRecurring,
+          recurringTotalAmount: null,
+        });
+
+        // Total due today still renders; the future-charge row does not.
+        expect(await screen.findByText("Total due today")).toBeInTheDocument();
+        expect(screen.queryByText(/^Due on /)).not.toBeInTheDocument();
+        // Falls back to today's total on the product row, and to the plain
+        // cadence label under the headline amount.
+        expect(screen.getByText("billed monthly")).toBeInTheDocument();
+      });
     });
   });
 });

--- a/src/ui/organisms/paddle-order-summary.svelte
+++ b/src/ui/organisms/paddle-order-summary.svelte
@@ -21,6 +21,7 @@
     type OfferPhase,
   } from "../../helpers/paywall-offer-helpers";
   import { getPeriodDurationLabel } from "../../helpers/price-labels";
+  import { toBcp47Locale } from "../../helpers/locale-helper";
   import { LocalizationKeys } from "../localization/supportedLanguages";
   import type { PaddleCheckoutTotals } from "../../paddle/paddle-service";
 
@@ -156,11 +157,13 @@
     if (recurringMicros === null || !firstPeriod) return null;
     const renewalDate = getNextRenewalDate(new Date(), firstPeriod, true);
     if (!renewalDate) return null;
-    return $translator.translateDate(renewalDate, {
-      day: "numeric",
-      month: "long",
-      year: "numeric",
-    });
+    // Formatted off selectedLocale, not the translator's resolved locale: only
+    // language-level translations exist, so `en-GB` resolves to `en` and would
+    // render the US month-first order instead of day-first.
+    return renewalDate.toLocaleDateString(
+      toBcp47Locale($translator.selectedLocale),
+      { day: "numeric", month: "long", year: "numeric" },
+    );
   });
 </script>
 

--- a/src/ui/organisms/paddle-order-summary.svelte
+++ b/src/ui/organisms/paddle-order-summary.svelte
@@ -16,7 +16,11 @@
     getNextRenewalDate,
     type Period,
   } from "../../helpers/duration-helper";
-  import { toBcp47Locale } from "../../helpers/locale-helper";
+  import {
+    getOfferDuration,
+    type OfferPhase,
+  } from "../../helpers/paywall-offer-helpers";
+  import { getPeriodDurationLabel } from "../../helpers/price-labels";
   import { LocalizationKeys } from "../localization/supportedLanguages";
   import type { PaddleCheckoutTotals } from "../../paddle/paddle-service";
 
@@ -45,19 +49,63 @@
   const isSubscriptionOption = (
     option: PurchaseOption,
   ): option is SubscriptionOption => "base" in option;
-  const basePeriod: Period | null = isSubscriptionOption(purchaseOption)
-    ? (purchaseOption.base.period ?? null)
-    : null;
+  const subscriptionOption: SubscriptionOption | null = $derived(
+    isSubscriptionOption(purchaseOption) ? purchaseOption : null,
+  );
+  const basePeriod: Period | null = $derived(
+    subscriptionOption?.base.period ?? null,
+  );
+
+  // The first phase the customer actually pays for, which is what today's total
+  // covers and what determines when the recurring price kicks in. Matches the
+  // precedence in paywall-offer-helpers' setOfferVariables. (secure-checkout-rc
+  // and purchase-option-price-helper deliberately omit the trial: they quote a
+  // price, and a trial has none.)
+  const offerPhase: OfferPhase | null = $derived(
+    subscriptionOption?.discount ??
+      subscriptionOption?.trial ??
+      subscriptionOption?.introPrice ??
+      null,
+  );
+  // A "forever" discount has no end, so getOfferDuration returns null and we
+  // fall back to the base cadence — which is correct, it renews at that rate.
+  const firstPeriod: Period | null = $derived(
+    (offerPhase ? getOfferDuration(offerPhase) : null) ?? basePeriod,
+  );
+  // A phase sitting between the first one and the base price — the same
+  // "secondaryOffer" paywall-offer-helpers models. Only a trial can have one:
+  // a discount supersedes both the trial and the intro price.
+  const middlePhase = $derived(
+    subscriptionOption?.trial && !subscriptionOption.discount
+      ? (subscriptionOption.introPrice ?? null)
+      : null,
+  );
+  // Paddle's recurring total is the base price, so "then <recurring>" only
+  // holds when the first phase steps straight up to it. With a middle phase the
+  // next charge is that phase's price, which these two totals cannot express,
+  // so say nothing about the future rather than quote a price that is not next.
+  const hasUndescribedMiddlePhase = $derived(middlePhase !== null);
 
   const toMicros = (amount: number): number => Math.round(amount * 1_000_000);
 
-  const fallbackPrice = getInitialPriceFromPurchaseOption(
-    productDetails,
-    purchaseOption,
+  const fallbackPrice = $derived(
+    getInitialPriceFromPurchaseOption(productDetails, purchaseOption),
   );
   const currency = $derived(totals?.currencyCode ?? fallbackPrice.currency);
   const totalMicros = $derived(
     totals ? toMicros(totals.totalAmount) : fallbackPrice.amountMicros,
+  );
+  // What the customer pays each period once any intro/trial phase is over.
+  const recurringMicros = $derived(
+    totals?.recurringTotalAmount != null && !hasUndescribedMiddlePhase
+      ? toMicros(totals.recurringTotalAmount)
+      : null,
+  );
+  // Comparing the two amounts Paddle reports is a more direct signal than
+  // comparing periods: it also catches a same-length offer (a first month at
+  // $3 against a $20 monthly base), which a period comparison would miss.
+  const stepsUpToRecurring = $derived(
+    recurringMicros !== null && recurringMicros !== totalMicros,
   );
 
   const formatAmount = (micros: number): string =>
@@ -72,24 +120,47 @@
       : null,
   );
 
+  // "first week" rather than "first 1 week" — the shared helper keeps that
+  // collapse gated to English, where the surrounding copy needs it.
+  const firstPeriodLabel = $derived(
+    getPeriodDurationLabel(firstPeriod, $translator, {
+      collapseSingularInEnglish: true,
+    }),
+  );
+
+  // The headline amount is today's total, so a bare "billed monthly" underneath
+  // would read as "$3.00 monthly" while the customer is still in a 1-week intro
+  // phase. Spell out the intro window and the price it steps up to instead.
+  const billedSummaryLabel = $derived(
+    !billedFrequencyLabel
+      ? null
+      : stepsUpToRecurring && firstPeriodLabel
+        ? `first ${firstPeriodLabel}, then ${formatAmount(recurringMicros!)} ${billedFrequencyLabel}`
+        : `billed ${billedFrequencyLabel}`,
+  );
+
   const productName = $derived(totals?.productName ?? productDetails.title);
   const priceName = $derived(totals?.priceName ?? null);
   const hasTax = $derived(!!totals && totals.taxAmount > 0);
 
-  // Best-effort next billing date for the recurring row: today + the base
-  // period, formatted in the active locale. Reuses getNextRenewalDate so the
-  // leap-year / month-overflow edge cases live in one place. The exact Paddle
-  // renewal date isn't exposed through checkout events.
+  // Best-effort next billing date for the recurring row: today + the first
+  // phase's duration (the intro/trial window when there is one, otherwise the
+  // base period). Reuses getNextRenewalDate so the leap-year / month-overflow
+  // edge cases live in one place.
+  //
+  // The period comes from the RevenueCat catalog rather than Paddle because
+  // Paddle's checkout events don't carry it: `items[].billing_cycle` is the
+  // recurring cycle and `items[].trial_period` only covers free trials, so
+  // neither describes a paid intro window.
   const nextBillingLabel = $derived.by(() => {
-    if (!totals || totals.recurringTotalAmount === null || !basePeriod)
-      return null;
-    const renewalDate = getNextRenewalDate(new Date(), basePeriod, true);
+    if (recurringMicros === null || !firstPeriod) return null;
+    const renewalDate = getNextRenewalDate(new Date(), firstPeriod, true);
     if (!renewalDate) return null;
-    return new Intl.DateTimeFormat(toBcp47Locale($translator.selectedLocale), {
+    return $translator.translateDate(renewalDate, {
       day: "numeric",
       month: "long",
       year: "numeric",
-    }).format(renewalDate);
+    });
   });
 </script>
 
@@ -102,8 +173,8 @@
         <span class="rcb-paddle-summary-muted">inc. tax</span>
       {/if}
     </div>
-    {#if billedFrequencyLabel}
-      <Typography size="body-small">billed {billedFrequencyLabel}</Typography>
+    {#if billedSummaryLabel}
+      <Typography size="body-small">{billedSummaryLabel}</Typography>
     {/if}
 
     <div class="rcb-paddle-summary-product">
@@ -114,7 +185,11 @@
         >
       {/if}
       <div class="rcb-paddle-summary-product-price">
-        <span>{formatAmount(totalMicros)}</span>
+        <!-- The recurring price, not today's total: this row is suffixed with
+             "/ month", which describes what each period costs once any intro
+             phase is over. Today's charge is the headline amount and the
+             "Total due today" row. -->
+        <span>{formatAmount(recurringMicros ?? totalMicros)}</span>
         {#if periodUnitLabel}
           <span class="rcb-paddle-summary-muted">/ {periodUnitLabel}</span>
         {/if}
@@ -148,11 +223,11 @@
         >
         <span>{formatAmount(toMicros(totals.totalAmount))}</span>
       </div>
-      {#if totals.recurringTotalAmount !== null && nextBillingLabel}
+      {#if recurringMicros !== null && nextBillingLabel}
         <div class="rcb-paddle-summary-row">
           <span class="rcb-paddle-summary-muted">Due on {nextBillingLabel}</span
           >
-          <span>{formatAmount(toMicros(totals.recurringTotalAmount))}</span>
+          <span>{formatAmount(recurringMicros)}</span>
         </div>
       {/if}
     </div>


### PR DESCRIPTION
## Summary

A subscription with a **paid intro phase** showed the wrong next-charge date in the Paddle inline checkout. For a product configured as *1 week @ $3.00, then $20.00/month*, the order summary rendered (on Aug 7):

```
$3.00  inc. tax
billed monthly
Monthly sub
$3.00 / month
...
Total due today            $3.00
Due on September 7, 2026  $20.00   ← the $20.00 actually lands Aug 14
```

Three problems, one cause: the summary derived everything from `purchaseOption.base.period` and never looked at the intro/trial/discount phase.

1. The date counted a month out instead of a week.
2. `billed monthly` sat directly under the `$3.00` intro amount, reading as $3.00/month.
3. The product row paired the intro amount with the base period — `$3.00 / month` is a price that is never charged.

This derives the summary from the option's first pricing phase instead, using the same `discount ?? trial ?? introPrice` precedence already used by `paywall-offer-helpers` and `secure-checkout-rc`, falling back to the base period when there is no offer phase (or when a discount runs forever). The product row now shows the recurring price, which is what its `/ month` suffix describes, and the cadence label spells out the intro window and the price it steps up to:

```
$3.00  inc. tax
first week, then $20.00 monthly
Monthly sub
$20.00 / month
...
Total due today          $3.00
Due on August 14, 2026  $20.00
```

`getOfferDuration` and `OfferPhase` become exported so the phase-duration logic (period × cycle count, `null` for forever discounts) lives in one place rather than being re-derived in the component. No change to `paddle-service.ts` — `recurring_totals` was already being forwarded.

### Note on the data source

The date is computed from RevenueCat's offering data, not from Paddle's checkout events (Paddle doesn't expose the renewal date there). Worth a sanity check against a real transaction that Paddle's actual billing schedule for a paid intro matches the configured phase.

### Not included

The RC Billing / Stripe pricing table has a related but different gap — it omits the future-charge row for intro prices entirely rather than getting it wrong. That's #1033, stacked on this.

## Test plan

- [x] `pnpm test` — 775 passing
- [x] Typecheck / lint / `svelte-check` / build clean
- [x] New tests verified non-vacuous: stashing the component fix makes the 4 behaviour tests fail while the 2 regression guards still pass
- [ ] Manual: Paddle inline checkout for a 1-week-intro monthly product shows `Due on <today + 1 week>` with the recurring amount

<details>
<summary>AI assistance</summary>

Investigated and implemented with Claude Code (Opus 5). The audit covered all three checkout surfaces (Paddle inline, RC/Stripe header, RC/Stripe footer) against the reported product to establish which were actually wrong; the footer and header turned out correct and were left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Customer-facing checkout pricing and renewal-date copy; logic is guarded by tests and conservative silence when trial+intro cannot be described accurately from Paddle totals.
> 
> **Overview**
> Fixes the Paddle inline checkout **order summary** when subscriptions have intro, trial, or discount phases. It no longer derives the next billing date and cadence copy only from the **base** period.
> 
> **`paddle-order-summary.svelte`** picks the first paid phase with the same `discount → trial → introPrice` precedence as `paywall-offer-helpers`, uses `getOfferDuration` for when the recurring price starts, and compares Paddle’s today vs recurring totals to detect step-ups (including same-length intro vs base). Copy can read like **first week, then $20.00 monthly** instead of **billed monthly** under the intro total; the product row shows the **recurring** amount with `/ month`. If a **trial precedes a paid intro**, future-charge rows are hidden so Paddle’s recurring total isn’t shown as the next charge. Dates use `selectedLocale` for regional formatting (e.g. `en-GB`).
> 
> Shared helpers: **`toLanguageCode`** in `locale-helper.ts`, **`getPeriodDurationLabel`** in `price-labels.ts` (optional English singular collapse, e.g. “week” vs “1 week”), and exports of **`getOfferDuration`** / **`OfferPhase`** from `paywall-offer-helpers.ts`.
> 
> Tests cover `getPeriodDurationLabel` and Paddle UI order-summary scenarios (intro week, trial, discount, trial+intro, locale, missing recurring total).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 239873ace117b0ff726d67566f3ac2ac67736b64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->