### PR TITLE
fix(vega): inject the vega IAP SDK new module entrypoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,6 +214,9 @@ jobs:
           name: Build
           command: pnpm run build
       - run:
+          name: Verify standard and Vega entry point boundaries
+          command: pnpm run verify:entry-point-boundaries
+      - run:
           name: Extract API using api-extractor
           command: pnpm run extract-api
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,7 @@ jobs:
           name: Build
           command: pnpm run build
       - run:
-          name: Verify standard and Vega entry point boundaries
+          name: Confirm Amazon AppStore SDK is only present in the Vega entry point
           command: pnpm run verify:entry-point-boundaries
       - run:
           name: Extract API using api-extractor

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ pnpm install
 pnpm run build:dev
 ```
 
+For automatic rebuilds of the web entry point during development, run:
+
+```bash
+pnpm run build:dev-watch
+```
+
+`build:dev-watch` is web-only. It preserves the Vega artifacts produced by
+`build:dev`, but does not rebuild them; rerun `pnpm run build:dev` after
+changing code used by the Vega entry point.
+
 To avoid publishing the package you can use pnpm's link feature:
 
 1. In the purchases-js directory, register the package:

--- a/examples/amazonvega-demo/PurchaseTester/src/components/AllOfferingsList.tsx
+++ b/examples/amazonvega-demo/PurchaseTester/src/components/AllOfferingsList.tsx
@@ -5,7 +5,7 @@ import {
   type Offering,
   type Package,
   type Product,
-} from '@revenuecat/purchases-js';
+} from '@revenuecat/purchases-js/vega';
 import {styles} from './AllOfferingsList.styles';
 import {Button} from './Button';
 

--- a/examples/amazonvega-demo/PurchaseTester/src/screens/ConfigureScreen.tsx
+++ b/examples/amazonvega-demo/PurchaseTester/src/screens/ConfigureScreen.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import {Text, View} from 'react-native';
-import {LogLevel, Purchases} from '@revenuecat/purchases-js';
+import {LogLevel, Purchases} from '@revenuecat/purchases-js/vega';
 import {Button} from '../components/Button';
 import {API_KEY, APP_USER_ID} from '../constants';
 import {ScreenContainer} from '../ScreenContainer';

--- a/examples/amazonvega-demo/PurchaseTester/src/screens/HomeScreen.tsx
+++ b/examples/amazonvega-demo/PurchaseTester/src/screens/HomeScreen.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import {View} from 'react-native';
-import {Purchases} from '@revenuecat/purchases-js';
+import {Purchases} from '@revenuecat/purchases-js/vega';
 import {AllOfferingsList} from '../components/AllOfferingsList';
 import {Button} from '../components/Button';
 import {ScreenContainer} from '../ScreenContainer';

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "version": "1.53.1",
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "vega.js"
   ],
   "main": "./dist/Purchases.umd.js",
   "module": "./dist/Purchases.es.js",
@@ -14,6 +15,11 @@
     ".": {
       "import": "./dist/Purchases.es.js",
       "require": "./dist/Purchases.umd.js"
+    },
+    "./vega": {
+      "types": "./dist/Purchases.es.d.ts",
+      "import": "./dist/Purchases.vega.es.js",
+      "require": "./dist/Purchases.vega.umd.js"
     },
     "./styles": {
       "import": "./dist/style.css",
@@ -37,7 +43,7 @@
   ],
   "scripts": {
     "watch": "vite build --watch",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && vite build --config vite.vega.config.js",
     "build:dev": "tsc && vite build --mode development",
     "build:dev-watch": "tsc && vite build --mode development --watch",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "format": "prettier --write .",
     "pack-build": "npm run build && npm pack",
     "test": "vitest run",
+    "verify:entry-point-boundaries": "node scripts/verify-entry-point-boundaries.mjs",
     "test:watch": "vitest watch",
     "test:typecheck": "tsc --project tsconfig.test.json",
     "typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
     "iap"
   ],
   "scripts": {
-    "watch": "vite build --watch",
+    "watch": "vite build --config vite.watch.config.js --watch",
     "build": "tsc && vite build && vite build --config vite.vega.config.js",
-    "build:dev": "tsc && vite build --mode development",
-    "build:dev-watch": "tsc && vite build --mode development --watch",
+    "build:dev": "tsc && vite build --mode development && vite build --config vite.vega.config.js --mode development",
+    "build:dev-watch": "tsc && vite build --mode development --config vite.watch.config.js --watch",
     "preview": "vite preview",
     "lint": "prettier --check . && eslint src/",
     "format": "prettier --write .",

--- a/scripts/verify-entry-point-boundaries.mjs
+++ b/scripts/verify-entry-point-boundaries.mjs
@@ -1,0 +1,39 @@
+/**
+ * Verifies the published bundle boundary between the standard and Vega entry
+ * points. This deliberately inspects generated artifacts rather than source
+ * imports: it catches a bundler change that could otherwise pull the Vega-only
+ * Amazon dependency into web, React Native web, or Flutter web consumers.
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const amazonModule = "@amazon-devices/keplerscript-appstore-iap-lib";
+const defaultArtifacts = ["dist/Purchases.es.js", "dist/Purchases.umd.js"];
+const vegaArtifacts = [
+  "dist/Purchases.vega.es.js",
+  "dist/Purchases.vega.umd.js",
+];
+
+for (const artifact of defaultArtifacts) {
+  const contents = readFileSync(artifact, "utf8");
+
+  assert.ok(
+    !contents.includes(amazonModule),
+    `${artifact} must not reference the Vega-only Amazon IAP module`,
+  );
+  assert.ok(
+    !contents.includes("Purchases.vega"),
+    `${artifact} must not reference the Vega entry point`,
+  );
+}
+
+for (const artifact of vegaArtifacts) {
+  const contents = readFileSync(artifact, "utf8");
+
+  assert.ok(
+    contents.includes(amazonModule),
+    `${artifact} must reference the Amazon IAP module`,
+  );
+}
+
+console.log("Verified standard and Vega entry point bundle boundaries.");

--- a/scripts/verify-entry-point-boundaries.mjs
+++ b/scripts/verify-entry-point-boundaries.mjs
@@ -1,8 +1,9 @@
 /**
- * Verifies the published bundle boundary between the standard and Vega entry
- * points. This deliberately inspects generated artifacts rather than source
- * imports: it catches a bundler change that could otherwise pull the Vega-only
- * Amazon dependency into web, React Native web, or Flutter web consumers.
+ * Makes sure Amazon AppStore support is included only in the Vega entry
+ * point of the SDK.
+ *
+ * This checks the files we publish, so web, React Native web, and Flutter web
+ * apps do not receive Amazon/Vega-specific dependencies.
  */
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
@@ -19,11 +20,11 @@ for (const artifact of defaultArtifacts) {
 
   assert.ok(
     !contents.includes(amazonModule),
-    `${artifact} must not reference the Vega-only Amazon IAP module`,
+    `${artifact} should not include Amazon AppStore support`,
   );
   assert.ok(
     !contents.includes("Purchases.vega"),
-    `${artifact} must not reference the Vega entry point`,
+    `${artifact} should not include the Vega code.`,
   );
 }
 
@@ -32,8 +33,10 @@ for (const artifact of vegaArtifacts) {
 
   assert.ok(
     contents.includes(amazonModule),
-    `${artifact} must reference the Amazon IAP module`,
+    `${artifact} should include Amazon AppStore support`,
   );
 }
 
-console.log("Verified standard and Vega entry point bundle boundaries.");
+console.log(
+  "Confirmed that Amazon AppStore support is only in the Vega entry point.",
+);

--- a/src/amazon/amazon-appstore-iap-sdk-loader.ts
+++ b/src/amazon/amazon-appstore-iap-sdk-loader.ts
@@ -1,0 +1,43 @@
+import type * as AmazonVegaSdk from "@amazon-devices/keplerscript-appstore-iap-lib";
+import { ErrorCode, PurchasesError } from "../entities/errors";
+
+/**
+ * Shared Amazon AppStore IAP SDK loader contract used by AmazonBillingWrapper.
+ *
+ * Keeping this as an injected dependency lets the default purchases-js module
+ * include the shared wrapper without importing the Flow-based Amazon IAP
+ * package. The Vega module installs an implementation that loads the
+ * native Amazon module before re-exporting the public SDK API.
+ */
+export type AmazonAppstoreIAPSDK = typeof AmazonVegaSdk;
+export type AmazonAppstoreIAPSDKLoader = () => Promise<AmazonAppstoreIAPSDK>;
+
+// The default implementation intentionally throws an error. This loader is replaced
+// with a complete implementation as a side effect of
+// importing `@revenuecat/purchases-js/vega`.
+let amazonAppstoreIAPSDKLoader: AmazonAppstoreIAPSDKLoader = async () => {
+  throw new PurchasesError(
+    ErrorCode.ConfigurationError,
+    "Amazon Appstore is supported only by the @revenuecat/purchases-js/vega entry point.",
+  );
+};
+
+/**
+ * Installs the runtime-specific Amazon SDK implementation.
+ *
+ * @internal
+ */
+export function setAmazonAppstoreIAPSDKLoader(
+  loader: AmazonAppstoreIAPSDKLoader,
+): void {
+  amazonAppstoreIAPSDKLoader = loader;
+}
+
+/**
+ * Gets the SDK through the implementation selected by the active entry point.
+ *
+ * @internal
+ */
+export function loadAmazonAppstoreIAPSDK(): Promise<AmazonAppstoreIAPSDK> {
+  return amazonAppstoreIAPSDKLoader();
+}

--- a/src/amazon/amazon-appstore-iap-sdk-loader.ts
+++ b/src/amazon/amazon-appstore-iap-sdk-loader.ts
@@ -15,12 +15,16 @@ export type AmazonAppstoreIAPSDKLoader = () => Promise<AmazonAppstoreIAPSDK>;
 // The default implementation intentionally throws an error. This loader is replaced
 // with a complete implementation as a side effect of
 // importing `@revenuecat/purchases-js/vega`.
-let amazonAppstoreIAPSDKLoader: AmazonAppstoreIAPSDKLoader = async () => {
-  throw new PurchasesError(
-    ErrorCode.ConfigurationError,
-    "Amazon Appstore is supported only by the @revenuecat/purchases-js/vega entry point.",
-  );
-};
+const missingAmazonAppstoreIAPSDKLoader: AmazonAppstoreIAPSDKLoader =
+  async () => {
+    throw new PurchasesError(
+      ErrorCode.ConfigurationError,
+      "Amazon Appstore is supported only by the @revenuecat/purchases-js/vega entry point.",
+    );
+  };
+
+let amazonAppstoreIAPSDKLoader: AmazonAppstoreIAPSDKLoader =
+  missingAmazonAppstoreIAPSDKLoader;
 
 /**
  * Installs the runtime-specific Amazon SDK implementation.
@@ -31,6 +35,18 @@ export function setAmazonAppstoreIAPSDKLoader(
   loader: AmazonAppstoreIAPSDKLoader,
 ): void {
   amazonAppstoreIAPSDKLoader = loader;
+}
+
+/**
+ * Restores the loader used when no Amazon-capable entry point has configured one.
+ *
+ * This is primarily useful for tests that need to verify the standard entry
+ * point's failure mode.
+ *
+ * @internal
+ */
+export function resetAmazonAppstoreIAPSDKLoader(): void {
+  amazonAppstoreIAPSDKLoader = missingAmazonAppstoreIAPSDKLoader;
 }
 
 /**

--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -3,7 +3,6 @@ import type {
   ProductDataResponse,
   ProductType as AmazonProductType,
 } from "@amazon-devices/keplerscript-appstore-iap-lib";
-import type * as AmazonVegaSdk from "@amazon-devices/keplerscript-appstore-iap-lib";
 import { ErrorCode, PurchasesError } from "../entities/errors";
 import { Logger } from "../helpers/logger";
 import type { BillingWrapper } from "../helpers/billing-wrapper";
@@ -22,8 +21,10 @@ import type { CustomerInfo } from "../entities/customer-info";
 import type { RestorePurchasesResult } from "../entities/restore-purchases-result";
 import type { SubscriberResponse } from "../networking/responses/subscriber-response";
 import type { SyncPurchasesResult } from "../entities/sync-purchases-result";
-
-type AmazonAppstoreIAPSDK = typeof AmazonVegaSdk;
+import {
+  loadAmazonAppstoreIAPSDK,
+  type AmazonAppstoreIAPSDK,
+} from "./amazon-appstore-iap-sdk-loader";
 
 /**
  * Amazon billing wrapper. Defers loading the Amazon Appstore IAP SDK until
@@ -319,25 +320,7 @@ export class AmazonBillingWrapper implements BillingWrapper {
   }
 
   private getAmazonAppstoreIAPSDK(): Promise<AmazonAppstoreIAPSDK> {
-    return (this.amazonAppstoreIAPSDKPromise ??=
-      this.loadAmazonAppstoreIAPSDK());
-  }
-
-  private async loadAmazonAppstoreIAPSDK(): Promise<AmazonAppstoreIAPSDK> {
-    Logger.debugLog("Loading the Amazon AppStore IAP SDK.");
-    const amazonSdkModule = "@amazon-devices/keplerscript-appstore-iap-lib";
-
-    try {
-      // Keep web bundlers from following this Vega-only dependency into its
-      // Flow-based React Native source. Vega resolves it only at runtime.
-      return await import(/* @vite-ignore */ amazonSdkModule);
-    } catch (error) {
-      throw new PurchasesError(
-        ErrorCode.ConfigurationError,
-        "Amazon Vega IAP SDK is unavailable.",
-        error instanceof Error ? error.message : undefined,
-      );
-    }
+    return (this.amazonAppstoreIAPSDKPromise ??= loadAmazonAppstoreIAPSDK());
   }
 
   private async getProductsFromAmazonAppstoreIapLib(

--- a/src/helpers/configuration-validators.ts
+++ b/src/helpers/configuration-validators.ts
@@ -7,6 +7,7 @@ import {
   isStripeApiKey,
   isWebBillingApiKey,
 } from "./api-key-helper";
+import { isVegaEntryPoint } from "../vega-entry-point";
 
 export function validateApiKey(apiKey: string) {
   const isValidApiKey =
@@ -20,6 +21,13 @@ export function validateApiKey(apiKey: string) {
     throw new PurchasesError(
       ErrorCode.InvalidCredentialsError,
       "Invalid API key. Use a valid API key obtained from the RevenueCat Dashboard.",
+    );
+  }
+
+  if (isVegaEntryPoint() && !isAmazonApiKey(apiKey)) {
+    throw new PurchasesError(
+      ErrorCode.ConfigurationError,
+      "Vega applications must be configured with an Amazon Appstore API key.",
     );
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,7 +34,6 @@ import {
   isWebBillingApiKey,
   isWebBillingSandboxApiKey,
 } from "./helpers/api-key-helper";
-import { isVegaEntryPoint } from "./vega-entry-point";
 import {
   type OperationSessionSuccessfulResult,
   type PurchaseFlowError,
@@ -492,12 +491,6 @@ export class Purchases {
 
   private static validateConfig(config: PurchasesConfig) {
     validateApiKey(config.apiKey);
-    if (isVegaEntryPoint() && !isAmazonApiKey(config.apiKey)) {
-      throw new PurchasesError(
-        ErrorCode.ConfigurationError,
-        "Vega applications must be configured with an Amazon Appstore API key.",
-      );
-    }
     validateAppUserId(config.appUserId);
     validateProxyUrl(config.httpConfig?.proxyURL);
     validateAdditionalHeaders(config.httpConfig?.additionalHeaders);

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ import {
   isWebBillingApiKey,
   isWebBillingSandboxApiKey,
 } from "./helpers/api-key-helper";
+import { isVegaEntryPoint } from "./vega-entry-point";
 import {
   type OperationSessionSuccessfulResult,
   type PurchaseFlowError,
@@ -491,6 +492,12 @@ export class Purchases {
 
   private static validateConfig(config: PurchasesConfig) {
     validateApiKey(config.apiKey);
+    if (isVegaEntryPoint() && !isAmazonApiKey(config.apiKey)) {
+      throw new PurchasesError(
+        ErrorCode.ConfigurationError,
+        "Vega applications must be configured with an Amazon Appstore API key.",
+      );
+    }
     validateAppUserId(config.appUserId);
     validateProxyUrl(config.httpConfig?.proxyURL);
     validateAdditionalHeaders(config.httpConfig?.additionalHeaders);

--- a/src/tests/amazon/amazon-billing-wrapper.test.ts
+++ b/src/tests/amazon/amazon-billing-wrapper.test.ts
@@ -57,7 +57,10 @@ import {
   ProductType,
 } from "@amazon-devices/keplerscript-appstore-iap-lib";
 import * as AmazonVegaSdk from "@amazon-devices/keplerscript-appstore-iap-lib";
-import { setAmazonAppstoreIAPSDKLoader } from "../../amazon/amazon-appstore-iap-sdk-loader";
+import {
+  resetAmazonAppstoreIAPSDKLoader,
+  setAmazonAppstoreIAPSDKLoader,
+} from "../../amazon/amazon-appstore-iap-sdk-loader";
 import { AmazonBillingWrapper } from "../../amazon/amazon-billing-wrapper";
 import { ErrorCode } from "../../entities/errors";
 import type { PurchasesError } from "../../entities/errors";
@@ -162,6 +165,22 @@ describe("AmazonBillingWrapper", () => {
     notifyFulfillment.mockReset();
     purchase.mockReset();
     vi.restoreAllMocks();
+  });
+
+  test("fails clearly when the Amazon SDK loader has not been wired up", async () => {
+    resetAmazonAppstoreIAPSDKLoader();
+
+    await expect(
+      new AmazonBillingWrapper(createBackend()).getProducts("user", [
+        "monthly",
+      ]),
+    ).rejects.toMatchObject({
+      errorCode: ErrorCode.ConfigurationError,
+      message:
+        "Amazon Appstore is supported only by the @revenuecat/purchases-js/vega entry point.",
+    });
+
+    expect(getProductData).not.toHaveBeenCalled();
   });
 
   describe("product data requests", () => {

--- a/src/tests/amazon/amazon-billing-wrapper.test.ts
+++ b/src/tests/amazon/amazon-billing-wrapper.test.ts
@@ -56,6 +56,8 @@ import {
   PurchaseUpdatesResponseCode,
   ProductType,
 } from "@amazon-devices/keplerscript-appstore-iap-lib";
+import * as AmazonVegaSdk from "@amazon-devices/keplerscript-appstore-iap-lib";
+import { setAmazonAppstoreIAPSDKLoader } from "../../amazon/amazon-appstore-iap-sdk-loader";
 import { AmazonBillingWrapper } from "../../amazon/amazon-billing-wrapper";
 import { ErrorCode } from "../../entities/errors";
 import type { PurchasesError } from "../../entities/errors";
@@ -154,6 +156,7 @@ const createBackend = () =>
 
 describe("AmazonBillingWrapper", () => {
   beforeEach(() => {
+    setAmazonAppstoreIAPSDKLoader(async () => AmazonVegaSdk);
     getProductData.mockReset();
     getPurchaseUpdates.mockReset();
     notifyFulfillment.mockReset();

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -29,6 +29,7 @@ import { expectPromiseToError } from "./test-helpers";
 import { StatusCodes } from "http-status-codes";
 import type { BrandingInfoResponse } from "../networking/responses/branding-response";
 import { AmazonBillingWrapper } from "../amazon/amazon-billing-wrapper";
+import { setAmazonAppstoreIAPSDKLoader } from "../amazon/amazon-appstore-iap-sdk-loader";
 import { Logger } from "../helpers/logger";
 
 const { getAmazonProductData } = vi.hoisted(() => ({
@@ -40,6 +41,12 @@ vi.mock("@amazon-devices/keplerscript-appstore-iap-lib", () => ({
   ProductType: { CONSUMABLE: 1, ENTITLED: 2, SUBSCRIPTION: 3 },
   PurchasingService: { getProductData: getAmazonProductData },
 }));
+
+import * as AmazonVegaSdk from "@amazon-devices/keplerscript-appstore-iap-lib";
+
+beforeEach(() => {
+  setAmazonAppstoreIAPSDKLoader(async () => AmazonVegaSdk);
+});
 
 describe("Purchases.configure() legacy", () => {
   test("throws error if given invalid api key", () => {

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -29,23 +29,11 @@ import { expectPromiseToError } from "./test-helpers";
 import { StatusCodes } from "http-status-codes";
 import type { BrandingInfoResponse } from "../networking/responses/branding-response";
 import { AmazonBillingWrapper } from "../amazon/amazon-billing-wrapper";
-import { setAmazonAppstoreIAPSDKLoader } from "../amazon/amazon-appstore-iap-sdk-loader";
+import { resetAmazonAppstoreIAPSDKLoader } from "../amazon/amazon-appstore-iap-sdk-loader";
 import { Logger } from "../helpers/logger";
 
-const { getAmazonProductData } = vi.hoisted(() => ({
-  getAmazonProductData: vi.fn(),
-}));
-
-vi.mock("@amazon-devices/keplerscript-appstore-iap-lib", () => ({
-  ProductDataResponseCode: { SUCCESSFUL: 1, NOT_SUPPORTED: 2, FAILED: 3 },
-  ProductType: { CONSUMABLE: 1, ENTITLED: 2, SUBSCRIPTION: 3 },
-  PurchasingService: { getProductData: getAmazonProductData },
-}));
-
-import * as AmazonVegaSdk from "@amazon-devices/keplerscript-appstore-iap-lib";
-
 beforeEach(() => {
-  setAmazonAppstoreIAPSDKLoader(async () => AmazonVegaSdk);
+  resetAmazonAppstoreIAPSDKLoader();
 });
 
 describe("Purchases.configure() legacy", () => {
@@ -343,54 +331,30 @@ describe("Purchases.configure()", () => {
 });
 
 describe("billing wrapper selection", () => {
-  test("uses the Amazon IAP SDK for offerings with an Amazon API key", async () => {
-    getAmazonProductData.mockResolvedValue({
-      responseCode: 1,
-      productData: new Map(
-        ["monthly", "monthly_2"].map((sku) => [
-          sku,
-          {
-            coinsReward: { amount: 0 },
-            description: `${sku} description`,
-            price: {
-              priceStr: "$4.99",
-              priceCurrencyCode: "USD",
-              valueInMicros: 4_990_000n,
-            },
-            productType: 3,
-            sku,
-            smallIconUrl: "",
-            title: sku,
-            promotions: [],
-            subscriptionPeriod: "P1M",
-          },
-        ]),
-      ),
-      unavailableSkus: [],
-    });
+  test("requires the Vega entry point for offerings with an Amazon API key", async () => {
     const purchases = configurePurchases(
       testUserId,
       "rcSource",
       "amzn_valid_key",
     );
 
-    await purchases.getOfferings();
-
-    expect(getAmazonProductData).toHaveBeenCalledExactlyOnceWith({
-      skus: ["monthly", "monthly_2"],
-    });
-    expect(APIGetRequest).toHaveBeenCalledExactlyOnceWith({
-      url: `http://localhost:8000/v1/subscribers/${testUserId}/offerings`,
+    await expect(purchases.getOfferings()).rejects.toMatchObject({
+      errorCode: ErrorCode.ConfigurationError,
+      message:
+        "Amazon Appstore is supported only by the @revenuecat/purchases-js/vega entry point.",
     });
   });
 
   test("uses web billing for offerings with a non-Amazon API key", async () => {
-    getAmazonProductData.mockClear();
     const purchases = configurePurchases();
+    const getAmazonProducts = vi.spyOn(
+      AmazonBillingWrapper.prototype,
+      "getProducts",
+    );
 
     await purchases.getOfferings();
 
-    expect(getAmazonProductData).not.toHaveBeenCalled();
+    expect(getAmazonProducts).not.toHaveBeenCalled();
     expect(APIGetRequest).toHaveBeenCalledWith({
       url: `http://localhost:8000/rcbilling/v1/subscribers/${testUserId}/products?id=monthly&id=monthly_2`,
     });

--- a/src/tests/vega.test.ts
+++ b/src/tests/vega.test.ts
@@ -32,6 +32,26 @@ describe("Vega entry point", () => {
     expect(sdk.PurchasingService).toBe(purchasingService);
   });
 
+  test("configures with an Amazon API key", () => {
+    expect(() =>
+      Purchases.configure({
+        apiKey: "amzn_valid_key",
+        appUserId: testUserId,
+      }),
+    ).not.toThrow();
+  });
+
+  test("throws when configured with a non-Amazon API key", () => {
+    expect(() =>
+      Purchases.configure({
+        apiKey: "rcb_valid_key",
+        appUserId: testUserId,
+      }),
+    ).toThrowError(
+      "Vega applications must be configured with an Amazon Appstore API key.",
+    );
+  });
+
   test("uses the Amazon IAP SDK for offerings with an Amazon API key", async () => {
     purchasingService.getProductData.mockResolvedValue({
       responseCode: 1,

--- a/src/tests/vega.test.ts
+++ b/src/tests/vega.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const { purchasingService } = vi.hoisted(() => ({
+  purchasingService: { getProductData: vi.fn() },
+}));
+
+vi.mock("@amazon-devices/keplerscript-appstore-iap-lib", () => ({
+  ProductDataResponseCode: { SUCCESSFUL: 1, NOT_SUPPORTED: 2, FAILED: 3 },
+  ProductType: { CONSUMABLE: 1, ENTITLED: 2, SUBSCRIPTION: 3 },
+  PurchasingService: purchasingService,
+}));
+
+import { loadAmazonAppstoreIAPSDK } from "../amazon/amazon-appstore-iap-sdk-loader";
+import { defaultHttpConfig } from "../entities/http-config";
+import { Purchases } from "../vega";
+import { testUserId } from "./base.purchases_test";
+import { APIGetRequest } from "./test-responses";
+
+/**
+ * The Vega entry point configures the loader as an import side effect. This
+ * test keeps that contract separate from the standard-entry tests, which run
+ * deliberately without an Amazon SDK loader.
+ */
+describe("Vega entry point", () => {
+  beforeEach(() => {
+    purchasingService.getProductData.mockReset();
+  });
+
+  test("wires the Amazon Appstore IAP SDK loader", async () => {
+    const sdk = await loadAmazonAppstoreIAPSDK();
+
+    expect(sdk.PurchasingService).toBe(purchasingService);
+  });
+
+  test("uses the Amazon IAP SDK for offerings with an Amazon API key", async () => {
+    purchasingService.getProductData.mockResolvedValue({
+      responseCode: 1,
+      productData: new Map(
+        ["monthly", "monthly_2"].map((sku) => [
+          sku,
+          {
+            coinsReward: { amount: 0 },
+            description: `${sku} description`,
+            price: {
+              priceStr: "$4.99",
+              priceCurrencyCode: "USD",
+              valueInMicros: 4_990_000n,
+            },
+            productType: 3,
+            sku,
+            smallIconUrl: "",
+            title: sku,
+            promotions: [],
+            subscriptionPeriod: "P1M",
+          },
+        ]),
+      ),
+      unavailableSkus: [],
+    });
+    const purchases = Purchases.configure({
+      apiKey: "amzn_valid_key",
+      appUserId: testUserId,
+      httpConfig: defaultHttpConfig,
+      flags: { rcSource: "rcSource" },
+    });
+
+    await purchases.getOfferings();
+
+    expect(purchasingService.getProductData).toHaveBeenCalledExactlyOnceWith({
+      skus: ["monthly", "monthly_2"],
+    });
+    expect(APIGetRequest).toHaveBeenCalledExactlyOnceWith({
+      url: `http://localhost:8000/v1/subscribers/${testUserId}/offerings`,
+    });
+  });
+});

--- a/src/tests/vega.test.ts
+++ b/src/tests/vega.test.ts
@@ -52,6 +52,12 @@ describe("Vega entry point", () => {
     );
   });
 
+  test("throws when configured with a non-Amazon API key using positional arguments", () => {
+    expect(() => Purchases.configure("rcb_valid_key", testUserId)).toThrowError(
+      "Vega applications must be configured with an Amazon Appstore API key.",
+    );
+  });
+
   test("uses the Amazon IAP SDK for offerings with an Amazon API key", async () => {
     purchasingService.getProductData.mockResolvedValue({
       responseCode: 1,

--- a/src/vega-entry-point.ts
+++ b/src/vega-entry-point.ts
@@ -1,0 +1,20 @@
+/**
+ * Tracks whether the Vega entry point is active.
+ *
+ * The Vega module enables this as an import side effect before exposing the
+ * shared Purchases API. The default entry point leaves it disabled so it can
+ * continue to support all of its existing stores.
+ *
+ * @internal
+ */
+let isVegaEntryPointActive = false;
+
+/** @internal */
+export function activateVegaEntryPoint(): void {
+  isVegaEntryPointActive = true;
+}
+
+/** @internal */
+export function isVegaEntryPoint(): boolean {
+  return isVegaEntryPointActive;
+}

--- a/src/vega.ts
+++ b/src/vega.ts
@@ -14,7 +14,9 @@
  */
 import * as AmazonVegaSdk from "@amazon-devices/keplerscript-appstore-iap-lib";
 import { setAmazonAppstoreIAPSDKLoader } from "./amazon/amazon-appstore-iap-sdk-loader";
+import { activateVegaEntryPoint } from "./vega-entry-point";
 
 setAmazonAppstoreIAPSDKLoader(async () => AmazonVegaSdk);
+activateVegaEntryPoint();
 
 export * from "./main";

--- a/src/vega.ts
+++ b/src/vega.ts
@@ -1,0 +1,20 @@
+/**
+ * Vega-only entry point for Amazon Appstore support.
+ *
+ * The default `@revenuecat/purchases-js` entry point intentionally contains no
+ * runtime dependency on the Amazon IAP SDK, so it remains safe for web,
+ * React Native web, and Flutter web bundlers. This entry point installs the
+ * Vega implementation of the shared Amazon SDK loader, then re-exports the
+ * same public API as the default entry point.
+ *
+ * Import `@revenuecat/purchases-js/vega` only in Vega applications. Its
+ * dedicated build artifact statically imports the Amazon IAP SDK, allowing
+ * the Vega runtime to provide that native module without requiring dynamic
+ * imports or CSP-sensitive runtime code generation.
+ */
+import * as AmazonVegaSdk from "@amazon-devices/keplerscript-appstore-iap-lib";
+import { setAmazonAppstoreIAPSDKLoader } from "./amazon/amazon-appstore-iap-sdk-loader";
+
+setAmazonAppstoreIAPSDKLoader(async () => AmazonVegaSdk);
+
+export * from "./main";

--- a/vega.js
+++ b/vega.js
@@ -1,0 +1,6 @@
+/**
+ * Compatibility shim for Metro versions that do not resolve package subpath
+ * exports. Modern bundlers resolve `@revenuecat/purchases-js/vega` through
+ * package.json; legacy Metro resolves this physical file instead.
+ */
+export * from "./dist/Purchases.vega.es.js";

--- a/vite.vega.config.js
+++ b/vite.vega.config.js
@@ -1,0 +1,30 @@
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+import { defineConfig } from "vite";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Produces the Vega-only build exposed as `@revenuecat/purchases-js/vega`.
+ *
+ * This configuration is intentionally separate from the default build: Vite
+ * accepts one build configuration at a time, and the two entry points have
+ * different dependency boundaries. The Amazon package stays external here so
+ * the Vega bundle keeps a static module import that the Vega runtime resolves.
+ */
+export default defineConfig({
+  build: {
+    emptyOutDir: false,
+    lib: {
+      entry: resolve(__dirname, "src/vega.ts"),
+      name: "Purchases",
+      fileName: (format) => `Purchases.vega.${format}.js`,
+    },
+    rollupOptions: {
+      external: ["@amazon-devices/keplerscript-appstore-iap-lib"],
+    },
+  },
+  plugins: [svelte({ compilerOptions: { css: "injected" } })],
+});

--- a/vite.watch.config.js
+++ b/vite.watch.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, mergeConfig } from "vite";
+import defaultConfig from "./vite.config.js";
+
+// The default build clears dist. Watch builds run alongside the Vega watcher,
+// so they must preserve the other entry point's artifacts.
+export default mergeConfig(
+  defaultConfig,
+  defineConfig({
+    build: {
+      emptyOutDir: false,
+    },
+  }),
+);


### PR DESCRIPTION
## Changes introduced
Adds a Vega-specific `@revenuecat/purchases-js/vega` entry point the the JS SDK so Amazon Appstore support is isolated from the standard `purchases-js` bundle.

The default `@revenuecat/purchases-js` entry point no longer imports, dynamically imports, or attempts to import the Amazon IAP SDK. This keeps it safe for web, React Native Web/Expo, Flutter web, and consumers such as `@revenuecat/purchases-js-hybrid-mappings`.

The Vega entry point statically imports the Amazon SDK and configures it through an injected SDK-loader interface. It also exports the entire normal entry point of the SDK, so the rest of the SDK can be used normally. 

Amazon API keys used through the standard entry point now fail with an error directing developers to the Vega entry point.

With these changes, Vega app developers still install the SDK with `npm install @revenuecat/purchases-js`, but when they import the SDK, they'll import it like so:

```typescript
import {Purchases} from '@revenuecat/purchases-js/vega';
```

The PR also updates the SDK's tests:
- Tests are added to ensure:
   - That the SDK throws when Amazon actions are taken when the SDK is imported via the normal entry point
   - That the SDK correctly wires up the Amazon SDK when the SDK is imported via the vega entry point
- A new test is added to the CI's `test` job that builds the SDK and ensures that the vega artifacts are not imported in the files exposed by the standard entry point


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Amazon Appstore IAP is loaded and published, which can break Vega or web bundlers if the wrong entry point is used. Billing behavior itself is largely unchanged.
> 
> **Overview**
> Isolates Amazon Appstore IAP from the default SDK bundle by adding a dedicated `@revenuecat/purchases-js/vega` entry point. Vega apps should import that subpath; the default package no longer dynamically imports the Amazon SDK.
> 
> The Vega build statically imports `@amazon-devices/keplerscript-appstore-iap-lib` and injects it via a loader. Using an Amazon API key on the standard entry point now fails with a configuration error; Vega configure requires an Amazon key.
> 
> CI verifies published artifacts keep Amazon code out of the web bundles. The Vega demo imports the new subpath, and `build:dev-watch` is web-only so it does not wipe Vega artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a328a5407c2378eac56b5227d042f7262e77684. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->