### PR TITLE
feat(vega): purchase tester improvements

### DIFF
--- a/examples/amazonvega-demo/PurchaseTester/pnpm-lock.yaml
+++ b/examples/amazonvega-demo/PurchaseTester/pnpm-lock.yaml
@@ -1814,6 +1814,9 @@ packages:
     resolution: {directory: ../../.., type: directory}
     peerDependencies:
       '@amazon-devices/keplerscript-appstore-iap-lib': 2.12.16
+    peerDependenciesMeta:
+      '@amazon-devices/keplerscript-appstore-iap-lib':
+        optional: true
 
   '@rnx-kit/tools-node@2.1.2':
     resolution:
@@ -8757,7 +8760,7 @@ snapshots:
       react-native: 0.72.0(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react@18.2.0)
 
   '@revenuecat/purchases-js@file:../../..(@amazon-devices/keplerscript-appstore-iap-lib@2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))':
-    dependencies:
+    optionalDependencies:
       '@amazon-devices/keplerscript-appstore-iap-lib': 2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))
 
   '@rnx-kit/tools-node@2.1.2': {}

--- a/examples/amazonvega-demo/PurchaseTester/src/components/AllOfferingsList.styles.ts
+++ b/examples/amazonvega-demo/PurchaseTester/src/components/AllOfferingsList.styles.ts
@@ -1,27 +1,10 @@
 import {StyleSheet} from 'react-native';
 
 export const styles = StyleSheet.create({
-  card: {
-    backgroundColor: '#FFFFFF',
-    borderColor: 'rgba(60, 60, 67, 0.12)',
-    borderRadius: 20,
-    borderWidth: 1,
-    marginBottom: 16,
-    padding: 24,
-  },
-  cardHeader: {
-    alignItems: 'center',
+  actions: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
-  cardTitleGroup: {
-    flex: 1,
-    paddingRight: 16,
-  },
-  chevron: {
-    color: '#1479B8',
-    fontSize: 32,
-    lineHeight: 32,
+    gap: 12,
+    marginTop: 20,
   },
   content: {
     paddingBottom: 24,
@@ -36,62 +19,77 @@ export const styles = StyleSheet.create({
     fontSize: 18,
     marginTop: 32,
   },
-  expandedCard: {
-    borderColor: '#9CCFEB',
-  },
-  focusedCard: {
-    borderColor: '#0077B6',
-    borderWidth: 3,
-  },
   identifier: {
     color: 'rgba(60, 60, 67, 0.6)',
     fontSize: 18,
     marginTop: 8,
   },
+  jsonScroll: {
+    flex: 1,
+  },
   list: {
     flex: 1,
   },
-  productIdentifier: {
-    color: 'rgba(60, 60, 67, 0.6)',
-    fontSize: 16,
-    marginTop: 4,
+  offering: {
+    marginBottom: 32,
   },
-  packageIdentifier: {
-    color: 'rgba(32, 84, 122, 0.8)',
-    fontSize: 15,
-    marginTop: 4,
-  },
-  productCount: {
-    color: '#1479B8',
-    fontSize: 17,
-    fontWeight: '600',
-    marginTop: 16,
-  },
-  productDetails: {
-    backgroundColor: '#EAF6FF',
-    borderColor: '#B8DEF5',
-    borderRadius: 14,
+  productCard: {
+    backgroundColor: '#FFFFFF',
+    borderColor: 'rgba(60, 60, 67, 0.12)',
+    borderRadius: 20,
     borderWidth: 1,
     marginTop: 16,
-    padding: 16,
+    padding: 24,
+  },
+  productDuration: {
+    color: 'rgba(60, 60, 67, 0.7)',
+    fontSize: 17,
+    marginTop: 8,
   },
   productFields: {
     color: '#173B55',
     fontFamily: 'monospace',
     fontSize: 14,
     lineHeight: 20,
-    marginTop: 12,
+    paddingBottom: 24,
   },
-  productHeading: {
+  productId: {
+    color: '#111111',
+    fontSize: 21,
+    fontWeight: '700',
+  },
+  productPrice: {
     color: '#0B5F91',
-    fontSize: 18,
-    fontWeight: 'bold',
+    fontSize: 22,
+    fontWeight: '700',
+    marginTop: 16,
   },
-  productSection: {
-    borderBottomColor: 'rgba(20, 121, 184, 0.2)',
+  sheet: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 20,
+    height: '80%',
+    padding: 24,
+    width: '84%',
+  },
+  sheetBackdrop: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.45)',
+    flex: 1,
+    justifyContent: 'center',
+  },
+  sheetHeader: {
+    alignItems: 'center',
+    borderBottomColor: 'rgba(60, 60, 67, 0.12)',
     borderBottomWidth: 1,
-    paddingBottom: 16,
-    paddingTop: 16,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 16,
+    paddingBottom: 12,
+  },
+  sheetTitle: {
+    color: '#111111',
+    fontSize: 24,
+    fontWeight: 'bold',
   },
   title: {
     color: '#111111',

--- a/examples/amazonvega-demo/PurchaseTester/src/components/AllOfferingsList.tsx
+++ b/examples/amazonvega-demo/PurchaseTester/src/components/AllOfferingsList.tsx
@@ -1,7 +1,13 @@
 import React, {useEffect, useState} from 'react';
-import {Pressable, ScrollView, Text, View} from 'react-native';
-import {Purchases, type Offering, type Product} from '@revenuecat/purchases-js';
+import {Modal, ScrollView, Text, View} from 'react-native';
+import {
+  Purchases,
+  type Offering,
+  type Package,
+  type Product,
+} from '@revenuecat/purchases-js';
 import {styles} from './AllOfferingsList.styles';
+import {Button} from './Button';
 
 const formatProduct = (product: Product): string =>
   JSON.stringify(
@@ -10,12 +16,19 @@ const formatProduct = (product: Product): string =>
     2,
   );
 
+const formatDuration = (product: Product): string => {
+  if (product.period === null) {
+    return 'One-time purchase';
+  }
+
+  const {number, unit} = product.period;
+  return `Every ${number} ${unit}${number === 1 ? '' : 's'}`;
+};
+
 export const AllOfferingsList = () => {
   const [offerings, setOfferings] = useState<Offering[]>([]);
-  const [expandedOfferingIds, setExpandedOfferingIds] = useState<Set<string>>(
-    new Set(),
-  );
-  const [focusedOfferingId, setFocusedOfferingId] = useState<string | null>(
+  const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+  const [purchasingPackageId, setPurchasingPackageId] = useState<string | null>(
     null,
   );
   const [error, setError] = useState<string | null>(null);
@@ -41,6 +54,25 @@ export const AllOfferingsList = () => {
     void loadOfferings();
   }, []);
 
+  const purchase = async (pkg: Package) => {
+    setPurchasingPackageId(pkg.identifier);
+    console.log(`Purchasing ${pkg.webBillingProduct.identifier}...`);
+
+    try {
+      await Purchases.getSharedInstance().purchase({rcPackage: pkg});
+      console.log(
+        `Successfully purchased ${pkg.webBillingProduct.identifier}.`,
+      );
+    } catch (purchaseError) {
+      console.error(
+        `Failed to purchase ${pkg.webBillingProduct.identifier}:`,
+        purchaseError,
+      );
+    } finally {
+      setPurchasingPackageId(null);
+    }
+  };
+
   if (error) {
     return <Text style={styles.error}>Unable to load offerings: {error}</Text>;
   }
@@ -49,73 +81,71 @@ export const AllOfferingsList = () => {
     return <Text style={styles.empty}>Loading offerings…</Text>;
   }
 
-  const toggleOffering = (offeringId: string) => {
-    setExpandedOfferingIds((currentIds) => {
-      const nextIds = new Set(currentIds);
-
-      if (nextIds.has(offeringId)) {
-        nextIds.delete(offeringId);
-      } else {
-        nextIds.add(offeringId);
-      }
-
-      return nextIds;
-    });
-  };
-
   return (
-    <ScrollView style={styles.list} contentContainerStyle={styles.content}>
-      {offerings.map((offering) => {
-        const isExpanded = expandedOfferingIds.has(offering.identifier);
-        const isFocused = focusedOfferingId === offering.identifier;
-        const productCount = offering.availablePackages.length;
+    <>
+      <ScrollView style={styles.list} contentContainerStyle={styles.content}>
+        {offerings.map((offering) => (
+          <View key={offering.identifier} style={styles.offering}>
+            <Text style={styles.title}>{offering.serverDescription}</Text>
+            <Text style={styles.identifier}>ID: {offering.identifier}</Text>
+            {offering.availablePackages.map((pkg) => {
+              const product = pkg.webBillingProduct;
+              const isPurchasing = purchasingPackageId === pkg.identifier;
 
-        return (
-          <Pressable
-            key={offering.identifier}
-            accessibilityRole="button"
-            accessibilityState={{expanded: isExpanded}}
-            onBlur={() => setFocusedOfferingId(null)}
-            onFocus={() => setFocusedOfferingId(offering.identifier)}
-            onPress={() => toggleOffering(offering.identifier)}
-            style={[
-              styles.card,
-              isExpanded && styles.expandedCard,
-              isFocused && styles.focusedCard,
-            ]}>
-            <View style={styles.cardHeader}>
-              <View style={styles.cardTitleGroup}>
-                <Text style={styles.title}>{offering.serverDescription}</Text>
-                <Text style={styles.identifier}>ID: {offering.identifier}</Text>
-              </View>
-              <Text style={styles.chevron}>{isExpanded ? '⌃' : '⌄'}</Text>
-            </View>
-            <Text style={styles.productCount}>
-              {productCount} {productCount === 1 ? 'product' : 'products'}
-            </Text>
-            {isExpanded && (
-              <View style={styles.productDetails}>
-                {offering.availablePackages.map((pkg) => (
-                  <View key={pkg.identifier} style={styles.productSection}>
-                    <Text style={styles.productHeading}>
-                      {pkg.webBillingProduct.identifier}
-                    </Text>
-                    <Text style={styles.packageIdentifier}>
-                      Package: {pkg.identifier}
-                    </Text>
-                    <Text style={styles.productFields}>
-                      {formatProduct(pkg.webBillingProduct)}
-                    </Text>
+              return (
+                <View key={pkg.identifier} style={styles.productCard}>
+                  <Text style={styles.productId}>{product.identifier}</Text>
+                  <Text style={styles.productPrice}>
+                    {product.price.formattedPrice}
+                  </Text>
+                  <Text style={styles.productDuration}>
+                    {formatDuration(product)}
+                  </Text>
+                  <View style={styles.actions}>
+                    <Button
+                      disabled={isPurchasing}
+                      label={isPurchasing ? 'Purchasing…' : 'Purchase'}
+                      onPress={() => void purchase(pkg)}
+                    />
+                    <Button
+                      label="View details"
+                      onPress={() => setSelectedProduct(product)}
+                      variant="secondary"
+                    />
                   </View>
-                ))}
-              </View>
-            )}
-          </Pressable>
-        );
-      })}
-      {offerings.length === 0 && (
-        <Text style={styles.empty}>No offerings are available.</Text>
-      )}
-    </ScrollView>
+                </View>
+              );
+            })}
+          </View>
+        ))}
+        {offerings.length === 0 && (
+          <Text style={styles.empty}>No offerings are available.</Text>
+        )}
+      </ScrollView>
+
+      <Modal
+        animationType="slide"
+        onRequestClose={() => setSelectedProduct(null)}
+        transparent
+        visible={selectedProduct !== null}>
+        <View style={styles.sheetBackdrop}>
+          <View style={styles.sheet}>
+            <View style={styles.sheetHeader}>
+              <Text style={styles.sheetTitle}>Product details</Text>
+              <Button
+                label="Close"
+                onPress={() => setSelectedProduct(null)}
+                variant="secondary"
+              />
+            </View>
+            <ScrollView style={styles.jsonScroll}>
+              <Text style={styles.productFields}>
+                {selectedProduct === null ? '' : formatProduct(selectedProduct)}
+              </Text>
+            </ScrollView>
+          </View>
+        </View>
+      </Modal>
+    </>
   );
 };

--- a/examples/amazonvega-demo/PurchaseTester/src/components/AllOfferingsList.tsx
+++ b/examples/amazonvega-demo/PurchaseTester/src/components/AllOfferingsList.tsx
@@ -55,6 +55,10 @@ export const AllOfferingsList = () => {
   }, []);
 
   const purchase = async (pkg: Package) => {
+    if (purchasingPackageId !== null) {
+      return;
+    }
+
     setPurchasingPackageId(pkg.identifier);
     console.log(`Purchasing ${pkg.webBillingProduct.identifier}...`);
 
@@ -103,7 +107,6 @@ export const AllOfferingsList = () => {
                   </Text>
                   <View style={styles.actions}>
                     <Button
-                      disabled={isPurchasing}
                       label={isPurchasing ? 'Purchasing…' : 'Purchase'}
                       onPress={() => void purchase(pkg)}
                     />
@@ -133,6 +136,7 @@ export const AllOfferingsList = () => {
             <View style={styles.sheetHeader}>
               <Text style={styles.sheetTitle}>Product details</Text>
               <Button
+                hasTVPreferredFocus
                 label="Close"
                 onPress={() => setSelectedProduct(null)}
                 variant="secondary"

--- a/examples/amazonvega-demo/PurchaseTester/src/components/Button.styles.ts
+++ b/examples/amazonvega-demo/PurchaseTester/src/components/Button.styles.ts
@@ -1,0 +1,34 @@
+import {StyleSheet} from 'react-native';
+
+export const styles = StyleSheet.create({
+  button: {
+    borderColor: 'transparent',
+    borderRadius: 10,
+    borderWidth: 3,
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+  },
+  disabledButton: {
+    opacity: 0.55,
+  },
+  focusedButton: {
+    borderColor: '#FF9900',
+  },
+  label: {
+    fontSize: 17,
+    fontWeight: '700',
+  },
+  primaryButton: {
+    backgroundColor: '#111111',
+  },
+  primaryLabel: {
+    color: '#FFFFFF',
+  },
+  secondaryButton: {
+    backgroundColor: '#FFFFFF',
+    borderColor: '#1479B8',
+  },
+  secondaryLabel: {
+    color: '#1479B8',
+  },
+});

--- a/examples/amazonvega-demo/PurchaseTester/src/components/Button.tsx
+++ b/examples/amazonvega-demo/PurchaseTester/src/components/Button.tsx
@@ -1,0 +1,46 @@
+import React, {useState} from 'react';
+import {Pressable, Text, type GestureResponderEvent} from 'react-native';
+import {styles} from './Button.styles';
+
+type ButtonVariant = 'primary' | 'secondary';
+
+interface ButtonProps {
+  label: string;
+  onPress: (event: GestureResponderEvent) => void;
+  disabled?: boolean;
+  hasTVPreferredFocus?: boolean;
+  variant?: ButtonVariant;
+}
+
+export const Button = ({
+  label,
+  onPress,
+  disabled = false,
+  hasTVPreferredFocus = false,
+  variant = 'primary',
+}: ButtonProps) => {
+  const [isFocused, setIsFocused] = useState(false);
+
+  return (
+    <Pressable
+      disabled={disabled}
+      hasTVPreferredFocus={hasTVPreferredFocus}
+      onBlur={() => setIsFocused(false)}
+      onFocus={() => setIsFocused(true)}
+      onPress={onPress}
+      style={[
+        styles.button,
+        variant === 'primary' ? styles.primaryButton : styles.secondaryButton,
+        isFocused && styles.focusedButton,
+        disabled && styles.disabledButton,
+      ]}>
+      <Text
+        style={[
+          styles.label,
+          variant === 'primary' ? styles.primaryLabel : styles.secondaryLabel,
+        ]}>
+        {label}
+      </Text>
+    </Pressable>
+  );
+};

--- a/examples/amazonvega-demo/PurchaseTester/src/screens/ConfigureScreen.styles.ts
+++ b/examples/amazonvega-demo/PurchaseTester/src/screens/ConfigureScreen.styles.ts
@@ -65,18 +65,8 @@ export const styles = StyleSheet.create({
     lineHeight: 24,
     marginTop: 6,
   },
-  configureButton: {
-    alignItems: 'center',
-    backgroundColor: '#111111',
-    borderRadius: 10,
+  configureButtonContainer: {
     marginTop: 20,
-    paddingHorizontal: 40,
-    paddingVertical: 14,
-  },
-  configureButtonText: {
-    color: '#FFFFFF',
-    fontSize: 20,
-    fontWeight: 'bold',
   },
   configureError: {
     color: '#B42318',

--- a/examples/amazonvega-demo/PurchaseTester/src/screens/ConfigureScreen.tsx
+++ b/examples/amazonvega-demo/PurchaseTester/src/screens/ConfigureScreen.tsx
@@ -65,11 +65,13 @@ export const ConfigureScreen = ({onConfigured}: ConfigureScreenProps) => {
         <Text style={styles.secondary}>
           Modify these values in constants.ts
         </Text>
-        <Button
-          hasTVPreferredFocus
-          label="Configure"
-          onPress={configurePurchases}
-        />
+        <View style={styles.configureButtonContainer}>
+          <Button
+            hasTVPreferredFocus
+            label="Configure"
+            onPress={configurePurchases}
+          />
+        </View>
         {configureError && (
           <Text style={styles.configureError}>{configureError}</Text>
         )}

--- a/examples/amazonvega-demo/PurchaseTester/src/screens/ConfigureScreen.tsx
+++ b/examples/amazonvega-demo/PurchaseTester/src/screens/ConfigureScreen.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
-import {Pressable, Text, View} from 'react-native';
-import {Purchases} from '@revenuecat/purchases-js';
+import {Text, View} from 'react-native';
+import {LogLevel, Purchases} from '@revenuecat/purchases-js';
+import {Button} from '../components/Button';
 import {API_KEY, APP_USER_ID} from '../constants';
 import {ScreenContainer} from '../ScreenContainer';
 import {styles} from './ConfigureScreen.styles';
@@ -18,6 +19,7 @@ export const ConfigureScreen = ({onConfigured}: ConfigureScreenProps) => {
   const configurePurchases = () => {
     console.log('Configuring the RevenueCat SDK...');
     try {
+      Purchases.setLogLevel(LogLevel.Verbose);
       Purchases.configure({
         apiKey: API_KEY,
         appUserId,
@@ -63,12 +65,11 @@ export const ConfigureScreen = ({onConfigured}: ConfigureScreenProps) => {
         <Text style={styles.secondary}>
           Modify these values in constants.ts
         </Text>
-        <Pressable
+        <Button
           hasTVPreferredFocus
-          style={styles.configureButton}
-          onPress={configurePurchases}>
-          <Text style={styles.configureButtonText}>Configure</Text>
-        </Pressable>
+          label="Configure"
+          onPress={configurePurchases}
+        />
         {configureError && (
           <Text style={styles.configureError}>{configureError}</Text>
         )}

--- a/examples/amazonvega-demo/PurchaseTester/src/screens/HomeScreen.tsx
+++ b/examples/amazonvega-demo/PurchaseTester/src/screens/HomeScreen.tsx
@@ -1,12 +1,34 @@
 import React, {useState} from 'react';
-import {Pressable, Text, View} from 'react-native';
+import {View} from 'react-native';
+import {Purchases} from '@revenuecat/purchases-js';
 import {AllOfferingsList} from '../components/AllOfferingsList';
+import {Button} from '../components/Button';
 import {ScreenContainer} from '../ScreenContainer';
 import {LogsScreen} from './LogsScreen';
 import {styles} from './LogsScreen.styles';
 
 export const HomeScreen = () => {
   const [isShowingLogs, setIsShowingLogs] = useState(false);
+
+  const syncPurchases = async () => {
+    console.log('Syncing purchases...');
+    try {
+      await Purchases.getSharedInstance().syncPurchases();
+      console.log('Successfully synced purchases.');
+    } catch (error) {
+      console.error('Failed to sync purchases:', error);
+    }
+  };
+
+  const restorePurchases = async () => {
+    console.log('Restoring purchases...');
+    try {
+      await Purchases.getSharedInstance().restorePurchases();
+      console.log('Successfully restored purchases.');
+    } catch (error) {
+      console.error('Failed to restore purchases:', error);
+    }
+  };
 
   if (isShowingLogs) {
     return <LogsScreen onBack={() => setIsShowingLogs(false)} />;
@@ -15,12 +37,16 @@ export const HomeScreen = () => {
   return (
     <ScreenContainer subtitle="Home">
       <View style={styles.actions}>
-        <Pressable
+        <Button label="Sync purchases" onPress={() => void syncPurchases()} />
+        <Button
+          label="Restore purchases"
+          onPress={() => void restorePurchases()}
+        />
+        <Button
           hasTVPreferredFocus
-          style={styles.button}
-          onPress={() => setIsShowingLogs(true)}>
-          <Text style={styles.buttonText}>View app logs</Text>
-        </Pressable>
+          label="View app logs"
+          onPress={() => setIsShowingLogs(true)}
+        />
       </View>
       <AllOfferingsList />
     </ScreenContainer>

--- a/examples/amazonvega-demo/PurchaseTester/src/screens/LogsScreen.tsx
+++ b/examples/amazonvega-demo/PurchaseTester/src/screens/LogsScreen.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {Pressable, ScrollView, Text, View} from 'react-native';
+import {ScrollView, Text, View} from 'react-native';
 import {
   clearAppLogs,
   getAppLogs,
@@ -7,6 +7,7 @@ import {
   subscribeToAppLogs,
   type AppLogEntry,
 } from '../app-logs';
+import {Button} from '../components/Button';
 import {ScreenContainer} from '../ScreenContainer';
 import {styles} from './LogsScreen.styles';
 
@@ -17,17 +18,18 @@ interface LogsScreenProps {
 export const LogsScreen = ({onBack}: LogsScreenProps) => {
   const [logs, setLogs] = useState<readonly AppLogEntry[]>(getAppLogs());
 
-  useEffect(() => subscribeToAppLogs(() => setLogs([...getAppLogs()])), []);
+  useEffect(() => {
+    const unsubscribe = subscribeToAppLogs(() => setLogs([...getAppLogs()]));
+    return () => {
+      unsubscribe();
+    };
+  }, []);
 
   return (
     <ScreenContainer subtitle={`App logs (${logs.length}/${maxAppLogEntries})`}>
       <View style={styles.actions}>
-        <Pressable hasTVPreferredFocus style={styles.button} onPress={onBack}>
-          <Text style={styles.buttonText}>Back</Text>
-        </Pressable>
-        <Pressable style={styles.button} onPress={clearAppLogs}>
-          <Text style={styles.buttonText}>Clear logs</Text>
-        </Pressable>
+        <Button hasTVPreferredFocus label="Back" onPress={onBack} />
+        <Button label="Clear logs" onPress={clearAppLogs} />
       </View>
       <ScrollView style={styles.list} contentContainerStyle={styles.content}>
         {logs.length === 0 ? (


### PR DESCRIPTION
## Changes introduced
Introduces new functionality and QoL improvements to the Vega Purchase Tester app, including:
- Buttons on the home screen to trigger `syncPurchases()`/`restorePurchases()`
- Previously, the offering list was difficult to manage, since each product had their entire JSON printed on the screen. That has been replaced with a button that, when tapped, shows a dismissable sheet with the product's JSON on it
- Display the price/duration of products in the offering list
- A button is introduced to allow you to purchase a package
- An orange border now appears on the focused button, making the app MUCH easier to navigate

This code has been tested and code-reviewed by me, but was 100% agent generated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Demo-only UI and SDK usage in the Vega Purchase Tester; no production or security-critical code.
> 
> **Overview**
> Improves the Vega Purchase Tester so testers can actually exercise purchases instead of only browsing expandable JSON.
> 
> The offerings list now shows price and duration per package, with **Purchase** (guarded against double-taps) and **View details** (JSON in a modal). Home adds **Sync purchases** and **Restore purchases**. A shared `Button` with an orange TV focus ring replaces ad-hoc `Pressable`s, and configure now sets `LogLevel.Verbose`. The Amazon IAP peer dep is marked optional in the lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 440d7133f6581b3a2d824c0de23492d4040f6c79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->