### PR TITLE
feat(vega): sync/restore purchases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ commands:
 
 jobs:
   build-vega-purchase-tester:
-    # Vega SDK CI requirements: https://developer.amazon.com/docs/vega/0.24/continuous-integration.html
+    # Vega SDK CI requirements: https://developer.amazon.com/docs/vega/0.23/continuous-integration.html
     machine:
       image: ubuntu-2404:current
     steps:
@@ -73,7 +73,7 @@ jobs:
           command: |
             export NONINTERACTIVE=true
             export SKIP_VVD_INSTALL=true
-            export VEGA_SDK_VERSION=0.24.9914
+            export VEGA_SDK_VERSION=0.23.9221
             curl -fsSL https://sdk-installer.vega.labcollab.net/get_vvm.sh | bash
             echo 'export PATH="$HOME/vega/bin:$PATH"' >> "$BASH_ENV"
             source "$BASH_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ commands:
 
 jobs:
   build-vega-purchase-tester:
-    # Vega SDK CI requirements: https://developer.amazon.com/docs/vega/0.23/continuous-integration.html
+    # Vega SDK CI requirements: https://developer.amazon.com/docs/vega/0.24/continuous-integration.html
     machine:
       image: ubuntu-2404:current
     steps:
@@ -73,7 +73,7 @@ jobs:
           command: |
             export NONINTERACTIVE=true
             export SKIP_VVD_INSTALL=true
-            export VEGA_SDK_VERSION=0.23.9221
+            export VEGA_SDK_VERSION=0.24.9914
             curl -fsSL https://sdk-installer.vega.labcollab.net/get_vvm.sh | bash
             echo 'export PATH="$HOME/vega/bin:$PATH"' >> "$BASH_ENV"
             source "$BASH_ENV"

--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -7879,6 +7879,51 @@
             },
             {
               "kind": "Method",
+              "canonicalReference": "@revenuecat/purchases-js!Purchases#restorePurchases:member(1)",
+              "docComment": "/**\n * Restores purchases made with the current store account for the current user. This method posts all purchases associated with the current Amazon Appstore account to RevenueCat and associates them with the current `appUserId`. If a receipt is already used by an existing user, the current `appUserId` may be aliased with that user's `appUserId` depending on your app's Restore Behavior. For more information, refer to https://www.revenuecat.com/docs/projects/restore-behavior\n *\n * This method also sends expired subscriptions and consumed one-time purchases to RevenueCat.\n *\n * You shouldn't use this method if you have your own account system. In that case, restoration is provided by your app passing the same `appUserId` that was used for the original purchase.\n *\n * Currently only supported on the Amazon Store when configured with an Amazon API key.\n *\n * @warning This operation can take a relatively long time when the user has many purchases.\n *\n * @returns The {@link CustomerInfo} with restored purchases.\n *\n * @throws\n *\n * {@link PurchasesError} if the SDK is not configured with an Amazon Appstore API key or restoration fails.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "restorePurchases(): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "RestorePurchasesResult",
+                  "canonicalReference": "@revenuecat/purchases-js!RestorePurchasesResult:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ">"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 5
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "restorePurchases"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "@revenuecat/purchases-js!Purchases#setAttributes:member(1)",
               "docComment": "/**\n * Sets attributes for the current user. Attributes are useful for storing additional, structured information on a customer that can be used elsewhere in the system. For example, you could store your customer's email address or additional system identifiers through the applicable reserved attributes, or store arbitrary facts like onboarding survey responses, feature usage, or other dimensions as custom attributes.\n *\n * Note: Unlike our mobile SDKs, the web SDK does not cache or retry sending attributes if the request fails. If the request fails, the attributes will not be saved and you will need to retry the operation.\n *\n * @param attributes - A dictionary of attributes to set for the current user.\n *\n * @throws\n *\n * {@link PurchasesError} if there is an error while setting the attributes or if the customer doesn't exist.\n */\n",
               "excerptTokens": [
@@ -8089,6 +8134,51 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "setPlatformInfo"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@revenuecat/purchases-js!Purchases#syncPurchases:member(1)",
+              "docComment": "/**\n * Sends purchases made with the current store account to the RevenueCat backend. Call this when using your own purchase implementation whenever a sync is needed, such as while migrating existing users to RevenueCat. It resolves when all purchases have been synced successfully or when there are no purchases to sync; otherwise it throws with the first error encountered.\n *\n * This method also sends expired subscriptions and consumed one-time purchases to RevenueCat.\n *\n * Currently only supported on the Amazon Store when configured with an Amazon API key.\n *\n * @warning This operation can take a relatively long time when the user has many purchases.\n *\n * @returns The {@link CustomerInfo} after purchases have been synced.\n *\n * @throws\n *\n * {@link PurchasesError} if the SDK is not configured with an Amazon Appstore API key or syncing fails.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "syncPurchases(): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "SyncPurchasesResult",
+                  "canonicalReference": "@revenuecat/purchases-js!SyncPurchasesResult:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ">"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 5
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "syncPurchases"
             }
           ],
           "implementsTokenRanges": []
@@ -9655,6 +9745,52 @@
           ]
         },
         {
+          "kind": "Interface",
+          "canonicalReference": "@revenuecat/purchases-js!RestorePurchasesResult:interface",
+          "docComment": "/**\n * The result of restoring purchases.\n *\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare interface RestorePurchasesResult "
+            }
+          ],
+          "fileUrlPath": "dist/Purchases.es.d.ts",
+          "releaseTag": "Public",
+          "name": "RestorePurchasesResult",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!RestorePurchasesResult#customerInfo:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "customerInfo: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "CustomerInfo",
+                  "canonicalReference": "@revenuecat/purchases-js!CustomerInfo:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "customerInfo",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
+          "extendsTokenRanges": []
+        },
+        {
           "kind": "TypeAlias",
           "canonicalReference": "@revenuecat/purchases-js!Store:type",
           "docComment": "/**\n * The store where the user originally subscribed.\n *\n * @public\n */\n",
@@ -10531,6 +10667,52 @@
               "endIndex": 2
             }
           ]
