### PR TITLE
WEB-4597 Allow runtime purchase appearance overrides

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -4538,6 +4538,47 @@
           "members": [
             {
               "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentPaywallParams#brandingAppearanceOverride:member",
+              "docComment": "/**\n * Overrides the branding appearance for the purchase started from this paywall. Only the provided values are overridden. These values take precedence over the override passed to `Purchases.configure()`.\n *\n * For Stripe Checkout, this customizes the supported mobile wallet experience. The Stripe-hosted fallback opened through \"Pay another way\" remains light and cannot currently be customized.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly brandingAppearanceOverride?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Partial",
+                  "canonicalReference": "!Partial:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "BrandingAppearance",
+                  "canonicalReference": "@revenuecat/purchases-js!BrandingAppearance:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ">"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "brandingAppearanceOverride",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 5
+              }
+            },
+            {
+              "kind": "PropertySignature",
               "canonicalReference": "@revenuecat/purchases-js!PresentPaywallParams#customerEmail:member",
               "docComment": "/**\n * The email of the customer starting the purchase. If passed the checkout flow will not ask for it to the customer.\n */\n",
               "excerptTokens": [
@@ -6147,6 +6188,47 @@
           "name": "PurchaseParams",
           "preserveMemberOrder": false,
           "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PurchaseParams#brandingAppearanceOverride:member",
+              "docComment": "/**\n * Overrides the Dashboard branding appearance for this purchase. Only the provided values are overridden; all other values keep their Dashboard configuration.\n *\n * For Stripe Checkout, this customizes the supported mobile wallet experience. The Stripe-hosted fallback opened through \"Pay another way\" remains light and cannot currently be customized.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "brandingAppearanceOverride?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Partial",
+                  "canonicalReference": "!Partial:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "BrandingAppearance",
+                  "canonicalReference": "@revenuecat/purchases-js!BrandingAppearance:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ">"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "brandingAppearanceOverride",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 5
+              }
+            },
             {
               "kind": "PropertySignature",
               "canonicalReference": "@revenuecat/purchases-js!PurchaseParams#customerEmail:member",
@@ -8078,6 +8160,47 @@
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PurchasesConfig#brandingAppearanceOverride:member",
+              "docComment": "/**\n * Overrides the Dashboard branding appearance for purchases created by this instance, including purchases started through {@link Purchases.presentPaywall}. Only the provided values are overridden. A value passed directly to {@link PurchaseParams.brandingAppearanceOverride} takes precedence for that purchase.\n *\n * For Stripe Checkout, this customizes the supported mobile wallet experience. The Stripe-hosted fallback opened through \"Pay another way\" remains light and cannot currently be customized.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "brandingAppearanceOverride?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Partial",
+                  "canonicalReference": "!Partial:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<"
+                },
+                {
+                  "kind": "Reference",
+                  "text": "BrandingAppearance",
+                  "canonicalReference": "@revenuecat/purchases-js!BrandingAppearance:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ">"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "brandingAppearanceOverride",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 5
               }
             },
             {

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -331,6 +331,7 @@ export interface PresentExpressPurchaseButtonParams {
 
 // @public
 export interface PresentPaywallParams {
+    readonly brandingAppearanceOverride?: Partial<BrandingAppearance>;
     readonly customerEmail?: string;
     readonly customVariables?: CustomVariables;
     readonly discountCode?: string;
@@ -423,6 +424,7 @@ export interface PurchaseOption {
 
 // @public
 export interface PurchaseParams {
+    brandingAppearanceOverride?: Partial<BrandingAppearance>;
     customerEmail?: string;
     defaultLocale?: string;
     discountCode?: string;
@@ -456,6 +458,7 @@ export class Purchases {
     /* Excluded from this release type: _loadingResourcesPromise */
     /* Excluded from this release type: _flags */
     /* Excluded from this release type: _subscriberToken */
+    /* Excluded from this release type: _brandingAppearanceOverride */
     /* Excluded from this release type: _context */
     /* Excluded from this release type: backend */
     /* Excluded from this release type: purchaseOperationHelper */
@@ -504,6 +507,7 @@ export class Purchases {
 export interface PurchasesConfig {
     apiKey: string;
     appUserId: string;
+    brandingAppearanceOverride?: Partial<BrandingAppearance>;
     flags?: FlagsConfig;
     httpConfig?: HttpConfig;
     /* Excluded from this release type: subscriberToken */

--- a/examples/webbilling-demo/README.md
+++ b/examples/webbilling-demo/README.md
@@ -157,3 +157,7 @@ Before a paywall will appear, you need an offering configured in the [RevenueCat
 4. Click **"Continue (RC Paywall)"** to view the RC paywall
 
 If you see a blank page or "No offering found!", check that your offering is set as the **default offering** in the dashboard (or that the identifier you entered is correct) and has a paywall configured.
+
+### Testing runtime appearance overrides
+
+From the login page, select **Runtime appearance demo**. The page configures Purchases with a purple and lavender palette, then lets you compare that baseline with a green and peach override passed to either `purchase()` or `presentPaywall()`.

--- a/examples/webbilling-demo/src/App.css
+++ b/examples/webbilling-demo/src/App.css
@@ -464,12 +464,167 @@ button.button:focus-visible {
 
 .button-group {
   display: flex;
+  flex-wrap: wrap;
   gap: 16px;
   margin-top: 16px;
 }
 
 .button-group button {
+  flex: 1 1 220px;
+}
+
+.appearance-demo {
+  box-sizing: border-box;
+  min-height: 100vh;
+  padding: 72px 32px;
+  background: var(--color-page-muted);
+  color: var(--color-text-strong);
+}
+
+.appearance-demo--empty {
+  text-align: center;
+}
+
+.appearance-demo__header,
+.appearance-demo__palettes,
+.appearance-demo__controls {
+  width: min(100%, 920px);
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.appearance-demo__header {
+  text-align: center;
+}
+
+.appearance-demo__eyebrow {
+  display: inline-block;
+  margin-bottom: 12px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--color-shade-1);
+  color: var(--color-text-strong);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.appearance-demo__header h1 {
+  margin-bottom: 16px;
+  color: var(--color-purple);
+  font-size: clamp(36px, 7vw, 58px);
+  line-height: 1.08;
+}
+
+.appearance-demo__header p {
+  max-width: 720px;
+  margin: 0 auto;
+  color: var(--color-text-muted);
+  font-size: 17px;
+}
+
+.appearance-demo__palettes,
+.appearance-demo__flow-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.appearance-demo__palettes {
+  margin-top: 36px;
+}
+
+.appearance-demo__palette-card,
+.appearance-demo__flow-card,
+.appearance-demo__controls {
+  border: 1px solid var(--color-grey-ui-dark);
+  border-radius: 20px;
+  background: var(--color-page-surface);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
+}
+
+.appearance-demo__palette-card,
+.appearance-demo__flow-card {
+  padding: 24px;
+}
+
+.appearance-demo__palette-card h2,
+.appearance-demo__flow-card h2 {
+  margin: 18px 0 8px;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.appearance-demo__palette-card p,
+.appearance-demo__flow-card p {
+  color: var(--color-text-muted);
+  font-size: 14px;
+}
+
+.appearance-demo__swatches {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  height: 52px;
+  overflow: hidden;
+  border: 1px solid var(--color-grey-ui-dark);
+  border-radius: 12px;
+}
+
+.appearance-demo__controls {
+  box-sizing: border-box;
+  margin-top: 20px;
+  padding: 28px;
+}
+
+.appearance-demo__controls > label {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.appearance-demo__controls > select {
+  margin-bottom: 24px;
+}
+
+.appearance-demo__flow-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: none;
+}
+
+.appearance-demo__flow-card h2,
+.appearance-demo__flow-card p {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.appearance-demo__flow-card p {
   flex: 1;
+  margin-bottom: 8px;
+}
+
+.appearance-demo__flow-card button:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+.appearance-demo__status {
+  margin-top: 22px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: var(--color-page-muted);
+  font-size: 14px;
+}
+
+.appearance-demo__status--success {
+  background: var(--color-green);
+}
+
+.appearance-demo__status--error {
+  color: var(--color-danger);
 }
 
 @media (max-width: 1300px) {
@@ -559,6 +714,19 @@ button.button:focus-visible {
 }
 
 @media (max-width: 600px) {
+  .appearance-demo {
+    padding: 64px 16px 32px;
+  }
+
+  .appearance-demo__palettes,
+  .appearance-demo__flow-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .appearance-demo__controls {
+    padding: 18px;
+  }
+
   .rc-paywall h1 {
     margin-top: 2rem;
     margin-bottom: 3rem;

--- a/examples/webbilling-demo/src/App.tsx
+++ b/examples/webbilling-demo/src/App.tsx
@@ -12,6 +12,7 @@ import PaywallPage from "./pages/paywall";
 import SuccessPage from "./pages/success";
 import {
   loadPurchases,
+  loadPurchasesWithAppearanceOverride,
   loadPurchasesWithDelayedStore,
 } from "./util/PurchasesLoader";
 import RCPaywallPage from "./pages/rc_paywall";
@@ -24,6 +25,7 @@ import ExpressPurchaseButtonsPackageSelector from "./pages/express_purchase_butt
 import RCPaywallSettingsPage from "./pages/rc_paywall_settings";
 import UpgradePage from "./pages/upgrade";
 import UpgradePaywallPage from "./pages/upgrade_paywall";
+import AppearanceOverridesPage from "./pages/appearance_overrides";
 
 const router = createBrowserRouter([
   {
@@ -48,6 +50,11 @@ const router = createBrowserRouter([
         <PaywallPage />
       </WithoutEntitlement>
     ),
+  },
+  {
+    path: "/appearance-overrides/:app_user_id",
+    loader: loadPurchasesWithAppearanceOverride,
+    element: <AppearanceOverridesPage />,
   },
   {
     path: "/rc_paywall/:app_user_id",

--- a/examples/webbilling-demo/src/pages/appearance_overrides/index.tsx
+++ b/examples/webbilling-demo/src/pages/appearance_overrides/index.tsx
@@ -107,7 +107,9 @@ const AppearanceOverridesPage = () => {
       <LogoutButton />
 
       <header className="appearance-demo__header">
-        <span className="appearance-demo__eyebrow">WEB-4597 demo</span>
+        <span className="appearance-demo__eyebrow">
+          Appearance Override demo
+        </span>
         <h1>Runtime appearance overrides</h1>
         <p>
           Compare the Dashboard/default appearance with colors stored when

--- a/examples/webbilling-demo/src/pages/appearance_overrides/index.tsx
+++ b/examples/webbilling-demo/src/pages/appearance_overrides/index.tsx
@@ -1,0 +1,220 @@
+import type { Package } from "@revenuecat/purchases-js";
+import { useState } from "react";
+import LogoutButton from "../../components/LogoutButton";
+import { usePurchasesLoaderData } from "../../util/PurchasesLoader";
+import {
+  configuredAppearanceOverride,
+  operationAppearanceOverride,
+} from "../../util/runtime-appearance-overrides";
+
+type DemoStatus = {
+  kind: "idle" | "running" | "success" | "error";
+  message: string;
+};
+
+const getErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : String(error);
+
+const AppearanceOverridesPage = () => {
+  const { purchases, offering } = usePurchasesLoaderData();
+  const packages =
+    offering?.availablePackages.filter((pkg) => pkg.webBillingProduct) ?? [];
+  const [selectedPackageId, setSelectedPackageId] = useState(
+    packages[0]?.identifier ?? "",
+  );
+  const [status, setStatus] = useState<DemoStatus>({
+    kind: "idle",
+    message: "Choose a flow to open checkout.",
+  });
+
+  const selectedPackage = packages.find(
+    (pkg) => pkg.identifier === selectedPackageId,
+  );
+  const isRunning = status.kind === "running";
+
+  const runFlow = async (label: string, operation: () => Promise<unknown>) => {
+    setStatus({ kind: "running", message: `Opening ${label}…` });
+
+    try {
+      await operation();
+      setStatus({ kind: "success", message: `${label} completed.` });
+    } catch (error) {
+      setStatus({
+        kind: "error",
+        message: `${label} closed or failed: ${getErrorMessage(error)}`,
+      });
+    }
+  };
+
+  const purchase = (pkg: Package, useOperationOverride: boolean) =>
+    runFlow(
+      useOperationOverride ? "per-purchase checkout" : "configured checkout",
+      () =>
+        purchases.purchase({
+          rcPackage: pkg,
+          ...(useOperationOverride
+            ? { brandingAppearanceOverride: operationAppearanceOverride }
+            : {}),
+        }),
+    );
+
+  const presentPaywall = (useOperationOverride: boolean) => {
+    if (!offering) return Promise.resolve();
+
+    return runFlow(
+      useOperationOverride
+        ? "presentPaywall-time paywall"
+        : "configured paywall",
+      () =>
+        purchases.presentPaywall({
+          offering,
+          ...(useOperationOverride
+            ? { brandingAppearanceOverride: operationAppearanceOverride }
+            : {}),
+        }),
+    );
+  };
+
+  if (!offering || !packages.length || !selectedPackage) {
+    return (
+      <main className="appearance-demo appearance-demo--empty">
+        <LogoutButton />
+        <h1>Runtime appearance overrides</h1>
+        <p>
+          This page needs an offering with at least one purchasable package.
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="appearance-demo">
+      <LogoutButton />
+
+      <header className="appearance-demo__header">
+        <span className="appearance-demo__eyebrow">WEB-4597 demo</span>
+        <h1>Runtime appearance overrides</h1>
+        <p>
+          Compare colors stored when Purchases is configured with colors passed
+          only to one purchase or paywall presentation. Operation colors should
+          win when both are present.
+        </p>
+      </header>
+
+      <section className="appearance-demo__palettes" aria-label="Demo palettes">
+        <article className="appearance-demo__palette-card">
+          <div className="appearance-demo__swatches" aria-hidden="true">
+            <span
+              style={{
+                backgroundColor:
+                  configuredAppearanceOverride.color_buttons_primary,
+              }}
+            />
+            <span
+              style={{
+                backgroundColor:
+                  configuredAppearanceOverride.color_product_info_bg,
+              }}
+            />
+            <span
+              style={{
+                backgroundColor: configuredAppearanceOverride.color_page_bg,
+              }}
+            />
+          </div>
+          <h2>Configure-time palette</h2>
+          <p>Purple buttons, a lavender product panel, and rounded shapes.</p>
+        </article>
+
+        <article className="appearance-demo__palette-card">
+          <div className="appearance-demo__swatches" aria-hidden="true">
+            <span
+              style={{
+                backgroundColor:
+                  operationAppearanceOverride.color_buttons_primary,
+              }}
+            />
+            <span
+              style={{
+                backgroundColor:
+                  operationAppearanceOverride.color_product_info_bg,
+              }}
+            />
+            <span
+              style={{
+                backgroundColor: operationAppearanceOverride.color_accent,
+              }}
+            />
+          </div>
+          <h2>Operation palette</h2>
+          <p>Green buttons, a peach product panel, and pill shapes.</p>
+        </article>
+      </section>
+
+      <section className="appearance-demo__controls">
+        <label htmlFor="appearance-demo-package">Package</label>
+        <select
+          id="appearance-demo-package"
+          className="compact-input"
+          value={selectedPackageId}
+          onChange={(event) => setSelectedPackageId(event.target.value)}
+        >
+          {packages.map((pkg) => (
+            <option key={pkg.identifier} value={pkg.identifier}>
+              {pkg.webBillingProduct?.title ?? pkg.identifier}
+            </option>
+          ))}
+        </select>
+
+        <div className="appearance-demo__flow-grid">
+          <article className="appearance-demo__flow-card">
+            <h2>Direct purchase</h2>
+            <p>Calls purchases.purchase() for the selected package.</p>
+            <button
+              className="compact-button compact-button--secondary"
+              disabled={isRunning}
+              onClick={() => purchase(selectedPackage, false)}
+            >
+              Use configure-time colors
+            </button>
+            <button
+              className="compact-button compact-button--primary"
+              disabled={isRunning}
+              onClick={() => purchase(selectedPackage, true)}
+            >
+              Override this purchase
+            </button>
+          </article>
+
+          <article className="appearance-demo__flow-card">
+            <h2>RevenueCat Paywall</h2>
+            <p>Calls purchases.presentPaywall() for the current offering.</p>
+            <button
+              className="compact-button compact-button--secondary"
+              disabled={isRunning}
+              onClick={() => presentPaywall(false)}
+            >
+              Use configure-time colors
+            </button>
+            <button
+              className="compact-button compact-button--primary"
+              disabled={isRunning}
+              onClick={() => presentPaywall(true)}
+            >
+              Override this paywall
+            </button>
+          </article>
+        </div>
+
+        <p
+          className={`appearance-demo__status appearance-demo__status--${status.kind}`}
+          role="status"
+        >
+          {status.message}
+        </p>
+      </section>
+    </main>
+  );
+};
+
+export default AppearanceOverridesPage;

--- a/examples/webbilling-demo/src/pages/appearance_overrides/index.tsx
+++ b/examples/webbilling-demo/src/pages/appearance_overrides/index.tsx
@@ -12,11 +12,25 @@ type DemoStatus = {
   message: string;
 };
 
+type AppearanceMode = "default" | "configured" | "operation";
+
+const purchaseLabels: Record<AppearanceMode, string> = {
+  default: "checkout without a runtime override",
+  configured: "configure-time checkout",
+  operation: "per-purchase checkout",
+};
+
+const paywallLabels: Record<AppearanceMode, string> = {
+  default: "paywall without a runtime override",
+  configured: "configure-time paywall",
+  operation: "presentPaywall-time paywall",
+};
+
 const getErrorMessage = (error: unknown) =>
   error instanceof Error ? error.message : String(error);
 
 const AppearanceOverridesPage = () => {
-  const { purchases, offering } = usePurchasesLoaderData();
+  const { purchases, defaultPurchases, offering } = usePurchasesLoaderData();
   const packages =
     offering?.availablePackages.filter((pkg) => pkg.webBillingProduct) ?? [];
   const [selectedPackageId, setSelectedPackageId] = useState(
@@ -46,32 +60,33 @@ const AppearanceOverridesPage = () => {
     }
   };
 
-  const purchase = (pkg: Package, useOperationOverride: boolean) =>
-    runFlow(
-      useOperationOverride ? "per-purchase checkout" : "configured checkout",
-      () =>
-        purchases.purchase({
-          rcPackage: pkg,
-          ...(useOperationOverride
-            ? { brandingAppearanceOverride: operationAppearanceOverride }
-            : {}),
-        }),
-    );
+  const purchase = (pkg: Package, appearanceMode: AppearanceMode) => {
+    const purchaseInstance =
+      appearanceMode === "default" ? defaultPurchases : purchases;
 
-  const presentPaywall = (useOperationOverride: boolean) => {
+    return runFlow(purchaseLabels[appearanceMode], () =>
+      purchaseInstance.purchase({
+        rcPackage: pkg,
+        ...(appearanceMode === "operation"
+          ? { brandingAppearanceOverride: operationAppearanceOverride }
+          : {}),
+      }),
+    );
+  };
+
+  const presentPaywall = (appearanceMode: AppearanceMode) => {
     if (!offering) return Promise.resolve();
 
-    return runFlow(
-      useOperationOverride
-        ? "presentPaywall-time paywall"
-        : "configured paywall",
-      () =>
-        purchases.presentPaywall({
-          offering,
-          ...(useOperationOverride
-            ? { brandingAppearanceOverride: operationAppearanceOverride }
-            : {}),
-        }),
+    const purchaseInstance =
+      appearanceMode === "default" ? defaultPurchases : purchases;
+
+    return runFlow(paywallLabels[appearanceMode], () =>
+      purchaseInstance.presentPaywall({
+        offering,
+        ...(appearanceMode === "operation"
+          ? { brandingAppearanceOverride: operationAppearanceOverride }
+          : {}),
+      }),
     );
   };
 
@@ -95,9 +110,10 @@ const AppearanceOverridesPage = () => {
         <span className="appearance-demo__eyebrow">WEB-4597 demo</span>
         <h1>Runtime appearance overrides</h1>
         <p>
-          Compare colors stored when Purchases is configured with colors passed
-          only to one purchase or paywall presentation. Operation colors should
-          win when both are present.
+          Compare the Dashboard/default appearance with colors stored when
+          Purchases is configured and colors passed only to one purchase or
+          paywall presentation. Operation colors should win when both are
+          present.
         </p>
       </header>
 
@@ -173,14 +189,21 @@ const AppearanceOverridesPage = () => {
             <button
               className="compact-button compact-button--secondary"
               disabled={isRunning}
-              onClick={() => purchase(selectedPackage, false)}
+              onClick={() => purchase(selectedPackage, "default")}
+            >
+              No runtime override
+            </button>
+            <button
+              className="compact-button compact-button--secondary"
+              disabled={isRunning}
+              onClick={() => purchase(selectedPackage, "configured")}
             >
               Use configure-time colors
             </button>
             <button
               className="compact-button compact-button--primary"
               disabled={isRunning}
-              onClick={() => purchase(selectedPackage, true)}
+              onClick={() => purchase(selectedPackage, "operation")}
             >
               Override this purchase
             </button>
@@ -192,14 +215,21 @@ const AppearanceOverridesPage = () => {
             <button
               className="compact-button compact-button--secondary"
               disabled={isRunning}
-              onClick={() => presentPaywall(false)}
+              onClick={() => presentPaywall("default")}
+            >
+              No runtime override
+            </button>
+            <button
+              className="compact-button compact-button--secondary"
+              disabled={isRunning}
+              onClick={() => presentPaywall("configured")}
             >
               Use configure-time colors
             </button>
             <button
               className="compact-button compact-button--primary"
               disabled={isRunning}
-              onClick={() => presentPaywall(true)}
+              onClick={() => presentPaywall("operation")}
             >
               Override this paywall
             </button>

--- a/examples/webbilling-demo/src/pages/login/index.tsx
+++ b/examples/webbilling-demo/src/pages/login/index.tsx
@@ -14,7 +14,7 @@ const LoginPage: React.FC = () => {
 
   const navigateToAppUserIDPaywall = (
     appUserId?: string,
-    useRCPaywall = false,
+    destination: "paywall" | "rc_paywall" = "paywall",
   ) => {
     if (appUserId) {
       const params = new URLSearchParams();
@@ -31,8 +31,7 @@ const LoginPage: React.FC = () => {
       params.append("useCustomLogger", useCustomLogger.toString());
 
       const queryString = params.toString();
-      const base = useRCPaywall ? "rc_paywall" : "paywall";
-      const url = `/${base}/${encodeURIComponent(appUserId)}${queryString ? `?${queryString}` : ""}`;
+      const url = `/${destination}/${encodeURIComponent(appUserId)}${queryString ? `?${queryString}` : ""}`;
       navigate(url);
     }
   };
@@ -101,7 +100,22 @@ const LoginPage: React.FC = () => {
           <Button
             caption="Continue (RC Paywall)"
             onClick={() => {
-              navigateToAppUserIDPaywall(appUserId, true);
+              navigateToAppUserIDPaywall(appUserId, "rc_paywall");
+            }}
+          />
+          <Button
+            caption="Runtime appearance demo"
+            onClick={() => {
+              const userId =
+                appUserId || Purchases.generateRevenueCatAnonymousAppUserId();
+              const params = new URLSearchParams();
+              if (offeringId.trim()) {
+                params.append("offeringId", offeringId.trim());
+              }
+              const queryString = params.toString();
+              window.location.assign(
+                `/appearance-overrides/${encodeURIComponent(userId)}${queryString ? `?${queryString}` : ""}`,
+              );
             }}
           />
           <Button

--- a/examples/webbilling-demo/src/util/PurchasesLoader.ts
+++ b/examples/webbilling-demo/src/util/PurchasesLoader.ts
@@ -26,6 +26,7 @@ export const isStripeApiKey = /^strp_[a-zA-Z0-9_.-]+$/.test(apiKey);
 
 type IPurchasesLoaderData = {
   purchases: Purchases;
+  defaultPurchases: Purchases;
   customerInfo: CustomerInfo;
   offering: Offering;
 };
@@ -112,20 +113,35 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
 
   Purchases.setLogLevel(LogLevel.Verbose);
   try {
-    if (!Purchases.isConfigured()) {
-      Purchases.configure({
+    const purchasesConfig = {
+      apiKey,
+      appUserId,
+      httpConfig,
+      flags: flagsConfig,
+    };
+    let purchases: Purchases;
+    let defaultPurchases: Purchases;
+
+    if (useConfiguredAppearanceOverride) {
+      defaultPurchases = Purchases.configure(purchasesConfig);
+      purchases = Purchases.configure({
+        ...purchasesConfig,
+        brandingAppearanceOverride: configuredAppearanceOverride,
+      });
+    } else if (!Purchases.isConfigured()) {
+      purchases = Purchases.configure({
         apiKey,
         appUserId,
         httpConfig,
         flags: flagsConfig,
-        ...(useConfiguredAppearanceOverride
-          ? { brandingAppearanceOverride: configuredAppearanceOverride }
-          : {}),
       });
+      defaultPurchases = purchases;
     } else {
       await Purchases.getSharedInstance().changeUser(appUserId);
+      purchases = Purchases.getSharedInstance();
+      defaultPurchases = purchases;
     }
-    const purchases = Purchases.getSharedInstance();
+
     const [customerInfo, offerings] = await Promise.all([
       purchases.getCustomerInfo(),
       purchases.getOfferings({
@@ -143,6 +159,7 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
 
     return {
       purchases,
+      defaultPurchases,
       customerInfo,
       offering,
     };

--- a/examples/webbilling-demo/src/util/PurchasesLoader.ts
+++ b/examples/webbilling-demo/src/util/PurchasesLoader.ts
@@ -9,6 +9,7 @@ import {
 } from "@revenuecat/purchases-js";
 import type { LoaderFunction } from "react-router-dom";
 import { redirect, useLoaderData } from "react-router-dom";
+import { configuredAppearanceOverride } from "./runtime-appearance-overrides";
 
 declare global {
   interface Window {
@@ -46,6 +47,8 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
   const useCustomLogger = searchParams.get("useCustomLogger") === "true";
   const storeLoadTime =
     (searchParams.get("storeLoadTime") as StoreLoadTime) || undefined;
+  const useConfiguredAppearanceOverride =
+    searchParams.get("configuredAppearanceOverride") === "true";
 
   if (!appUserId) {
     throw redirect("/");
@@ -115,6 +118,9 @@ const loadPurchases: LoaderFunction<IPurchasesLoaderData> = async ({
         appUserId,
         httpConfig,
         flags: flagsConfig,
+        ...(useConfiguredAppearanceOverride
+          ? { brandingAppearanceOverride: configuredAppearanceOverride }
+          : {}),
       });
     } else {
       await Purchases.getSharedInstance().changeUser(appUserId);
@@ -160,4 +166,20 @@ const loadPurchasesWithDelayedStore: LoaderFunction<
   });
 };
 
-export { loadPurchases, loadPurchasesWithDelayedStore, usePurchasesLoaderData };
+const loadPurchasesWithAppearanceOverride: LoaderFunction<
+  IPurchasesLoaderData
+> = async (args) => {
+  const url = new URL(args.request.url);
+  url.searchParams.set("configuredAppearanceOverride", "true");
+  return loadPurchases({
+    ...args,
+    request: new Request(url, args.request),
+  });
+};
+
+export {
+  loadPurchases,
+  loadPurchasesWithAppearanceOverride,
+  loadPurchasesWithDelayedStore,
+  usePurchasesLoaderData,
+};

--- a/examples/webbilling-demo/src/util/runtime-appearance-overrides.ts
+++ b/examples/webbilling-demo/src/util/runtime-appearance-overrides.ts
@@ -7,7 +7,7 @@ export const configuredAppearanceOverride = {
   color_error: "#d94a4a",
   color_product_info_bg: "#d8b9ff",
   color_form_bg: "#ffffff",
-  color_page_bg: "#f5f5f5",
+  color_page_bg: "#d8b9ff",
   shapes: "rounded",
 } satisfies Partial<BrandingAppearance>;
 
@@ -18,6 +18,6 @@ export const operationAppearanceOverride = {
   color_error: "#d94a4a",
   color_product_info_bg: "#ffcdc2",
   color_form_bg: "#ffffff",
-  color_page_bg: "#f5f5f5",
+  color_page_bg: "#ffcdc2",
   shapes: "pill",
 } satisfies Partial<BrandingAppearance>;

--- a/examples/webbilling-demo/src/util/runtime-appearance-overrides.ts
+++ b/examples/webbilling-demo/src/util/runtime-appearance-overrides.ts
@@ -1,0 +1,23 @@
+import type { BrandingAppearance } from "@revenuecat/purchases-js";
+
+export const configuredAppearanceOverride = {
+  color_buttons_primary: "#9c4eff",
+  color_buttons_primary_text: "#ffffff",
+  color_accent: "#9c4eff",
+  color_error: "#d94a4a",
+  color_product_info_bg: "#d8b9ff",
+  color_form_bg: "#ffffff",
+  color_page_bg: "#f5f5f5",
+  shapes: "rounded",
+} satisfies Partial<BrandingAppearance>;
+
+export const operationAppearanceOverride = {
+  color_buttons_primary: "#b4fab7",
+  color_buttons_primary_text: "#000000",
+  color_accent: "#9c4eff",
+  color_error: "#d94a4a",
+  color_product_info_bg: "#ffcdc2",
+  color_form_bg: "#ffffff",
+  color_page_bg: "#f5f5f5",
+  shapes: "pill",
+} satisfies Partial<BrandingAppearance>;

--- a/src/entities/branding.ts
+++ b/src/entities/branding.ts
@@ -15,3 +15,17 @@ export interface BrandingAppearance {
   shapes: "default" | "rectangle" | "rounded" | "pill";
   show_product_description: boolean;
 }
+
+/** @internal */
+export const DEFAULT_BRANDING_APPEARANCE: BrandingAppearance = {
+  color_buttons_primary: "#576CDB",
+  color_buttons_primary_text: null,
+  color_accent: "#1148B8",
+  color_error: "#B0171F",
+  color_product_info_bg: "#EFF3FA",
+  color_form_bg: "#FFFFFF",
+  color_page_bg: "#EFF3FA",
+  font: "default",
+  shapes: "default",
+  show_product_description: false,
+};

--- a/src/entities/present-paywall-params.ts
+++ b/src/entities/present-paywall-params.ts
@@ -1,6 +1,7 @@
 import type { Offering, PurchaseMetadata } from "./offerings";
 import type { PaywallListener } from "./paywall-listener";
 import type { ProductChangeInfo } from "./product-change-params";
+import type { BrandingAppearance } from "./branding";
 import type {
   CompleteWorkflowNavigateArgs,
   CustomVariables,
@@ -44,6 +45,17 @@ export interface PresentPaywallParams {
    * to the RC transaction as metadata.
    */
   readonly metadata?: PurchaseMetadata;
+
+  /**
+   * Overrides the branding appearance for the purchase started from this
+   * paywall. Only the provided values are overridden. These values take
+   * precedence over the override passed to `Purchases.configure()`.
+   *
+   * For Stripe Checkout, this customizes the supported mobile wallet experience.
+   * The Stripe-hosted fallback opened through "Pay another way" remains light and
+   * cannot currently be customized.
+   */
+  readonly brandingAppearanceOverride?: Partial<BrandingAppearance>;
 
   /**
    * @experimental

--- a/src/entities/purchase-params.ts
+++ b/src/entities/purchase-params.ts
@@ -160,16 +160,15 @@ export interface PurchaseParams {
   onDiscountCodeChanged?: (discountCode: string | null) => void;
 
   /**
-   * Defines an optional override for the default branding appearance.
+   * Overrides the Dashboard branding appearance for this purchase.
+   * Only the provided values are overridden; all other values keep their
+   * Dashboard configuration.
    *
-   * This property is used internally at RevenueCat to handle dynamic themes such
-   * as the ones coming from the Web Paywall Links. We suggest to use the Dashboard
-   * configuration to set up the appearance since a configuration passed as parameter
-   * using this method might break in future releases of `purchases-js`.
-   *
-   * @internal
+   * For Stripe Checkout, this customizes the supported mobile wallet experience.
+   * The Stripe-hosted fallback opened through "Pay another way" remains light and
+   * cannot currently be customized.
    */
-  brandingAppearanceOverride?: BrandingAppearance;
+  brandingAppearanceOverride?: Partial<BrandingAppearance>;
 
   /**
    * @internal

--- a/src/entities/purchases-config.ts
+++ b/src/entities/purchases-config.ts
@@ -1,5 +1,6 @@
 import type { FlagsConfig } from "./flags-config";
 import type { HttpConfig } from "./http-config";
+import type { BrandingAppearance } from "./branding";
 
 /**
  * Contextual information specific to workflows.
@@ -64,6 +65,18 @@ export interface PurchasesConfig {
    * Advanced functionality configuration {@link FlagsConfig}.
    */
   flags?: FlagsConfig;
+  /**
+   * Overrides the Dashboard branding appearance for purchases created by this
+   * instance, including purchases started through {@link Purchases.presentPaywall}.
+   * Only the provided values are overridden. A value passed directly to
+   * {@link PurchaseParams.brandingAppearanceOverride} takes precedence for that
+   * purchase.
+   *
+   * For Stripe Checkout, this customizes the supported mobile wallet experience.
+   * The Stripe-hosted fallback opened through "Pay another way" remains light and
+   * cannot currently be customized.
+   */
+  brandingAppearanceOverride?: Partial<BrandingAppearance>;
   /**
    * Optional short-lived subscriber access token used for RevenueCat Billing
    * product-change checkout. Minted server-side via the Developer API (https://www.revenuecat.com/docs/api-v2)

--- a/src/helpers/branding-appearance-helper.ts
+++ b/src/helpers/branding-appearance-helper.ts
@@ -1,4 +1,7 @@
-import type { BrandingAppearance } from "../entities/branding";
+import {
+  DEFAULT_BRANDING_APPEARANCE,
+  type BrandingAppearance,
+} from "../entities/branding";
 import type { BrandingInfoResponse } from "../networking/responses/branding-response";
 
 export function mergeBrandingAppearanceOverrides(
@@ -22,8 +25,9 @@ export function applyBrandingAppearanceOverride(
 
   return {
     ...brandingInfo,
-    appearance: brandingInfo.appearance
-      ? { ...brandingInfo.appearance, ...appearanceOverride }
-      : null,
+    appearance: {
+      ...(brandingInfo.appearance ?? DEFAULT_BRANDING_APPEARANCE),
+      ...appearanceOverride,
+    },
   };
 }

--- a/src/helpers/branding-appearance-helper.ts
+++ b/src/helpers/branding-appearance-helper.ts
@@ -1,0 +1,29 @@
+import type { BrandingAppearance } from "../entities/branding";
+import type { BrandingInfoResponse } from "../networking/responses/branding-response";
+
+export function mergeBrandingAppearanceOverrides(
+  configuredOverride?: Partial<BrandingAppearance>,
+  purchaseOverride?: Partial<BrandingAppearance>,
+): Partial<BrandingAppearance> | undefined {
+  if (!configuredOverride && !purchaseOverride) {
+    return undefined;
+  }
+
+  return { ...configuredOverride, ...purchaseOverride };
+}
+
+export function applyBrandingAppearanceOverride(
+  brandingInfo: BrandingInfoResponse | null,
+  appearanceOverride?: Partial<BrandingAppearance>,
+): BrandingInfoResponse | null {
+  if (!brandingInfo || !appearanceOverride) {
+    return brandingInfo;
+  }
+
+  return {
+    ...brandingInfo,
+    appearance: brandingInfo.appearance
+      ? { ...brandingInfo.appearance, ...appearanceOverride }
+      : null,
+  };
+}

--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -38,6 +38,7 @@ import {
   type SubscriptionChangeCheckoutStartResponse,
 } from "../networking/responses/subscription-change-response";
 import type { ProductChangeResult } from "../entities/product-change-params";
+import type { BrandingAppearance } from "../entities/branding";
 
 export enum PurchaseFlowErrorCode {
   ErrorSettingUpPurchase = 0,
@@ -139,6 +140,7 @@ interface CheckoutStartParams {
   locale?: string;
 
   attributionMetadata?: AttributionMetadata;
+  appearanceOverride?: Partial<BrandingAppearance>;
 
   /**
    * When set, asks the backend to start a subscription-change
@@ -275,6 +277,7 @@ export class PurchaseOperationHelper {
     metadata,
     locale,
     attributionMetadata,
+    appearanceOverride,
     productChange,
     subscriberToken,
   }: CheckoutStartParams): Promise<
@@ -302,6 +305,7 @@ export class PurchaseOperationHelper {
         metadata,
         locale,
         attributionMetadata,
+        ...(appearanceOverride ? { appearanceOverride } : {}),
         productChange,
         subscriberToken,
       });

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,6 +56,7 @@ import {
 } from "./entities/get-offerings-params";
 import { validateCurrency } from "./helpers/validators";
 import { type BrandingInfoResponse } from "./networking/responses/branding-response";
+import type { BrandingAppearance } from "./entities/branding";
 import { requiresLoadedResources } from "./helpers/decorators";
 import { resolveTermsAndConditionsUrl } from "./helpers/checkout-consent-helper";
 import {
@@ -150,6 +151,10 @@ import {
   removeManagedAppleTouchIcon,
   syncManagedAppleTouchIcon,
 } from "./helpers/apple-touch-icon";
+import {
+  applyBrandingAppearanceOverride,
+  mergeBrandingAppearanceOverrides,
+} from "./helpers/branding-appearance-helper";
 
 type UIComponentInteractionFields = UIComponentInteractionData & {
   componentURL?: string;
@@ -272,6 +277,9 @@ export class Purchases {
 
   /** @internal */
   private readonly _subscriberToken: string | null;
+
+  /** @internal */
+  private readonly _brandingAppearanceOverride?: Partial<BrandingAppearance>;
 
   /** @internal */
   private readonly _context?: PurchasesContext;
@@ -444,6 +452,7 @@ export class Purchases {
       httpConfig,
       flags,
       subscriberToken,
+      brandingAppearanceOverride,
       context,
       trace_id,
     } = config;
@@ -457,6 +466,7 @@ export class Purchases {
       finalHttpConfig,
       finalFlags,
       subscriberToken,
+      brandingAppearanceOverride,
       context,
       trace_id,
     );
@@ -543,6 +553,7 @@ export class Purchases {
     httpConfig: HttpConfig = defaultHttpConfig,
     flags: FlagsConfig = defaultFlagsConfig,
     subscriberToken?: string,
+    brandingAppearanceOverride?: Partial<BrandingAppearance>,
     context?: PurchasesContext,
     trace_id?: string,
   ) {
@@ -550,6 +561,9 @@ export class Purchases {
     this._appUserId = appUserId;
     this._flags = { ...defaultFlagsConfig, ...flags };
     this._subscriberToken = subscriberToken ?? null;
+    this._brandingAppearanceOverride = brandingAppearanceOverride
+      ? { ...brandingAppearanceOverride }
+      : undefined;
     this._context = context;
     if (RC_ENDPOINT === undefined) {
       Logger.errorLog(
@@ -816,6 +830,7 @@ export class Purchases {
         htmlTarget: paywallParams.purchaseHtmlTarget,
         customerEmail: paywallParams.customerEmail,
         metadata: paywallParams.metadata,
+        brandingAppearanceOverride: paywallParams.brandingAppearanceOverride,
         showDiscountCodeField: paywallParams.showDiscountCodeField,
         discountCode: paywallParams.discountCode,
         onDiscountCodeChanged: paywallParams.onDiscountCodeChanged,
@@ -1655,9 +1670,17 @@ export class Purchases {
    */
   @requiresLoadedResources
   public async purchase(params: PurchaseParams): Promise<PurchaseResult> {
+    const appearanceOverride = mergeBrandingAppearanceOverrides(
+      this._brandingAppearanceOverride,
+      params.brandingAppearanceOverride,
+    );
+    const effectiveParams = appearanceOverride
+      ? { ...params, brandingAppearanceOverride: appearanceOverride }
+      : params;
+
     if (isSimulatedStoreApiKey(this._API_KEY)) {
       const purchaseResult = await purchaseSimulatedStoreProduct(
-        params,
+        effectiveParams,
         this.backend,
         this._appUserId,
       );
@@ -1667,15 +1690,15 @@ export class Purchases {
 
     const isPaddle = isPaddleApiKey(this._API_KEY);
     if (isPaddle) {
-      return await this.performPaddlePurchase(params);
+      return await this.performPaddlePurchase(effectiveParams);
     }
 
     const isStripe = isStripeApiKey(this._API_KEY);
     if (isStripe) {
-      return await this.performStripePurchase(params);
+      return await this.performStripePurchase(effectiveParams);
     }
 
-    return await this.performWebBillingPurchase(params);
+    return await this.performWebBillingPurchase(effectiveParams);
   }
 
   private async performStripePurchase(
@@ -1723,11 +1746,10 @@ export class Purchases {
 
     let component: ReturnType<typeof mount> | null = null;
 
-    const finalBrandingInfo: BrandingInfoResponse | null = this._brandingInfo;
-
-    if (finalBrandingInfo && params.brandingAppearanceOverride) {
-      finalBrandingInfo.appearance = params.brandingAppearanceOverride;
-    }
+    const finalBrandingInfo = applyBrandingAppearanceOverride(
+      this._brandingInfo,
+      params.brandingAppearanceOverride,
+    );
 
     const isInElement = htmlTarget !== undefined;
 
@@ -1781,7 +1803,8 @@ export class Purchases {
           onClose,
           onError,
           eventsTracker: this.eventsTracker,
-          brandingInfo: this._brandingInfo,
+          brandingInfo: finalBrandingInfo,
+          appearanceOverride: params.brandingAppearanceOverride,
           purchaseOperationHelper: this.purchaseOperationHelper,
           selectedLocale: localeToBeUsed,
           metadata: metadata,
@@ -1840,11 +1863,10 @@ export class Purchases {
 
     let component: ReturnType<typeof mount> | null = null;
 
-    const finalBrandingInfo: BrandingInfoResponse | null = this._brandingInfo;
-
-    if (finalBrandingInfo && params.brandingAppearanceOverride) {
-      finalBrandingInfo.appearance = params.brandingAppearanceOverride;
-    }
+    const finalBrandingInfo = applyBrandingAppearanceOverride(
+      this._brandingInfo,
+      params.brandingAppearanceOverride,
+    );
 
     const termsAndConditionsUrl = resolveTermsAndConditionsUrl({
       brandingInfo: finalBrandingInfo,
@@ -1929,7 +1951,8 @@ export class Purchases {
           onError,
           purchases: this,
           eventsTracker: this.eventsTracker,
-          brandingInfo: this._brandingInfo,
+          brandingInfo: finalBrandingInfo,
+          appearanceOverride: params.brandingAppearanceOverride,
           purchaseOperationHelper: this.purchaseOperationHelper,
           selectedLocale: localeToBeUsed,
           metadata: metadata,
@@ -1980,11 +2003,10 @@ export class Purchases {
       ...(params.metadata || {}),
     };
 
-    const finalBrandingInfo: BrandingInfoResponse | null = this._brandingInfo;
-
-    if (finalBrandingInfo && params.brandingAppearanceOverride) {
-      finalBrandingInfo.appearance = params.brandingAppearanceOverride;
-    }
+    const finalBrandingInfo = applyBrandingAppearanceOverride(
+      this._brandingInfo,
+      params.brandingAppearanceOverride,
+    );
 
     const event = createCheckoutSessionStartEvent({
       appearance: this._brandingInfo?.appearance,
@@ -2042,7 +2064,7 @@ export class Purchases {
           target: certainHTMLTarget,
           props: {
             eventsTracker: this.eventsTracker,
-            brandingInfo: this._brandingInfo,
+            brandingInfo: finalBrandingInfo,
             selectedLocale: selectedLocale || defaultLocale,
             defaultLocale,
             customTranslations: params.labelsOverride,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1677,6 +1677,10 @@ export class Purchases {
     const effectiveParams = appearanceOverride
       ? { ...params, brandingAppearanceOverride: appearanceOverride }
       : params;
+    const effectiveBrandingInfo = applyBrandingAppearanceOverride(
+      this._brandingInfo,
+      appearanceOverride,
+    );
 
     if (isSimulatedStoreApiKey(this._API_KEY)) {
       const purchaseResult = await purchaseSimulatedStoreProduct(
@@ -1690,19 +1694,29 @@ export class Purchases {
 
     const isPaddle = isPaddleApiKey(this._API_KEY);
     if (isPaddle) {
-      return await this.performPaddlePurchase(effectiveParams);
+      return await this.performPaddlePurchase(
+        effectiveParams,
+        effectiveBrandingInfo,
+      );
     }
 
     const isStripe = isStripeApiKey(this._API_KEY);
     if (isStripe) {
-      return await this.performStripePurchase(effectiveParams);
+      return await this.performStripePurchase(
+        effectiveParams,
+        effectiveBrandingInfo,
+      );
     }
 
-    return await this.performWebBillingPurchase(effectiveParams);
+    return await this.performWebBillingPurchase(
+      effectiveParams,
+      effectiveBrandingInfo,
+    );
   }
 
   private async performStripePurchase(
     params: PurchaseParams,
+    brandingInfo: BrandingInfoResponse | null,
   ): Promise<PurchaseResult> {
     const {
       rcPackage,
@@ -1732,7 +1746,7 @@ export class Purchases {
       purchaseOption ?? rcPackage.webBillingProduct.defaultPurchaseOption;
 
     const event = createCheckoutSessionStartEvent({
-      appearance: this._brandingInfo?.appearance,
+      appearance: brandingInfo?.appearance,
       rcPackage,
       purchaseOptionToUse,
       customerEmail,
@@ -1745,11 +1759,6 @@ export class Purchases {
     const metadata = { ...utmParamsMetadata, ...(params.metadata || {}) };
 
     let component: ReturnType<typeof mount> | null = null;
-
-    const finalBrandingInfo = applyBrandingAppearanceOverride(
-      this._brandingInfo,
-      params.brandingAppearanceOverride,
-    );
 
     const isInElement = htmlTarget !== undefined;
 
@@ -1803,7 +1812,7 @@ export class Purchases {
           onClose,
           onError,
           eventsTracker: this.eventsTracker,
-          brandingInfo: finalBrandingInfo,
+          brandingInfo,
           appearanceOverride: params.brandingAppearanceOverride,
           purchaseOperationHelper: this.purchaseOperationHelper,
           selectedLocale: localeToBeUsed,
@@ -1818,6 +1827,7 @@ export class Purchases {
 
   private async performWebBillingPurchase(
     params: PurchaseParams,
+    brandingInfo: BrandingInfoResponse | null,
   ): Promise<PurchaseResult> {
     const productChange = this.resolveProductChange(params);
     const {
@@ -1849,7 +1859,7 @@ export class Purchases {
       purchaseOption ?? rcPackage.webBillingProduct.defaultPurchaseOption;
 
     const event = createCheckoutSessionStartEvent({
-      appearance: this._brandingInfo?.appearance,
+      appearance: brandingInfo?.appearance,
       rcPackage,
       purchaseOptionToUse,
       customerEmail,
@@ -1863,13 +1873,8 @@ export class Purchases {
 
     let component: ReturnType<typeof mount> | null = null;
 
-    const finalBrandingInfo = applyBrandingAppearanceOverride(
-      this._brandingInfo,
-      params.brandingAppearanceOverride,
-    );
-
     const termsAndConditionsUrl = resolveTermsAndConditionsUrl({
-      brandingInfo: finalBrandingInfo,
+      brandingInfo,
       termsAndConditionsUrl: params.termsAndConditionsUrl,
     });
 
@@ -1951,7 +1956,7 @@ export class Purchases {
           onError,
           purchases: this,
           eventsTracker: this.eventsTracker,
-          brandingInfo: finalBrandingInfo,
+          brandingInfo,
           appearanceOverride: params.brandingAppearanceOverride,
           purchaseOperationHelper: this.purchaseOperationHelper,
           selectedLocale: localeToBeUsed,
@@ -1971,6 +1976,7 @@ export class Purchases {
 
   private async performPaddlePurchase(
     params: PurchaseParams,
+    brandingInfo: BrandingInfoResponse | null,
   ): Promise<PurchaseResult> {
     const {
       rcPackage,
@@ -2003,13 +2009,8 @@ export class Purchases {
       ...(params.metadata || {}),
     };
 
-    const finalBrandingInfo = applyBrandingAppearanceOverride(
-      this._brandingInfo,
-      params.brandingAppearanceOverride,
-    );
-
     const event = createCheckoutSessionStartEvent({
-      appearance: this._brandingInfo?.appearance,
+      appearance: brandingInfo?.appearance,
       rcPackage,
       purchaseOptionToUse,
       customerEmail,
@@ -2064,7 +2065,7 @@ export class Purchases {
           target: certainHTMLTarget,
           props: {
             eventsTracker: this.eventsTracker,
-            brandingInfo: finalBrandingInfo,
+            brandingInfo,
             selectedLocale: selectedLocale || defaultLocale,
             defaultLocale,
             customTranslations: params.labelsOverride,

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -45,6 +45,7 @@ import { isWebBillingSandboxApiKey } from "../helpers/api-key-helper";
 import type { IdentifyResponse } from "./responses/identify-response";
 import type { CheckoutPrepareResponse } from "./responses/checkout-prepare-response";
 import type { AttributionMetadata } from "../entities/purchase-params";
+import type { BrandingAppearance } from "../entities/branding";
 
 const MAX_GET_PRODUCTS_URL_PATH_LENGTH = 2000;
 
@@ -69,6 +70,7 @@ interface CheckoutStartRequestParams {
   locale?: string;
 
   attributionMetadata?: AttributionMetadata;
+  appearanceOverride?: Partial<BrandingAppearance>;
 
   /**
    * When set, will attempt a subscription change. Requires
@@ -294,6 +296,7 @@ export class Backend {
     metadata,
     locale,
     attributionMetadata,
+    appearanceOverride,
     productChange,
     subscriberToken,
   }: CheckoutStartRequestParams): Promise<T> {
@@ -320,6 +323,7 @@ export class Backend {
         paywall_session_id?: string;
       };
       attribution_metadata?: AttributionMetadata;
+      appearance_override?: Partial<BrandingAppearance>;
       product_change?: {
         subscription_id?: string;
         from_product_id?: string;
@@ -382,6 +386,10 @@ export class Backend {
 
     if (attributionMetadata) {
       requestBody.attribution_metadata = attributionMetadata;
+    }
+
+    if (appearanceOverride) {
+      requestBody.appearance_override = appearanceOverride;
     }
 
     if (productChange) {

--- a/src/tests/helpers/branding-appearance-helper.test.ts
+++ b/src/tests/helpers/branding-appearance-helper.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "vitest";
+import type { BrandingInfoResponse } from "../../networking/responses/branding-response";
+import {
+  applyBrandingAppearanceOverride,
+  mergeBrandingAppearanceOverrides,
+} from "../../helpers/branding-appearance-helper";
+
+const brandingInfo: BrandingInfoResponse = {
+  id: "test-branding-id",
+  app_name: "Test App",
+  app_icon: null,
+  app_icon_webp: null,
+  app_wordmark: null,
+  app_wordmark_webp: null,
+  appearance: {
+    color_buttons_primary: "#000000",
+    color_accent: "#111111",
+    color_error: "#222222",
+    color_product_info_bg: "#333333",
+    color_form_bg: "#444444",
+    color_page_bg: "#555555",
+    font: "sans-serif",
+    shapes: "rounded",
+    show_product_description: true,
+  },
+  gateway_tax_collection_enabled: false,
+  brand_font_config: null,
+};
+
+describe("applyBrandingAppearanceOverride", () => {
+  test("merges partial values without changing the cached branding", () => {
+    const result = applyBrandingAppearanceOverride(brandingInfo, {
+      color_buttons_primary: "#ffffff",
+      color_page_bg: "#101010",
+    });
+
+    expect(result?.appearance).toEqual({
+      ...brandingInfo.appearance,
+      color_buttons_primary: "#ffffff",
+      color_page_bg: "#101010",
+    });
+    expect(brandingInfo.appearance?.color_buttons_primary).toBe("#000000");
+    expect(brandingInfo.appearance?.color_page_bg).toBe("#555555");
+  });
+
+  test("returns the cached branding unchanged when no override is provided", () => {
+    expect(applyBrandingAppearanceOverride(brandingInfo)).toBe(brandingInfo);
+  });
+});
+
+describe("mergeBrandingAppearanceOverrides", () => {
+  test("uses per-purchase values over configured values", () => {
+    expect(
+      mergeBrandingAppearanceOverrides(
+        {
+          color_buttons_primary: "#000000",
+          color_page_bg: "#111111",
+        },
+        {
+          color_page_bg: "#ffffff",
+          shapes: "pill",
+        },
+      ),
+    ).toEqual({
+      color_buttons_primary: "#000000",
+      color_page_bg: "#ffffff",
+      shapes: "pill",
+    });
+  });
+});

--- a/src/tests/helpers/branding-appearance-helper.test.ts
+++ b/src/tests/helpers/branding-appearance-helper.test.ts
@@ -46,6 +46,32 @@ describe("applyBrandingAppearanceOverride", () => {
   test("returns the cached branding unchanged when no override is provided", () => {
     expect(applyBrandingAppearanceOverride(brandingInfo)).toBe(brandingInfo);
   });
+
+  test("applies overrides over defaults when cached branding has no appearance", () => {
+    const brandingWithoutAppearance = {
+      ...brandingInfo,
+      appearance: null,
+    };
+
+    const result = applyBrandingAppearanceOverride(brandingWithoutAppearance, {
+      color_buttons_primary: "#abcdef",
+      color_page_bg: "#123456",
+    });
+
+    expect(result?.appearance).toEqual({
+      color_buttons_primary: "#abcdef",
+      color_buttons_primary_text: null,
+      color_accent: "#1148B8",
+      color_error: "#B0171F",
+      color_product_info_bg: "#EFF3FA",
+      color_form_bg: "#FFFFFF",
+      color_page_bg: "#123456",
+      font: "default",
+      shapes: "default",
+      show_product_description: false,
+    });
+    expect(brandingWithoutAppearance.appearance).toBeNull();
+  });
 });
 
 describe("mergeBrandingAppearanceOverrides", () => {

--- a/src/tests/helpers/purchase-operation-helper.test.ts
+++ b/src/tests/helpers/purchase-operation-helper.test.ts
@@ -245,6 +245,34 @@ describe("PurchaseOperationHelper", () => {
     });
   });
 
+  test("checkoutStart passes an appearance override to the backend", async () => {
+    const mockPostCheckoutStart = vi
+      .spyOn(backend, "postCheckoutStart")
+      .mockResolvedValue(checkoutStartResponse);
+
+    await purchaseOperationHelper.checkoutStart({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      presentedOfferingContext: {
+        offeringIdentifier: "test-offering-id",
+        targetingContext: null,
+        placementIdentifier: null,
+      },
+      appearanceOverride: {
+        color_buttons_primary: "#ffffff",
+      },
+    });
+
+    expect(mockPostCheckoutStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appearanceOverride: {
+          color_buttons_primary: "#ffffff",
+        },
+      }),
+    );
+  });
+
   test("checkoutStart passes locale to backend when provided", async () => {
     const mockPostCheckoutStart = vi
       .spyOn(backend, "postCheckoutStart")

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -6,6 +6,7 @@ import {
   LogLevel,
   Purchases,
   type PurchasesConfig,
+  type PurchaseParams,
   PurchasesError,
   ReservedCustomerAttribute,
 } from "../main";
@@ -663,10 +664,43 @@ describe("Purchases.identifyUser", () => {
 
 describe("Purchases.purchase()", () => {
   type PurchaseRouterMethods = {
-    performPaddlePurchase: (params: unknown) => Promise<unknown>;
-    performStripePurchase: (params: unknown) => Promise<unknown>;
-    performWebBillingPurchase: (params: unknown) => Promise<unknown>;
+    performPaddlePurchase: (params: PurchaseParams) => Promise<unknown>;
+    performStripePurchase: (params: PurchaseParams) => Promise<unknown>;
+    performWebBillingPurchase: (params: PurchaseParams) => Promise<unknown>;
   };
+
+  test("applies configured appearance defaults to every purchase", async () => {
+    const purchases = Purchases.configure({
+      apiKey: testApiKey,
+      appUserId: testUserId,
+      brandingAppearanceOverride: {
+        color_buttons_primary: "#000000",
+        color_page_bg: "#111111",
+      },
+    });
+    const purchasesInternal = purchases as unknown as PurchaseRouterMethods;
+    const performWebBillingPurchaseSpy = vi
+      .spyOn(purchasesInternal, "performWebBillingPurchase")
+      .mockResolvedValue({});
+
+    await purchases.purchase({
+      rcPackage: createMonthlyPackageMock(),
+      brandingAppearanceOverride: {
+        color_page_bg: "#ffffff",
+        shapes: "pill",
+      },
+    });
+
+    expect(performWebBillingPurchaseSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brandingAppearanceOverride: {
+          color_buttons_primary: "#000000",
+          color_page_bg: "#ffffff",
+          shapes: "pill",
+        },
+      }),
+    );
+  });
 
   test("pressing back button unmounts the component", async () => {
     const unmountSpy = vi.spyOn(svelte, "unmount").mockImplementation(() => {

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -665,7 +665,6 @@ describe("Purchases.identifyUser", () => {
 
 describe("Purchases.purchase()", () => {
   type PurchaseRouterMethods = {
-    _brandingInfo: BrandingInfoResponse | null;
     performPaddlePurchase: (
       params: PurchaseParams,
       brandingInfo: BrandingInfoResponse | null,
@@ -690,21 +689,6 @@ describe("Purchases.purchase()", () => {
       },
     });
     const purchasesInternal = purchases as unknown as PurchaseRouterMethods;
-    await purchases.preload();
-    purchasesInternal._brandingInfo = {
-      ...purchasesInternal._brandingInfo!,
-      appearance: {
-        color_buttons_primary: "#aaaaaa",
-        color_accent: "#bbbbbb",
-        color_error: "#cc0000",
-        color_product_info_bg: "#eeeeee",
-        color_form_bg: "#dddddd",
-        color_page_bg: "#cccccc",
-        font: "default",
-        shapes: "default",
-        show_product_description: true,
-      },
-    };
     const performWebBillingPurchaseSpy = vi
       .spyOn(purchasesInternal, "performWebBillingPurchase")
       .mockResolvedValue({});

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -27,6 +27,7 @@ import { waitFor } from "@testing-library/svelte";
 import { http, HttpResponse } from "msw";
 import { expectPromiseToError } from "./test-helpers";
 import { StatusCodes } from "http-status-codes";
+import type { BrandingInfoResponse } from "../networking/responses/branding-response";
 
 describe("Purchases.configure() legacy", () => {
   test("throws error if given invalid api key", () => {
@@ -664,12 +665,22 @@ describe("Purchases.identifyUser", () => {
 
 describe("Purchases.purchase()", () => {
   type PurchaseRouterMethods = {
-    performPaddlePurchase: (params: PurchaseParams) => Promise<unknown>;
-    performStripePurchase: (params: PurchaseParams) => Promise<unknown>;
-    performWebBillingPurchase: (params: PurchaseParams) => Promise<unknown>;
+    _brandingInfo: BrandingInfoResponse | null;
+    performPaddlePurchase: (
+      params: PurchaseParams,
+      brandingInfo: BrandingInfoResponse | null,
+    ) => Promise<unknown>;
+    performStripePurchase: (
+      params: PurchaseParams,
+      brandingInfo: BrandingInfoResponse | null,
+    ) => Promise<unknown>;
+    performWebBillingPurchase: (
+      params: PurchaseParams,
+      brandingInfo: BrandingInfoResponse | null,
+    ) => Promise<unknown>;
   };
 
-  test("applies configured appearance defaults to every purchase", async () => {
+  test("resolves appearance overrides before routing the purchase", async () => {
     const purchases = Purchases.configure({
       apiKey: testApiKey,
       appUserId: testUserId,
@@ -679,6 +690,21 @@ describe("Purchases.purchase()", () => {
       },
     });
     const purchasesInternal = purchases as unknown as PurchaseRouterMethods;
+    await purchases.preload();
+    purchasesInternal._brandingInfo = {
+      ...purchasesInternal._brandingInfo!,
+      appearance: {
+        color_buttons_primary: "#aaaaaa",
+        color_accent: "#bbbbbb",
+        color_error: "#cc0000",
+        color_product_info_bg: "#eeeeee",
+        color_form_bg: "#dddddd",
+        color_page_bg: "#cccccc",
+        font: "default",
+        shapes: "default",
+        show_product_description: true,
+      },
+    };
     const performWebBillingPurchaseSpy = vi
       .spyOn(purchasesInternal, "performWebBillingPurchase")
       .mockResolvedValue({});
@@ -698,6 +724,13 @@ describe("Purchases.purchase()", () => {
           color_page_bg: "#ffffff",
           shapes: "pill",
         },
+      }),
+      expect.objectContaining({
+        appearance: expect.objectContaining({
+          color_buttons_primary: "#000000",
+          color_page_bg: "#ffffff",
+          shapes: "pill",
+        }),
       }),
     );
   });

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -820,6 +820,35 @@ describe("postCheckoutStart request", () => {
     expect(result).toEqual(checkoutStartResponse);
   });
 
+  test("includes a partial appearance override when provided", async () => {
+    setCheckoutStartResponse(
+      HttpResponse.json(checkoutStartResponse, { status: 200 }),
+    );
+
+    await backend.postCheckoutStart({
+      appUserId: "someAppUserId",
+      productId: "monthly",
+      presentedOfferingContext: {
+        offeringIdentifier: "offering_1",
+        targetingContext: null,
+        placementIdentifier: null,
+      },
+      purchaseOption: { id: "base_option", priceId: "test_price_id" },
+      traceId: "test-trace-id",
+      appearanceOverride: {
+        color_buttons_primary: "#ffffff",
+        color_page_bg: "#101010",
+      },
+    });
+
+    const request = purchaseMethodAPIMock.mock.calls[0][0].request;
+    const requestBody = await request.json();
+    expect(requestBody.appearance_override).toEqual({
+      color_buttons_primary: "#ffffff",
+      color_page_bg: "#101010",
+    });
+  });
+
   test("handles workflow identifier correctly", async () => {
     const backendWithContext = new Backend("test_api_key", undefined, {
       workflowContext: { workflowIdentifier: "workflow_456" },

--- a/src/tests/present-paywall.events.test.ts
+++ b/src/tests/present-paywall.events.test.ts
@@ -95,6 +95,37 @@ describe("Purchases.presentPaywall() paywall events", () => {
     document.body.innerHTML = "";
   });
 
+  test("passes an appearance override to the purchase started from the paywall", async () => {
+    const purchases = configurePurchases();
+    const offering = createOfferingWithPaywall();
+    const packageId = offering.availablePackages[0]!.identifier;
+    const purchaseSpy = vi
+      .spyOn(purchases, "purchase")
+      .mockResolvedValue({} as PurchaseResult);
+
+    void purchases.presentPaywall({
+      offering,
+      brandingAppearanceOverride: {
+        color_buttons_primary: "#ffffff",
+        color_page_bg: "#101010",
+      },
+    });
+
+    await vi.waitFor(() => expect(paywallProps).toBeDefined());
+    paywallProps!.onPurchaseClicked(packageId);
+
+    await vi.waitFor(() => {
+      expect(purchaseSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          brandingAppearanceOverride: {
+            color_buttons_primary: "#ffffff",
+            color_page_bg: "#101010",
+          },
+        }),
+      );
+    });
+  });
+
   test("fires paywall_cancel and paywall_close when purchase is cancelled and paywall is dismissed", async () => {
     const purchases = configurePurchases();
     const offering = createOfferingWithPaywall();

--- a/src/tests/ui/stripe-checkout-purchases-ui.test.ts
+++ b/src/tests/ui/stripe-checkout-purchases-ui.test.ts
@@ -120,6 +120,31 @@ describe("StripeCheckoutPurchasesUi", () => {
     });
   });
 
+  test("passes an appearance override to checkoutStart", async () => {
+    const checkoutStartSpy = vi
+      .spyOn(purchaseOperationHelperMock, "checkoutStart")
+      .mockResolvedValue(checkoutStartResponseWithoutStripeParams);
+
+    render(StripeCheckoutPurchasesUi, {
+      props: {
+        ...baseProps,
+        appearanceOverride: {
+          color_buttons_primary: "#ffffff",
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(checkoutStartSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appearanceOverride: {
+            color_buttons_primary: "#ffffff",
+          },
+        }),
+      );
+    });
+  });
+
   test("passes undefined workflowPurchaseContext to checkoutStart when not provided", async () => {
     const checkoutStartSpy = vi
       .spyOn(purchaseOperationHelperMock, "checkoutStart")

--- a/src/ui/purchases-ui.svelte
+++ b/src/ui/purchases-ui.svelte
@@ -71,6 +71,7 @@
     attributionMetadata?: AttributionMetadata;
     paywallId?: string;
     paywallSessionId?: string;
+    appearanceOverride?: Partial<BrandingAppearance>;
     productChange?: {
       subscriptionId?: string;
       productIdentifier?: string;
@@ -106,6 +107,7 @@
     attributionMetadata,
     paywallId,
     paywallSessionId,
+    appearanceOverride,
     productChange = undefined,
     onFinished,
     onProductChangeFinished = undefined,
@@ -246,6 +248,7 @@
         paywallId,
         paywallSessionId,
         locale: selectedLocale,
+        ...(appearanceOverride ? { appearanceOverride } : {}),
         productChange: productChange
           ? {
               subscriptionId: productChange.subscriptionId,
@@ -274,6 +277,7 @@
             paywallId,
             paywallSessionId,
             locale: selectedLocale,
+            ...(appearanceOverride ? { appearanceOverride } : {}),
             productChange: productChange
               ? {
                   subscriptionId: productChange.subscriptionId,

--- a/src/ui/stripe-checkout-purchases-ui.svelte
+++ b/src/ui/stripe-checkout-purchases-ui.svelte
@@ -48,6 +48,7 @@
     attributionMetadata?: AttributionMetadata;
     paywallId?: string;
     paywallSessionId?: string;
+    appearanceOverride?: Partial<BrandingAppearance>;
   }
 
   const {
@@ -70,6 +71,7 @@
     attributionMetadata,
     paywallId,
     paywallSessionId,
+    appearanceOverride,
   }: Props = $props();
   let productDetails: Product = rcPackage.webBillingProduct;
   let translator: Translator = new Translator(
@@ -181,6 +183,7 @@
         paywallId,
         paywallSessionId,
         locale: selectedLocale,
+        ...(appearanceOverride ? { appearanceOverride } : {}),
       });
 
       if (


### PR DESCRIPTION
## Summary

Apps need to adapt checkout branding at runtime, for example when switching between light and dark presentation. Previously, `purchases-js` only used the Dashboard branding configuration and its internal appearance override was neither public nor sent to checkout start.

This change exposes a partial `brandingAppearanceOverride` through `Purchases.configure()`, `presentPaywall()`, and `purchase()`. Configure-time values become instance defaults, while values passed for a specific paywall or purchase take precedence. The resolved override also updates the SDK checkout UI without mutating cached branding and is forwarded to `/checkout/start` as `appearance_override`.

The override is intentionally per SDK instance or purchase and is not persisted through checkout sessions.

## Compatibility and rollout

- Existing integrations are unchanged when no override is supplied.
- Stripe's mobile wallet presentation can use the supported branding values, but the Stripe-hosted "Pay another way" fallback remains light and cannot be fully themed.
- End-to-end Stripe customization depends on Khepri accepting and applying `appearance_override` on `/rcbilling/v1/checkout/start`.

Closes WEB-4597.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches purchase/checkout start and all payment paths (Web Billing, Stripe, Paddle) with new API surface; behavior is backward-compatible when overrides are omitted, but incorrect merge or backend handling of `appearance_override` could affect checkout presentation.
> 
> **Overview**
> Adds public **`brandingAppearanceOverride`** (`Partial<BrandingAppearance>`) on **`Purchases.configure()`**, **`purchase()`**, and **`presentPaywall()`** so checkout can be themed at runtime without relying only on Dashboard branding.
> 
> **Precedence:** instance configure-time defaults merge with per-purchase/per-paywall overrides; operation-level fields win. Overrides are applied for checkout UI via merge helpers that **do not mutate** cached branding info, and the resolved partial override is sent to checkout start as **`appearance_override`**. **`presentPaywall`** forwards paywall overrides into the nested **`purchase()`** call.
> 
> **API shift:** `PurchaseParams.brandingAppearanceOverride` moves from an internal full override to this public partial model (with Stripe wallet theming notes in docs). **`DEFAULT_BRANDING_APPEARANCE`** backs merges when dashboard appearance is missing.
> 
> The webbilling demo adds a **Runtime appearance demo** route and loader path to compare default, configure-time, and per-operation palettes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b938960ff5b978762838ec914d4db823400a28e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->