### PR TITLE
fix(vega): dont load branding info for amazon store

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -518,12 +518,12 @@ export class Purchases {
   /** @internal */
   private async fetchAndCacheBrandingInfo(): Promise<void> {
     if (isSimulatedStoreApiKey(this._API_KEY)) {
-      Logger.warnLog(
+      Logger.verboseLog(
         "Branding info is not available for RC Test Store API keys.",
       );
       return;
     } else if (isAmazonApiKey(this._API_KEY)) {
-      Logger.warnLog(
+      Logger.verboseLog(
         "Branding info is not available for Amazon Store API keys.",
       );
       return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -522,6 +522,11 @@ export class Purchases {
         "Branding info is not available for RC Test Store API keys.",
       );
       return;
+    } else if (isAmazonApiKey(this._API_KEY)) {
+      Logger.warnLog(
+        "Branding info is not available for Amazon Store API keys.",
+      );
+      return;
     }
     this._brandingInfo = await this.backend.getBrandingInfo();
     this.syncApplePayWebsiteIcon();

--- a/src/tests/purchase.test.ts
+++ b/src/tests/purchase.test.ts
@@ -63,6 +63,20 @@ describe("preload", () => {
     expect(APIGetRequest).not.toHaveBeenCalledWith(expectedRequest);
   });
 
+  test("does not load branding info if using Amazon Store api key", async () => {
+    const purchases = configurePurchases(
+      "test-app-user-id",
+      "test-rc-source",
+      "amzn_store_api_key",
+    );
+    const expectedRequest: GetRequest = {
+      url: "http://localhost:8000/rcbilling/v1/branding",
+    };
+    expect(APIGetRequest).not.toHaveBeenCalledWith(expectedRequest);
+    await purchases.preload();
+    expect(APIGetRequest).not.toHaveBeenCalledWith(expectedRequest);
+  });
+
   test("does not inject an apple-touch-icon when the flag is disabled", async () => {
     server.use(
       http.get("http://localhost:8000/rcbilling/v1/branding", ({ request }) => {


### PR DESCRIPTION
## Changes introduced
When testing out making purchases on the Amazon Store, I noticed this error message was being consistently logged before the purchase reached the Amazon SDK:

```bash
[Purchases] Error fetching branding info: There was a credentials issue. 
Check the underlying error for more details.. Underlying error: Invalid API Key.
```

This is because the `@requiresLoadedResources` decorator is applied to the `main.ts`'s `purchase()` function, which ensures that branding info is loaded before executing the purchase function. This PR prevents the SDK from loading branding info when the SDK is configured with an Amazon API key to prevent an unnecessary backend API and error log.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, store-specific skip of an optional branding request; Amazon checkout does not use branding UI.
> 
> **Overview**
> Stops the SDK from fetching branding info when configured with an Amazon Store API key, matching the existing skip for RC Test Store keys.
> 
> `purchase()` still preloads resources via `@requiresLoadedResources`, so Amazon keys previously hit `/rcbilling/v1/branding` with an invalid key and logged a credentials error. The fetch now returns early with a verbose log. The Test Store skip log is also lowered from warn to verbose.
> 
> Adds a preload test that Amazon keys do not call the branding endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f515e6003d3389006e2d47167ce99ea06fa070d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->