+        },
+        {
+          "kind": "Interface",
+          "canonicalReference": "@revenuecat/purchases-js!SyncPurchasesResult:interface",
+          "docComment": "/**\n * The result of syncing purchases.\n *\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare interface SyncPurchasesResult "
+            }
+          ],
+          "fileUrlPath": "dist/Purchases.es.d.ts",
+          "releaseTag": "Public",
+          "name": "SyncPurchasesResult",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!SyncPurchasesResult#customerInfo:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "customerInfo: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "CustomerInfo",
+                  "canonicalReference": "@revenuecat/purchases-js!CustomerInfo:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "customerInfo",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
+          "extendsTokenRanges": []
         },
         {
           "kind": "Interface",

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -500,6 +500,7 @@ export class Purchases {
     static setLogHandler(handler: LogHandler | null): void;
     static setLogLevel(logLevel: LogLevel): void;
     static setPlatformInfo(platformInfo: PlatformInfo): void;
+    syncPurchases(): Promise<SyncPurchasesResult>;
     /* Excluded from this release type: _trackEvent */
     /* Excluded from this release type: _flushAllEvents */
 }
@@ -594,6 +595,12 @@ export enum ReservedCustomerAttribute {
 }
 
 // @public
+export interface RestorePurchasesResult {
+    // (undocumented)
+    customerInfo: CustomerInfo;
+}
+
+// @public
 export type Store = "app_store" | "mac_app_store" | "play_store" | "amazon" | "stripe" | "rc_billing" | "promotional" | "paddle" | "test_store" | "galaxy" | "unknown";
 
 // @public @deprecated
@@ -636,6 +643,12 @@ export interface SubscriptionOption extends PurchaseOption {
     readonly introPrice: PricingPhase | null;
     readonly trial: PricingPhase | null;
     /* Excluded from this release type: discount */
+}
+
+// @public
+export interface SyncPurchasesResult {
+    // (undocumented)
+    customerInfo: CustomerInfo;
 }
 
 // @public

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -494,6 +494,7 @@ export class Purchases {
     purchase(params: PurchaseParams): Promise<PurchaseResult>;
     // @deprecated
     purchasePackage(rcPackage: Package, customerEmail?: string, htmlTarget?: HTMLElement): Promise<PurchaseResult>;
+    restorePurchases(): Promise<RestorePurchasesResult>;
     setAttributes(attributes: {
         [key: string | ReservedCustomerAttribute]: string | null;
     }): Promise<void>;

--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -15,7 +15,7 @@ import type {
   SubscriptionOptionResponse,
 } from "../networking/responses/products-response";
 import type { PurchaseParams, PurchaseResult } from "../main";
-import type { Backend} from "../networking/backend";
+import type { Backend } from "../networking/backend";
 import { PostReceiptInitiationSource } from "../networking/backend";
 import { toCustomerInfo } from "../entities/customer-info";
 import type { CustomerInfo } from "../entities/customer-info";
@@ -180,7 +180,7 @@ export class AmazonBillingWrapper implements BillingWrapper {
       >;
       try {
         response = await PurchasingService.getPurchaseUpdates({
-          reset: true,
+          reset: executedGetPurchaseUpdatesRequests == 0 ? true : false,
         });
       } catch (error) {
         Logger.errorLog(

--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -17,6 +17,10 @@ import type {
 import type { PurchaseParams, PurchaseResult } from "../main";
 import type { Backend } from "../networking/backend";
 import { toCustomerInfo } from "../entities/customer-info";
+import type { CustomerInfo } from "../entities/customer-info";
+import type { RestorePurchasesResult } from "../entities/restore-purchases-result";
+import type { SubscriberResponse } from "../networking/responses/subscriber-response";
+import type { SyncPurchasesResult } from "../entities/sync-purchases-result";
 
 type AmazonAppstoreIAPSDK = typeof AmazonVegaSdk;
 
@@ -31,6 +35,13 @@ export class AmazonBillingWrapper implements BillingWrapper {
   private amazonAppstoreIAPSDKPromise:
     | Promise<AmazonAppstoreIAPSDK>
     | undefined;
+
+  /**
+   * Receipt IDs successfully posted by syncPurchases or restorePurchases during
+   * this wrapper's lifetime. We avoid caching this persistently on-device to avoid
+   * adding another dependency for Vega OS apps.
+   */
+  private readonly syncedReceiptIds = new Set<string>();
 
   public async getProducts(
     _appUserId: string,
@@ -102,7 +113,6 @@ export class AmazonBillingWrapper implements BillingWrapper {
         ? receipt.termSku
         : receipt.sku;
 
-    // Post receipt to RevenueCat backend
     const subscriberResponse = await this.backend.postReceipt(
       appUserId,
       productIdentifier,
@@ -135,6 +145,138 @@ export class AmazonBillingWrapper implements BillingWrapper {
     };
   }
 
+  async syncPurchases(appUserId: string): Promise<SyncPurchasesResult> {
+    Logger.debugLog("Syncing purchases with the Amazon Store.");
+    return {
+      customerInfo: await this.fetchAndPostReceipts(appUserId, false),
+    };
+  }
+
+  async restorePurchases(appUserId: string): Promise<RestorePurchasesResult> {
+    Logger.debugLog("Restoring purchases for the Amazon Store.");
+    return {
+      customerInfo: await this.fetchAndPostReceipts(appUserId, true),
+    };
+  }
+
+  private async fetchAndPostReceipts(
+    appUserId: string,
+    isRestore: boolean,
+  ): Promise<CustomerInfo> {
+    const amazonAppstoreIAPSDK = await this.getAmazonAppstoreIAPSDK();
+    const {
+      PurchasingService,
+      PurchaseUpdatesResponseCode,
+      ProductType: AmazonProductType,
+    } = amazonAppstoreIAPSDK;
+
+    let doneFetching = false;
+    let mostRecentSubscriberResponse: SubscriberResponse | null = null;
+    let executedGetPurchaseUpdatesRequests = 0;
+    while (!doneFetching) {
+      let response: Awaited<
+        ReturnType<typeof PurchasingService.getPurchaseUpdates>
+      >;
+      try {
+        response = await PurchasingService.getPurchaseUpdates({
+          reset: true,
+        });
+      } catch (error) {
+        Logger.errorLog(
+          `Failed to ${isRestore ? "restore" : "sync"} purchases from the Amazon Store: getPurchaseUpdates() threw an error.`,
+        );
+        throw new PurchasesError(
+          ErrorCode.StoreProblemError,
+          `${isRestore ? "Restoring" : "Syncing"} purchases with the Amazon Store failed.`,
+          error instanceof Error ? error.message : undefined,
+        );
+      }
+      executedGetPurchaseUpdatesRequests += 1;
+
+      switch (response.responseCode) {
+        case PurchaseUpdatesResponseCode.SUCCESSFUL:
+          Logger.verboseLog(
+            `Successfully completed getPurchaseUpdates() call: fetchedReceipts=${response.receiptList.length}, hasMore=${response.hasMore}`,
+          );
+          break;
+        case PurchaseUpdatesResponseCode.NOT_SUPPORTED:
+          Logger.warnLog(
+            `Failed to ${isRestore ? "restore" : "sync"} purchases from the Amazon Store: getPurchaseUpdates() is not supported.`,
+          );
+          throw new PurchasesError(
+            ErrorCode.UnsupportedError,
+            `${isRestore ? "Restoring" : "Syncing"} purchases is not supported.`,
+          );
+        case PurchaseUpdatesResponseCode.FAILED:
+          Logger.errorLog(
+            `Failed to ${isRestore ? "restore" : "sync"} purchases from the Amazon Store: getPurchaseUpdates() failed.`,
+          );
+          throw new PurchasesError(
+            ErrorCode.StoreProblemError,
+            `${isRestore ? "Restoring" : "Syncing"} purchases with the Amazon Store failed.`,
+          );
+        default:
+          Logger.warnLog(
+            `Failed to ${isRestore ? "restore" : "sync"} purchases from the Amazon Store: received an unexpected repsonse ${response.responseCode} from getPurchaseUpdates().`,
+          );
+          throw new PurchasesError(
+            ErrorCode.StoreProblemError,
+            `Received an unexpected response code from the Amazon Store while ${isRestore ? "restoring" : "syncing"} purchases.`,
+          );
+      }
+
+      for (const receipt of response.receiptList) {
+        if (this.syncedReceiptIds.has(receipt.receiptId)) {
+          Logger.verboseLog(
+            `Skipping posting Amazon receipt ${receipt.receiptId} because it has already been synced during this session.`,
+          );
+          continue;
+        }
+
+        let productId: string;
+        if (receipt.productType == AmazonProductType.SUBSCRIPTION) {
+          productId = receipt.termSku;
+        } else {
+          productId = receipt.sku;
+        }
+
+        mostRecentSubscriberResponse = await this.backend.postReceipt(
+          appUserId,
+          productId,
+          null,
+          receipt.receiptId,
+          null,
+          "restore",
+          undefined,
+          response.userData.userId,
+          isRestore,
+        );
+        this.syncedReceiptIds.add(receipt.receiptId);
+      }
+
+      if (response.hasMore && response.receiptList.length === 0) {
+        Logger.verboseLog(
+          "getPurchaseUpdates() returned hasMore=true, but also returned 0 receipts. Will not call getPurchaseUpdates() again. This is likely an issue with the Amazon Store.",
+        );
+        doneFetching = true;
+      } else if (!response.hasMore) {
+        doneFetching = true;
+      } else if (executedGetPurchaseUpdatesRequests > 100) {
+        Logger.debugLog(
+          `We have already called getPurchaseUpdates() ${executedGetPurchaseUpdatesRequests} times. Will stop calling it to avoid calling it excessively.`,
+        );
+        doneFetching = true;
+      }
+    }
+
+    if (mostRecentSubscriberResponse == null) {
+      mostRecentSubscriberResponse =
+        await this.backend.getCustomerInfo(appUserId);
+    }
+
+    return toCustomerInfo(mostRecentSubscriberResponse);
+  }
+
   private async notifyFulfillment(receiptId: string) {
     const amazonAppstoreIAPSDK = await this.getAmazonAppstoreIAPSDK();
     const {
@@ -163,7 +305,7 @@ export class AmazonBillingWrapper implements BillingWrapper {
         );
         break;
       case NotifyFulfillmentResponseCode.FAILED:
-        Logger.warnLog(
+        Logger.errorLog(
           `Failed to fulfill receipt ID ${receiptId} with the Amazon Store.`,
         );
         break;

--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -15,7 +15,8 @@ import type {
   SubscriptionOptionResponse,
 } from "../networking/responses/products-response";
 import type { PurchaseParams, PurchaseResult } from "../main";
-import type { Backend } from "../networking/backend";
+import type { Backend} from "../networking/backend";
+import { PostReceiptInitiationSource } from "../networking/backend";
 import { toCustomerInfo } from "../entities/customer-info";
 import type { CustomerInfo } from "../entities/customer-info";
 import type { RestorePurchasesResult } from "../entities/restore-purchases-result";

--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -119,7 +119,7 @@ export class AmazonBillingWrapper implements BillingWrapper {
       rcPackage.webBillingProduct.price.currency,
       receipt.receiptId,
       rcPackage.webBillingProduct.presentedOfferingContext,
-      "purchase",
+      PostReceiptInitiationSource.PURCHASE,
       undefined,
       storeUserId,
     );
@@ -246,7 +246,7 @@ export class AmazonBillingWrapper implements BillingWrapper {
           null,
           receipt.receiptId,
           null,
-          "restore",
+          PostReceiptInitiationSource.RESTORE,
           undefined,
           response.userData.userId,
           isRestore,

--- a/src/entities/restore-purchases-result.ts
+++ b/src/entities/restore-purchases-result.ts
@@ -1,0 +1,9 @@
+import type { CustomerInfo } from "./customer-info";
+
+/**
+ * The result of restoring purchases.
+ * @public
+ */
+export interface RestorePurchasesResult {
+  customerInfo: CustomerInfo;
+}

--- a/src/entities/sync-purchases-result.ts
+++ b/src/entities/sync-purchases-result.ts
@@ -1,0 +1,9 @@
+import type { CustomerInfo } from "./customer-info";
+
+/**
+ * The result of syncing purchases.
+ * @public
+ */
+export interface SyncPurchasesResult {
+  customerInfo: CustomerInfo;
+}

--- a/src/helpers/billing-wrapper.ts
+++ b/src/helpers/billing-wrapper.ts
@@ -1,6 +1,8 @@
 import type { ProductsResponse } from "../networking/responses/products-response";
 import type { PurchaseResult } from "src/entities/purchase-result";
 import type { PurchaseParams } from "src/entities/purchase-params";
+import type { RestorePurchasesResult } from "src/entities/restore-purchases-result";
+import type { SyncPurchasesResult } from "src/entities/sync-purchases-result";
 
 /**
  * Abstract interface for store-specific billing operations.
@@ -30,4 +32,8 @@ export interface BillingWrapper {
    * @returns The result of the purchase operation.
    */
   purchase(params: PurchaseParams, appUserId: string): Promise<PurchaseResult>;
+
+  restorePurchases(appUserId: string): Promise<RestorePurchasesResult>;
+
+  syncPurchases(appUserId: string): Promise<SyncPurchasesResult>;
 }

--- a/src/helpers/simulated-store-post-receipt-helper.ts
+++ b/src/helpers/simulated-store-post-receipt-helper.ts
@@ -1,5 +1,8 @@
 import type { Product } from "../entities/offerings";
-import type { Backend } from "../networking/backend";
+import {
+  PostReceiptInitiationSource,
+  type Backend,
+} from "../networking/backend";
 import type { PurchaseResult } from "../entities/purchase-result";
 import { generateUUID } from "./uuid-helper";
 import type { StoreTransaction } from "../entities/store-transaction";
@@ -28,7 +31,7 @@ export async function postSimulatedStoreReceipt(
     product.price.currency,
     fetchToken,
     product.presentedOfferingContext,
-    "purchase",
+    PostReceiptInitiationSource.PURCHASE,
     paywallId,
   );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -158,6 +158,8 @@ import {
 } from "./helpers/branding-appearance-helper";
 import type { BillingWrapper } from "./helpers/billing-wrapper";
 import { AmazonBillingWrapper } from "./amazon/amazon-billing-wrapper";
+import type { RestorePurchasesResult } from "./entities/restore-purchases-result";
+import type { SyncPurchasesResult } from "./entities/sync-purchases-result";
 
 type UIComponentInteractionFields = UIComponentInteractionData & {
   componentURL?: string;
@@ -219,6 +221,8 @@ export type { FlagsConfig, StoreLoadTime } from "./entities/flags-config";
 export { LogLevel } from "./entities/logging";
 export type { LogHandler } from "./entities/logging";
 export type { IdentifyResult } from "./entities/identify-result";
+export type { RestorePurchasesResult } from "./entities/restore-purchases-result";
+export type { SyncPurchasesResult } from "./entities/sync-purchases-result";
 export type { GetOfferingsParams } from "./entities/get-offerings-params";
 export { OfferingKeyword } from "./entities/get-offerings-params";
 export type {
@@ -1505,6 +1509,62 @@ export class Purchases {
       customerEmail,
       htmlTarget,
     });
+  }
+
+  /**
+   * Restores purchases made with the current store account for the current user.
+   * This method posts all purchases associated with the current Amazon Appstore account to RevenueCat and associates
+   * them with the current `appUserId`. If a receipt is already used by an existing user, the current `appUserId`
+   * may be aliased with that user's `appUserId` depending on your app's Restore Behavior. For more information,
+   * refer to https://www.revenuecat.com/docs/projects/restore-behavior
+   *
+   * This method also sends expired subscriptions and consumed one-time purchases to RevenueCat.
+   *
+   * You shouldn't use this method if you have your own account system. In that case, restoration is provided by
+   * your app passing the same `appUserId` that was used for the original purchase.
+   *
+   * Currently only supported on the Amazon Store when configured with an Amazon API key.
+   *
+   * @warning This operation can take a relatively long time when the user has many purchases.
+   * @returns The {@link CustomerInfo} with restored purchases.
+   * @throws {@link PurchasesError} if the SDK is not configured with an Amazon Appstore API key or restoration fails.
+   */
+  public async restorePurchases(): Promise<RestorePurchasesResult> {
+    if (!isAmazonApiKey(this._API_KEY)) {
+      throw new PurchasesError(
+        ErrorCode.ConfigurationError,
+        "restorePurchases() is only supported for Amazon Appstore API keys.",
+      );
+    }
+    return await this.unwrappedAmazonBillingWrapper().restorePurchases(
+      this._appUserId,
+    );
+  }
+
+  /**
+   * Sends purchases made with the current store account to the RevenueCat backend.
+   * Call this when using your own purchase implementation whenever a sync is needed, such as while migrating
+   * existing users to RevenueCat. It resolves when all purchases have been synced successfully or when there are
+   * no purchases to sync; otherwise it throws with the first error encountered.
+   *
+   * This method also sends expired subscriptions and consumed one-time purchases to RevenueCat.
+   *
+   * Currently only supported on the Amazon Store when configured with an Amazon API key.
+   *
+   * @warning This operation can take a relatively long time when the user has many purchases.
+   * @returns The {@link CustomerInfo} after purchases have been synced.
+   * @throws {@link PurchasesError} if the SDK is not configured with an Amazon Appstore API key or syncing fails.
+   */
+  public async syncPurchases(): Promise<SyncPurchasesResult> {
+    if (!isAmazonApiKey(this._API_KEY)) {
+      throw new PurchasesError(
+        ErrorCode.ConfigurationError,
+        "syncPurchases() is only supported for Amazon Appstore API keys.",
+      );
+    }
+    return await this.unwrappedAmazonBillingWrapper().syncPurchases(
+      this._appUserId,
+    );
   }
 
   /**

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -549,12 +549,13 @@ export class Backend {
   async postReceipt(
     appUserId: string,
     productId: string,
-    currency: string,
+    currency: string | null,
     fetchToken: string,
-    presentedOfferingContext: PresentedOfferingContext,
+    presentedOfferingContext: PresentedOfferingContext | null,
     initiationSource: string,
     paywallId?: string,
     storeUserId?: string,
+    is_restore?: boolean,
   ): Promise<SubscriberResponse> {
     type PostReceiptTargetingRule = {
       rule_id: string;
@@ -563,9 +564,9 @@ export class Backend {
     type PostReceiptRequestBody = {
       fetch_token: string;
       product_id: string;
-      currency: string;
+      currency: string | null;
       app_user_id: string;
-      presented_offering_identifier: string;
+      presented_offering_identifier: string | null;
       presented_placement_identifier: string | null;
       presented_workflow_id?: string | null;
       applied_targeting_rule?: PostReceiptTargetingRule | null;
@@ -574,10 +575,11 @@ export class Backend {
         paywall_id: string;
       };
       store_user_id?: string;
+      is_restore?: boolean;
     };
 
     let targetingInfo: PostReceiptTargetingRule | null = null;
-    if (presentedOfferingContext.targetingContext) {
+    if (presentedOfferingContext?.targetingContext) {
       targetingInfo = {
         rule_id: presentedOfferingContext.targetingContext.ruleId,
         revision: presentedOfferingContext.targetingContext.revision,
@@ -590,14 +592,15 @@ export class Backend {
       currency: currency,
       app_user_id: appUserId,
       presented_offering_identifier:
-        presentedOfferingContext.offeringIdentifier,
+        presentedOfferingContext?.offeringIdentifier ?? null,
       presented_placement_identifier:
-        presentedOfferingContext.placementIdentifier,
+        presentedOfferingContext?.placementIdentifier ?? null,
       presented_workflow_id:
         this.purchasesContext?.workflowContext?.workflowIdentifier,
       applied_targeting_rule: targetingInfo,
       initiation_source: initiationSource,
       store_user_id: storeUserId,
+      is_restore: is_restore,
     };
 
     if (paywallId) {

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -552,7 +552,7 @@ export class Backend {
     currency: string | null,
     fetchToken: string,
     presentedOfferingContext: PresentedOfferingContext | null,
-    initiationSource: string,
+    initiationSource: PostReceiptInitiationSource,
     paywallId?: string,
     storeUserId?: string,
     is_restore?: boolean,
@@ -676,4 +676,14 @@ export class Backend {
     }
     return (await cdnResponse.json()) as WorkflowDataResponse;
   }
+}
+
+/**
+ * The different intiation sources for a receipt posted to the backend.
+ *
+ * @internal
+ */
+export enum PostReceiptInitiationSource {
+  PURCHASE = "purchase",
+  RESTORE = "restore",
 }

--- a/src/tests/amazon/amazon-billing-wrapper.test.ts
+++ b/src/tests/amazon/amazon-billing-wrapper.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-const { getProductData, notifyFulfillment, purchase } = vi.hoisted(() => ({
-  getProductData: vi.fn(),
-  notifyFulfillment: vi.fn(),
-  purchase: vi.fn(),
-}));
+const { getProductData, getPurchaseUpdates, notifyFulfillment, purchase } =
+  vi.hoisted(() => ({
+    getProductData: vi.fn(),
+    getPurchaseUpdates: vi.fn(),
+    notifyFulfillment: vi.fn(),
+    purchase: vi.fn(),
+  }));
 
 vi.mock("@amazon-devices/keplerscript-appstore-iap-lib", () => ({
   FulfillmentResult: { FULFILLED: 1 },
@@ -25,12 +27,22 @@ vi.mock("@amazon-devices/keplerscript-appstore-iap-lib", () => ({
     NOT_SUPPORTED: 3,
     FAILED: 4,
   },
+  PurchaseUpdatesResponseCode: {
+    SUCCESSFUL: 1,
+    NOT_SUPPORTED: 2,
+    FAILED: 3,
+  },
   ProductType: {
     CONSUMABLE: 1,
     ENTITLED: 2,
     SUBSCRIPTION: 3,
   },
-  PurchasingService: { getProductData, notifyFulfillment, purchase },
+  PurchasingService: {
+    getProductData,
+    getPurchaseUpdates,
+    notifyFulfillment,
+    purchase,
+  },
 }));
 
 import {
@@ -41,6 +53,7 @@ import {
   ProductDataResponseCode,
   type PurchaseResponse,
   PurchaseResponseCode,
+  PurchaseUpdatesResponseCode,
   ProductType,
 } from "@amazon-devices/keplerscript-appstore-iap-lib";
 import { AmazonBillingWrapper } from "../../amazon/amazon-billing-wrapper";
@@ -112,14 +125,37 @@ const successfulPurchaseResponse = (): PurchaseResponse => ({
   },
 });
 
+const successfulPurchaseUpdatesResponse = (
+  receiptId = "amazon-receipt-id",
+) => ({
+  receiptList: [
+    {
+      ...successfulPurchaseResponse().receipt,
+      receiptId,
+    },
+  ],
+  responseCode: 1,
+  userData: successfulPurchaseResponse().userData,
+  hasMore: false,
+});
+
+const purchaseUpdatesResponse = (
+  overrides: Partial<ReturnType<typeof successfulPurchaseUpdatesResponse>> = {},
+) => ({
+  ...successfulPurchaseUpdatesResponse(),
+  ...overrides,
+});
+
 const createBackend = () =>
   ({
+    getCustomerInfo: vi.fn().mockResolvedValue(customerInfoResponse),
     postReceipt: vi.fn(),
   }) as unknown as Backend;
 
 describe("AmazonBillingWrapper", () => {
   beforeEach(() => {
     getProductData.mockReset();
+    getPurchaseUpdates.mockReset();
     notifyFulfillment.mockReset();
     purchase.mockReset();
     vi.restoreAllMocks();
@@ -285,6 +321,256 @@ describe("AmazonBillingWrapper", () => {
           "An error occurred when fetching product data. An unrecognized ProductDataResponseCode was received.",
       } satisfies Partial<PurchasesError>);
     });
+  });
+
+  describe("purchase syncing", () => {
+    test.each([
+      ["syncPurchases", false],
+      ["restorePurchases", true],
+    ] as const)(
+      "%s requests the complete Amazon purchase history",
+      async (method) => {
+        const backend = createBackend();
+        vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
+        getPurchaseUpdates.mockResolvedValue(
+          successfulPurchaseUpdatesResponse(),
+        );
+
+        await new AmazonBillingWrapper(backend)[method]("app-user-id");
+
+        expect(getPurchaseUpdates).toHaveBeenCalledExactlyOnceWith({
+          reset: true,
+        });
+      },
+    );
+
+    test("does not post a receipt more than once during the wrapper lifetime", async () => {
+      const backend = createBackend();
+      vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
+      getPurchaseUpdates.mockResolvedValue(successfulPurchaseUpdatesResponse());
+      const wrapper = new AmazonBillingWrapper(backend);
+
+      await wrapper.syncPurchases("app-user-id");
+      await wrapper.syncPurchases("app-user-id");
+      await wrapper.restorePurchases("app-user-id");
+
+      expect(backend.postReceipt).toHaveBeenCalledExactlyOnceWith(
+        "app-user-id",
+        "monthly",
+        null,
+        "amazon-receipt-id",
+        null,
+        "restore",
+        undefined,
+        "amazon-store-user-id",
+        false,
+      );
+      expect(backend.getCustomerInfo).toHaveBeenCalledTimes(2);
+      expect(backend.getCustomerInfo).toHaveBeenNthCalledWith(1, "app-user-id");
+      expect(backend.getCustomerInfo).toHaveBeenNthCalledWith(2, "app-user-id");
+    });
+
+    test.each([
+      ["syncPurchases", false],
+      ["restorePurchases", true],
+    ] as const)(
+      "%s posts every receipt across paginated responses",
+      async (method, isRestore) => {
+        const backend = createBackend();
+        vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
+        getPurchaseUpdates
+          .mockResolvedValueOnce(
+            purchaseUpdatesResponse({
+              hasMore: true,
+              receiptList: [
+                {
+                  ...successfulPurchaseResponse().receipt,
+                  receiptId: "first-receipt",
+                  productType: ProductType.SUBSCRIPTION,
+                  termSku: "monthly",
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            purchaseUpdatesResponse({
+              hasMore: false,
+              receiptList: [
+                {
+                  ...successfulPurchaseResponse().receipt,
+                  receiptId: "second-receipt",
+                  productType: ProductType.CONSUMABLE,
+                  sku: "coin-pack",
+                  termSku: "unused-term-sku",
+                },
+              ],
+            }),
+          );
+
+        await new AmazonBillingWrapper(backend)[method]("app-user-id");
+
+        expect(getPurchaseUpdates).toHaveBeenCalledTimes(2);
+        expect(getPurchaseUpdates).toHaveBeenNthCalledWith(1, { reset: true });
+        expect(getPurchaseUpdates).toHaveBeenNthCalledWith(2, { reset: true });
+        expect(backend.postReceipt).toHaveBeenNthCalledWith(
+          1,
+          "app-user-id",
+          "monthly",
+          null,
+          "first-receipt",
+          null,
+          "restore",
+          undefined,
+          "amazon-store-user-id",
+          isRestore,
+        );
+        expect(backend.postReceipt).toHaveBeenNthCalledWith(
+          2,
+          "app-user-id",
+          "coin-pack",
+          null,
+          "second-receipt",
+          null,
+          "restore",
+          undefined,
+          "amazon-store-user-id",
+          isRestore,
+        );
+      },
+    );
+
+    test.each([
+      ["syncPurchases", false],
+      ["restorePurchases", true],
+    ] as const)(
+      "%s fetches customer info when no receipts are returned",
+      async (method) => {
+        const backend = createBackend();
+        getPurchaseUpdates.mockResolvedValue(
+          purchaseUpdatesResponse({ receiptList: [] }),
+        );
+
+        await new AmazonBillingWrapper(backend)[method]("app-user-id");
+
+        expect(backend.postReceipt).not.toHaveBeenCalled();
+        expect(backend.getCustomerInfo).toHaveBeenCalledExactlyOnceWith(
+          "app-user-id",
+        );
+      },
+    );
+
+    test.each(["syncPurchases", "restorePurchases"] as const)(
+      "%s stops when Amazon reports more pages but returns an empty page",
+      async (method) => {
+        const backend = createBackend();
+        getPurchaseUpdates.mockResolvedValue(
+          purchaseUpdatesResponse({ hasMore: true, receiptList: [] }),
+        );
+
+        await new AmazonBillingWrapper(backend)[method]("app-user-id");
+
+        expect(getPurchaseUpdates).toHaveBeenCalledExactlyOnceWith({
+          reset: true,
+        });
+        expect(backend.getCustomerInfo).toHaveBeenCalledExactlyOnceWith(
+          "app-user-id",
+        );
+      },
+    );
+
+    test.each(["syncPurchases", "restorePurchases"] as const)(
+      "%s does not mark a receipt as synced when posting it fails",
+      async (method) => {
+        const backend = createBackend();
+        const error = new Error("backend unavailable");
+        vi.mocked(backend.postReceipt)
+          .mockRejectedValueOnce(error)
+          .mockResolvedValueOnce(customerInfoResponse);
+        getPurchaseUpdates.mockResolvedValue(
+          successfulPurchaseUpdatesResponse(),
+        );
+        const wrapper = new AmazonBillingWrapper(backend);
+
+        await expect(wrapper[method]("app-user-id")).rejects.toBe(error);
+        await wrapper[method]("app-user-id");
+
+        expect(backend.postReceipt).toHaveBeenCalledTimes(2);
+      },
+    );
+
+    test.each([
+      [
+        "syncPurchases",
+        PurchaseUpdatesResponseCode.NOT_SUPPORTED,
+        ErrorCode.UnsupportedError,
+        "Syncing purchases is not supported.",
+      ],
+      [
+        "restorePurchases",
+        PurchaseUpdatesResponseCode.NOT_SUPPORTED,
+        ErrorCode.UnsupportedError,
+        "Restoring purchases is not supported.",
+      ],
+      [
+        "syncPurchases",
+        PurchaseUpdatesResponseCode.FAILED,
+        ErrorCode.StoreProblemError,
+        "Syncing purchases with the Amazon Store failed.",
+      ],
+      [
+        "restorePurchases",
+        PurchaseUpdatesResponseCode.FAILED,
+        ErrorCode.StoreProblemError,
+        "Restoring purchases with the Amazon Store failed.",
+      ],
+      [
+        "syncPurchases",
+        999 as PurchaseUpdatesResponseCode,
+        ErrorCode.StoreProblemError,
+        "Received an unexpected response code from the Amazon Store while syncing purchases.",
+      ],
+      [
+        "restorePurchases",
+        999 as PurchaseUpdatesResponseCode,
+        ErrorCode.StoreProblemError,
+        "Received an unexpected response code from the Amazon Store while restoring purchases.",
+      ],
+    ] as const)(
+      "%s maps response code %s to an error",
+      async (method, responseCode, errorCode, message) => {
+        const backend = createBackend();
+        getPurchaseUpdates.mockResolvedValue(
+          purchaseUpdatesResponse({ responseCode }),
+        );
+
+        await expect(
+          new AmazonBillingWrapper(backend)[method]("app-user-id"),
+        ).rejects.toMatchObject({ errorCode, message });
+
+        expect(backend.postReceipt).not.toHaveBeenCalled();
+        expect(backend.getCustomerInfo).not.toHaveBeenCalled();
+      },
+    );
+
+    test.each(["syncPurchases", "restorePurchases"] as const)(
+      "%s wraps an error thrown by Amazon in a PurchasesError",
+      async (method) => {
+        const backend = createBackend();
+        const error = new Error("Amazon IAP unavailable");
+        getPurchaseUpdates.mockRejectedValue(error);
+
+        await expect(
+          new AmazonBillingWrapper(backend)[method]("app-user-id"),
+        ).rejects.toMatchObject({
+          errorCode: ErrorCode.StoreProblemError,
+          message: `${method === "restorePurchases" ? "Restoring" : "Syncing"} purchases with the Amazon Store failed.`,
+          underlyingErrorMessage: "Amazon IAP unavailable",
+        });
+
+        expect(backend.postReceipt).not.toHaveBeenCalled();
+        expect(backend.getCustomerInfo).not.toHaveBeenCalled();
+      },
+    );
   });
 
   describe("purchases", () => {
@@ -470,23 +756,24 @@ describe("AmazonBillingWrapper", () => {
     test.each([
       [
         NotifyFulfillmentResponseCode.NOT_SUPPORTED,
+        "warnLog",
         "Failed to fulfill receipt ID amazon-receipt-id with the Amazon Store: fulfillment is not supported.",
       ],
       [
         NotifyFulfillmentResponseCode.FAILED,
+        "errorLog",
         "Failed to fulfill receipt ID amazon-receipt-id with the Amazon Store.",
       ],
       [
         999 as NotifyFulfillmentResponseCode,
+        "warnLog",
         "Received an unexpected response code from Amazon when fulfilling receipt ID amazon-receipt-id.",
       ],
     ])(
       "returns a completed purchase and logs fulfillment response %s",
-      async (responseCode, expectedWarning) => {
+      async (responseCode, logMethod, expectedLog) => {
         const backend = createBackend();
-        const warningLog = vi
-          .spyOn(Logger, "warnLog")
-          .mockImplementation(() => {});
+        const log = vi.spyOn(Logger, logMethod).mockImplementation(() => {});
         vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
         notifyFulfillment.mockResolvedValue({ responseCode });
 
@@ -498,7 +785,7 @@ describe("AmazonBillingWrapper", () => {
         ).resolves.toMatchObject({ operationSessionId: "amazon-receipt-id" });
 
         expect(notifyFulfillment).toHaveBeenCalledOnce();
-        expect(warningLog).toHaveBeenCalledWith(expectedWarning);
+        expect(log).toHaveBeenCalledWith(expectedLog);
       },
     );
 

--- a/src/tests/amazon/amazon-billing-wrapper.test.ts
+++ b/src/tests/amazon/amazon-billing-wrapper.test.ts
@@ -408,7 +408,7 @@ describe("AmazonBillingWrapper", () => {
 
         expect(getPurchaseUpdates).toHaveBeenCalledTimes(2);
         expect(getPurchaseUpdates).toHaveBeenNthCalledWith(1, { reset: true });
-        expect(getPurchaseUpdates).toHaveBeenNthCalledWith(2, { reset: true });
+        expect(getPurchaseUpdates).toHaveBeenNthCalledWith(2, { reset: false });
         expect(backend.postReceipt).toHaveBeenNthCalledWith(
           1,
           "app-user-id",

--- a/src/tests/amazon/amazon-billing-wrapper.test.ts
+++ b/src/tests/amazon/amazon-billing-wrapper.test.ts
@@ -324,10 +324,7 @@ describe("AmazonBillingWrapper", () => {
   });
 
   describe("purchase syncing", () => {
-    test.each([
-      ["syncPurchases", false],
-      ["restorePurchases", true],
-    ] as const)(
+    test.each([["syncPurchases"], ["restorePurchases"]] as const)(
       "%s requests the complete Amazon purchase history",
       async (method) => {
         const backend = createBackend();
@@ -439,10 +436,7 @@ describe("AmazonBillingWrapper", () => {
       },
     );
 
-    test.each([
-      ["syncPurchases", false],
-      ["restorePurchases", true],
-    ] as const)(
+    test.each([["syncPurchases"], ["restorePurchases"]] as const)(
       "%s fetches customer info when no receipts are returned",
       async (method) => {
         const backend = createBackend();
@@ -673,7 +667,7 @@ describe("AmazonBillingWrapper", () => {
         ErrorCode.StoreProblemError,
         "Amazon purchase failed",
       ],
-    ])(
+    ] as const)(
       "maps Amazon purchase response code %s to the appropriate error",
       async (responseCode, errorCode, message) => {
         const backend = createBackend();
@@ -753,7 +747,7 @@ describe("AmazonBillingWrapper", () => {
       expect(notifyFulfillment).not.toHaveBeenCalled();
     });
 
-    test.each([
+    test.each<[NotifyFulfillmentResponseCode, "warnLog" | "errorLog", string]>([
       [
         NotifyFulfillmentResponseCode.NOT_SUPPORTED,
         "warnLog",
@@ -773,7 +767,11 @@ describe("AmazonBillingWrapper", () => {
       "returns a completed purchase and logs fulfillment response %s",
       async (responseCode, logMethod, expectedLog) => {
         const backend = createBackend();
-        const log = vi.spyOn(Logger, logMethod).mockImplementation(() => {});
+        const log =
+          logMethod === "warnLog"
+            ? vi.spyOn(Logger, "warnLog")
+            : vi.spyOn(Logger, "errorLog");
+        log.mockImplementation(() => {});
         vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
         notifyFulfillment.mockResolvedValue({ responseCode });
 

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -379,6 +379,88 @@ describe("billing wrapper selection", () => {
   });
 });
 
+describe("Purchases.syncPurchases and Purchases.restorePurchases", () => {
+  test.each([
+    ["syncPurchases", "syncPurchases"],
+    ["restorePurchases", "restorePurchases"],
+  ] as const)(
+    "%s delegates to the Amazon billing wrapper for Amazon API keys",
+    async (method, wrapperMethod) => {
+      const purchases = configurePurchases(
+        testUserId,
+        "rcSource",
+        "amzn_valid_key",
+      );
+      const expectedResult = { customerInfo: {} as CustomerInfo };
+      const syncPurchasesSpy = vi
+        .spyOn(AmazonBillingWrapper.prototype, "syncPurchases")
+        .mockResolvedValue(expectedResult);
+      const restorePurchasesSpy = vi
+        .spyOn(AmazonBillingWrapper.prototype, "restorePurchases")
+        .mockResolvedValue(expectedResult);
+
+      await expect(purchases[method]()).resolves.toBe(expectedResult);
+
+      const expectedSpy =
+        wrapperMethod === "syncPurchases"
+          ? syncPurchasesSpy
+          : restorePurchasesSpy;
+      const otherSpy =
+        wrapperMethod === "syncPurchases"
+          ? restorePurchasesSpy
+          : syncPurchasesSpy;
+      expect(expectedSpy).toHaveBeenCalledExactlyOnceWith(testUserId);
+      expect(otherSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(["syncPurchases", "restorePurchases"] as const)(
+    "%s rejects for non-Amazon API keys without calling the Amazon wrapper",
+    async (method) => {
+      const purchases = configurePurchases();
+      const syncPurchasesSpy = vi.spyOn(
+        AmazonBillingWrapper.prototype,
+        "syncPurchases",
+      );
+      const restorePurchasesSpy = vi.spyOn(
+        AmazonBillingWrapper.prototype,
+        "restorePurchases",
+      );
+
+      await expect(purchases[method]()).rejects.toMatchObject({
+        errorCode: ErrorCode.ConfigurationError,
+        message: `${method}() is only supported for Amazon Appstore API keys.`,
+      });
+
+      expect(syncPurchasesSpy).not.toHaveBeenCalled();
+      expect(restorePurchasesSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    ["syncPurchases", "syncPurchases"],
+    ["restorePurchases", "restorePurchases"],
+  ] as const)(
+    "%s propagates errors from the Amazon billing wrapper",
+    async (method, wrapperMethod) => {
+      const purchases = configurePurchases(
+        testUserId,
+        "rcSource",
+        "amzn_valid_key",
+      );
+      const error = new PurchasesError(
+        ErrorCode.StoreProblemError,
+        "Amazon unavailable",
+      );
+      vi.spyOn(AmazonBillingWrapper.prototype, wrapperMethod).mockRejectedValue(
+        error,
+      );
+
+      await expect(purchases[method]()).rejects.toBe(error);
+    },
+  );
+});
+
 describe("Purchases.isConfigured()", () => {
   test("returns false if not configured", () => {
     expect(Purchases.isConfigured()).toBeFalsy();

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -1647,6 +1647,25 @@ describe("postReceipt request", () => {
     expect(result).toEqual(customerInfoResponse);
   });
 
+  test("posts a null currency when provided", async () => {
+    setPostReceiptResponse(
+      HttpResponse.json(customerInfoResponse, { status: 200 }),
+    );
+
+    await backend.postReceipt(
+      "someAppUserId",
+      "monthly",
+      null,
+      "test_fetch_token",
+      null,
+      "restore",
+    );
+
+    const request = postReceiptAPIMock.mock.calls[0][0].request;
+    const requestBody = await request.json();
+    expect(requestBody.currency).toBeNull();
+  });
+
   test("includes targeting context when provided", async () => {
     setPostReceiptResponse(
       HttpResponse.json(customerInfoResponse, { status: 200 }),
@@ -1686,6 +1705,35 @@ describe("postReceipt request", () => {
     });
 
     expect(result).toEqual(customerInfoResponse);
+  });
+
+  test("uses null offering context fields when no offering context is provided", async () => {
+    setPostReceiptResponse(
+      HttpResponse.json(customerInfoResponse, { status: 200 }),
+    );
+
+    await backend.postReceipt(
+      "someAppUserId",
+      "monthly",
+      "EUR",
+      "test_fetch_token",
+      null,
+      "restore",
+    );
+
+    const request = postReceiptAPIMock.mock.calls[0][0].request;
+    const requestBody = await request.json();
+    expect(requestBody).toMatchObject({
+      fetch_token: "test_fetch_token",
+      product_id: "monthly",
+      currency: "EUR",
+      app_user_id: "someAppUserId",
+      presented_offering_identifier: null,
+      presented_placement_identifier: null,
+      applied_targeting_rule: null,
+      initiation_source: "restore",
+    });
+    expect(requestBody).not.toHaveProperty("presented_workflow_id");
   });
 
   test("handles placement identifier correctly", async () => {

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -11,7 +11,7 @@ import {
   getVirtualCurrenciesResponseWith3Currencies,
   getVirtualCurrenciesResponseWithNoCurrencies,
 } from "../test-responses";
-import { Backend } from "../../networking/backend";
+import { Backend, PostReceiptInitiationSource } from "../../networking/backend";
 import { StatusCodes } from "http-status-codes";
 import {
   BackendErrorCode,
@@ -1621,7 +1621,7 @@ describe("postReceipt request", () => {
         targetingContext: null,
         placementIdentifier: null,
       },
-      "restore",
+      PostReceiptInitiationSource.RESTORE,
       undefined,
       "amazon_store_user_id",
     );
@@ -1658,7 +1658,7 @@ describe("postReceipt request", () => {
       null,
       "test_fetch_token",
       null,
-      "restore",
+      PostReceiptInitiationSource.RESTORE,
     );
 
     const request = postReceiptAPIMock.mock.calls[0][0].request;
@@ -1684,7 +1684,7 @@ describe("postReceipt request", () => {
         },
         placementIdentifier: "placement_1",
       },
-      "purchase",
+      PostReceiptInitiationSource.PURCHASE,
     );
 
     expect(postReceiptAPIMock).toHaveBeenCalledTimes(1);
@@ -1718,7 +1718,7 @@ describe("postReceipt request", () => {
       "EUR",
       "test_fetch_token",
       null,
-      "restore",
+      PostReceiptInitiationSource.RESTORE,
     );
 
     const request = postReceiptAPIMock.mock.calls[0][0].request;
@@ -1751,7 +1751,7 @@ describe("postReceipt request", () => {
         targetingContext: null,
         placementIdentifier: "home_screen",
       },
-      "purchase",
+      PostReceiptInitiationSource.PURCHASE,
     );
 
     const request = postReceiptAPIMock.mock.calls[0][0].request;
@@ -1778,7 +1778,7 @@ describe("postReceipt request", () => {
         targetingContext: null,
         placementIdentifier: null,
       },
-      "purchase",
+      PostReceiptInitiationSource.PURCHASE,
     );
 
     const request = postReceiptAPIMock.mock.calls[0][0].request;
@@ -1801,7 +1801,7 @@ describe("postReceipt request", () => {
         targetingContext: null,
         placementIdentifier: null,
       },
-      "purchase",
+      PostReceiptInitiationSource.PURCHASE,
     );
 
     const request = postReceiptAPIMock.mock.calls[0][0].request;
@@ -1824,7 +1824,7 @@ describe("postReceipt request", () => {
           targetingContext: null,
           placementIdentifier: null,
         },
-        "restore",
+        PostReceiptInitiationSource.RESTORE,
       ),
       new PurchasesError(
         ErrorCode.UnknownBackendError,
@@ -1855,7 +1855,7 @@ describe("postReceipt request", () => {
           targetingContext: null,
           placementIdentifier: null,
         },
-        "restore",
+        PostReceiptInitiationSource.RESTORE,
       ),
       new PurchasesError(
         ErrorCode.InvalidCredentialsError,
@@ -1878,7 +1878,7 @@ describe("postReceipt request", () => {
           targetingContext: null,
           placementIdentifier: null,
         },
-        "restore",
+        PostReceiptInitiationSource.RESTORE,
       ),
       new PurchasesError(
         ErrorCode.NetworkError,
@@ -1909,7 +1909,7 @@ describe("postReceipt request", () => {
           targetingContext: null,
           placementIdentifier: null,
         },
-        "restore",
+        PostReceiptInitiationSource.RESTORE,
       ),
       new PurchasesError(
         ErrorCode.InvalidReceiptError,

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,6 +9,15 @@ const __dirname = dirname(__filename);
 
 export default defineConfig({
   build: {
+    // Metro transforms `await of(...)` into `yield of(...)`, which the Vega
+    // Hermes compiler cannot parse. Keep identifier mangling enabled, but do
+    // not let it rename an async helper to the contextual `of` identifier.
+    minify: "terser",
+    terserOptions: {
+      mangle: {
+        reserved: ["of"],
+      },
+    },
     lib: {
       entry: resolve(__dirname, "src/main.ts"),
       name: "Purchases",


### PR DESCRIPTION
## Changes introduced
This PR introduces `restorePurchases()` and `syncPurchases()` to the `purchases-js` SDK.

The most notable difference from their mobile counterparts is that the SDK doesn't persist synced IDs across app launches; instead, it caches them in-memory. This is to avoid adding a dependency on `@amazon-devices/react-native-async-storage__async-storage`, which is recommended to persist items on-disk for Vega OS apps.

The PR introduces unit tests for these functions. We'll add them to the purchase tester in a follow-up PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches receipt posting and restore/alias behavior for Amazon users. Logic is store-specific and gated to Amazon API keys, with unit tests covering pagination and errors.
> 
> **Overview**
> Adds public `restorePurchases()` and `syncPurchases()` on the JS SDK for Amazon Appstore (Vega). Both paginate Amazon purchase history, post receipts to RevenueCat, and return `CustomerInfo`. Non-Amazon API keys throw a configuration error.
> 
> Restore vs sync is distinguished via `is_restore` on `postReceipt`. Synced receipt IDs are cached **in memory only** for the wrapper lifetime (no on-device persistence). `postReceipt` now accepts nullable currency/offering context and a typed `PostReceiptInitiationSource`.
> 
> Also reserves the `of` identifier in Terser so Vega/Hermes does not break on mangled async helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b7fcad958ad49c6ed53dcd54dca808e5e53869b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->