### PR TITLE
ci: enable turbosnap

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,6 +198,7 @@ jobs:
               export CHROMATIC_BRANCH=${CIRCLE_BRANCH}
               NODE_OPTIONS=--max-old-space-size=4096 npx chromatic \
                 --ci \
+                --only-changed \
                 --exit-once-uploaded \
                 --branch-name ${CIRCLE_BRANCH} \
                 --patch-build=${CIRCLE_BRANCH}...main
@@ -205,6 +206,7 @@ jobs:
               NODE_OPTIONS=--max-old-space-size=4096 npx chromatic \
                 --auto-accept-changes \
                 --ci \
+                --only-changed \
                 --exit-once-uploaded
             fi
 


### PR DESCRIPTION
## Motivation / Description

Stop running all stories unnecessarily.

<img width="928" height="690" alt="CleanShot 2026-08-20 at 17 49 08@2x" src="https://github.com/user-attachments/assets/dd7b56e4-b6be-4575-abec-f18c146b1cfc" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Chromatic flag change; no application, auth, or data-handling code is modified. Missed snapshots are the main residual risk if TurboSnap tracing is incomplete.
> 
> **Overview**
> Enables Chromatic TurboSnap so Storybook visual tests only snapshot stories affected by a change, instead of the full suite.
> 
> Adds `--only-changed` to both the PR and `main` Chromatic invocations in the CircleCI `test` job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeb1cf736b9b3a988da613a7b228290730236a1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->