### PR TITLE
feat(vega) sync/restore purchases enhancements

### DIFF
--- a/examples/amazonvega-demo/PurchaseTester/package.json
+++ b/examples/amazonvega-demo/PurchaseTester/package.json
@@ -19,6 +19,7 @@
     "release": "npm-run-all lint test build:app"
   },
   "dependencies": {
+    "@amazon-devices/kepler-file-system": "0.0.7",
     "@amazon-devices/react-native-kepler": "^2.0.0",
     "@amazon-devices/keplerscript-appstore-iap-lib": "2.12.16",
     "@revenuecat/purchases-js": "file:../../..",

--- a/examples/amazonvega-demo/PurchaseTester/pnpm-lock.yaml
+++ b/examples/amazonvega-demo/PurchaseTester/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 importers:
   .:
     dependencies:
+      '@amazon-devices/kepler-file-system':
+        specifier: 0.0.7
+        version: 0.0.7(@babel/preset-env@7.29.7(@babel/core@7.29.7))
       '@amazon-devices/keplerscript-appstore-iap-lib':
         specifier: 2.12.16
         version: 2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))
@@ -104,6 +107,12 @@ packages:
       '@react-native/js-polyfills': '*'
       '@react-native/metro-config': '*'
       react-native: '*'
+
+  '@amazon-devices/kepler-file-system@0.0.7':
+    resolution:
+      {
+        integrity: sha512-rj6f0rtgB17Eg8XcuSH6KhE9QW7pz0aekps/YdkgYTMzlJmAX3Zkiwb+qvzlmFRQ7zr8sT036zfabz/VFrndHw==,
+      }
 
   '@amazon-devices/kepler-compatibility-metro-config@0.0.7':
     resolution:
@@ -7050,6 +7059,13 @@ snapshots:
       yargs: 17.7.3
     optionalDependencies:
       '@amazon-devices/js-bundle-system-allow-list': 0.0.22
+
+  '@amazon-devices/kepler-file-system@0.0.7(@babel/preset-env@7.29.7(@babel/core@7.29.7))':
+    dependencies:
+      '@amazon-devices/keplerscript-turbomodule-api': 1.2.5(@babel/preset-env@7.29.7(@babel/core@7.29.7))
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
 
   '@amazon-devices/keplerscript-appstore-iap-lib@2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))':
     dependencies:

--- a/examples/amazonvega-demo/PurchaseTester/pnpm-lock.yaml
+++ b/examples/amazonvega-demo/PurchaseTester/pnpm-lock.yaml
@@ -108,16 +108,16 @@ packages:
       '@react-native/metro-config': '*'
       react-native: '*'
 
-  '@amazon-devices/kepler-file-system@0.0.7':
-    resolution:
-      {
-        integrity: sha512-rj6f0rtgB17Eg8XcuSH6KhE9QW7pz0aekps/YdkgYTMzlJmAX3Zkiwb+qvzlmFRQ7zr8sT036zfabz/VFrndHw==,
-      }
-
   '@amazon-devices/kepler-compatibility-metro-config@0.0.7':
     resolution:
       {
         integrity: sha512-SKdbd/Hv+mWgjhxj56y4U4Zmnq1krPOJMob5rL9kb0vxPhwCcweES0moC0NFjpauNxF5dy5FEjOouJ0JIkI1YA==,
+      }
+
+  '@amazon-devices/kepler-file-system@0.0.7':
+    resolution:
+      {
+        integrity: sha512-rj6f0rtgB17Eg8XcuSH6KhE9QW7pz0aekps/YdkgYTMzlJmAX3Zkiwb+qvzlmFRQ7zr8sT036zfabz/VFrndHw==,
       }
 
   '@amazon-devices/kepler-module-manifest-builder@0.1.15':
@@ -1822,8 +1822,11 @@ packages:
   '@revenuecat/purchases-js@file:../../..':
     resolution: {directory: ../../.., type: directory}
     peerDependencies:
+      '@amazon-devices/kepler-file-system': 0.0.7
       '@amazon-devices/keplerscript-appstore-iap-lib': 2.12.16
     peerDependenciesMeta:
+      '@amazon-devices/kepler-file-system':
+        optional: true
       '@amazon-devices/keplerscript-appstore-iap-lib':
         optional: true
 
@@ -7051,6 +7054,13 @@ snapshots:
 
   '@amazon-devices/kepler-compatibility-metro-config@0.0.7': {}
 
+  '@amazon-devices/kepler-file-system@0.0.7(@babel/preset-env@7.29.7(@babel/core@7.29.7))':
+    dependencies:
+      '@amazon-devices/keplerscript-turbomodule-api': 1.2.5(@babel/preset-env@7.29.7(@babel/core@7.29.7))
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+
   '@amazon-devices/kepler-module-manifest-builder@0.1.15':
     dependencies:
       lodash: 4.17.21
@@ -7059,13 +7069,6 @@ snapshots:
       yargs: 17.7.3
     optionalDependencies:
       '@amazon-devices/js-bundle-system-allow-list': 0.0.22
-
-  '@amazon-devices/kepler-file-system@0.0.7(@babel/preset-env@7.29.7(@babel/core@7.29.7))':
-    dependencies:
-      '@amazon-devices/keplerscript-turbomodule-api': 1.2.5(@babel/preset-env@7.29.7(@babel/core@7.29.7))
-    transitivePeerDependencies:
-      - '@babel/preset-env'
-      - supports-color
 
   '@amazon-devices/keplerscript-appstore-iap-lib@2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))':
     dependencies:
@@ -8775,8 +8778,9 @@ snapshots:
       nullthrows: 1.1.1
       react-native: 0.72.0(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react@18.2.0)
 
-  '@revenuecat/purchases-js@file:../../..(@amazon-devices/keplerscript-appstore-iap-lib@2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))':
+  '@revenuecat/purchases-js@file:../../..(@amazon-devices/kepler-file-system@0.0.7(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(@amazon-devices/keplerscript-appstore-iap-lib@2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))':
     optionalDependencies:
+      '@amazon-devices/kepler-file-system': 0.0.7(@babel/preset-env@7.29.7(@babel/core@7.29.7))
       '@amazon-devices/keplerscript-appstore-iap-lib': 2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))
 
   '@rnx-kit/tools-node@2.1.2': {}

--- a/examples/amazonvega-demo/PurchaseTester/pnpm-lock.yaml
+++ b/examples/amazonvega-demo/PurchaseTester/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         version: 2.0.9000000000(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react-native@0.72.0(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react@18.2.0))(react@18.2.0)
       '@revenuecat/purchases-js':
         specifier: file:../../..
-        version: file:../../..(@amazon-devices/keplerscript-appstore-iap-lib@2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))
+        version: file:../../..(@amazon-devices/kepler-file-system@0.0.7(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(@amazon-devices/keplerscript-appstore-iap-lib@2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))
       react:
         specifier: 18.2.0
         version: 18.2.0

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "prepare": "husky"
   },
   "devDependencies": {
+    "@amazon-devices/kepler-file-system": "0.0.7",
     "@amazon-devices/keplerscript-appstore-iap-lib": "2.12.16",
     "@eslint/js": "^9.16.0",
     "@microsoft/api-extractor": "^7.48.0",
@@ -112,9 +113,13 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
+    "@amazon-devices/kepler-file-system": "0.0.7",
     "@amazon-devices/keplerscript-appstore-iap-lib": "2.12.16"
   },
   "peerDependenciesMeta": {
+    "@amazon-devices/kepler-file-system": {
+      "optional": true
+    },
     "@amazon-devices/keplerscript-appstore-iap-lib": {
       "optional": true
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 importers:
   .:
     devDependencies:
+      "@amazon-devices/kepler-file-system":
+        specifier: 0.0.7
+        version: 0.0.7(@babel/preset-env@7.29.7(@babel/core@7.29.7))
       "@amazon-devices/keplerscript-appstore-iap-lib":
         specifier: 2.12.16
         version: 2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))
@@ -156,11 +159,14 @@ packages:
         integrity: sha512-31Bjn9kaX2ThY7VcezVzEM4+khrLoq2qnEeOs0NkwYZ+VnSMXgTQwdpMlWKxjvKhcBdBD9ZUAPLlrLigNVqQag==,
       }
 
+  "@amazon-devices/kepler-file-system@0.0.7":
+    resolution: {integrity: sha512-rj6f0rtgB17Eg8XcuSH6KhE9QW7pz0aekps/YdkgYTMzlJmAX3Zkiwb+qvzlmFRQ7zr8sT036zfabz/VFrndHw==}
+
+  "@amazon-devices/keplerscript-appstore-iap-lib@2.12.16":
+    resolution: {integrity: sha512-31Bjn9kaX2ThY7VcezVzEM4+khrLoq2qnEeOs0NkwYZ+VnSMXgTQwdpMlWKxjvKhcBdBD9ZUAPLlrLigNVqQag==}
+
   "@amazon-devices/keplerscript-turbomodule-api@1.2.5":
-    resolution:
-      {
-        integrity: sha512-zg4vQ7iZLZkoajyjxYtGs293y3+FfpM5de63Xx6sPdIubNLh6Cjf5o7vxPnJ4+SnXOk4IlcSndnGIpJ7vtgJiw==,
-      }
+    resolution: {integrity: sha512-zg4vQ7iZLZkoajyjxYtGs293y3+FfpM5de63Xx6sPdIubNLh6Cjf5o7vxPnJ4+SnXOk4IlcSndnGIpJ7vtgJiw==}
     hasBin: true
 
   "@amazon-devices/react-native-kepler@2.1.0":
@@ -9296,6 +9302,13 @@ packages:
 
 snapshots:
   "@adobe/css-tools@4.4.1": {}
