### PR TITLE
fix(types): bundle purchases-ui-js types into the rollup so consumers don't hit TS2307

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -18,6 +18,7 @@ export default defineConfig({
   plugins: [
     dts({
       rollupTypes: true,
+      bundledPackages: ["@revenuecat/purchases-ui-js"],
     }),
     svelte({ compilerOptions: { css: "injected" } }),
   ],


### PR DESCRIPTION
Fixes #731.

Installing `@revenuecat/purchases-js` without also installing `@revenuecat/purchases-ui-js` produces `TS2307: Cannot find module '@revenuecat/purchases-ui-js'` from `dist/Purchases.es.d.ts`.

**Root cause:** types are rolled up by `vite-plugin-dts` (`rollupTypes: true`), but with no `bundledPackages` set, types re-exported from `purchases-ui-js` (`UIConfig`, `PaywallData`, `WalletButtonTheme`, `PackageInfo`, and others) are emitted as external imports in the shipped `.d.ts`. Runtime is unaffected because vite bundles `purchases-ui-js` (it's a devDependency, not externalized); only the types leak.

**Fix:** pass `bundledPackages: ["@revenuecat/purchases-ui-js"]` to the `dts()` plugin so api-extractor inlines those types into the rollup, making the shipped `.d.ts` self-contained. No runtime or peer dependency added. (Note: it has to be set on the `dts()` plugin, not in `api-extractor.json`, because `vite-plugin-dts`'s rollup generates its own api-extractor config and ignores that file's `bundledPackages`.)

**Verified locally:** after `pnpm build`, `dist/Purchases.es.d.ts` has zero `@revenuecat/purchases-ui-js` imports (was 8), with `PaywallData`, `UIConfig`, `WalletButtonTheme`, etc. now declared inline. A consumer that doesn't install `purchases-ui-js` type-checks cleanly.

**Alternative considered:** declaring `purchases-ui-js` as a dependency (or optional peer) also fixes it, but forces consumers to install a package that's already bundled at runtime; inlining the types is lighter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time type rollup only; no runtime or API behavior change.
> 
> **Overview**
> Fixes consumer **TS2307** when `@revenuecat/purchases-js` is installed without `@revenuecat/purchases-ui-js`. Rolled-up `dist/Purchases.es.d.ts` was leaving types from `purchases-ui-js` as external imports even though runtime already bundles that package.
> 
> The `vite-plugin-dts` config now sets **`bundledPackages: ["@revenuecat/purchases-ui-js"]`** so api-extractor inlines those types into the shipped declarations (`PaywallData`, `UIConfig`, etc.). No new runtime or peer dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 286b8beab54a865a9c398782faf2a751c7b99f3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->