### PR TITLE
"No Offering" placement not returning null

### DIFF
--- a/src/helpers/offerings-parser.ts
+++ b/src/helpers/offerings-parser.ts
@@ -51,11 +51,24 @@ export const getOfferingIdForPlacement = (
   offeringIdForPlacement: string | null;
   fallbackOfferingId: string | null;
 } => {
-  const placementOfferingId =
-    placementsData.offering_ids_by_placement?.[placementId] ?? null;
+  const offeringIdsByPlacement = placementsData.offering_ids_by_placement ?? {};
+
+  if (placementId in offeringIdsByPlacement) {
+    const placementOfferingId = offeringIdsByPlacement[placementId] ?? null;
+    return {
+      offeringIdForPlacement: placementOfferingId,
+      // An explicit null means "No Offering" was selected in the dashboard,
+      // so the fallback must not apply. The fallback only exists for
+      // placements that are missing from the map entirely.
+      fallbackOfferingId:
+        placementOfferingId === null
+          ? null
+          : placementsData.fallback_offering_id,
+    };
+  }
 
   return {
-    offeringIdForPlacement: placementOfferingId,
+    offeringIdForPlacement: null,
     fallbackOfferingId: placementsData.fallback_offering_id,
   };
 };

--- a/src/tests/purchase.offerings.test.ts
+++ b/src/tests/purchase.offerings.test.ts
@@ -882,16 +882,22 @@ describe("getOfferings placements", () => {
     ).toEqual("missing_placement_id");
   });
 
-  test("gets fallback offering if placement id has null offering id", async () => {
+  test("gets null offering when placement is explicitly set to No Offering, even with a fallback configured", async () => {
     const purchases = configurePurchases();
     const offeringWithPlacement =
       await purchases.getCurrentOfferingForPlacement("test_null_placement_id");
-    expect(offeringWithPlacement).not.toBeNull();
-    expect(offeringWithPlacement?.identifier).toEqual("offering_1");
-    expect(
-      offeringWithPlacement!.availablePackages[0].webBillingProduct
-        .presentedOfferingContext.placementIdentifier,
-    ).toEqual("test_null_placement_id");
+    expect(offeringWithPlacement).toBeNull();
+  });
+
+  test("does not fetch any products when placement is explicitly set to No Offering", async () => {
+    const purchases = configurePurchases();
+    await purchases.getCurrentOfferingForPlacement("test_null_placement_id");
+    const productsUrl =
+      "http://localhost:8000/rcbilling/v1/subscribers/someAppUserId/products";
+    const productRequests = APIGetRequest.mock.calls.filter(([request]) =>
+      request.url.startsWith(productsUrl),
+    );
+    expect(productRequests).toHaveLength(0);
   });
 
   test("gets fallback offering if placement id maps to a non-existent offering", async () => {


### PR DESCRIPTION
## Motivation / Description


> TL;DR: `offering_ids_by_placement?.[placementId] ?? null` maps both "placement missing" (`undefined`) and "placement set to No Offering" (`null`) to the same `null`, so the resolver can't tell them apart and applies the fallback to both. An explicit No Offering should return null, like on iOS and Android.

The issue
-
A placement explicitly set to **No Offering** in the dashboard resolves to the fallback offering on web instead of null. iOS and Android honor the explicit **null** and return nothing, but the web SDK is returning `fallback_offering_id` on **No Offering**.

Reported in Zendesk ticket [#83293](https://revenuecat.zendesk.com/agent/tickets/83293), project `94c07d90` (summarizing the report here since the ticket may not be accessible to everyone)
- the customer has a single targeting rule with five placements
- one of them (`campaign_test_none`) set to **No Offering**
- `default` serving "for all other cases". 
- the `/offerings` payload is correct, as `offering_ids_by_placement` contains `campaign_test_none: null` alongside `fallback_offering_id: "default"`
- calling `getCurrentOfferingForPlacement("campaign_test_none")` returns the `default` offering, so a full paywall presents where the dashboard says none should. 
 
They rely on **No Offering** as a campaign kill switch, which doesn't quite work as of now.

From our docs
> Simply select **No Offering** for a given Placement in order to have a null value returned when your app requests Offerings for that Placement for customers matching that Targeting Rule.
https://www.revenuecat.com/docs/tools/targeting/placements#serving-no-offering-at-a-given-placement

Looking around, the root cause seems to be `getOfferingIdForPlacement`, where `offering_ids_by_placement?.[placementId] ?? null` collapses "placement present with a null value" into the same shape as "placement missing from the map". By the time the fallback branch runs, an actual expected **No Offering** and an unregistered placement look the same, so both get the fallback.

For platform parity reference, iOS checks key presence first in `Offerings.swift` (`currentOffering(forPlacement:)`, with the comment "Don't use fallback since placement id was explicity set in the dictionary"), and Android does the same in `Offerings.kt` via `showNoOffering = offeringIdsByPlacement.containsKey(placementId)`. 

## Changes introduced

- `getOfferingIdForPlacement` now checks whether the placement key exists in the map. An explicit null suppresses the fallback and the call resolves to no offering. A placement missing from the map keeps falling back, matching iOS and Android.
- a placement mapped to an offering that can't be resolved (unknown id, products unavailable) still falls back, unchanged from current behavior and intentionally out of scope here.
- the existing test that codified the old behavior ("gets fallback offering if placement id has null offering id") now expects null, and a new test asserts we don't fetch any products for an explicit No Offering placement.

## Linear ticket (if any)

None yet, tracked via Zendesk [#83293](https://revenuecat.zendesk.com/agent/tickets/83293).

## Additional comments

To test what the customer reported, I did an end to end repro with a sample app generated by the [Web Purchase Tester](https://revenuecat.github.io/web-purchase-tester/) against the affected project's sandbox key, on the current 1.53.0 release (the customer reported on 1.52.0; the resolution code is unchanged between the two). The script dumps the raw `/offerings` placements payload and then calls `getCurrentOfferingForPlacement` for every configured placement plus a made-up one as a control:

| Placement | Dashboard config | SDK returned |
| --- | --- | --- |
| `app_quota_last` | `quota_last` | `quota_last` |
| `app_quota_none` | `quota_none` | `quota_none` |
| `app_feature_refusal` | `default` | `default` |
| `campaign_test_ok` | `default` | `default` |
| `campaign_test_none` | No Offering (null) | `default` (bug) |
| `missing_placement` (control) | not in map | `default` (correct, fallback) |

Full test suite passes (813 tests), along with lint and typecheck.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core placement/offering resolution used by paywalls and campaign kill switches; behavior change is intentional but affects any app relying on the old fallback-on-null behavior.
> 
> **Overview**
> Fixes placement resolution so dashboard **No Offering** (`null` in `offering_ids_by_placement`) returns no offering instead of the configured fallback, matching iOS/Android and RevenueCat docs.
> 
> `getOfferingIdForPlacement` now uses **key presence** (`placementId in offeringIdsByPlacement`) instead of treating missing keys and explicit `null` the same. When the key exists and the value is `null`, `fallbackOfferingId` is set to `null` so `getCurrentOfferingForPlacement` exits early with no product fetch.
> 
> Placements **not** in the map still use `fallback_offering_id` as before. Tests now expect null for `test_null_placement_id` and assert zero product API calls for that case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44b8bf2f17fb650d6601c27ff4ec8a158e0012e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->