+
+  "@amazon-devices/kepler-file-system@0.0.7(@babel/preset-env@7.29.7(@babel/core@7.29.7))":
+    dependencies:
+      "@amazon-devices/keplerscript-turbomodule-api": 1.2.5(@babel/preset-env@7.29.7(@babel/core@7.29.7))
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
 
   "@amazon-devices/keplerscript-appstore-iap-lib@2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))":
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,13 +160,16 @@ packages:
       }
 
   "@amazon-devices/kepler-file-system@0.0.7":
-    resolution: {integrity: sha512-rj6f0rtgB17Eg8XcuSH6KhE9QW7pz0aekps/YdkgYTMzlJmAX3Zkiwb+qvzlmFRQ7zr8sT036zfabz/VFrndHw==}
-
-  "@amazon-devices/keplerscript-appstore-iap-lib@2.12.16":
-    resolution: {integrity: sha512-31Bjn9kaX2ThY7VcezVzEM4+khrLoq2qnEeOs0NkwYZ+VnSMXgTQwdpMlWKxjvKhcBdBD9ZUAPLlrLigNVqQag==}
+    resolution:
+      {
+        integrity: sha512-rj6f0rtgB17Eg8XcuSH6KhE9QW7pz0aekps/YdkgYTMzlJmAX3Zkiwb+qvzlmFRQ7zr8sT036zfabz/VFrndHw==,
+      }
 
   "@amazon-devices/keplerscript-turbomodule-api@1.2.5":
-    resolution: {integrity: sha512-zg4vQ7iZLZkoajyjxYtGs293y3+FfpM5de63Xx6sPdIubNLh6Cjf5o7vxPnJ4+SnXOk4IlcSndnGIpJ7vtgJiw==}
+    resolution:
+      {
+        integrity: sha512-zg4vQ7iZLZkoajyjxYtGs293y3+FfpM5de63Xx6sPdIubNLh6Cjf5o7vxPnJ4+SnXOk4IlcSndnGIpJ7vtgJiw==,
+      }
     hasBin: true
 
   "@amazon-devices/react-native-kepler@2.1.0":
@@ -9307,7 +9310,7 @@ snapshots:
     dependencies:
       "@amazon-devices/keplerscript-turbomodule-api": 1.2.5(@babel/preset-env@7.29.7(@babel/core@7.29.7))
     transitivePeerDependencies:
-      - '@babel/preset-env'
+      - "@babel/preset-env"
       - supports-color
 
   "@amazon-devices/keplerscript-appstore-iap-lib@2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))":

--- a/scripts/verify-entry-point-boundaries.mjs
+++ b/scripts/verify-entry-point-boundaries.mjs
@@ -9,6 +9,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const amazonModule = "@amazon-devices/keplerscript-appstore-iap-lib";
+const fileSystemModule = "@amazon-devices/kepler-file-system";
 const defaultArtifacts = ["dist/Purchases.es.js", "dist/Purchases.umd.js"];
 const vegaArtifacts = [
   "dist/Purchases.vega.es.js",
@@ -23,6 +24,10 @@ for (const artifact of defaultArtifacts) {
     `${artifact} should not include Amazon AppStore support`,
   );
   assert.ok(
+    !contents.includes(fileSystemModule),
+    `${artifact} should not include Vega File System support`,
+  );
+  assert.ok(
     !contents.includes("Purchases.vega"),
     `${artifact} should not include the Vega code.`,
   );
@@ -34,6 +39,10 @@ for (const artifact of vegaArtifacts) {
   assert.ok(
     contents.includes(amazonModule),
     `${artifact} should include Amazon AppStore support`,
+  );
+  assert.ok(
+    contents.includes(fileSystemModule),
+    `${artifact} should include Vega File System support`,
   );
 }
 

--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -133,17 +133,17 @@ export class AmazonBillingWrapper implements BillingWrapper {
       storeUserId,
     );
 
+    let fulfillmentSucceeded = false;
     try {
-      if (await this.notifyFulfillment(receipt.receiptId)) {
-        await this.deviceCache.addSuccessfullyPostedReceiptId(
-          receipt.receiptId,
-        );
-        Logger.debugLog("Amazon purchase completed successfully.");
-      }
+      fulfillmentSucceeded = await this.notifyFulfillment(receipt.receiptId);
     } catch (error: unknown) {
       Logger.warnLog(
         `Failed to fulfill receipt ID ${receipt.receiptId} with the Amazon Store: ${String(error)}`,
       );
+    }
+    if (fulfillmentSucceeded) {
+      await this.cacheSuccessfullyPostedReceiptId(receipt.receiptId);
+      Logger.debugLog("Amazon purchase completed successfully.");
     }
 
     return {
@@ -285,21 +285,21 @@ export class AmazonBillingWrapper implements BillingWrapper {
       );
 
       if (isRestore) {
+        let fulfillmentSucceeded = false;
         try {
-          if (await this.notifyFulfillment(receipt.receiptId)) {
-            await this.deviceCache.addSuccessfullyPostedReceiptId(
-              receipt.receiptId,
-            );
-          }
+          fulfillmentSucceeded = await this.notifyFulfillment(
+            receipt.receiptId,
+          );
         } catch (error: unknown) {
           Logger.warnLog(
             `Failed to fulfill receipt ID ${receipt.receiptId} with the Amazon Store: ${String(error)}`,
           );
         }
+        if (fulfillmentSucceeded) {
+          await this.cacheSuccessfullyPostedReceiptId(receipt.receiptId);
+        }
       } else {
-        await this.deviceCache.addSuccessfullyPostedReceiptId(
-          receipt.receiptId,
-        );
+        await this.cacheSuccessfullyPostedReceiptId(receipt.receiptId);
       }
     }
 
@@ -343,6 +343,18 @@ export class AmazonBillingWrapper implements BillingWrapper {
           `Received an unexpected response code from Amazon when fulfilling receipt ID ${receiptId}.`,
         );
         return false;
+    }
+  }
+
+  private async cacheSuccessfullyPostedReceiptId(
+    receiptId: string,
+  ): Promise<void> {
+    try {
+      await this.deviceCache.addSuccessfullyPostedReceiptId(receiptId);
+    } catch (error: unknown) {
+      Logger.warnLog(
+        `Failed to cache successfully posted receipt ID ${receiptId}: ${String(error)}`,
+      );
     }
   }
 

--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -2,6 +2,7 @@ import type {
   Product,
   ProductDataResponse,
   ProductType as AmazonProductType,
+  Receipt,
 } from "@amazon-devices/keplerscript-appstore-iap-lib";
 import { ErrorCode, PurchasesError } from "../entities/errors";
 import { Logger } from "../helpers/logger";
@@ -19,13 +20,17 @@ import { PostReceiptInitiationSource } from "../networking/backend";
 import { toCustomerInfo } from "../entities/customer-info";
 import type { CustomerInfo } from "../entities/customer-info";
 import type { RestorePurchasesResult } from "../entities/restore-purchases-result";
-import type { SubscriberResponse } from "../networking/responses/subscriber-response";
 import type { SyncPurchasesResult } from "../entities/sync-purchases-result";
 import {
   loadAmazonAppstoreIAPSDK,
   type AmazonAppstoreIAPSDK,
 } from "./amazon-appstore-iap-sdk-loader";
 import { VegaDeviceCache } from "./vega-device-cache";
