### PR TITLE
vega: getProducts() optimizations

### DIFF
--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -237,15 +237,30 @@ export class AmazonBillingWrapper implements BillingWrapper {
         .map(productForAmazonProduct)
         .filter((product): product is ProductResponse => product !== null);
 
-    const response = await PurchasingService.getProductData({
-      skus: productIds,
-    });
+    const uniqueProductIds = [...new Set(productIds)];
+    const productDetails: ProductResponse[] = [];
+    const maximumProductsPerRequest = 100;
 
-    const purchasesError = purchasesErrorForProductDataResponse(response);
-    if (purchasesError) {
-      throw purchasesError;
+    for (
+      let startIndex = 0;
+      startIndex < uniqueProductIds.length;
+      startIndex += maximumProductsPerRequest
+    ) {
+      const response = await PurchasingService.getProductData({
+        skus: uniqueProductIds.slice(
+          startIndex,
+          startIndex + maximumProductsPerRequest,
+        ),
+      });
+
+      const purchasesError = purchasesErrorForProductDataResponse(response);
+      if (purchasesError) {
+        throw purchasesError;
+      }
+
+      productDetails.push(...productsForProductDataResponse(response));
     }
 
-    return { product_details: productsForProductDataResponse(response) };
+    return { product_details: productDetails };
   }
 }

--- a/src/tests/amazon/amazon-billing-wrapper.test.ts
+++ b/src/tests/amazon/amazon-billing-wrapper.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const { getProductData } = vi.hoisted(() => ({
   getProductData: vi.fn(),
@@ -67,6 +67,10 @@ async function getProducts(response: ProductDataResponse) {
 }
 
 describe("AmazonBillingWrapper", () => {
+  beforeEach(() => {
+    getProductData.mockClear();
+  });
+
   describe("product data requests", () => {
     test("loads and maps products from the Amazon IAP SDK", async () => {
       getProductData.mockResolvedValue(
@@ -98,6 +102,98 @@ describe("AmazonBillingWrapper", () => {
             trial: { period_duration: "P7D" },
           },
         },
+      });
+    });
+
+    test("deduplicates product IDs before requesting product data", async () => {
+      getProductData.mockResolvedValue(
+        responseForProducts([product({ sku: "monthly" })]),
+      );
+
+      await new AmazonBillingWrapper().getProducts("user", [
+        "monthly",
+        "yearly",
+        "monthly",
+        "yearly",
+      ]);
+
+      expect(getProductData).toHaveBeenCalledExactlyOnceWith({
+        skus: ["monthly", "yearly"],
+      });
+    });
+
+    test("requests fewer than 100 unique product IDs in a single batch", async () => {
+      const productIds = Array.from(
+        { length: 99 },
+        (_, index) => `product-${index}`,
+      );
+      getProductData.mockResolvedValue(responseForProducts([]));
+
+      await new AmazonBillingWrapper().getProducts("user", productIds);
+
+      expect(getProductData).toHaveBeenCalledExactlyOnceWith({
+        skus: productIds,
+      });
+    });
+
+    test("requests more than 100 unique product IDs in sequential batches and combines the results", async () => {
+      const productIds = Array.from(
+        { length: 201 },
+        (_, index) => `product-${index}`,
+      );
+      getProductData
+        .mockResolvedValueOnce(
+          responseForProducts([product({ sku: "product-0" })]),
+        )
+        .mockResolvedValueOnce(
+          responseForProducts([product({ sku: "product-100" })]),
+        )
+        .mockResolvedValueOnce(
+          responseForProducts([product({ sku: "product-200" })]),
+        );
+
+      const result = await new AmazonBillingWrapper().getProducts(
+        "user",
+        productIds,
+      );
+
+      expect(getProductData).toHaveBeenNthCalledWith(1, {
+        skus: productIds.slice(0, 100),
+      });
+      expect(getProductData).toHaveBeenNthCalledWith(2, {
+        skus: productIds.slice(100, 200),
+      });
+      expect(getProductData).toHaveBeenNthCalledWith(3, {
+        skus: productIds.slice(200),
+      });
+      expect(
+        result.product_details.map(({ identifier }) => identifier),
+      ).toEqual(["product-0", "product-100", "product-200"]);
+    });
+
+    test("deduplicates product IDs across batch boundaries", async () => {
+      const uniqueProductIds = Array.from(
+        { length: 101 },
+        (_, index) => `product-${index}`,
+      );
+      const requestedProductIds = [
+        ...uniqueProductIds.slice(0, 100),
+        "product-0",
+        "product-50",
+        "product-100",
+      ];
+      getProductData
+        .mockResolvedValueOnce(responseForProducts([]))
+        .mockResolvedValueOnce(responseForProducts([]));
+
+      await new AmazonBillingWrapper().getProducts("user", requestedProductIds);
+
+      expect(getProductData).toHaveBeenCalledTimes(2);
+      expect(getProductData).toHaveBeenNthCalledWith(1, {
+        skus: uniqueProductIds.slice(0, 100),
+      });
+      expect(getProductData).toHaveBeenNthCalledWith(2, {
+        skus: ["product-100"],
       });
     });
   });


### PR DESCRIPTION
## Changes introduced
This PR introduces two optimizations to how the SDK fetches products for the Amazon store:
1. The Amazon Store only allows you to fetch up to 100 products at a time. To satisfy this requirement, this PR chunks product requests to only request up to 100 products at a time serially. The function will return once all product requests have completely.
2. If duplicate product IDs are passed into `getProducts()`, they will be de-duplicated so that we only request each product ID once.

The PR also includes unit tests to verify the new behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Amazon IAP fetch change with no auth or payment-flow impact. Sequential batching can fail the whole call if a later batch errors, which matches prior single-request error handling.
> 
> **Overview**
> Amazon `getProducts` now respects the store’s 100-SKU cap and avoids redundant lookups.
> 
> Duplicate product IDs are unique’d first, then `PurchasingService.getProductData` is called in sequential batches of 100. Results are concatenated; a failed batch still throws as before. Tests cover deduping, single vs multi-batch requests, and combining responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4f95af7c2ac05f82170093ad5e9463be785679f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->