### PR TITLE
fix(vega): ensure IAP lib import is only resolvable at runtime

### DIFF
--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -325,7 +325,12 @@ export class AmazonBillingWrapper implements BillingWrapper {
 
   private async loadAmazonAppstoreIAPSDK(): Promise<AmazonAppstoreIAPSDK> {
     Logger.debugLog("Loading the Amazon AppStore IAP SDK.");
-    const amazonSdkModule = "@amazon-devices/keplerscript-appstore-iap-lib";
+    // Keep this globalThis.String() call. It prevents minifiers from turning the
+    // runtime-only import below into a static import, which would make web bundlers
+    // require this Vega-only optional dependency even when an Amazon API key is not used.
+    const amazonSdkModule = globalThis.String(
+      "@amazon-devices/keplerscript-appstore-iap-lib",
+    );
 
     try {
       // Keep web bundlers from following this Vega-only dependency into its


### PR DESCRIPTION
## Motivation / Description
purchases-js loads `@amazon-devices/keplerscript-appstore-iap-lib` only when configured with an Amazon API key. The module must remain a runtime-only import so web applications don't accidentally install the vega-only optional dependency.

Before this change, we were importing the Appstore IAP SDK like this:

```typescript
const amazonSdkModule = "@amazon-devices/keplerscript-appstore-iap-lib";
await import(amazonSdkModule);
```

This works, except for one quirk: in purchase-hybrid-common's `purchases-js-hybrid-mappings, we use terser to minify the code. Terser was optimizing away the `amazonSdkModule` variable, so the code was effectively this:

```typescript
await import("@amazon-devices/keplerscript-appstore-iap-lib");
```

This is normally a smart optimization, but this meant that web builds would then find the import for `@amazon-devices/keplerscript-appstore-iap-lib`, try to import it, and then their builds would fail, since that dependency is only available on the Vega OS.

## Changes introduced

Wrapping the module specifier with `globalThis.String(...)` prevents Vite and subsequent Rollup/Terser builds from folding the dynamic import into a statically resolvable string. This keeps the Amazon package out of ordinary web builds while preserving runtime loading on Vega.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line bundling/minification guard in Amazon billing loader; no runtime billing logic changes.
> 
> **Overview**
> **Fixes web/hybrid builds** that minify `purchases-js` and were failing because Terser folded the Amazon IAP module path into a **static** `import("@amazon-devices/keplerscript-appstore-iap-lib")`, forcing bundlers to resolve a Vega-only optional package even when no Amazon API key is configured.
> 
> In `loadAmazonAppstoreIAPSDK`, the module specifier is now built via `globalThis.String(...)` with an explicit comment so minifiers cannot inline it back to a literal string. The existing dynamic `import(/* @vite-ignore */ amazonSdkModule)` behavior on Vega is unchanged; web builds no longer statically pull in that dependency at bundle time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 429fbcd8485fcce53c51f07672cde011461b973d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->