### PR TITLE
fix(vega): show all SDK logs when running on vega

### DIFF
--- a/src/helpers/logger.ts
+++ b/src/helpers/logger.ts
@@ -3,6 +3,7 @@ import { LogLevel, type LogHandler } from "../entities/logging";
 export class Logger {
   private static logLevel: LogLevel = LogLevel.Silent;
   private static logHandler: LogHandler | null = null;
+  private static useConsoleLogForDebugMessages = false;
 
   static setLogLevel(logLevel: LogLevel) {
     this.logLevel = logLevel;
@@ -10,6 +11,11 @@ export class Logger {
 
   static setLogHandler(handler: LogHandler | null) {
     this.logHandler = handler;
+  }
+
+  /** @internal */
+  static enableConsoleLogForDebugMessages() {
+    this.useConsoleLogForDebugMessages = true;
   }
 
   static log(message: string, logLevel: LogLevel = this.logLevel): void {
@@ -36,10 +42,18 @@ export class Logger {
         console.info(messageWithTag);
         break;
       case LogLevel.Debug:
-        console.debug(messageWithTag);
+        if (this.useConsoleLogForDebugMessages) {
+          console.log(messageWithTag);
+        } else {
+          console.debug(messageWithTag);
+        }
         break;
       case LogLevel.Verbose:
-        console.debug(messageWithTag);
+        if (this.useConsoleLogForDebugMessages) {
+          console.log(messageWithTag);
+        } else {
+          console.debug(messageWithTag);
+        }
         break;
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -470,6 +470,13 @@ export class Purchases {
     const finalFlags = flags ?? defaultFlagsConfig;
 
     Purchases.validateConfig(config);
+
+    // Vega does not surface console.debug() at its default logging threshold,
+    // so use console.log() for SDK debug messages when using the Amazon store.
+    if (isAmazonApiKey(apiKey)) {
+      Logger.enableConsoleLogForDebugMessages();
+    }
+
     Purchases.instance = new Purchases(
       apiKey,
       appUserId,

--- a/src/tests/helpers/logger.test.ts
+++ b/src/tests/helpers/logger.test.ts
@@ -7,6 +7,7 @@ describe("Logger", () => {
     // Reset logger state before each test
     Logger.setLogLevel(LogLevel.Silent);
     Logger.setLogHandler(null);
+    Reflect.set(Logger, "useConsoleLogForDebugMessages", false);
   });
 
   afterEach(() => {
@@ -47,6 +48,22 @@ describe("Logger", () => {
       expect(consoleSpy).toHaveBeenCalledWith("[Purchases] test message 2");
 
       consoleSpy.mockRestore();
+    });
+
+    test("should keep using a custom handler when Amazon console logging is enabled", () => {
+      const mockHandler = vi.fn();
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      Logger.enableConsoleLogForDebugMessages();
+      Logger.setLogHandler(mockHandler);
+      Logger.setLogLevel(LogLevel.Debug);
+
+      Logger.debugLog("debug message");
+
+      expect(mockHandler).toHaveBeenCalledWith(
+        LogLevel.Debug,
+        "[Purchases] debug message",
+      );
+      expect(consoleSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -215,6 +232,20 @@ describe("Logger", () => {
         "[Purchases] verbose message",
       );
       consoleSpy.mockRestore();
+    });
+
+    test("should use console.log for debug and verbose logs when configured for Amazon", () => {
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+      Logger.enableConsoleLogForDebugMessages();
+      Logger.setLogLevel(LogLevel.Verbose);
+
+      Logger.debugLog("debug message");
+      Logger.verboseLog("verbose message");
+
+      expect(logSpy).toHaveBeenNthCalledWith(1, "[Purchases] debug message");
+      expect(logSpy).toHaveBeenNthCalledWith(2, "[Purchases] verbose message");
+      expect(debugSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -29,6 +29,7 @@ import { expectPromiseToError } from "./test-helpers";
 import { StatusCodes } from "http-status-codes";
 import type { BrandingInfoResponse } from "../networking/responses/branding-response";
 import { AmazonBillingWrapper } from "../amazon/amazon-billing-wrapper";
+import { Logger } from "../helpers/logger";
 
 const { getAmazonProductData } = vi.hoisted(() => ({
   getAmazonProductData: vi.fn(),
@@ -229,21 +230,31 @@ describe("Purchases.configure()", () => {
   });
 
   test("does not throw error if given valid Amazon API key", () => {
+    const loggerSpy = vi.spyOn(Logger, "enableConsoleLogForDebugMessages");
+
     expect(() =>
       Purchases.configure({
         apiKey: "amzn_valid_key",
         appUserId: testUserId,
       }),
     ).not.toThrow();
+
+    expect(loggerSpy).toHaveBeenCalledOnce();
+    loggerSpy.mockRestore();
   });
 
   test("does not throw error if given valid web billing api key", () => {
+    const loggerSpy = vi.spyOn(Logger, "enableConsoleLogForDebugMessages");
+
     expect(() =>
       Purchases.configure({
         apiKey: testApiKey,
         appUserId: testUserId,
       }),
     ).not.toThrow();
+
+    expect(loggerSpy).not.toHaveBeenCalled();
+    loggerSpy.mockRestore();
   });
 
   test("does not throw error if given valid simulated store api key", () => {


### PR DESCRIPTION
## Changes introduced

Improves SDK logging when running on Vega by routing debug and verbose logs through `console.log`, since the Vega OS does not surface `console.debug` logs.

Also adds test coverage to verify:
- Amazon API keys enable the Vega-specific logging behavior.
- Web billing API keys do not enable it.
- Custom log handlers continue to take precedence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change gated to Amazon keys; no auth, billing, or data-handling behavior is modified.
> 
> **Overview**
> Makes SDK debug and verbose logs visible on Vega by sending them through `console.log` instead of `console.debug`, which Vega does not surface at its default log threshold.
> 
> `Purchases.configure` enables this only for Amazon API keys. Custom log handlers still take precedence. Tests cover the Amazon vs web-billing configure path and the logger fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a003f9be4eff53cdf14f4c403eaff2e63b628da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->