### PR TITLE
feat(checkout): show when a paid intro price steps up to the base price

### DIFF
--- a/src/helpers/locale-helper.ts
+++ b/src/helpers/locale-helper.ts
@@ -1,3 +1,12 @@
+/**
+ * The bare language subtag of a locale, lowercased: `en_US`, `en-US` and `EN`
+ * all become `en`. Mirrors the fallback `Translator` uses to resolve a locale
+ * with a region to its language's translations, so callers that branch on a
+ * language match agree with the strings they will actually get back.
+ */
+export const toLanguageCode = (locale: string): string =>
+  locale.split("_")[0].split("-")[0].toLowerCase();
+
 export const toBcp47Locale = (locale?: string): string | undefined => {
   if (!locale) {
     return locale;

--- a/src/helpers/paywall-offer-helpers.ts
+++ b/src/helpers/paywall-offer-helpers.ts
@@ -10,7 +10,7 @@ import { getNextRenewalDate, type Period } from "./duration-helper";
 import { getPeriodVariables } from "./paywall-period-helpers";
 import { getPriceVariables } from "./paywall-price-helpers";
 
-type OfferPhase = PricingPhase | DiscountPhase;
+export type OfferPhase = PricingPhase | DiscountPhase;
 
 function getOfferCycleCount(offer: OfferPhase): number {
   return offer.cycleCount > 0 ? offer.cycleCount : 1;
@@ -35,7 +35,7 @@ function getOfferPricingPeriod(
   return offer.period;
 }
 
-function getOfferDuration(offer: OfferPhase): Period | null {
+export function getOfferDuration(offer: OfferPhase): Period | null {
   if (offer.period === null) {
     return null;
   }

--- a/src/helpers/price-labels.ts
+++ b/src/helpers/price-labels.ts
@@ -1,8 +1,9 @@
-import { parseISODuration } from "./duration-helper";
+import { parseISODuration, type Period } from "./duration-helper";
 import { type Translator } from "../ui/localization/translator";
 
 import { LocalizationKeys } from "../ui/localization/supportedLanguages";
-import { toBcp47Locale } from "./locale-helper";
+import { englishLocale } from "../ui/localization/constants";
+import { toBcp47Locale, toLanguageCode } from "./locale-helper";
 
 const microsToDollars = (micros: number): number => {
   return micros / 1000000;
@@ -97,4 +98,41 @@ export const getTranslatedPeriodLength = (
     translator.translatePeriod(period.number, period.unit) ||
     `${period.number} ${period.unit}s`
   );
+};
+
+/**
+ * A duration as a customer-facing label ("1 week", "2 weeks", "7 days").
+ *
+ * Takes an already-resolved {@link Period} rather than a pricing phase so the
+ * period-times-cycle-count arithmetic stays in `getOfferDuration`, which is the
+ * one place that also clamps a zero cycle count.
+ *
+ * `collapseSingularInEnglish` drops the leading "1" so a one-unit duration
+ * reads as "week" rather than "1 week". Only pass it where the surrounding copy
+ * reads better that way ("First week for $1.49"); "After week, on Aug 14" does
+ * not, so it defaults off.
+ */
+export const getPeriodDurationLabel = (
+  period: Period | null,
+  translator: Translator,
+  { collapseSingularInEnglish = false } = {},
+): string => {
+  if (!period) return "";
+
+  // This is a customer paper cut that we want to fix, but we run into limitations of the templating translation system.
+  // In order to avoid impact to other locales, we only apply this to the English locale.
+  // Matched on the language subtag, not the whole locale: selectedLocale is
+  // often navigator.language ("en-US") or a paywall locale key ("en_US"), both
+  // of which resolve to the English strings this collapse is written for.
+  if (
+    collapseSingularInEnglish &&
+    period.number === 1 &&
+    toLanguageCode(translator.selectedLocale) === englishLocale
+  ) {
+    return (
+      translator.translatePeriodUnit(period.unit, { noWhitespace: true }) || ""
+    );
+  }
+
+  return translator.translatePeriod(period.number, period.unit) || "";
 };

--- a/src/stories/molecules/pricing-table.stories.svelte
+++ b/src/stories/molecules/pricing-table.stories.svelte
@@ -12,6 +12,7 @@
     subscriptionOptionWithDiscount,
     subscriptionOptionWithDiscountOneTime,
     subscriptionOptionWithDiscountForever,
+    subscriptionOptionWithSingleWeekIntroPriceRecurring,
     subscriptionOptionWithTrial,
     subscriptionOptionWithYearlyBillingAndSixMonthDiscount,
   } from "../fixtures";
@@ -36,6 +37,7 @@
   ) => ({
     priceBreakdown,
     basePhase: option.base,
+    discountPhase: option.discount,
     resolvedDiscount: resolveDiscountBreakdown({
       priceBreakdown,
       purchaseOptionDiscount: option.discount,
@@ -66,6 +68,8 @@
       priceBreakdown: getPriceBreakdownTaxDisabled(subscriptionOption),
       trialPhase: null,
       basePhase: null,
+      introPricePhase: null,
+      discountPhase: null,
       resolvedDiscount: null,
       showDiscountCodeField: false,
       appliedDiscountCode: null,
@@ -79,6 +83,29 @@
   name="Disabled Tax Trial"
   args={{
     trialPhase: subscriptionOptionWithTrial.trial,
+  }}
+/>
+<Story
+  name="Disabled Tax Intro Price"
+  args={{
+    priceBreakdown: getPriceBreakdownTaxDisabled(
+      subscriptionOptionWithSingleWeekIntroPriceRecurring,
+    ),
+    introPricePhase:
+      subscriptionOptionWithSingleWeekIntroPriceRecurring.introPrice,
+    basePhase: subscriptionOptionWithSingleWeekIntroPriceRecurring.base,
+  }}
+/>
+<Story
+  name="Disabled Tax Trial And Intro Price"
+  args={{
+    priceBreakdown: getPriceBreakdownTaxDisabled(
+      subscriptionOptionWithSingleWeekIntroPriceRecurring,
+    ),
+    trialPhase: subscriptionOptionWithTrial.trial,
+    introPricePhase:
+      subscriptionOptionWithSingleWeekIntroPriceRecurring.introPrice,
+    basePhase: subscriptionOptionWithSingleWeekIntroPriceRecurring.base,
   }}
 />
 <Story

--- a/src/tests/helpers/price-labels.test.ts
+++ b/src/tests/helpers/price-labels.test.ts
@@ -2,9 +2,16 @@ import { describe, expect, test } from "vitest";
 import {
   floorMicrosToCurrencyUnit,
   formatPrice,
+  getPeriodDurationLabel,
   getTranslatedPeriodFrequency,
 } from "../../helpers/price-labels";
+import { getOfferDuration } from "../../helpers/paywall-offer-helpers";
+import { PeriodUnit } from "../../helpers/duration-helper";
 import { Translator } from "../../ui/localization/translator";
+import {
+  subscriptionOptionWithMultipleWeeksIntroPriceRecurring,
+  subscriptionOptionWithSingleWeekIntroPriceRecurring,
+} from "../../stories/fixtures";
 
 describe("getRenewsLabel", () => {
   const translator: Translator = new Translator();
@@ -78,5 +85,97 @@ describe("formatPrice", () => {
     expect(formatPrice(9990000, "USD", "en-GB")).toEqual("$9.99");
     expect(formatPrice(9990000, "CNY", "en-US")).toEqual("CN¥9.99");
     expect(formatPrice(9990000, "CNY", "zh-CN")).toEqual("¥9.99");
+  });
+});
+
+describe("getPeriodDurationLabel", () => {
+  const translator: Translator = new Translator();
+  const spanishTranslator: Translator = new Translator({}, "es", "en");
+
+  const oneWeek = { number: 1, unit: PeriodUnit.Week };
+  const twoWeeks = { number: 2, unit: PeriodUnit.Week };
+
+  test("pluralises multi-unit durations", () => {
+    expect(getPeriodDurationLabel(twoWeeks, translator)).toEqual("2 weeks");
+  });
+
+  test("keeps the leading 1 by default", () => {
+    expect(getPeriodDurationLabel(oneWeek, translator)).toEqual("1 week");
+  });
+
+  test("drops the leading 1 in English when asked", () => {
+    expect(
+      getPeriodDurationLabel(oneWeek, translator, {
+        collapseSingularInEnglish: true,
+      }),
+    ).toEqual("week");
+  });
+
+  test("keeps the leading 1 outside English even when asked", () => {
+    expect(
+      getPeriodDurationLabel(oneWeek, spanishTranslator, {
+        collapseSingularInEnglish: true,
+      }),
+    ).toEqual("1 semana");
+  });
+
+  test.each(["en-US", "en_US", "en-GB", "EN"])(
+    "collapses for the English variant %s",
+    (locale) => {
+      // selectedLocale is often navigator.language or a paywall locale key, and
+      // Translator resolves those to the English strings, so the collapse has to
+      // match on the language subtag rather than the whole locale.
+      expect(
+        getPeriodDurationLabel(oneWeek, new Translator({}, locale, "en"), {
+          collapseSingularInEnglish: true,
+        }),
+      ).toEqual("week");
+    },
+  );
+
+  test("does not collapse for a non-English regional locale", () => {
+    expect(
+      getPeriodDurationLabel(oneWeek, new Translator({}, "es-MX", "en"), {
+        collapseSingularInEnglish: true,
+      }),
+    ).toEqual("1 semana");
+  });
+
+  test("returns an empty label when there is no period", () => {
+    expect(getPeriodDurationLabel(null, translator)).toEqual("");
+  });
+
+  test("clamps a zero cycle count via getOfferDuration", () => {
+    // cycleCount defaults to 0 in the offerings entity, which must read as one
+    // cycle rather than "0 weeks" — the label and the end date are derived from
+    // the same getOfferDuration result so they cannot disagree.
+    const zeroCycleWeek = {
+      ...subscriptionOptionWithSingleWeekIntroPriceRecurring.introPrice!,
+      cycleCount: 0,
+    };
+    expect(
+      getPeriodDurationLabel(getOfferDuration(zeroCycleWeek), translator),
+    ).toEqual("1 week");
+  });
+
+  test("multiplies the phase period by its cycle count via getOfferDuration", () => {
+    const threeCyclesOfOneWeek = {
+      ...subscriptionOptionWithSingleWeekIntroPriceRecurring.introPrice!,
+      cycleCount: 3,
+    };
+    expect(
+      getPeriodDurationLabel(
+        getOfferDuration(threeCyclesOfOneWeek),
+        translator,
+      ),
+    ).toEqual("3 weeks");
+    expect(
+      getPeriodDurationLabel(
+        getOfferDuration(
+          subscriptionOptionWithMultipleWeeksIntroPriceRecurring.introPrice!,
+        ),
+        translator,
+      ),
+    ).toEqual("2 weeks");
   });
 });

--- a/src/tests/ui/molecules/pricing-table.test.ts
+++ b/src/tests/ui/molecules/pricing-table.test.ts
@@ -1,0 +1,123 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { writable } from "svelte/store";
+import type { ComponentProps } from "svelte";
+import PricingTable from "../../../ui/molecules/pricing-table.svelte";
+import { Translator } from "../../../ui/localization/translator";
+import { translatorContextKey } from "../../../ui/localization/constants";
+import {
+  subscriptionOption,
+  subscriptionOptionWithDiscount,
+  subscriptionOptionWithMultipleWeeksIntroPriceRecurring,
+  subscriptionOptionWithSingleWeekIntroPriceRecurring,
+  subscriptionOptionWithSingleWeekWithTrialAndIntroPriceRecurring,
+  subscriptionOptionWithTrial,
+} from "../../../stories/fixtures";
+import { getPriceBreakdownTaxDisabled } from "../../../stories/helpers/get-price-breakdown";
+import type { SubscriptionOption } from "../../../entities/offerings";
+
+const context = new Map(
+  Object.entries({
+    [translatorContextKey]: writable(new Translator()),
+  }),
+);
+
+const renderTable = (option: SubscriptionOption) => {
+  const props: ComponentProps<PricingTable> = {
+    priceBreakdown: getPriceBreakdownTaxDisabled(option),
+    trialPhase: option.trial,
+    basePhase: option.base,
+    introPricePhase: option.introPrice,
+    discountPhase: option.discount,
+    resolvedDiscount: null,
+    showDiscountCodeField: false,
+    discountCode: "",
+    appliedDiscountCode: null,
+    discountCodeError: null,
+    isUpdatingDiscountCode: false,
+    isDiscountCodeControlsEnabled: false,
+    onDiscountCodeChange: undefined,
+    onApplyDiscountCode: undefined,
+    onRemoveDiscountCode: undefined,
+  };
+
+  return render(PricingTable, { props, context });
+};
+
+describe("PricingTable", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-08-07T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("after-intro-price row", () => {
+    test("tells the customer when the intro price ends and what they pay then", () => {
+      // 1-week intro at $1.49, base $9.90/month.
+      renderTable(subscriptionOptionWithSingleWeekIntroPriceRecurring);
+
+      expect(
+        screen.getByText("After 1 week, on Aug 14, 2026"),
+      ).toBeInTheDocument();
+      // The base price, not today's $1.49 intro total.
+      expect(screen.getByText("$9.90")).toBeInTheDocument();
+    });
+
+    test("counts every cycle of a multi-cycle intro phase", () => {
+      renderTable(subscriptionOptionWithMultipleWeeksIntroPriceRecurring);
+
+      expect(
+        screen.getByText("After 2 weeks, on Aug 21, 2026"),
+      ).toBeInTheDocument();
+    });
+
+    test("still charges only the intro price today", () => {
+      renderTable(subscriptionOptionWithSingleWeekIntroPriceRecurring);
+
+      expect(screen.getByText("Total due today")).toBeInTheDocument();
+      expect(screen.getByText("$1.49")).toBeInTheDocument();
+    });
+
+    test("defers to the trial row when the option also has a free trial", () => {
+      renderTable(
+        subscriptionOptionWithSingleWeekWithTrialAndIntroPriceRecurring,
+      );
+
+      // Exactly one future-charge row, and it is the trial one.
+      expect(screen.getAllByText(/^After /)).toHaveLength(1);
+      expect(
+        screen.getByText("After trial ends, on Aug 14, 2026"),
+      ).toBeInTheDocument();
+    });
+
+    test("is not rendered when a discount supersedes the intro price", () => {
+      // A discount replaces the intro price everywhere else too, so an intro
+      // step-up row would describe a schedule that is not in effect.
+      renderTable({
+        ...subscriptionOptionWithSingleWeekIntroPriceRecurring,
+        discount: subscriptionOptionWithDiscount.discount,
+      });
+
+      expect(screen.queryByText(/^After /)).not.toBeInTheDocument();
+    });
+
+    test("is not rendered for a plain subscription", () => {
+      renderTable(subscriptionOption);
+
+      expect(screen.queryByText(/^After /)).not.toBeInTheDocument();
+    });
+
+    test("leaves a trial-only subscription with just the trial row", () => {
+      renderTable(subscriptionOptionWithTrial);
+
+      expect(screen.getAllByText(/^After /)).toHaveLength(1);
+      expect(
+        screen.getByText("After trial ends, on Aug 14, 2026"),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/tests/ui/paddle-purchases-ui.test.ts
+++ b/src/tests/ui/paddle-purchases-ui.test.ts
@@ -795,12 +795,14 @@ describe("PaddlePurchasesUI", () => {
         purchaseOption,
         totalAmount = 3,
         recurringTotalAmount = 20,
+        selectedLocale = "en",
       }: {
         purchaseOption: ComponentProps<PaddlePurchasesUI>["purchaseOption"];
         // Paddle reports the same figure for both when there is no offer phase,
         // so tests for the plain case must pass a matching pair.
         totalAmount?: number;
         recurringTotalAmount?: number | null;
+        selectedLocale?: string;
       }) => {
         const paddleServiceMock = createPaddleServiceMock({
           inlineCheckoutEnabled: true,
@@ -823,6 +825,7 @@ describe("PaddlePurchasesUI", () => {
           props: {
             ...baseProps,
             purchaseOption,
+            selectedLocale,
             paddleService: paddleServiceMock,
           },
           context: defaultContext,
@@ -896,6 +899,19 @@ describe("PaddlePurchasesUI", () => {
           await screen.findByText("Due on September 7, 2026"),
         ).toBeInTheDocument();
         expect(await screen.findByText("billed monthly")).toBeInTheDocument();
+      });
+
+      test("formats the date for the region, not just the language", async () => {
+        // Only language-level translations exist, so the translator resolves
+        // en-GB to en. The date still has to follow the region's order.
+        renderWithTotals({
+          purchaseOption: subscriptionOptionWithSingleWeekIntroPriceRecurring,
+          selectedLocale: "en-GB",
+        });
+
+        expect(
+          await screen.findByText("Due on 14 August 2026"),
+        ).toBeInTheDocument();
       });
 
       test("describes a same-length intro that only differs in price", async () => {

--- a/src/tests/ui/paddle-purchases-ui.test.ts
+++ b/src/tests/ui/paddle-purchases-ui.test.ts
@@ -6,6 +6,11 @@ import {
   brandingInfo,
   rcPackage,
   subscriptionOption,
+  subscriptionOptionWithDiscount,
+  subscriptionOptionWithSingleMonthIntroPriceRecurring,
+  subscriptionOptionWithSingleWeekIntroPriceRecurring,
+  subscriptionOptionWithSingleWeekWithTrialAndIntroPriceRecurring,
+  subscriptionOptionWithTrial,
 } from "../../stories/fixtures";
 import { createEventsTrackerMock } from "../mocks/events-tracker-mock-provider";
 import { eventsTrackerContextKey } from "../../ui/constants";
@@ -780,6 +785,177 @@ describe("PaddlePurchasesUI", () => {
       // The subtotal (excl. tax) only renders when the tax breakdown is shown,
       // i.e. when we feed Paddle's calculated totals into the price breakdown.
       expect(await screen.findByText("$8.26")).toBeInTheDocument();
+    });
+
+    describe("order summary next billing date", () => {
+      // Paddle doesn't expose the renewal date through checkout events, so the
+      // summary derives it from the purchase option. It must count from the
+      // intro/trial phase when there is one, not the base period.
+      const renderWithTotals = ({
+        purchaseOption,
+        totalAmount = 3,
+        recurringTotalAmount = 20,
+      }: {
+        purchaseOption: ComponentProps<PaddlePurchasesUI>["purchaseOption"];
+        // Paddle reports the same figure for both when there is no offer phase,
+        // so tests for the plain case must pass a matching pair.
+        totalAmount?: number;
+        recurringTotalAmount?: number | null;
+      }) => {
+        const paddleServiceMock = createPaddleServiceMock({
+          inlineCheckoutEnabled: true,
+        });
+        vi.spyOn(paddleServiceMock, "purchase").mockImplementation((params) => {
+          params.onCheckoutTotals?.({
+            currencyCode: "USD",
+            subtotalAmount: totalAmount,
+            taxAmount: 0,
+            totalAmount,
+            recurringTotalAmount,
+            productName: "Premium",
+            priceName: "Monthly sub",
+          });
+          // Keep the checkout open so the summary stays mounted.
+          return new Promise(() => {});
+        });
+
+        return render(PaddlePurchasesUI, {
+          props: {
+            ...baseProps,
+            purchaseOption,
+            paddleService: paddleServiceMock,
+          },
+          context: defaultContext,
+        });
+      };
+
+      beforeEach(() => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        vi.setSystemTime(new Date("2026-08-07T12:00:00Z"));
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      test("counts from the intro price period, not the base period", async () => {
+        // 1-week intro at $1.49, then $20.00/month. The next charge lands a week
+        // out (Aug 14), not a month out (Sep 7).
+        renderWithTotals({
+          purchaseOption: subscriptionOptionWithSingleWeekIntroPriceRecurring,
+        });
+
+        expect(
+          await screen.findByText("Due on August 14, 2026"),
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByText("Due on September 7, 2026"),
+        ).not.toBeInTheDocument();
+      });
+
+      test("describes the intro window and the price it steps up to", async () => {
+        renderWithTotals({
+          purchaseOption: subscriptionOptionWithSingleWeekIntroPriceRecurring,
+        });
+
+        // Not "billed monthly", which would read as $3.00/month next to the
+        // headline amount while the customer is still in the intro week.
+        expect(
+          await screen.findByText("first week, then $20.00 monthly"),
+        ).toBeInTheDocument();
+        expect(screen.queryByText("billed monthly")).not.toBeInTheDocument();
+      });
+
+      test("shows the recurring price on the product row", async () => {
+        renderWithTotals({
+          purchaseOption: subscriptionOptionWithSingleWeekIntroPriceRecurring,
+        });
+
+        // "/ month" describes the recurring price, so the row pairs it with
+        // $20.00 rather than today's $3.00 intro total.
+        await screen.findByText("Due on August 14, 2026");
+        expect(screen.getAllByText("$20.00").length).toBeGreaterThan(0);
+      });
+
+      test("counts from the trial period when the option has a free trial", async () => {
+        renderWithTotals({ purchaseOption: subscriptionOptionWithTrial });
+
+        expect(
+          await screen.findByText("Due on August 14, 2026"),
+        ).toBeInTheDocument();
+      });
+
+      test("counts from the base period when there is no intro or trial", async () => {
+        // Nothing steps up, so Paddle reports the same figure for both.
+        renderWithTotals({
+          purchaseOption: subscriptionOption,
+          totalAmount: 20,
+        });
+
+        expect(
+          await screen.findByText("Due on September 7, 2026"),
+        ).toBeInTheDocument();
+        expect(await screen.findByText("billed monthly")).toBeInTheDocument();
+      });
+
+      test("describes a same-length intro that only differs in price", async () => {
+        // A first month at $3 against a $20 monthly base: the durations match,
+        // so only the amounts reveal the step-up.
+        renderWithTotals({
+          purchaseOption: subscriptionOptionWithSingleMonthIntroPriceRecurring,
+        });
+
+        expect(
+          await screen.findByText("first month, then $20.00 monthly"),
+        ).toBeInTheDocument();
+        expect(screen.queryByText("billed monthly")).not.toBeInTheDocument();
+      });
+
+      test("still describes the future when a discount supersedes a trial and intro", async () => {
+        // A discount replaces both the trial and the intro price, so there is
+        // no hidden middle phase and the step-up copy is safe to show.
+        renderWithTotals({
+          purchaseOption: {
+            ...subscriptionOptionWithSingleWeekWithTrialAndIntroPriceRecurring,
+            discount: subscriptionOptionWithDiscount.discount,
+          },
+        });
+
+        // 3-month time window discount, so the base price resumes 3 months out.
+        expect(
+          await screen.findByText("Due on November 7, 2026"),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText("first 3 months, then $20.00 monthly"),
+        ).toBeInTheDocument();
+      });
+
+      test("says nothing about the future when a trial precedes a paid intro", async () => {
+        // The sequence is trial -> intro -> base, so Paddle's recurring total is
+        // not what gets charged next. Better silent than confidently wrong.
+        renderWithTotals({
+          purchaseOption:
+            subscriptionOptionWithSingleWeekWithTrialAndIntroPriceRecurring,
+        });
+
+        expect(await screen.findByText("Total due today")).toBeInTheDocument();
+        expect(screen.queryByText(/^Due on /)).not.toBeInTheDocument();
+        expect(screen.getByText("billed monthly")).toBeInTheDocument();
+      });
+
+      test("hides the recurring row when Paddle reports no recurring total", async () => {
+        renderWithTotals({
+          purchaseOption: subscriptionOptionWithSingleWeekIntroPriceRecurring,
+          recurringTotalAmount: null,
+        });
+
+        // Total due today still renders; the future-charge row does not.
+        expect(await screen.findByText("Total due today")).toBeInTheDocument();
+        expect(screen.queryByText(/^Due on /)).not.toBeInTheDocument();
+        // Falls back to today's total on the product row, and to the plain
+        // cadence label under the headline amount.
+        expect(screen.getByText("billed monthly")).toBeInTheDocument();
+      });
     });
   });
 });

--- a/src/ui/molecules/pricing-summary.svelte
+++ b/src/ui/molecules/pricing-summary.svelte
@@ -4,11 +4,12 @@
   import { LocalizationKeys } from "../localization/supportedLanguages";
   import { Translator } from "../localization/translator";
   import { getContext } from "svelte";
+  import { translatorContextKey } from "../localization/constants";
   import {
-    translatorContextKey,
-    englishLocale,
-  } from "../localization/constants";
-  import { getTranslatedPeriodLength } from "../../helpers/price-labels";
+    getPeriodDurationLabel,
+    getTranslatedPeriodLength,
+  } from "../../helpers/price-labels";
+  import { getOfferDuration } from "../../helpers/paywall-offer-helpers";
   import { type PriceBreakdown } from "../ui-types";
   import {
     type PricingPhase,
@@ -40,28 +41,19 @@
     !!discountPhase || (priceBreakdown.appliedDiscounts?.length ?? 0) > 0,
   );
 
-  const promoPriceDurationText = $derived.by(() => {
-    if (!hasLimitedTimePromotion || !introPricePhase?.period) return "";
-
-    const totalPeriods =
-      introPricePhase.period.number * introPricePhase?.cycleCount;
-    const unit = introPricePhase.period.unit;
-
-    if (totalPeriods == null || unit == null) return "";
-
-    // Specifically for English locale, instead of showing "First 1 week for..." we show "First week for..."
-    // This is a customer paper cut that we want to fix, but we run into limitations of the templating translation system.
-    // In order to avoid impact to other locales, we only apply this to the English locale.
-    if (
-      totalPeriods === 1 &&
-      !hasTrial &&
-      $translator.selectedLocale === englishLocale
-    ) {
-      return $translator.translatePeriodUnit(unit) || "";
-    }
-
-    return $translator.translatePeriod(totalPeriods, unit) || "";
-  });
+  const promoPriceDurationText = $derived(
+    hasLimitedTimePromotion
+      ? getPeriodDurationLabel(
+          getOfferDuration(introPricePhase!),
+          $translator,
+          {
+            // "First week for $1.49", not "First 1 week for $1.49". Skipped when
+            // there is a trial, where the copy is "Then 1 week for $1.49".
+            collapseSingularInEnglish: !hasTrial,
+          },
+        )
+      : "",
+  );
 
   const promoFrequencyText = $derived.by(() => {
     if (!introPricePhase?.period) return "";

--- a/src/ui/molecules/pricing-table.svelte
+++ b/src/ui/molecules/pricing-table.svelte
@@ -6,7 +6,12 @@
   import { LocalizationKeys } from "../localization/supportedLanguages";
   import { type PriceBreakdown } from "../ui-types";
   import { getNextRenewalDate } from "../../helpers/duration-helper";
-  import { type PricingPhase } from "../../entities/offerings";
+  import { getPeriodDurationLabel } from "../../helpers/price-labels";
+  import { getOfferDuration } from "../../helpers/paywall-offer-helpers";
+  import {
+    type DiscountPhase,
+    type PricingPhase,
+  } from "../../entities/offerings";
   import type { ResolvedDiscountBreakdown } from "../../helpers/discount-breakdown-helper";
   import DiscountInput from "./discount-input.svelte";
   import PricingDropdown from "./pricing-dropdown.svelte";
@@ -17,6 +22,8 @@
     priceBreakdown: PriceBreakdown;
     trialPhase: PricingPhase | null;
     basePhase: PricingPhase | null;
+    introPricePhase: PricingPhase | null;
+    discountPhase: DiscountPhase | null;
     resolvedDiscount: ResolvedDiscountBreakdown | null;
     showDiscountCodeField: boolean;
     discountCode: string;
@@ -35,6 +42,8 @@
     priceBreakdown,
     trialPhase,
     basePhase,
+    introPricePhase,
+    discountPhase,
     resolvedDiscount,
     showDiscountCodeField,
     discountCode,
@@ -56,6 +65,29 @@
   );
 
   const translator: Writable<Translator> = getContext(translatorContextKey);
+
+  // When a paid intro phase steps up to the base price, tell the customer when
+  // that happens and how much it will be.
+  //
+  // Suppressed in two cases. With a trial the sequence is trial -> intro ->
+  // base, and one row cannot describe both step-ups; the trial row still states
+  // the trial end date, so that case is under-described rather than wrong. With
+  // a discount the intro price does not apply at all — a discount supersedes it
+  // everywhere else too (see paywall-offer-helpers' primaryOffer) — so an intro
+  // step-up date would describe a schedule that is not in effect. Discounts do
+  // not get a row of their own yet; that needs new copy in every locale.
+  const introDuration = $derived(
+    introPricePhase ? getOfferDuration(introPricePhase) : null,
+  );
+  const introPriceEndDate = $derived(
+    !trialEndDate && !discountPhase && introDuration
+      ? getNextRenewalDate(new Date(), introDuration, true)
+      : null,
+  );
+
+  const introPriceDurationLabel = $derived(
+    getPeriodDurationLabel(introDuration, $translator),
+  );
 
   const isTaxCalculationPending = $derived(
     priceBreakdown.taxCalculationStatus === "loading" ||
@@ -279,6 +311,34 @@
           <Typography size="body-small">
             {$translator.formatPrice(
               priceBreakdown.totalAmountInMicros,
+              priceBreakdown.currency,
+            )}
+          </Typography>
+        </div>
+      </div>
+    {:else if introPriceEndDate}
+      <div class="rcb-pricing-table-row">
+        <div class="rcb-pricing-table-header">
+          <Typography size="body-small">
+            {$translator.translate(
+              LocalizationKeys.ProductInfoPriceAfterIntroPrice,
+              {
+                introPriceDuration: introPriceDurationLabel,
+                renewalDate: $translator.translateDate(introPriceEndDate, {
+                  dateStyle: "medium",
+                }),
+              },
+            )}
+          </Typography>
+        </div>
+        <div class="rcb-pricing-table-value">
+          <Typography size="body-small">
+            <!-- The base price, not totalAmountInMicros: that is today's
+                 discounted intro total, while this row is what the customer
+                 pays once the intro phase ends. Matches the header. -->
+            {$translator.formatPrice(
+              basePhase?.price?.amountMicros ??
+                priceBreakdown.totalAmountInMicros,
               priceBreakdown.currency,
             )}
           </Typography>

--- a/src/ui/organisms/paddle-order-summary.svelte
+++ b/src/ui/organisms/paddle-order-summary.svelte
@@ -21,6 +21,7 @@
     type OfferPhase,
   } from "../../helpers/paywall-offer-helpers";
   import { getPeriodDurationLabel } from "../../helpers/price-labels";
+  import { toBcp47Locale } from "../../helpers/locale-helper";
   import { LocalizationKeys } from "../localization/supportedLanguages";
   import type { PaddleCheckoutTotals } from "../../paddle/paddle-service";
 
@@ -156,11 +157,13 @@
     if (recurringMicros === null || !firstPeriod) return null;
     const renewalDate = getNextRenewalDate(new Date(), firstPeriod, true);
     if (!renewalDate) return null;
-    return $translator.translateDate(renewalDate, {
-      day: "numeric",
-      month: "long",
-      year: "numeric",
-    });
+    // Formatted off selectedLocale, not the translator's resolved locale: only
+    // language-level translations exist, so `en-GB` resolves to `en` and would
+    // render the US month-first order instead of day-first.
+    return renewalDate.toLocaleDateString(
+      toBcp47Locale($translator.selectedLocale),
+      { day: "numeric", month: "long", year: "numeric" },
+    );
   });
 </script>
 

--- a/src/ui/organisms/paddle-order-summary.svelte
+++ b/src/ui/organisms/paddle-order-summary.svelte
@@ -16,7 +16,11 @@
     getNextRenewalDate,
     type Period,
   } from "../../helpers/duration-helper";
-  import { toBcp47Locale } from "../../helpers/locale-helper";
+  import {
+    getOfferDuration,
+    type OfferPhase,
+  } from "../../helpers/paywall-offer-helpers";
+  import { getPeriodDurationLabel } from "../../helpers/price-labels";
   import { LocalizationKeys } from "../localization/supportedLanguages";
   import type { PaddleCheckoutTotals } from "../../paddle/paddle-service";
 
@@ -45,19 +49,63 @@
   const isSubscriptionOption = (
     option: PurchaseOption,
   ): option is SubscriptionOption => "base" in option;
-  const basePeriod: Period | null = isSubscriptionOption(purchaseOption)
-    ? (purchaseOption.base.period ?? null)
-    : null;
+  const subscriptionOption: SubscriptionOption | null = $derived(
+    isSubscriptionOption(purchaseOption) ? purchaseOption : null,
+  );
+  const basePeriod: Period | null = $derived(
+    subscriptionOption?.base.period ?? null,
+  );
+
+  // The first phase the customer actually pays for, which is what today's total
+  // covers and what determines when the recurring price kicks in. Matches the
+  // precedence in paywall-offer-helpers' setOfferVariables. (secure-checkout-rc
+  // and purchase-option-price-helper deliberately omit the trial: they quote a
+  // price, and a trial has none.)
+  const offerPhase: OfferPhase | null = $derived(
+    subscriptionOption?.discount ??
+      subscriptionOption?.trial ??
+      subscriptionOption?.introPrice ??
+      null,
+  );
+  // A "forever" discount has no end, so getOfferDuration returns null and we
+  // fall back to the base cadence — which is correct, it renews at that rate.
+  const firstPeriod: Period | null = $derived(
+    (offerPhase ? getOfferDuration(offerPhase) : null) ?? basePeriod,
+  );
+  // A phase sitting between the first one and the base price — the same
+  // "secondaryOffer" paywall-offer-helpers models. Only a trial can have one:
+  // a discount supersedes both the trial and the intro price.
+  const middlePhase = $derived(
+    subscriptionOption?.trial && !subscriptionOption.discount
+      ? (subscriptionOption.introPrice ?? null)
+      : null,
+  );
+  // Paddle's recurring total is the base price, so "then <recurring>" only
+  // holds when the first phase steps straight up to it. With a middle phase the
+  // next charge is that phase's price, which these two totals cannot express,
+  // so say nothing about the future rather than quote a price that is not next.
+  const hasUndescribedMiddlePhase = $derived(middlePhase !== null);
 
   const toMicros = (amount: number): number => Math.round(amount * 1_000_000);
 
-  const fallbackPrice = getInitialPriceFromPurchaseOption(
-    productDetails,
-    purchaseOption,
+  const fallbackPrice = $derived(
+    getInitialPriceFromPurchaseOption(productDetails, purchaseOption),
   );
   const currency = $derived(totals?.currencyCode ?? fallbackPrice.currency);
   const totalMicros = $derived(
     totals ? toMicros(totals.totalAmount) : fallbackPrice.amountMicros,
+  );
+  // What the customer pays each period once any intro/trial phase is over.
+  const recurringMicros = $derived(
+    totals?.recurringTotalAmount != null && !hasUndescribedMiddlePhase
+      ? toMicros(totals.recurringTotalAmount)
+      : null,
+  );
+  // Comparing the two amounts Paddle reports is a more direct signal than
+  // comparing periods: it also catches a same-length offer (a first month at
+  // $3 against a $20 monthly base), which a period comparison would miss.
+  const stepsUpToRecurring = $derived(
+    recurringMicros !== null && recurringMicros !== totalMicros,
   );
 
   const formatAmount = (micros: number): string =>
@@ -72,24 +120,47 @@
       : null,
   );
 
+  // "first week" rather than "first 1 week" — the shared helper keeps that
+  // collapse gated to English, where the surrounding copy needs it.
+  const firstPeriodLabel = $derived(
+    getPeriodDurationLabel(firstPeriod, $translator, {
+      collapseSingularInEnglish: true,
+    }),
+  );
+
+  // The headline amount is today's total, so a bare "billed monthly" underneath
+  // would read as "$3.00 monthly" while the customer is still in a 1-week intro
+  // phase. Spell out the intro window and the price it steps up to instead.
+  const billedSummaryLabel = $derived(
+    !billedFrequencyLabel
+      ? null
+      : stepsUpToRecurring && firstPeriodLabel
+        ? `first ${firstPeriodLabel}, then ${formatAmount(recurringMicros!)} ${billedFrequencyLabel}`
+        : `billed ${billedFrequencyLabel}`,
+  );
+
   const productName = $derived(totals?.productName ?? productDetails.title);
   const priceName = $derived(totals?.priceName ?? null);
   const hasTax = $derived(!!totals && totals.taxAmount > 0);
 
-  // Best-effort next billing date for the recurring row: today + the base
-  // period, formatted in the active locale. Reuses getNextRenewalDate so the
-  // leap-year / month-overflow edge cases live in one place. The exact Paddle
-  // renewal date isn't exposed through checkout events.
+  // Best-effort next billing date for the recurring row: today + the first
+  // phase's duration (the intro/trial window when there is one, otherwise the
+  // base period). Reuses getNextRenewalDate so the leap-year / month-overflow
+  // edge cases live in one place.
+  //
+  // The period comes from the RevenueCat catalog rather than Paddle because
+  // Paddle's checkout events don't carry it: `items[].billing_cycle` is the
+  // recurring cycle and `items[].trial_period` only covers free trials, so
+  // neither describes a paid intro window.
   const nextBillingLabel = $derived.by(() => {
-    if (!totals || totals.recurringTotalAmount === null || !basePeriod)
-      return null;
-    const renewalDate = getNextRenewalDate(new Date(), basePeriod, true);
+    if (recurringMicros === null || !firstPeriod) return null;
+    const renewalDate = getNextRenewalDate(new Date(), firstPeriod, true);
     if (!renewalDate) return null;
-    return new Intl.DateTimeFormat(toBcp47Locale($translator.selectedLocale), {
+    return $translator.translateDate(renewalDate, {
       day: "numeric",
       month: "long",
       year: "numeric",
-    }).format(renewalDate);
+    });
   });
 </script>
 
@@ -102,8 +173,8 @@
         <span class="rcb-paddle-summary-muted">inc. tax</span>
       {/if}
     </div>
-    {#if billedFrequencyLabel}
-      <Typography size="body-small">billed {billedFrequencyLabel}</Typography>
+    {#if billedSummaryLabel}
+      <Typography size="body-small">{billedSummaryLabel}</Typography>
     {/if}
 
     <div class="rcb-paddle-summary-product">
@@ -114,7 +185,11 @@
         >
       {/if}
       <div class="rcb-paddle-summary-product-price">
-        <span>{formatAmount(totalMicros)}</span>
+        <!-- The recurring price, not today's total: this row is suffixed with
+             "/ month", which describes what each period costs once any intro
+             phase is over. Today's charge is the headline amount and the
+             "Total due today" row. -->
+        <span>{formatAmount(recurringMicros ?? totalMicros)}</span>
         {#if periodUnitLabel}
           <span class="rcb-paddle-summary-muted">/ {periodUnitLabel}</span>
         {/if}
@@ -148,11 +223,11 @@
         >
         <span>{formatAmount(toMicros(totals.totalAmount))}</span>
       </div>
-      {#if totals.recurringTotalAmount !== null && nextBillingLabel}
+      {#if recurringMicros !== null && nextBillingLabel}
         <div class="rcb-paddle-summary-row">
           <span class="rcb-paddle-summary-muted">Due on {nextBillingLabel}</span
           >
-          <span>{formatAmount(toMicros(totals.recurringTotalAmount))}</span>
+          <span>{formatAmount(recurringMicros)}</span>
         </div>
       {/if}
     </div>

--- a/src/ui/organisms/product-info.svelte
+++ b/src/ui/organisms/product-info.svelte
@@ -99,6 +99,8 @@
     {priceBreakdown}
     {trialPhase}
     {basePhase}
+    {introPricePhase}
+    {discountPhase}
     {resolvedDiscount}
     {showDiscountCodeField}
     {discountCode}

--- a/src/ui/organisms/upgrade-product-info.svelte
+++ b/src/ui/organisms/upgrade-product-info.svelte
@@ -119,6 +119,8 @@
     {priceBreakdown}
     trialPhase={null}
     basePhase={null}
+    introPricePhase={null}
+    discountPhase={null}
     resolvedDiscount={null}
     showDiscountCodeField={false}
     discountCode=""


### PR DESCRIPTION
## Summary

Stacked on #1032 — review/merge that first.

The RC Billing / Stripe pricing table only rendered a future-charge row for **free trials**. A subscription with a **paid intro phase** (1 week @ $1.49, then $9.90/month) showed `Total due today $1.49` and nothing else, so the customer was never told that $9.90 lands a week later.

Unlike the Paddle summary in #1032, this wasn't showing a *wrong* date — the row was simply absent. This adds it:

```
After 1 week, on Aug 14, 2026   $9.90
Total due today                 $1.49
```

Rendered only when there is an intro phase and no trial; the existing trial row already covers the trial + intro case.

The amount is the **base price**, not `priceBreakdown.totalAmountInMicros` — the latter is today's discounted intro total. This matches what the product header already shows for the intro case.

### The copy already existed

`ProductInfoPriceAfterIntroPrice` (`"After {{introPriceDuration}}, on {{renewalDate}}"`) was defined in `supportedLanguages.ts` and translated in every one of the 30+ locale files, but referenced nowhere in the code. This is the row it was written for — no new strings needed.

### Shared duration label

The intro-duration logic moves out of `pricing-summary.svelte` into `getIntroPriceDurationLabel` so both surfaces share it. Its English `"1 week"` → `"week"` collapse becomes an opt-in flag rather than implicit behaviour: it reads well in the header's *"First week for $1.49"* but not in *"After week, on Aug 14"*, so the table takes the `"After 1 week"` form. The header's rendering is unchanged.

### Not included

**Discounts** have the same missing row. Left out deliberately: no localization key exists for them, so it needs new copy across every locale, and it overlaps the known copy debt in `secure-checkout-rc.svelte` (`DISCOUNT_*_TERMS_INFO` are hardcoded English with a `TODO WEB-4205 - Translations`). Better as its own change alongside that work.

## Test plan

- [x] `pnpm test` — 780 passing
- [x] Typecheck / lint / `svelte-check` / build clean
- [x] New tests verified non-vacuous: stashing the `pricing-table.svelte` change makes the 2 behaviour tests fail while the 4 guards still pass
- [x] Header refactor covered by new `getIntroPriceDurationLabel` unit tests (both collapse modes, plus a non-English locale)
- [ ] Chromatic: two new `PricingTable` stories (intro price, trial + intro price)
- [ ] Manual: RC/Stripe checkout for a 1-week-intro monthly product shows both the after-intro row and the correct total due today

<details>
<summary>AI assistance</summary>

Investigated and implemented with Claude Code (Opus 5). Found during an audit of all three checkout surfaces prompted by the Paddle bug in #1032 — this gap was the quieter half of the same root cause, and the orphaned localization key suggests the row was intended at some point and got dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Checkout pricing display only; no payment or auth changes. Logic is gated on trial/discount presence with tests covering edge cases.
> 
> **Overview**
> The checkout **pricing table** now shows a future-charge row when a subscription has a **paid intro phase** and no free trial—e.g. *After 1 week, on Aug 14, 2026* with the **base** price ($9.90), while *Total due today* still reflects the intro amount ($1.49). It uses the existing `ProductInfoPriceAfterIntroPrice` localization key that was previously unused.
> 
> The row is **suppressed** when a trial is present (only the trial row is shown) or when a **discount** supersedes the intro phase, so the schedule shown matches what actually applies.
> 
> `pricing-summary` no longer builds intro-duration text inline; it uses shared `getPeriodDurationLabel` / `getOfferDuration`, with English singular collapse (`"week"` vs `"1 week"`) only for the header copy via an opt-in flag—the table keeps *After 1 week*.
> 
> `PricingTable` gains `introPricePhase` and `discountPhase` props; `product-info` passes them through; upgrade checkout passes nulls. Storybook adds intro-only and trial+intro stories; new component tests cover dates, multi-cycle intros, and guard cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a03185ae542a5ad20397e9eedd3755e49d854685. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->