+
+type ReceiptWithStoreUserId = {
+  receipt: Receipt;
+  storeUserId: string;
+};
 
 /**
  * Amazon billing wrapper. Defers loading the Amazon Appstore IAP SDK until
@@ -46,13 +51,6 @@ export class AmazonBillingWrapper implements BillingWrapper {
   private amazonAppstoreIAPSDKPromise:
     | Promise<AmazonAppstoreIAPSDK>
     | undefined;
-
-  /**
-   * Receipt IDs successfully posted by syncPurchases or restorePurchases during
-   * this wrapper's lifetime. We avoid caching this persistently on-device to avoid
-   * adding another dependency for Vega OS apps.
-   */
-  private readonly syncedReceiptIds = new Set<string>();
 
   public async getProducts(
     _appUserId: string,
@@ -136,13 +134,17 @@ export class AmazonBillingWrapper implements BillingWrapper {
     );
 
     try {
-      await this.notifyFulfillment(receipt.receiptId);
+      if (await this.notifyFulfillment(receipt.receiptId)) {
+        await this.deviceCache.addSuccessfullyPostedReceiptId(
+          receipt.receiptId,
+        );
+        Logger.debugLog("Amazon purchase completed successfully.");
+      }
     } catch (error: unknown) {
       Logger.warnLog(
         `Failed to fulfill receipt ID ${receipt.receiptId} with the Amazon Store: ${String(error)}`,
       );
     }
-    Logger.debugLog("Amazon purchase completed successfully.");
 
     return {
       customerInfo: toCustomerInfo(subscriberResponse),
@@ -180,9 +182,9 @@ export class AmazonBillingWrapper implements BillingWrapper {
       PurchaseUpdatesResponseCode,
       ProductType: AmazonProductType,
     } = amazonAppstoreIAPSDK;
+    const receiptsToPost: ReceiptWithStoreUserId[] = [];
 
     let doneFetching = false;
-    let mostRecentSubscriberResponse: SubscriberResponse | null = null;
     let executedGetPurchaseUpdatesRequests = 0;
     while (!doneFetching) {
       let response: Awaited<
@@ -236,34 +238,12 @@ export class AmazonBillingWrapper implements BillingWrapper {
           );
       }
 
-      for (const receipt of response.receiptList) {
-        if (this.syncedReceiptIds.has(receipt.receiptId)) {
-          Logger.verboseLog(
-            `Skipping posting Amazon receipt ${receipt.receiptId} because it has already been synced during this session.`,
-          );
-          continue;
-        }
-
-        let productId: string;
-        if (receipt.productType == AmazonProductType.SUBSCRIPTION) {
-          productId = receipt.termSku;
-        } else {
-          productId = receipt.sku;
-        }
-
-        mostRecentSubscriberResponse = await this.backend.postReceipt(
-          appUserId,
-          productId,
-          null,
-          receipt.receiptId,
-          null,
-          PostReceiptInitiationSource.RESTORE,
-          undefined,
-          response.userData.userId,
-          isRestore,
-        );
-        this.syncedReceiptIds.add(receipt.receiptId);
-      }
+      receiptsToPost.push(
+        ...response.receiptList.map((receipt) => ({
+          receipt,
+          storeUserId: response.userData.userId,
+        })),
+      );
 
       if (response.hasMore && response.receiptList.length === 0) {
         Logger.verboseLog(
@@ -280,15 +260,53 @@ export class AmazonBillingWrapper implements BillingWrapper {
       }
     }
 
-    if (mostRecentSubscriberResponse == null) {
-      mostRecentSubscriberResponse =
-        await this.backend.getCustomerInfo(appUserId);
+    receiptsToPost.sort(
+      (first, second) =>
+        first.receipt.purchaseDate.getTime() -
+        second.receipt.purchaseDate.getTime(),
+    );
+
+    for (const { receipt, storeUserId } of receiptsToPost) {
+      const productId =
+        receipt.productType == AmazonProductType.SUBSCRIPTION
+          ? receipt.termSku
+          : receipt.sku;
+
+      await this.backend.postReceipt(
+        appUserId,
+        productId,
+        null,
+        receipt.receiptId,
+        null,
+        PostReceiptInitiationSource.RESTORE,
+        undefined,
+        storeUserId,
+        isRestore,
+      );
+
+      if (isRestore) {
+        try {
+          if (await this.notifyFulfillment(receipt.receiptId)) {
+            await this.deviceCache.addSuccessfullyPostedReceiptId(
+              receipt.receiptId,
+            );
+          }
+        } catch (error: unknown) {
+          Logger.warnLog(
+            `Failed to fulfill receipt ID ${receipt.receiptId} with the Amazon Store: ${String(error)}`,
+          );
+        }
+      } else {
+        await this.deviceCache.addSuccessfullyPostedReceiptId(
+          receipt.receiptId,
+        );
+      }
     }
 
-    return toCustomerInfo(mostRecentSubscriberResponse);
+    return toCustomerInfo(await this.backend.getCustomerInfo(appUserId));
   }
 
-  private async notifyFulfillment(receiptId: string) {
+  private async notifyFulfillment(receiptId: string): Promise<boolean> {
     const amazonAppstoreIAPSDK = await this.getAmazonAppstoreIAPSDK();
     const {
       PurchasingService,
@@ -309,23 +327,22 @@ export class AmazonBillingWrapper implements BillingWrapper {
         Logger.debugLog(
           `Successfully fulfilled receipt ID ${receiptId} with the Amazon Store.`,
         );
-        this.deviceCache.addSuccessfullyPostedReceiptId(receiptId);
-        break;
+        return true;
       case NotifyFulfillmentResponseCode.NOT_SUPPORTED:
         Logger.warnLog(
           `Failed to fulfill receipt ID ${receiptId} with the Amazon Store: fulfillment is not supported.`,
         );
-        break;
+        return false;
       case NotifyFulfillmentResponseCode.FAILED:
         Logger.errorLog(
           `Failed to fulfill receipt ID ${receiptId} with the Amazon Store.`,
         );
-        break;
+        return false;
       default:
         Logger.warnLog(
           `Received an unexpected response code from Amazon when fulfilling receipt ID ${receiptId}.`,
         );
-        break;
+        return false;
     }
   }
 

--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -309,6 +309,7 @@ export class AmazonBillingWrapper implements BillingWrapper {
         Logger.debugLog(
           `Successfully fulfilled receipt ID ${receiptId} with the Amazon Store.`,
         );
+        this.deviceCache.addSuccessfullyPostedReceiptId(receiptId);
         break;
       case NotifyFulfillmentResponseCode.NOT_SUPPORTED:
         Logger.warnLog(

--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -353,7 +353,7 @@ export class AmazonBillingWrapper implements BillingWrapper {
       await this.deviceCache.addSuccessfullyPostedReceiptId(receiptId);
     } catch (error: unknown) {
       Logger.warnLog(
-        `Failed to cache successfully posted receipt ID ${receiptId}: ${String(error)}`,
+        `Failed to cache successfully posted receipt ID ${receiptId}: ${formatCacheError(error)}`,
       );
     }
   }
@@ -572,4 +572,30 @@ export class AmazonBillingWrapper implements BillingWrapper {
 
     return { product_details: productDetails };
   }
+}
+
+function formatCacheError(error: unknown): string {
+  if (error instanceof Error) {
+    return String(error);
+  }
+
+  if (typeof error === "object" && error !== null) {
+    const { code, message } = error as {
+      code?: unknown;
+      message?: unknown;
+    };
+    if (typeof message === "string") {
+      return typeof code === "string" || typeof code === "number"
+        ? `${code}: ${message}`
+        : message;
+    }
+
+    try {
+      return JSON.stringify(error);
+    } catch {
+      // Fall through to the string representation below.
+    }
+  }
+
+  return String(error);
 }

--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -25,6 +25,7 @@ import {
   loadAmazonAppstoreIAPSDK,
   type AmazonAppstoreIAPSDK,
 } from "./amazon-appstore-iap-sdk-loader";
+import { VegaDeviceCache } from "./vega-device-cache";
 
 /**
  * Amazon billing wrapper. Defers loading the Amazon Appstore IAP SDK until
@@ -32,7 +33,15 @@ import {
  * @internal
  */
 export class AmazonBillingWrapper implements BillingWrapper {
-  constructor(private readonly backend: Backend) {}
+  private readonly deviceCache: VegaDeviceCache;
+
+  constructor(
+    private readonly backend: Backend,
+    apiKey: string,
+  ) {
+    this.deviceCache = new VegaDeviceCache(apiKey);
+    void this.deviceCache;
+  }
 
   private amazonAppstoreIAPSDKPromise:
     | Promise<AmazonAppstoreIAPSDK>

--- a/src/amazon/kepler-file-system-loader.ts
+++ b/src/amazon/kepler-file-system-loader.ts
@@ -1,0 +1,53 @@
+import type { KeplerFileSystem as AmazonKeplerFileSystem } from "@amazon-devices/kepler-file-system";
+import { ErrorCode, PurchasesError } from "../entities/errors";
+
+/**
+ * Shared Kepler File System loader contract used by VegaDeviceCache.
+ *
+ * Keeping this as an injected dependency lets the default purchases-js module
+ * avoid importing the Vega-only File System package. The Vega entry point
+ * installs the native module implementation before re-exporting the public
+ * SDK API.
+ */
+export type KeplerFileSystem = typeof AmazonKeplerFileSystem;
+export type KeplerFileSystemLoader = () => Promise<KeplerFileSystem>;
+
+const missingKeplerFileSystemLoader: KeplerFileSystemLoader = async () => {
+  throw new PurchasesError(
+    ErrorCode.ConfigurationError,
+    "Kepler File System is supported only by the @revenuecat/purchases-js/vega entry point.",
+  );
+};
+
+let keplerFileSystemLoader: KeplerFileSystemLoader =
+  missingKeplerFileSystemLoader;
+
+/**
+ * Installs the runtime-specific Kepler File System implementation.
+ *
+ * @internal
+ */
+export function setKeplerFileSystemLoader(
+  loader: KeplerFileSystemLoader,
+): void {
+  keplerFileSystemLoader = loader;
+}
+
+/**
+ * Restores the loader used when no Vega-capable entry point has configured one.
+ *
+ * @internal
+ */
+export function resetKeplerFileSystemLoader(): void {
+  keplerFileSystemLoader = missingKeplerFileSystemLoader;
+}
+
+/**
+ * Gets the Kepler File System through the implementation selected by the
+ * active entry point.
+ *
+ * @internal
+ */
+export function loadKeplerFileSystem(): Promise<KeplerFileSystem> {
+  return keplerFileSystemLoader();
+}

--- a/src/amazon/vega-device-cache.ts
+++ b/src/amazon/vega-device-cache.ts
@@ -39,11 +39,33 @@ export class VegaDeviceCache {
       }
 
       const fileSystem = await this.fileSystemLoader();
-      await fileSystem.writeStringToFile(
-        this.tokensCachePath,
-        JSON.stringify([...receiptIds, receiptId]),
-        "UTF-8",
-      );
+      const updatedReceiptIds = [...receiptIds, receiptId];
+      if (await fileSystem.exists(this.tokensCachePath)) {
+        await fileSystem.removeFile(this.tokensCachePath);
+      }
+      try {
+        await fileSystem.writeStringToFile(
+          this.tokensCachePath,
+          JSON.stringify(updatedReceiptIds),
+          "UTF-8",
+        );
+      } catch (error: unknown) {
+        if (!isAlreadyExistsError(error)) {
+          throw error;
+        }
+
+        const currentReceiptIds = await this.getReceiptIds();
+        if (currentReceiptIds.includes(receiptId)) {
+          return;
+        }
+
+        await fileSystem.removeFile(this.tokensCachePath);
+        await fileSystem.writeStringToFile(
+          this.tokensCachePath,
+          JSON.stringify([...currentReceiptIds, receiptId]),
+          "UTF-8",
+        );
+      }
     });
 
     this.writeQueue = operation.catch(() => undefined);
@@ -74,4 +96,8 @@ function isReceiptCache(value: unknown): value is ReceiptCache {
   return (
     Array.isArray(value) && value.every((entry) => typeof entry === "string")
   );
+}
+
+function isAlreadyExistsError(error: unknown): boolean {
+  return String(error).includes("AlreadyExistsError");
 }

--- a/src/amazon/vega-device-cache.ts
+++ b/src/amazon/vega-device-cache.ts
@@ -20,7 +20,7 @@ export class VegaDeviceCache {
     private readonly apiKey: string,
     private readonly fileSystemLoader: KeplerFileSystemLoader = loadKeplerFileSystem,
   ) {
-    this.tokensCachePath = `/data/revenuecat/${this.sharedPreferencesPrefix}${this.apiKey}.${this.tokensCacheKey}`;
+    this.tokensCachePath = `/data/${this.sharedPreferencesPrefix}${this.apiKey}.${this.tokensCacheKey}`;
   }
 
   public async getPreviouslySentReceiptIds(): Promise<Set<string>> {

--- a/src/amazon/vega-device-cache.ts
+++ b/src/amazon/vega-device-cache.ts
@@ -11,8 +11,16 @@ type ReceiptCache = string[];
  * @internal
  */
 export class VegaDeviceCache {
-  private readonly rcStoragePrefix = "com.revenuecat.purchases.";
-  private readonly tokensCacheKey = "tokens";
+  // Apps operate in a sandboxed environment with a restricted view of the device file system.
+  // Vega makes the following app-specific directories available in the sandbox.
+  //
+  // The /data directory is a writable location for app data. It is persistent across
+  // device reboots and package upgrades, and is not shared between apps or services.
+  // The directory isn't persistent on app uninstall.
+  //
+  // More info: https://developer.amazon.com/docs/vega-api/0.24/README.amazon-devices_kepler-file-system.html
+  private readonly dataDirectory = "data";
+  private readonly rcStoragePrefix = "com.revenuecat.purchases";
   private readonly tokensCachePath: string;
   private writeQueue: Promise<void> = Promise.resolve();
 
@@ -20,7 +28,10 @@ export class VegaDeviceCache {
     private readonly apiKey: string,
     private readonly fileSystemLoader: KeplerFileSystemLoader = loadKeplerFileSystem,
   ) {
-    this.tokensCachePath = `/data/${this.rcStoragePrefix}${this.apiKey}.${this.tokensCacheKey}`;
+    // As of KeplerFileSystem SDK version 0.24, there is no way to create a directory, and any attempts
+    // to write to one throw a com.amazon.kepler.file_system.NotFoundError error. Therefore, we write
+    // our cache files to the /data directory.
+    this.tokensCachePath = `/${this.dataDirectory}/${this.rcStoragePrefix}.${this.apiKey}.tokens`;
   }
 
   public async getPreviouslySentReceiptIds(): Promise<Set<string>> {

--- a/src/amazon/vega-device-cache.ts
+++ b/src/amazon/vega-device-cache.ts
@@ -1,4 +1,9 @@
-import type { KeplerFileSystem } from "./kepler-file-system-loader";
+import {
+  loadKeplerFileSystem,
+  type KeplerFileSystemLoader,
+} from "./kepler-file-system-loader";
+
+type ReceiptCache = string[];
 
 /**
  * Class capable of caching items on a Vega device.
@@ -6,9 +11,67 @@ import type { KeplerFileSystem } from "./kepler-file-system-loader";
  * @internal
  */
 export class VegaDeviceCache {
-  public constructor(private readonly fileSystem: KeplerFileSystem) {
-    // Cache operations will use the injected Vega File System in a follow-up
-    // change. Retain it now so the cache boundary is already wired.
-    void this.fileSystem;
+  private readonly sharedPreferencesPrefix = "com.revenuecat.purchases.";
+  private readonly tokensCacheKey = "tokens";
+  private readonly tokensCachePath: string;
+  private writeQueue: Promise<void> = Promise.resolve();
+
+  public constructor(
+    private readonly apiKey: string,
+    private readonly fileSystemLoader: KeplerFileSystemLoader = loadKeplerFileSystem,
+  ) {
+    this.tokensCachePath = `/data/${this.sharedPreferencesPrefix}${this.apiKey}.${this.tokensCacheKey}`;
   }
+
+  public async getPreviouslySentReceiptIds(): Promise<Set<string>> {
+    await this.writeQueue;
+    return new Set(await this.getReceiptIds());
+  }
+
+  public async addSuccessfullyPostedReceiptId(
+    receiptId: string,
+  ): Promise<void> {
+    const operation = this.writeQueue.then(async () => {
+      const receiptIds = await this.getReceiptIds();
+
+      if (receiptIds.includes(receiptId)) {
+        return;
+      }
+
+      const fileSystem = await this.fileSystemLoader();
+      await fileSystem.writeStringToFile(
+        this.tokensCachePath,
+        JSON.stringify([...receiptIds, receiptId]),
+        "UTF-8",
+      );
+    });
+
+    this.writeQueue = operation.catch(() => undefined);
+    await operation;
+  }
+
+  private async getReceiptIds(): Promise<ReceiptCache> {
+    const fileSystem = await this.fileSystemLoader();
+    if (!(await fileSystem.exists(this.tokensCachePath))) {
+      return [];
+    }
+
+    try {
+      const serializedReceiptIds = await fileSystem.readFileAsString(
+        this.tokensCachePath,
+        "UTF-8",
+      );
+      const receiptIds: unknown = JSON.parse(serializedReceiptIds);
+
+      return isReceiptCache(receiptIds) ? receiptIds : [];
+    } catch {
+      return [];
+    }
+  }
+}
+
+function isReceiptCache(value: unknown): value is ReceiptCache {
+  return (
+    Array.isArray(value) && value.every((entry) => typeof entry === "string")
+  );
 }

--- a/src/amazon/vega-device-cache.ts
+++ b/src/amazon/vega-device-cache.ts
@@ -20,7 +20,7 @@ export class VegaDeviceCache {
     private readonly apiKey: string,
     private readonly fileSystemLoader: KeplerFileSystemLoader = loadKeplerFileSystem,
   ) {
-    this.tokensCachePath = `/data/${this.sharedPreferencesPrefix}${this.apiKey}.${this.tokensCacheKey}`;
+    this.tokensCachePath = `/revenuecat/${this.sharedPreferencesPrefix}${this.apiKey}.${this.tokensCacheKey}`;
   }
 
   public async getPreviouslySentReceiptIds(): Promise<Set<string>> {

--- a/src/amazon/vega-device-cache.ts
+++ b/src/amazon/vega-device-cache.ts
@@ -20,7 +20,7 @@ export class VegaDeviceCache {
     private readonly apiKey: string,
     private readonly fileSystemLoader: KeplerFileSystemLoader = loadKeplerFileSystem,
   ) {
-    this.tokensCachePath = `/revenuecat/${this.sharedPreferencesPrefix}${this.apiKey}.${this.tokensCacheKey}`;
+    this.tokensCachePath = `/data/revenuecat/${this.sharedPreferencesPrefix}${this.apiKey}.${this.tokensCacheKey}`;
   }
 
   public async getPreviouslySentReceiptIds(): Promise<Set<string>> {

--- a/src/amazon/vega-device-cache.ts
+++ b/src/amazon/vega-device-cache.ts
@@ -1,0 +1,14 @@
+import type { KeplerFileSystem } from "./kepler-file-system-loader";
+
+/**
+ * Class capable of caching items on a Vega device.
+ *
+ * @internal
+ */
+export class VegaDeviceCache {
+  public constructor(private readonly fileSystem: KeplerFileSystem) {
+    // Cache operations will use the injected Vega File System in a follow-up
+    // change. Retain it now so the cache boundary is already wired.
+    void this.fileSystem;
+  }
+}

--- a/src/amazon/vega-device-cache.ts
+++ b/src/amazon/vega-device-cache.ts
@@ -49,11 +49,7 @@ export class VegaDeviceCache {
           JSON.stringify(updatedReceiptIds),
           "UTF-8",
         );
-      } catch (error: unknown) {
-        if (!isAlreadyExistsError(error)) {
-          throw error;
-        }
-
+      } catch {
         const currentReceiptIds = await this.getReceiptIds();
         if (currentReceiptIds.includes(receiptId)) {
           return;
@@ -96,8 +92,4 @@ function isReceiptCache(value: unknown): value is ReceiptCache {
   return (
     Array.isArray(value) && value.every((entry) => typeof entry === "string")
   );
-}
-
-function isAlreadyExistsError(error: unknown): boolean {
-  return String(error).includes("AlreadyExistsError");
 }

--- a/src/amazon/vega-device-cache.ts
+++ b/src/amazon/vega-device-cache.ts
@@ -11,7 +11,7 @@ type ReceiptCache = string[];
  * @internal
  */
 export class VegaDeviceCache {
-  private readonly sharedPreferencesPrefix = "com.revenuecat.purchases.";
+  private readonly rcStoragePrefix = "com.revenuecat.purchases.";
   private readonly tokensCacheKey = "tokens";
   private readonly tokensCachePath: string;
   private writeQueue: Promise<void> = Promise.resolve();
@@ -20,7 +20,7 @@ export class VegaDeviceCache {
     private readonly apiKey: string,
     private readonly fileSystemLoader: KeplerFileSystemLoader = loadKeplerFileSystem,
   ) {
-    this.tokensCachePath = `/data/${this.sharedPreferencesPrefix}${this.apiKey}.${this.tokensCacheKey}`;
+    this.tokensCachePath = `/data/${this.rcStoragePrefix}${this.apiKey}.${this.tokensCacheKey}`;
   }
 
   public async getPreviouslySentReceiptIds(): Promise<Set<string>> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -618,7 +618,10 @@ export class Purchases {
       eventName: SDKEventName.SDKInitialized,
     });
     if (isAmazonApiKey(this._API_KEY)) {
-      this.amazonBillingWrapper = new AmazonBillingWrapper(this.backend);
+      this.amazonBillingWrapper = new AmazonBillingWrapper(
+        this.backend,
+        this._API_KEY,
+      );
     }
   }
 

--- a/src/tests/amazon/amazon-billing-wrapper.test.ts
+++ b/src/tests/amazon/amazon-billing-wrapper.test.ts
@@ -477,6 +477,73 @@ describe("AmazonBillingWrapper", () => {
       );
     });
 
+    test("sync continues when caching a successfully posted receipt fails", async () => {
+      const backend = createBackend();
+      vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
+      vi.mocked(
+        VegaDeviceCache.prototype.addSuccessfullyPostedReceiptId,
+      ).mockRejectedValueOnce(new Error("disk unavailable"));
+      getPurchaseUpdates.mockResolvedValue(
+        purchaseUpdatesResponse({
+          receiptList: [
+            {
+              ...successfulPurchaseResponse().receipt,
+              receiptId: "first-receipt",
+            },
+            {
+              ...successfulPurchaseResponse().receipt,
+              receiptId: "second-receipt",
+            },
+          ],
+        }),
+      );
+
+      await new AmazonBillingWrapper(backend, amazonApiKey).syncPurchases(
+        "app-user-id",
+      );
+
+      expect(backend.postReceipt).toHaveBeenCalledTimes(2);
+      expect(backend.postReceipt).toHaveBeenNthCalledWith(
+        2,
+        "app-user-id",
+        "monthly",
+        null,
+        "second-receipt",
+        null,
+        "restore",
+        undefined,
+        "amazon-store-user-id",
+        false,
+      );
+      expect(backend.getCustomerInfo).toHaveBeenCalledExactlyOnceWith(
+        "app-user-id",
+      );
+    });
+
+    test("restore logs a cache warning when fulfillment succeeds but caching fails", async () => {
+      const backend = createBackend();
+      const warningLog = vi
+        .spyOn(Logger, "warnLog")
+        .mockImplementation(() => {});
+      vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
+      notifyFulfillment.mockResolvedValue({
+        responseCode: NotifyFulfillmentResponseCode.SUCCESSFUL,
+      });
+      vi.mocked(
+        VegaDeviceCache.prototype.addSuccessfullyPostedReceiptId,
+      ).mockRejectedValueOnce(new Error("disk unavailable"));
+      getPurchaseUpdates.mockResolvedValue(successfulPurchaseUpdatesResponse());
+
+      await new AmazonBillingWrapper(backend, amazonApiKey).restorePurchases(
+        "app-user-id",
+      );
+
+      expect(notifyFulfillment).toHaveBeenCalledOnce();
+      expect(warningLog).toHaveBeenCalledWith(
+        "Failed to cache successfully posted receipt ID amazon-receipt-id: Error: disk unavailable",
+      );
+    });
+
     test.each([
       ["syncPurchases", false],
       ["restorePurchases", true],
@@ -808,6 +875,29 @@ describe("AmazonBillingWrapper", () => {
       expect(
         vi.mocked(VegaDeviceCache.prototype.addSuccessfullyPostedReceiptId),
       ).toHaveBeenCalledExactlyOnceWith("amazon-receipt-id");
+    });
+
+    test("logs a cache warning when fulfillment succeeds but caching fails", async () => {
+      const backend = createBackend();
+      const warningLog = vi
+        .spyOn(Logger, "warnLog")
+        .mockImplementation(() => {});
+      vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
+      vi.mocked(
+        VegaDeviceCache.prototype.addSuccessfullyPostedReceiptId,
+      ).mockRejectedValueOnce(new Error("disk unavailable"));
+
+      await expect(
+        new AmazonBillingWrapper(backend, amazonApiKey).purchase(
+          { rcPackage: createMonthlyPackageMock() },
+          appUserId,
+        ),
+      ).resolves.toMatchObject({ operationSessionId: "amazon-receipt-id" });
+
+      expect(notifyFulfillment).toHaveBeenCalledOnce();
+      expect(warningLog).toHaveBeenCalledWith(
+        "Failed to cache successfully posted receipt ID amazon-receipt-id: Error: disk unavailable",
+      );
     });
 
     test("uses a non-subscription receipt's SKU when posting and returning the purchase", async () => {

--- a/src/tests/amazon/amazon-billing-wrapper.test.ts
+++ b/src/tests/amazon/amazon-billing-wrapper.test.ts
@@ -166,6 +166,10 @@ describe("AmazonBillingWrapper", () => {
     notifyFulfillment.mockReset();
     purchase.mockReset();
     vi.restoreAllMocks();
+    vi.spyOn(
+      VegaDeviceCache.prototype,
+      "addSuccessfullyPostedReceiptId",
+    ).mockResolvedValue();
   });
 
   test("initializes the Vega device cache with its API key", () => {
@@ -655,6 +659,20 @@ describe("AmazonBillingWrapper", () => {
       });
     });
 
+    test("caches a receipt ID after Amazon successfully fulfills it", async () => {
+      const backend = createBackend();
+      vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
+
+      await new AmazonBillingWrapper(backend).purchase(
+        { rcPackage: createMonthlyPackageMock() },
+        appUserId,
+      );
+
+      expect(
+        vi.mocked(VegaDeviceCache.prototype.addSuccessfullyPostedReceiptId),
+      ).toHaveBeenCalledExactlyOnceWith("amazon-receipt-id");
+    });
+
     test("uses a non-subscription receipt's SKU when posting and returning the purchase", async () => {
       const backend = createBackend();
       const params = { rcPackage: createMonthlyPackageMock() };
@@ -824,6 +842,9 @@ describe("AmazonBillingWrapper", () => {
         ).resolves.toMatchObject({ operationSessionId: "amazon-receipt-id" });
 
         expect(notifyFulfillment).toHaveBeenCalledOnce();
+        expect(
+          vi.mocked(VegaDeviceCache.prototype.addSuccessfullyPostedReceiptId),
+        ).not.toHaveBeenCalled();
         expect(log).toHaveBeenCalledWith(expectedLog);
       },
     );

--- a/src/tests/amazon/amazon-billing-wrapper.test.ts
+++ b/src/tests/amazon/amazon-billing-wrapper.test.ts
@@ -482,7 +482,10 @@ describe("AmazonBillingWrapper", () => {
       vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
       vi.mocked(
         VegaDeviceCache.prototype.addSuccessfullyPostedReceiptId,
-      ).mockRejectedValueOnce(new Error("disk unavailable"));
+      ).mockRejectedValueOnce({
+        code: "EIO",
+        message: "disk unavailable",
+      });
       getPurchaseUpdates.mockResolvedValue(
         purchaseUpdatesResponse({
           receiptList: [
@@ -531,7 +534,10 @@ describe("AmazonBillingWrapper", () => {
       });
       vi.mocked(
         VegaDeviceCache.prototype.addSuccessfullyPostedReceiptId,
-      ).mockRejectedValueOnce(new Error("disk unavailable"));
+      ).mockRejectedValueOnce({
+        code: "EIO",
+        message: "disk unavailable",
+      });
       getPurchaseUpdates.mockResolvedValue(successfulPurchaseUpdatesResponse());
 
       await new AmazonBillingWrapper(backend, amazonApiKey).restorePurchases(
@@ -540,7 +546,7 @@ describe("AmazonBillingWrapper", () => {
 
       expect(notifyFulfillment).toHaveBeenCalledOnce();
       expect(warningLog).toHaveBeenCalledWith(
-        "Failed to cache successfully posted receipt ID amazon-receipt-id: Error: disk unavailable",
+        "Failed to cache successfully posted receipt ID amazon-receipt-id: EIO: disk unavailable",
       );
     });
 

--- a/src/tests/amazon/amazon-billing-wrapper.test.ts
+++ b/src/tests/amazon/amazon-billing-wrapper.test.ts
@@ -386,17 +386,24 @@ describe("AmazonBillingWrapper", () => {
       },
     );
 
-    test("does not post a receipt more than once during the wrapper lifetime", async () => {
+    test("sync posts receipts on every invocation, while restore posts them and fulfills them", async () => {
       const backend = createBackend();
       vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
       getPurchaseUpdates.mockResolvedValue(successfulPurchaseUpdatesResponse());
+      notifyFulfillment.mockResolvedValue({
+        responseCode: NotifyFulfillmentResponseCode.SUCCESSFUL,
+      });
+      const getPreviouslySentReceiptIds = vi
+        .spyOn(VegaDeviceCache.prototype, "getPreviouslySentReceiptIds")
+        .mockResolvedValue(new Set(["amazon-receipt-id"]));
       const wrapper = new AmazonBillingWrapper(backend);
 
       await wrapper.syncPurchases("app-user-id");
       await wrapper.syncPurchases("app-user-id");
       await wrapper.restorePurchases("app-user-id");
 
-      expect(backend.postReceipt).toHaveBeenCalledExactlyOnceWith(
+      expect(backend.postReceipt).toHaveBeenNthCalledWith(
+        1,
         "app-user-id",
         "monthly",
         null,
@@ -407,9 +414,59 @@ describe("AmazonBillingWrapper", () => {
         "amazon-store-user-id",
         false,
       );
+      expect(backend.postReceipt).toHaveBeenNthCalledWith(
+        2,
+        "app-user-id",
+        "monthly",
+        null,
+        "amazon-receipt-id",
+        null,
+        "restore",
+        undefined,
+        "amazon-store-user-id",
+        false,
+      );
+      expect(backend.postReceipt).toHaveBeenNthCalledWith(
+        3,
+        "app-user-id",
+        "monthly",
+        null,
+        "amazon-receipt-id",
+        null,
+        "restore",
+        undefined,
+        "amazon-store-user-id",
+        true,
+      );
+      expect(notifyFulfillment).toHaveBeenCalledExactlyOnceWith({
+        receiptId: "amazon-receipt-id",
+        fulfillmentResult: FulfillmentResult.FULFILLED,
+      });
+      expect(
+        vi.mocked(VegaDeviceCache.prototype.addSuccessfullyPostedReceiptId),
+      ).toHaveBeenNthCalledWith(1, "amazon-receipt-id");
+      expect(
+        vi.mocked(VegaDeviceCache.prototype.addSuccessfullyPostedReceiptId),
+      ).toHaveBeenNthCalledWith(2, "amazon-receipt-id");
       expect(backend.getCustomerInfo).toHaveBeenCalledTimes(2);
       expect(backend.getCustomerInfo).toHaveBeenNthCalledWith(1, "app-user-id");
       expect(backend.getCustomerInfo).toHaveBeenNthCalledWith(2, "app-user-id");
+      expect(getPreviouslySentReceiptIds).not.toHaveBeenCalled();
+    });
+
+    test("sync fetches customer info after posting receipts", async () => {
+      const backend = createBackend();
+      vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
+      getPurchaseUpdates.mockResolvedValue(successfulPurchaseUpdatesResponse());
+
+      await new AmazonBillingWrapper(backend).syncPurchases("app-user-id");
+
+      expect(backend.postReceipt).toHaveBeenCalledBefore(
+        backend.getCustomerInfo as ReturnType<typeof vi.fn>,
+      );
+      expect(backend.getCustomerInfo).toHaveBeenCalledExactlyOnceWith(
+        "app-user-id",
+      );
     });
 
     test.each([
@@ -477,6 +534,66 @@ describe("AmazonBillingWrapper", () => {
           undefined,
           "amazon-store-user-id",
           isRestore,
+        );
+      },
+    );
+
+    test.each(["syncPurchases", "restorePurchases"] as const)(
+      "%s posts receipts in purchase-date order across pages",
+      async (method) => {
+        const backend = createBackend();
+        vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
+        getPurchaseUpdates
+          .mockResolvedValueOnce(
+            purchaseUpdatesResponse({
+              hasMore: true,
+              receiptList: [
+                {
+                  ...successfulPurchaseResponse().receipt,
+                  receiptId: "later-receipt",
+                  purchaseDate: new Date("2026-08-14T17:00:00Z"),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            purchaseUpdatesResponse({
+              hasMore: false,
+              receiptList: [
+                {
+                  ...successfulPurchaseResponse().receipt,
+                  receiptId: "earlier-receipt",
+                  purchaseDate: new Date("2026-08-10T17:00:00Z"),
+                },
+              ],
+            }),
+          );
+
+        await new AmazonBillingWrapper(backend)[method]("app-user-id");
+
+        expect(backend.postReceipt).toHaveBeenNthCalledWith(
+          1,
+          "app-user-id",
+          "monthly",
+          null,
+          "earlier-receipt",
+          null,
+          "restore",
+          undefined,
+          "amazon-store-user-id",
+          method === "restorePurchases",
+        );
+        expect(backend.postReceipt).toHaveBeenNthCalledWith(
+          2,
+          "app-user-id",
+          "monthly",
+          null,
+          "later-receipt",
+          null,
+          "restore",
+          undefined,
+          "amazon-store-user-id",
+          method === "restorePurchases",
         );
       },
     );

--- a/src/tests/amazon/amazon-billing-wrapper.test.ts
+++ b/src/tests/amazon/amazon-billing-wrapper.test.ts
@@ -62,6 +62,7 @@ import {
   setAmazonAppstoreIAPSDKLoader,
 } from "../../amazon/amazon-appstore-iap-sdk-loader";
 import { AmazonBillingWrapper } from "../../amazon/amazon-billing-wrapper";
+import { VegaDeviceCache } from "../../amazon/vega-device-cache";
 import { ErrorCode } from "../../entities/errors";
 import type { PurchasesError } from "../../entities/errors";
 import { Logger } from "../../helpers/logger";
@@ -165,6 +166,24 @@ describe("AmazonBillingWrapper", () => {
     notifyFulfillment.mockReset();
     purchase.mockReset();
     vi.restoreAllMocks();
+  });
+
+  test("initializes the Vega device cache with its API key", () => {
+    const wrapper = new AmazonBillingWrapper(createBackend(), "amazon-api-key");
+
+    const deviceCache = (wrapper as unknown as { deviceCache: VegaDeviceCache })
+      .deviceCache;
+    expect(deviceCache).toBeInstanceOf(VegaDeviceCache);
+    expect(deviceCache as unknown as { apiKey: string }).toMatchObject({
+      apiKey: "amazon-api-key",
+    });
+    expect(
+      (
+        deviceCache as unknown as {
+          tokensCachePath: string;
+        }
+      ).tokensCachePath,
+    ).toBe("/data/com.revenuecat.purchases.amazon-api-key.tokens");
   });
 
   test("fails clearly when the Amazon SDK loader has not been wired up", async () => {

--- a/src/tests/amazon/amazon-billing-wrapper.test.ts
+++ b/src/tests/amazon/amazon-billing-wrapper.test.ts
@@ -70,6 +70,8 @@ import type { Backend } from "../../networking/backend";
 import { customerInfoResponse } from "../test-responses";
 import { createMonthlyPackageMock } from "../mocks/offering-mock-provider";
 
+const amazonApiKey = "amazon-api-key";
+
 const responseForCode = (
   responseCode: ProductDataResponseCode,
 ): ProductDataResponse => ({
@@ -102,10 +104,10 @@ const responseForProducts = (products: Product[]): ProductDataResponse => ({
 
 async function getProducts(response: ProductDataResponse) {
   getProductData.mockResolvedValue(response);
-  return await new AmazonBillingWrapper({} as Backend).getProducts(
-    "app-user-id",
-    ["product-id"],
-  );
+  return await new AmazonBillingWrapper(
+    {} as Backend,
+    amazonApiKey,
+  ).getProducts("app-user-id", ["product-id"]);
 }
 
 const successfulPurchaseResponse = (): PurchaseResponse => ({
@@ -194,9 +196,10 @@ describe("AmazonBillingWrapper", () => {
     resetAmazonAppstoreIAPSDKLoader();
 
     await expect(
-      new AmazonBillingWrapper(createBackend()).getProducts("user", [
-        "monthly",
-      ]),
+      new AmazonBillingWrapper(createBackend(), amazonApiKey).getProducts(
+        "user",
+        ["monthly"],
+      ),
     ).rejects.toMatchObject({
       errorCode: ErrorCode.ConfigurationError,
       message:
@@ -223,6 +226,7 @@ describe("AmazonBillingWrapper", () => {
 
       const result = await new AmazonBillingWrapper(
         createBackend(),
+        amazonApiKey,
       ).getProducts("user", ["monthly"]);
 
       expect(getProductData).toHaveBeenCalledExactlyOnceWith({
@@ -245,12 +249,10 @@ describe("AmazonBillingWrapper", () => {
         responseForProducts([product({ sku: "monthly" })]),
       );
 
-      await new AmazonBillingWrapper(createBackend()).getProducts("user", [
-        "monthly",
-        "yearly",
-        "monthly",
-        "yearly",
-      ]);
+      await new AmazonBillingWrapper(createBackend(), amazonApiKey).getProducts(
+        "user",
+        ["monthly", "yearly", "monthly", "yearly"],
+      );
 
       expect(getProductData).toHaveBeenCalledExactlyOnceWith({
         skus: ["monthly", "yearly"],
@@ -264,7 +266,7 @@ describe("AmazonBillingWrapper", () => {
       );
       getProductData.mockResolvedValue(responseForProducts([]));
 
-      await new AmazonBillingWrapper(createBackend()).getProducts(
+      await new AmazonBillingWrapper(createBackend(), amazonApiKey).getProducts(
         "user",
         productIds,
       );
@@ -292,6 +294,7 @@ describe("AmazonBillingWrapper", () => {
 
       const result = await new AmazonBillingWrapper(
         createBackend(),
+        amazonApiKey,
       ).getProducts("user", productIds);
 
       expect(getProductData).toHaveBeenNthCalledWith(1, {
@@ -323,7 +326,7 @@ describe("AmazonBillingWrapper", () => {
         .mockResolvedValueOnce(responseForProducts([]))
         .mockResolvedValueOnce(responseForProducts([]));
 
-      await new AmazonBillingWrapper(createBackend()).getProducts(
+      await new AmazonBillingWrapper(createBackend(), amazonApiKey).getProducts(
         "user",
         requestedProductIds,
       );
@@ -378,7 +381,9 @@ describe("AmazonBillingWrapper", () => {
           successfulPurchaseUpdatesResponse(),
         );
 
-        await new AmazonBillingWrapper(backend)[method]("app-user-id");
+        await new AmazonBillingWrapper(backend, amazonApiKey)[method](
+          "app-user-id",
+        );
 
         expect(getPurchaseUpdates).toHaveBeenCalledExactlyOnceWith({
           reset: true,
@@ -396,7 +401,7 @@ describe("AmazonBillingWrapper", () => {
       const getPreviouslySentReceiptIds = vi
         .spyOn(VegaDeviceCache.prototype, "getPreviouslySentReceiptIds")
         .mockResolvedValue(new Set(["amazon-receipt-id"]));
-      const wrapper = new AmazonBillingWrapper(backend);
+      const wrapper = new AmazonBillingWrapper(backend, amazonApiKey);
 
       await wrapper.syncPurchases("app-user-id");
       await wrapper.syncPurchases("app-user-id");
@@ -448,9 +453,10 @@ describe("AmazonBillingWrapper", () => {
       expect(
         vi.mocked(VegaDeviceCache.prototype.addSuccessfullyPostedReceiptId),
       ).toHaveBeenNthCalledWith(2, "amazon-receipt-id");
-      expect(backend.getCustomerInfo).toHaveBeenCalledTimes(2);
+      expect(backend.getCustomerInfo).toHaveBeenCalledTimes(3);
       expect(backend.getCustomerInfo).toHaveBeenNthCalledWith(1, "app-user-id");
       expect(backend.getCustomerInfo).toHaveBeenNthCalledWith(2, "app-user-id");
+      expect(backend.getCustomerInfo).toHaveBeenNthCalledWith(3, "app-user-id");
       expect(getPreviouslySentReceiptIds).not.toHaveBeenCalled();
     });
 
@@ -459,7 +465,9 @@ describe("AmazonBillingWrapper", () => {
       vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
       getPurchaseUpdates.mockResolvedValue(successfulPurchaseUpdatesResponse());
 
-      await new AmazonBillingWrapper(backend).syncPurchases("app-user-id");
+      await new AmazonBillingWrapper(backend, amazonApiKey).syncPurchases(
+        "app-user-id",
+      );
 
       expect(backend.postReceipt).toHaveBeenCalledBefore(
         backend.getCustomerInfo as ReturnType<typeof vi.fn>,
@@ -506,7 +514,9 @@ describe("AmazonBillingWrapper", () => {
             }),
           );
 
-        await new AmazonBillingWrapper(backend)[method]("app-user-id");
+        await new AmazonBillingWrapper(backend, amazonApiKey)[method](
+          "app-user-id",
+        );
 
         expect(getPurchaseUpdates).toHaveBeenCalledTimes(2);
         expect(getPurchaseUpdates).toHaveBeenNthCalledWith(1, { reset: true });
@@ -569,7 +579,9 @@ describe("AmazonBillingWrapper", () => {
             }),
           );
 
-        await new AmazonBillingWrapper(backend)[method]("app-user-id");
+        await new AmazonBillingWrapper(backend, amazonApiKey)[method](
+          "app-user-id",
+        );
 
         expect(backend.postReceipt).toHaveBeenNthCalledWith(
           1,
@@ -606,7 +618,9 @@ describe("AmazonBillingWrapper", () => {
           purchaseUpdatesResponse({ receiptList: [] }),
         );
 
-        await new AmazonBillingWrapper(backend)[method]("app-user-id");
+        await new AmazonBillingWrapper(backend, amazonApiKey)[method](
+          "app-user-id",
+        );
 
         expect(backend.postReceipt).not.toHaveBeenCalled();
         expect(backend.getCustomerInfo).toHaveBeenCalledExactlyOnceWith(
@@ -623,7 +637,9 @@ describe("AmazonBillingWrapper", () => {
           purchaseUpdatesResponse({ hasMore: true, receiptList: [] }),
         );
 
-        await new AmazonBillingWrapper(backend)[method]("app-user-id");
+        await new AmazonBillingWrapper(backend, amazonApiKey)[method](
+          "app-user-id",
+        );
 
         expect(getPurchaseUpdates).toHaveBeenCalledExactlyOnceWith({
           reset: true,
@@ -645,7 +661,7 @@ describe("AmazonBillingWrapper", () => {
         getPurchaseUpdates.mockResolvedValue(
           successfulPurchaseUpdatesResponse(),
         );
-        const wrapper = new AmazonBillingWrapper(backend);
+        const wrapper = new AmazonBillingWrapper(backend, amazonApiKey);
 
         await expect(wrapper[method]("app-user-id")).rejects.toBe(error);
         await wrapper[method]("app-user-id");
@@ -700,7 +716,9 @@ describe("AmazonBillingWrapper", () => {
         );
 
         await expect(
-          new AmazonBillingWrapper(backend)[method]("app-user-id"),
+          new AmazonBillingWrapper(backend, amazonApiKey)[method](
+            "app-user-id",
+          ),
         ).rejects.toMatchObject({ errorCode, message });
 
         expect(backend.postReceipt).not.toHaveBeenCalled();
@@ -716,7 +734,9 @@ describe("AmazonBillingWrapper", () => {
         getPurchaseUpdates.mockRejectedValue(error);
 
         await expect(
-          new AmazonBillingWrapper(backend)[method]("app-user-id"),
+          new AmazonBillingWrapper(backend, amazonApiKey)[method](
+            "app-user-id",
+          ),
         ).rejects.toMatchObject({
           errorCode: ErrorCode.StoreProblemError,
           message: `${method === "restorePurchases" ? "Restoring" : "Syncing"} purchases with the Amazon Store failed.`,
@@ -745,10 +765,10 @@ describe("AmazonBillingWrapper", () => {
       postReceipt.mockResolvedValue(customerInfoResponse);
       const params = { rcPackage: createMonthlyPackageMock() };
 
-      const result = await new AmazonBillingWrapper(backend).purchase(
-        params,
-        appUserId,
-      );
+      const result = await new AmazonBillingWrapper(
+        backend,
+        amazonApiKey,
+      ).purchase(params, appUserId);
 
       expect(purchase).toHaveBeenCalledExactlyOnceWith({ sku: "monthly" });
       expect(postReceipt).toHaveBeenCalledExactlyOnceWith(
@@ -780,7 +800,7 @@ describe("AmazonBillingWrapper", () => {
       const backend = createBackend();
       vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
 
-      await new AmazonBillingWrapper(backend).purchase(
+      await new AmazonBillingWrapper(backend, amazonApiKey).purchase(
         { rcPackage: createMonthlyPackageMock() },
         appUserId,
       );
@@ -804,10 +824,10 @@ describe("AmazonBillingWrapper", () => {
         },
       });
 
-      const result = await new AmazonBillingWrapper(backend).purchase(
-        params,
-        appUserId,
-      );
+      const result = await new AmazonBillingWrapper(
+        backend,
+        amazonApiKey,
+      ).purchase(params, appUserId);
 
       expect(backend.postReceipt).toHaveBeenCalledWith(
         appUserId,
@@ -853,7 +873,7 @@ describe("AmazonBillingWrapper", () => {
         });
 
         await expect(
-          new AmazonBillingWrapper(backend).purchase(
+          new AmazonBillingWrapper(backend, amazonApiKey).purchase(
             { rcPackage: createMonthlyPackageMock() },
             appUserId,
           ),
@@ -875,7 +895,7 @@ describe("AmazonBillingWrapper", () => {
       });
 
       await expect(
-        new AmazonBillingWrapper(backend).purchase(
+        new AmazonBillingWrapper(backend, amazonApiKey).purchase(
           { rcPackage: createMonthlyPackageMock() },
           appUserId,
         ),
@@ -898,7 +918,7 @@ describe("AmazonBillingWrapper", () => {
       vi.mocked(backend.postReceipt).mockRejectedValue(postReceiptError);
 
       await expect(
-        new AmazonBillingWrapper(backend).purchase(
+        new AmazonBillingWrapper(backend, amazonApiKey).purchase(
           { rcPackage: createMonthlyPackageMock() },
           appUserId,
         ),
@@ -913,7 +933,7 @@ describe("AmazonBillingWrapper", () => {
       purchase.mockRejectedValue(amazonError);
 
       await expect(
-        new AmazonBillingWrapper(backend).purchase(
+        new AmazonBillingWrapper(backend, amazonApiKey).purchase(
           { rcPackage: createMonthlyPackageMock() },
           appUserId,
         ),
@@ -952,7 +972,7 @@ describe("AmazonBillingWrapper", () => {
         notifyFulfillment.mockResolvedValue({ responseCode });
 
         await expect(
-          new AmazonBillingWrapper(backend).purchase(
+          new AmazonBillingWrapper(backend, amazonApiKey).purchase(
             { rcPackage: createMonthlyPackageMock() },
             appUserId,
           ),
@@ -976,7 +996,7 @@ describe("AmazonBillingWrapper", () => {
       notifyFulfillment.mockRejectedValue(fulfillmentError);
 
       await expect(
-        new AmazonBillingWrapper(backend).purchase(
+        new AmazonBillingWrapper(backend, amazonApiKey).purchase(
           { rcPackage: createMonthlyPackageMock() },
           appUserId,
         ),

--- a/src/tests/amazon/vega-device-cache.test.ts
+++ b/src/tests/amazon/vega-device-cache.test.ts
@@ -8,6 +8,9 @@ function createCache() {
   const files = new Map<string, string>();
   const fileSystem = {
     exists: vi.fn(async (path: string) => files.has(path)),
+    removeFile: vi.fn(async (path: string) => {
+      files.delete(path);
+    }),
     readFileAsString: vi.fn(async (path: string) => {
       const content = files.get(path);
       if (content === undefined) {
@@ -64,13 +67,34 @@ describe("VegaDeviceCache", () => {
   });
 
   test("stores multiple receipt IDs", async () => {
-    const { cache } = createCache();
+    const { cache, fileSystem } = createCache();
 
     await cache.addSuccessfullyPostedReceiptId("receipt-id-1");
     await cache.addSuccessfullyPostedReceiptId("receipt-id-2");
 
+    expect(fileSystem.removeFile).toHaveBeenCalledExactlyOnceWith(cachePath);
     await expect(cache.getPreviouslySentReceiptIds()).resolves.toEqual(
       new Set(["receipt-id-1", "receipt-id-2"]),
+    );
+  });
+
+  test("retries an existing-file error with the current cache contents", async () => {
+    const { cache, fileSystem, files } = createCache();
+    fileSystem.writeStringToFile
+      .mockImplementationOnce(async () => {
+        files.set(cachePath, JSON.stringify(["first-receipt-id"]));
+        throw new Error("[com.amazon.kepler.file_system.AlreadyExistsError]");
+      })
+      .mockImplementationOnce(async (path: string, content: string) => {
+        files.set(path, content);
+        return content.length;
+      });
+
+    await cache.addSuccessfullyPostedReceiptId("second-receipt-id");
+
+    expect(fileSystem.removeFile).toHaveBeenCalledExactlyOnceWith(cachePath);
+    await expect(cache.getPreviouslySentReceiptIds()).resolves.toEqual(
+      new Set(["first-receipt-id", "second-receipt-id"]),
     );
   });
 

--- a/src/tests/amazon/vega-device-cache.test.ts
+++ b/src/tests/amazon/vega-device-cache.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test, vi } from "vitest";
+import { VegaDeviceCache } from "../../amazon/vega-device-cache";
+import type { KeplerFileSystem } from "../../amazon/kepler-file-system-loader";
+
+const cachePath = "/data/com.revenuecat.purchases.amzn_api_key.tokens";
+
+function createCache() {
+  const files = new Map<string, string>();
+  const fileSystem = {
+    exists: vi.fn(async (path: string) => files.has(path)),
+    readFileAsString: vi.fn(async (path: string) => {
+      const content = files.get(path);
+      if (content === undefined) {
+        throw new Error("File not found");
+      }
+      return content;
+    }),
+    writeStringToFile: vi.fn(async (path: string, content: string) => {
+      files.set(path, content);
+      return content.length;
+    }),
+  };
+  const cache = new VegaDeviceCache(
+    "amzn_api_key",
+    async () => fileSystem as unknown as KeplerFileSystem,
+  );
+
+  return { cache, fileSystem, files };
+}
+
+describe("VegaDeviceCache", () => {
+  test("returns an empty set when no receipt cache exists", async () => {
+    const { cache, fileSystem } = createCache();
+
+    await expect(cache.getPreviouslySentReceiptIds()).resolves.toEqual(
+      new Set(),
+    );
+    expect(fileSystem.exists).toHaveBeenCalledExactlyOnceWith(cachePath);
+    expect(fileSystem.readFileAsString).not.toHaveBeenCalled();
+  });
+
+  test("stores raw receipt IDs", async () => {
+    const { cache, fileSystem } = createCache();
+
+    await cache.addSuccessfullyPostedReceiptId("receipt-id");
+
+    expect(fileSystem.writeStringToFile).toHaveBeenCalledExactlyOnceWith(
+      cachePath,
+      JSON.stringify(["receipt-id"]),
+      "UTF-8",
+    );
+    await expect(cache.getPreviouslySentReceiptIds()).resolves.toEqual(
+      new Set(["receipt-id"]),
+    );
+  });
+
+  test("does not write an already-cached receipt ID again", async () => {
+    const { cache, fileSystem } = createCache();
+
+    await cache.addSuccessfullyPostedReceiptId("receipt-id");
+    await cache.addSuccessfullyPostedReceiptId("receipt-id");
+
+    expect(fileSystem.writeStringToFile).toHaveBeenCalledOnce();
+  });
+
+  test("stores multiple receipt IDs", async () => {
+    const { cache } = createCache();
+
+    await cache.addSuccessfullyPostedReceiptId("receipt-id-1");
+    await cache.addSuccessfullyPostedReceiptId("receipt-id-2");
+
+    await expect(cache.getPreviouslySentReceiptIds()).resolves.toEqual(
+      new Set(["receipt-id-1", "receipt-id-2"]),
+    );
+  });
+
+  test("serializes concurrent writes", async () => {
+    const { cache, files } = createCache();
+
+    await Promise.all([
+      cache.addSuccessfullyPostedReceiptId("receipt-id-1"),
+      cache.addSuccessfullyPostedReceiptId("receipt-id-2"),
+    ]);
+
+    expect(JSON.parse(files.get(cachePath) ?? "")).toEqual([
+      "receipt-id-1",
+      "receipt-id-2",
+    ]);
+  });
+
+  test("treats malformed cache contents as empty", async () => {
+    const { cache, files } = createCache();
+    files.set(cachePath, "not JSON");
+
+    await expect(cache.getPreviouslySentReceiptIds()).resolves.toEqual(
+      new Set(),
+    );
+  });
+});

--- a/src/tests/vega.test.ts
+++ b/src/tests/vega.test.ts
@@ -4,13 +4,22 @@ const { purchasingService } = vi.hoisted(() => ({
   purchasingService: { getProductData: vi.fn() },
 }));
 
+const { keplerFileSystem } = vi.hoisted(() => ({
+  keplerFileSystem: { readFileAsString: vi.fn(), writeStringToFile: vi.fn() },
+}));
+
 vi.mock("@amazon-devices/keplerscript-appstore-iap-lib", () => ({
   ProductDataResponseCode: { SUCCESSFUL: 1, NOT_SUPPORTED: 2, FAILED: 3 },
   ProductType: { CONSUMABLE: 1, ENTITLED: 2, SUBSCRIPTION: 3 },
   PurchasingService: purchasingService,
 }));
 
+vi.mock("@amazon-devices/kepler-file-system", () => ({
+  KeplerFileSystem: keplerFileSystem,
+}));
+
 import { loadAmazonAppstoreIAPSDK } from "../amazon/amazon-appstore-iap-sdk-loader";
+import { loadKeplerFileSystem } from "../amazon/kepler-file-system-loader";
 import { defaultHttpConfig } from "../entities/http-config";
 import { Purchases } from "../vega";
 import { testUserId } from "./base.purchases_test";
@@ -30,6 +39,10 @@ describe("Vega entry point", () => {
     const sdk = await loadAmazonAppstoreIAPSDK();
 
     expect(sdk.PurchasingService).toBe(purchasingService);
+  });
+
+  test("wires the Kepler File System loader", async () => {
+    expect(await loadKeplerFileSystem()).toBe(keplerFileSystem);
   });
 
   test("configures with an Amazon API key", () => {

--- a/src/vega.ts
+++ b/src/vega.ts
@@ -13,10 +13,13 @@
  * imports or CSP-sensitive runtime code generation.
  */
 import * as AmazonVegaSdk from "@amazon-devices/keplerscript-appstore-iap-lib";
+import { KeplerFileSystem } from "@amazon-devices/kepler-file-system";
 import { setAmazonAppstoreIAPSDKLoader } from "./amazon/amazon-appstore-iap-sdk-loader";
+import { setKeplerFileSystemLoader } from "./amazon/kepler-file-system-loader";
 import { activateVegaEntryPoint } from "./vega-entry-point";
 
 setAmazonAppstoreIAPSDKLoader(async () => AmazonVegaSdk);
+setKeplerFileSystemLoader(async () => KeplerFileSystem);
 activateVegaEntryPoint();
 
 export * from "./main";

--- a/vite.vega.config.js
+++ b/vite.vega.config.js
@@ -23,7 +23,10 @@ export default defineConfig({
       fileName: (format) => `Purchases.vega.${format}.js`,
     },
     rollupOptions: {
-      external: ["@amazon-devices/keplerscript-appstore-iap-lib"],
+      external: [
+        "@amazon-devices/kepler-file-system",
+        "@amazon-devices/keplerscript-appstore-iap-lib",
+      ],
     },
   },
   plugins: [svelte({ compilerOptions: { css: "injected" } })],


### PR DESCRIPTION
## Changes introduced
This PR introduces a few enhancements to the `syncPurchases()`/`restorePurchases()` functions for the Amazon Store that bring them more in-line with the functions' behavior on Android. Specifically:

### syncPurchases/restorePurchases
- Now post the receipts sorted by purchase date
- Post all receipts during `syncPurchases()`
- Cache successfully synced receipt IDs on device
- Perform fulfillment for restored receipts and cache IDs after successful fulfillment;
- Explicitly fetch CustomerInfo from the backend after processing all receipts to match the behavior found in the Android SDK.

### Caching of Processed Receipts
The SDK now caches successfully processed receipts using a new `VegaDeviceCache` class, which uses [@amazon-devices/kepler-file-system](https://developer.amazon.com/docs/vega-api/0.23/README.amazon-devices_kepler-file-system.html) to persist the cache on the fire stick's disk.
- Adds a dependency on `@amazon-devices/kepler-file-system`
   - It's a peer dependency in the main module itself
   - The Vega SDK entrypoint injects the actual dependency at runtime
- Cache files are scoped per API key
- Receipts are cached:
   - After successful purchase/post receipt/fulfillment
   - `syncPurchases()`: after each receipt is successfully posted to the backend. `syncPurchases()` does not call fulfillment
   - `restorePurchases()`: after each receipt is successfully posted to the backend and Amazon fulfillment is successful
- Unlike in the Android SDK, the receiptIds are not hashed using SHA-1, and are stored as raw strings. We could use the [kepler crypto library](https://developer.amazon.com/docs/vega-api/0.23/README.amazon-devices_keplercrypto.html), but:
   - This library is not supported in the simulator
   - The library doesn't support SHA-1, which is used by the Android SDK
- `@amazon-devices/kepler-file-system` doesn't support overwriting files, so when update a file, we delete the existing one and rewrite it. 
 
If we think that hashing the receipts is necessary, I can do that in a follow-up PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Amazon purchase posting, fulfillment, and on-device persistence of receipt IDs. Scoped to the Vega entry point, but billing correctness and file-system cache behavior are easy to get wrong.
> 
> **Overview**
> Aligns Amazon Vega `syncPurchases` / `restorePurchases` with Android-style behavior: collect all purchase-update pages, post receipts oldest-first, then always refetch `CustomerInfo`. Restore now notifies Amazon fulfillment; sync posts every receipt each run instead of skipping in-memory duplicates.
> 
> Adds `VegaDeviceCache` (Kepler File System, optional peer `@amazon-devices/kepler-file-system`) wired only through the Vega entry point. Successfully posted (and, on restore/purchase, fulfilled) receipt IDs are written under `/data` per API key. Cache failures are logged and do not fail the purchase/sync. The cache is not yet used to skip re-posting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fed4e4d2ba55812a089b10ee70ca30fb4c283d91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->