### PR TITLE
Paddle Metadata

### DIFF
--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -337,6 +337,7 @@ export interface PresentPaywallParams {
     readonly hideBackButtons?: boolean;
     readonly htmlTarget?: HTMLElement;
     readonly listener?: PaywallListener;
+    readonly metadata?: PurchaseMetadata;
     readonly offering?: Offering;
     readonly onBack?: (closePaywall: () => void) => void;
     readonly onDiscountCodeChanged?: (discountCode: string | null) => void;

--- a/src/entities/present-paywall-params.ts
+++ b/src/entities/present-paywall-params.ts
@@ -1,4 +1,4 @@
-import type { Offering } from "./offerings";
+import type { Offering, PurchaseMetadata } from "./offerings";
 import type { PaywallListener } from "./paywall-listener";
 import type { ProductChangeInfo } from "./product-change-params";
 import type {
@@ -36,6 +36,14 @@ export interface PresentPaywallParams {
    * If passed the checkout flow will not ask for it to the customer.
    */
   readonly customerEmail?: string;
+
+  /**
+   * The purchase metadata to be passed to the backend when a purchase is started
+   * from the paywall.
+   * Any information provided here will be propagated to the payment gateway and
+   * to the RC transaction as metadata.
+   */
+  readonly metadata?: PurchaseMetadata;
 
   /**
    * @experimental

--- a/src/main.ts
+++ b/src/main.ts
@@ -814,6 +814,7 @@ export class Purchases {
         rcPackage: pkg,
         htmlTarget: paywallParams.purchaseHtmlTarget,
         customerEmail: paywallParams.customerEmail,
+        metadata: paywallParams.metadata,
         showDiscountCodeField: paywallParams.showDiscountCodeField,
         discountCode: paywallParams.discountCode,
         onDiscountCodeChanged: paywallParams.onDiscountCodeChanged,

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import type {
   Offerings,
   Package,
   Product,
+  PurchaseMetadata,
 } from "./entities/offerings";
 import PurchasesUi from "./ui/purchases-ui.svelte";
 import PaddlePurchasesUi from "./ui/paddle-purchases-ui.svelte";
@@ -1143,6 +1144,7 @@ export class Purchases {
         paywallParams.customerEmail,
         onError("Error presenting express purchase button"),
         listener,
+        paywallParams.metadata,
       );
 
       certainHTMLTarget.innerHTML = "";
@@ -1571,6 +1573,8 @@ export class Purchases {
    * @param onSuccess - The callback to be called when the purchase is successful.
    * @param customerEmail - The email of the user. If undefined, RevenueCat will ask the customer for their email.
    * @param onPurchaseError - The callback to be called when the purchase fails.
+   * @param listener - Optional paywall listener for purchase lifecycle events.
+   * @param metadata - Optional purchase metadata forwarded to express checkout.
    * @returns Function that renders the wallet button.
    */
   public getWalletButtonRender(
@@ -1579,6 +1583,7 @@ export class Purchases {
     customerEmail?: string,
     onError?: (error: Error) => void,
     listener?: PaywallListener,
+    metadata?: PurchaseMetadata,
   ): WalletButtonRender | undefined {
     if (!isWebBillingApiKey(this._API_KEY)) {
       return undefined;
@@ -1600,6 +1605,7 @@ export class Purchases {
         rcPackage: pkg,
         customerEmail: customerEmail,
         htmlTarget: element,
+        metadata,
         onButtonReady: (updater, walletsAvailable) => {
           buttonUpdater = updater;
           onReady?.(walletsAvailable);

--- a/src/tests/wallet-button-render.test.ts
+++ b/src/tests/wallet-button-render.test.ts
@@ -98,4 +98,22 @@ describe("Purchases.getWalletButtonRender()", () => {
     expect(result.selectedPackage).toBe(monthlyPackage);
     expect(result.storeTransaction.productIdentifier).toBe("monthly");
   });
+
+  test("forwards metadata to the express purchase button", async () => {
+    const metadata = { tolt_referral: "ref_123" };
+    const render = purchases.getWalletButtonRender(
+      offering,
+      onSuccess,
+      undefined,
+      undefined,
+      undefined,
+      metadata,
+    );
+    render!(document.createElement("div"), {
+      selectedPackageId: monthlyPackage.identifier,
+      onReady: vi.fn(),
+    });
+    await vi.waitFor(() => expect(buttonProps).toBeDefined());
+    expect(buttonProps!.metadata).toEqual(metadata);
+  });
 });


### PR DESCRIPTION
## Motivation / Description
Currently devs cannot pass metadata to Paddle. This is necessary for some integrations like Tolt.
Backend: khepri/pull/23967

## Changes introduced
src/entities/present-paywall-params.ts
-  Added metadata?: PurchaseMetadata

src/main.ts
- startPurchaseFlow now passes metadata: paywallParams.metadata into this.purchase(...)

api-report/purchases-js.api.md
- ran extract-api to generate it

## Linear ticket (if any)
ticket: 82631

## Additional comments


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional API and pass-through wiring with no auth or breaking signature changes beyond an extended internal wallet render helper.
> 
> **Overview**
> Adds optional **`metadata`** on **`PresentPaywallParams`** so integrators can attach key/value purchase metadata (e.g. partner referral IDs) when a purchase starts from the paywall.
> 
> That value is now threaded into the standard paywall **`purchase`** call and into **express wallet** checkout via **`getWalletButtonRender`** → **`presentExpressPurchaseButton`**, so it can reach the backend, payment gateway, and RC transaction metadata. The public API surface is updated accordingly, with a unit test asserting metadata is passed to the express purchase button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a1d4d4c0a001ac92fcb70b7733343fa7848ba14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->