### PR TITLE
WEB-4603 Use redemption redirect URLs in SDK-rendered QR codes

### DIFF
--- a/api-report/purchases-js.api.json
+++ b/api-report/purchases-js.api.json
@@ -4744,6 +4744,34 @@
             },
             {
               "kind": "PropertySignature",
+              "canonicalReference": "@revenuecat/purchases-js!PresentPaywallParams#metadata:member",
+              "docComment": "/**\n * The purchase metadata to be passed to the backend when a purchase is started from the paywall. Any information provided here will be propagated to the payment gateway and to the RC transaction as metadata.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly metadata?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "PurchaseMetadata",
+                  "canonicalReference": "@revenuecat/purchases-js!PurchaseMetadata:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "metadata",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
               "canonicalReference": "@revenuecat/purchases-js!PresentPaywallParams#offering:member",
               "docComment": "/**\n * The identifier of the offering to fetch the paywall for. Can be a string identifier or one of the predefined keywords.\n */\n",
               "excerptTokens": [
@@ -8627,7 +8655,7 @@
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "readonly redeemUrlRedirect?: "
+                  "text": "readonly redeemUrlRedirect: "
                 },
                 {
                   "kind": "Content",
@@ -8639,7 +8667,7 @@
                 }
               ],
               "isReadonly": true,
-              "isOptional": true,
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "redeemUrlRedirect",
               "propertyTypeTokenRange": {

--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -538,7 +538,7 @@ export interface PurchasesErrorExtra {
 // @public
 export interface RedemptionInfo {
     readonly redeemUrl: string | null;
-    readonly redeemUrlRedirect?: string | null;
+    readonly redeemUrlRedirect: string | null;
 }
 
 // @public

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@eslint/js": "^9.16.0",
     "@microsoft/api-extractor": "^7.48.0",
     "@paddle/paddle-js": "^1.6.4",
-    "@revenuecat/purchases-ui-js": "4.8.16",
+    "@revenuecat/purchases-ui-js": "4.8.18",
     "@storybook/addon-essentials": "^8.6.15",
     "@storybook/addon-interactions": "^8.6.15",
     "@storybook/addon-links": "^8.6.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^1.6.4
         version: 1.6.4
       "@revenuecat/purchases-ui-js":
-        specifier: 4.8.16
-        version: 4.8.16(svelte@5.46.4)
+        specifier: 4.8.18
+        version: 4.8.18(svelte@5.46.4)
       "@storybook/addon-essentials":
         specifier: ^8.6.15
         version: 8.6.15(@types/react@19.0.10)(storybook@8.6.15(prettier@3.4.2))
@@ -722,10 +722,10 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
 
-  "@revenuecat/purchases-ui-js@4.8.16":
+  "@revenuecat/purchases-ui-js@4.8.18":
     resolution:
       {
-        integrity: sha512-MNAM7H4yaPffzqXgrHY8XXSQM1vdOBRMvspoUSJHdJjNB8oVIyfAXSJKRPfR6W28LvSOE3Z5s6jG6ccfw1adPw==,
+        integrity: sha512-kacOKDUJp5JkY0EfsvnwVqi/PkX8i4RielFk33YB40oxpvRx/tXLXbe3sLN1CTL8mjsbaTy7RNtOXCcj2Tgqxw==,
       }
     engines: { node: ^22.18 || ^24.11 }
     peerDependencies:
@@ -6164,7 +6164,7 @@ snapshots:
 
   "@pkgr/core@0.1.1": {}
 
-  "@revenuecat/purchases-ui-js@4.8.16(svelte@5.46.4)":
+  "@revenuecat/purchases-ui-js@4.8.18(svelte@5.46.4)":
     dependencies:
       "@revenuecat/workflow-web-components-sdk": 0.1.4
       qrcode: 1.5.4

--- a/src/entities/redemption-info.ts
+++ b/src/entities/redemption-info.ts
@@ -15,7 +15,7 @@ export interface RedemptionInfo {
    * The HTTPS URL that redirects to the redeem URL.
    * Use this URL when a browser-compatible URL is required, such as for QR codes.
    */
-  readonly redeemUrlRedirect?: string | null;
+  readonly redeemUrlRedirect: string | null;
 }
 
 export function toRedemptionInfo(


### PR DESCRIPTION
### Motivation

[WEB-4603](https://linear.app/revenuecat/issue/WEB-4603)

purchases-js already exposes the alternative HTTP(S) redemption URL introduced for WEB-4553, but its bundled purchases-ui-js version does not use that URL when rendering redemption QR codes.

### Description

Update `@revenuecat/purchases-ui-js` from `4.8.16` to `4.8.18`.

The updated UI package:

- Uses the alternative HTTP(S) redemption URL for Redemption Button QR codes when available.
- Falls back to the existing custom-scheme URL when the alternative URL is missing or empty.
- Keeps direct mobile redemption on the existing custom-scheme URL.

This changes only the QR-code path for SDK-rendered paywalls. Existing integrations that do not receive the alternative URL retain their current behavior.

Related changes:

- UI: [RevenueCat/purchases-ui-js#369](https://github.com/RevenueCat/purchases-ui-js/pull/369)
- Funnels runtime: [RevenueCat/rc-workflows#286](https://github.com/RevenueCat/rc-workflows/pull/286)
- Original customer issue: [WEB-4553](https://linear.app/revenuecat/issue/WEB-4553)
