### PR TITLE
feat(vega): sync purchases when SDK is configured with amazon API key

### DIFF
--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -43,9 +43,16 @@ export class AmazonBillingWrapper implements BillingWrapper {
   constructor(
     private readonly backend: Backend,
     apiKey: string,
+    appUserId?: string,
   ) {
     this.deviceCache = new VegaDeviceCache(apiKey);
-    void this.deviceCache;
+    if (appUserId !== undefined) {
+      void this.syncPendingPurchases(appUserId).catch((error: unknown) => {
+        Logger.warnLog(
+          `Failed to sync pending Amazon purchases in the background: ${String(error)}`,
+        );
+      });
+    }
   }
 
   private amazonAppstoreIAPSDKPromise:
@@ -172,17 +179,112 @@ export class AmazonBillingWrapper implements BillingWrapper {
     };
   }
 
+  /**
+   * Posts and fulfills receipts which have not been successfully handled on
+   * this device. This is intended for the background automatic sync performed
+   * when the app starts or returns to the foreground.
+   * @internal
+   */
+  public async syncPendingPurchases(appUserId: string): Promise<void> {
+    Logger.debugLog("Syncing pending purchases with the Amazon Store.");
+
+    let previouslySentReceiptIds: Set<string>;
+    try {
+      previouslySentReceiptIds =
+        await this.deviceCache.getPreviouslySentReceiptIds();
+    } catch (error: unknown) {
+      Logger.warnLog(
+        `Failed to read the cache of successfully posted Amazon receipts: ${formatCacheError(error)}`,
+      );
+      previouslySentReceiptIds = new Set();
+    }
+
+    const receiptsToSync = (await this.fetchReceipts(false)).filter(
+      ({ receipt }) => !previouslySentReceiptIds.has(receipt.receiptId),
+    );
+    Logger.debugLog(
+      receiptsToSync.length === 0
+        ? "Found no receipts to sync"
+        : `Found ${receiptsToSync.length} receipts to sync`,
+    );
+
+    for (const { receipt, storeUserId } of receiptsToSync) {
+      const productId = await this.productIdForReceipt(receipt);
+      try {
+        await this.backend.postReceipt(
+          appUserId,
+          productId,
+          null,
+          receipt.receiptId,
+          null,
+          PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
+          undefined,
+          storeUserId,
+          false,
+        );
+
+        if (await this.notifyFulfillment(receipt.receiptId)) {
+          await this.cacheSuccessfullyPostedReceiptId(receipt.receiptId);
+          previouslySentReceiptIds.add(receipt.receiptId);
+        }
+      } catch (error: unknown) {
+        Logger.warnLog(
+          `Failed to sync pending Amazon receipt ID ${receipt.receiptId}: ${String(error)}`,
+        );
+      }
+    }
+  }
+
   private async fetchAndPostReceipts(
     appUserId: string,
     isRestore: boolean,
   ): Promise<CustomerInfo> {
+    const receiptsToPost = await this.fetchReceipts(isRestore);
+
+    for (const { receipt, storeUserId } of receiptsToPost) {
+      const productId = await this.productIdForReceipt(receipt);
+
+      await this.backend.postReceipt(
+        appUserId,
+        productId,
+        null,
+        receipt.receiptId,
+        null,
+        PostReceiptInitiationSource.RESTORE,
+        undefined,
+        storeUserId,
+        isRestore,
+      );
+
+      if (isRestore) {
+        let fulfillmentSucceeded = false;
+        try {
+          fulfillmentSucceeded = await this.notifyFulfillment(
+            receipt.receiptId,
+          );
+        } catch (error: unknown) {
+          Logger.warnLog(
+            `Failed to fulfill receipt ID ${receipt.receiptId} with the Amazon Store: ${String(error)}`,
+          );
+        }
+        if (fulfillmentSucceeded) {
+          await this.cacheSuccessfullyPostedReceiptId(receipt.receiptId);
+        }
+      } else {
+        await this.cacheSuccessfullyPostedReceiptId(receipt.receiptId);
+      }
+    }
+
+    return toCustomerInfo(await this.backend.getCustomerInfo(appUserId));
+  }
+
+  private async fetchReceipts(
+    isRestore: boolean,
+  ): Promise<ReceiptWithStoreUserId[]> {
     const amazonAppstoreIAPSDK = await this.getAmazonAppstoreIAPSDK();
-    const {
-      PurchasingService,
-      PurchaseUpdatesResponseCode,
-      ProductType: AmazonProductType,
-    } = amazonAppstoreIAPSDK;
-    const receiptsToPost: ReceiptWithStoreUserId[] = [];
+    const { PurchasingService, PurchaseUpdatesResponseCode } =
+      amazonAppstoreIAPSDK;
+    const receipts: ReceiptWithStoreUserId[] = [];
 
     let doneFetching = false;
     let executedGetPurchaseUpdatesRequests = 0;
@@ -238,7 +340,7 @@ export class AmazonBillingWrapper implements BillingWrapper {
           );
       }
 
-      receiptsToPost.push(
+      receipts.push(
         ...response.receiptList.map((receipt) => ({
           receipt,
           storeUserId: response.userData.userId,
@@ -260,50 +362,18 @@ export class AmazonBillingWrapper implements BillingWrapper {
       }
     }
 
-    receiptsToPost.sort(
+    return receipts.sort(
       (first, second) =>
         first.receipt.purchaseDate.getTime() -
         second.receipt.purchaseDate.getTime(),
     );
+  }
 
-    for (const { receipt, storeUserId } of receiptsToPost) {
-      const productId =
-        receipt.productType == AmazonProductType.SUBSCRIPTION
-          ? receipt.termSku
-          : receipt.sku;
-
-      await this.backend.postReceipt(
-        appUserId,
-        productId,
-        null,
-        receipt.receiptId,
-        null,
-        PostReceiptInitiationSource.RESTORE,
-        undefined,
-        storeUserId,
-        isRestore,
-      );
-
-      if (isRestore) {
-        let fulfillmentSucceeded = false;
-        try {
-          fulfillmentSucceeded = await this.notifyFulfillment(
-            receipt.receiptId,
-          );
-        } catch (error: unknown) {
-          Logger.warnLog(
-            `Failed to fulfill receipt ID ${receipt.receiptId} with the Amazon Store: ${String(error)}`,
-          );
-        }
-        if (fulfillmentSucceeded) {
-          await this.cacheSuccessfullyPostedReceiptId(receipt.receiptId);
-        }
-      } else {
-        await this.cacheSuccessfullyPostedReceiptId(receipt.receiptId);
-      }
-    }
-
-    return toCustomerInfo(await this.backend.getCustomerInfo(appUserId));
+  private async productIdForReceipt(receipt: Receipt): Promise<string> {
+    const { ProductType } = await this.getAmazonAppstoreIAPSDK();
+    return receipt.productType == ProductType.SUBSCRIPTION
+      ? receipt.termSku
+      : receipt.sku;
   }
 
   private async notifyFulfillment(receiptId: string): Promise<boolean> {

--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -239,7 +239,7 @@ export class AmazonBillingWrapper implements BillingWrapper {
     appUserId: string,
     isRestore: boolean,
   ): Promise<CustomerInfo> {
-    const receiptsToPost = await this.fetchReceipts(true);
+    const receiptsToPost = await this.fetchReceipts(isRestore);
 
     for (const { receipt, storeUserId } of receiptsToPost) {
       const productId = await this.productIdForReceipt(receipt);
@@ -279,7 +279,7 @@ export class AmazonBillingWrapper implements BillingWrapper {
   }
 
   private async fetchReceipts(
-    resetFirstRequest?: boolean,
+    isRestore: boolean,
   ): Promise<ReceiptWithStoreUserId[]> {
     const amazonAppstoreIAPSDK = await this.getAmazonAppstoreIAPSDK();
     const { PurchasingService, PurchaseUpdatesResponseCode } =
@@ -294,18 +294,15 @@ export class AmazonBillingWrapper implements BillingWrapper {
       >;
       try {
         response = await PurchasingService.getPurchaseUpdates({
-          reset:
-            executedGetPurchaseUpdatesRequests == 0
-              ? (resetFirstRequest ?? true)
-              : false,
+          reset: executedGetPurchaseUpdatesRequests == 0 ? true : false,
         });
       } catch (error) {
         Logger.errorLog(
-          `Failed to fetch receipts from the Amazon Store: getPurchaseUpdates() threw an error.`,
+          `Failed to ${isRestore ? "restore" : "sync"} purchases from the Amazon Store: getPurchaseUpdates() threw an error.`,
         );
         throw new PurchasesError(
           ErrorCode.StoreProblemError,
-          "Fetching purchases from the Amazon Store failed.",
+          `${isRestore ? "Restoring" : "Syncing"} purchases with the Amazon Store failed.`,
           error instanceof Error ? error.message : undefined,
         );
       }
@@ -319,27 +316,27 @@ export class AmazonBillingWrapper implements BillingWrapper {
           break;
         case PurchaseUpdatesResponseCode.NOT_SUPPORTED:
           Logger.warnLog(
-            "Failed to fetch purchases from the Amazon Store: getPurchaseUpdates() is not supported.",
+            `Failed to ${isRestore ? "restore" : "sync"} purchases from the Amazon Store: getPurchaseUpdates() is not supported.`,
           );
           throw new PurchasesError(
             ErrorCode.UnsupportedError,
-            "Fetching purchases is not supported.",
+            `${isRestore ? "Restoring" : "Syncing"} purchases is not supported.`,
           );
         case PurchaseUpdatesResponseCode.FAILED:
           Logger.errorLog(
-            "Failed to fetch purchases from the Amazon Store: getPurchaseUpdates() failed.",
+            `Failed to ${isRestore ? "restore" : "sync"} purchases from the Amazon Store: getPurchaseUpdates() failed.`,
           );
           throw new PurchasesError(
             ErrorCode.StoreProblemError,
-            "Fetching purchases with the Amazon Store failed.",
+            `${isRestore ? "Restoring" : "Syncing"} purchases with the Amazon Store failed.`,
           );
         default:
           Logger.warnLog(
-            `Failed to fetch purchases from the Amazon Store: received an unexpected repsonse ${response.responseCode} from getPurchaseUpdates().`,
+            `Failed to ${isRestore ? "restore" : "sync"} purchases from the Amazon Store: received an unexpected repsonse ${response.responseCode} from getPurchaseUpdates().`,
           );
           throw new PurchasesError(
             ErrorCode.StoreProblemError,
-            `Received an unexpected response code ${response.responseCode} from the Amazon Store while fetching purchases.`,
+            `Received an unexpected response code from the Amazon Store while ${isRestore ? "restoring" : "syncing"} purchases.`,
           );
       }
 

--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -239,7 +239,7 @@ export class AmazonBillingWrapper implements BillingWrapper {
     appUserId: string,
     isRestore: boolean,
   ): Promise<CustomerInfo> {
-    const receiptsToPost = await this.fetchReceipts(isRestore);
+    const receiptsToPost = await this.fetchReceipts(true);
 
     for (const { receipt, storeUserId } of receiptsToPost) {
       const productId = await this.productIdForReceipt(receipt);
@@ -279,7 +279,7 @@ export class AmazonBillingWrapper implements BillingWrapper {
   }
 
   private async fetchReceipts(
-    isRestore: boolean,
+    resetFirstRequest?: boolean,
   ): Promise<ReceiptWithStoreUserId[]> {
     const amazonAppstoreIAPSDK = await this.getAmazonAppstoreIAPSDK();
     const { PurchasingService, PurchaseUpdatesResponseCode } =
@@ -294,15 +294,18 @@ export class AmazonBillingWrapper implements BillingWrapper {
       >;
       try {
         response = await PurchasingService.getPurchaseUpdates({
-          reset: executedGetPurchaseUpdatesRequests == 0 ? true : false,
+          reset:
+            executedGetPurchaseUpdatesRequests == 0
+              ? (resetFirstRequest ?? true)
+              : false,
         });
       } catch (error) {
         Logger.errorLog(
-          `Failed to ${isRestore ? "restore" : "sync"} purchases from the Amazon Store: getPurchaseUpdates() threw an error.`,
+          `Failed to fetch receipts from the Amazon Store: getPurchaseUpdates() threw an error.`,
         );
         throw new PurchasesError(
           ErrorCode.StoreProblemError,
-          `${isRestore ? "Restoring" : "Syncing"} purchases with the Amazon Store failed.`,
+          "Fetching purchases from the Amazon Store failed.",
           error instanceof Error ? error.message : undefined,
         );
       }
@@ -316,27 +319,27 @@ export class AmazonBillingWrapper implements BillingWrapper {
           break;
         case PurchaseUpdatesResponseCode.NOT_SUPPORTED:
           Logger.warnLog(
-            `Failed to ${isRestore ? "restore" : "sync"} purchases from the Amazon Store: getPurchaseUpdates() is not supported.`,
+            "Failed to fetch purchases from the Amazon Store: getPurchaseUpdates() is not supported.",
           );
           throw new PurchasesError(
             ErrorCode.UnsupportedError,
-            `${isRestore ? "Restoring" : "Syncing"} purchases is not supported.`,
+            "Fetching purchases is not supported.",
           );
         case PurchaseUpdatesResponseCode.FAILED:
           Logger.errorLog(
-            `Failed to ${isRestore ? "restore" : "sync"} purchases from the Amazon Store: getPurchaseUpdates() failed.`,
+            "Failed to fetch purchases from the Amazon Store: getPurchaseUpdates() failed.",
           );
           throw new PurchasesError(
             ErrorCode.StoreProblemError,
-            `${isRestore ? "Restoring" : "Syncing"} purchases with the Amazon Store failed.`,
+            "Fetching purchases with the Amazon Store failed.",
           );
         default:
           Logger.warnLog(
-            `Failed to ${isRestore ? "restore" : "sync"} purchases from the Amazon Store: received an unexpected repsonse ${response.responseCode} from getPurchaseUpdates().`,
+            `Failed to fetch purchases from the Amazon Store: received an unexpected repsonse ${response.responseCode} from getPurchaseUpdates().`,
           );
           throw new PurchasesError(
             ErrorCode.StoreProblemError,
-            `Received an unexpected response code from the Amazon Store while ${isRestore ? "restoring" : "syncing"} purchases.`,
+            `Received an unexpected response code ${response.responseCode} from the Amazon Store while fetching purchases.`,
           );
       }
 

--- a/src/amazon/vega-device-cache.ts
+++ b/src/amazon/vega-device-cache.ts
@@ -81,7 +81,8 @@ export class VegaDeviceCache {
 
   private async getReceiptIds(): Promise<ReceiptCache> {
     const fileSystem = await this.fileSystemLoader();
-    if (!(await fileSystem.exists(this.tokensCachePath))) {
+    const cacheExists = await fileSystem.exists(this.tokensCachePath);
+    if (!cacheExists) {
       return [];
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -621,6 +621,7 @@ export class Purchases {
       this.amazonBillingWrapper = new AmazonBillingWrapper(
         this.backend,
         this._API_KEY,
+        this._appUserId,
       );
     }
   }

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -686,4 +686,5 @@ export class Backend {
 export enum PostReceiptInitiationSource {
   PURCHASE = "purchase",
   RESTORE = "restore",
+  UNSYNCED_ACTIVE_PURCHASES = "unsynced_active_purchases",
 }

--- a/src/tests/amazon/amazon-billing-wrapper.test.ts
+++ b/src/tests/amazon/amazon-billing-wrapper.test.ts
@@ -278,37 +278,6 @@ describe("AmazonBillingWrapper", () => {
     expect(debugLog).toHaveBeenCalledWith("Found no receipts to sync");
   });
 
-  test("does not reset purchase updates while syncing pending purchases", async () => {
-    const backend = createBackend();
-    vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
-    getPurchaseUpdates
-      .mockResolvedValueOnce(
-        purchaseUpdatesResponse({
-          hasMore: true,
-        }),
-      )
-      .mockResolvedValueOnce(
-        purchaseUpdatesResponse({
-          hasMore: false,
-          receiptList: [],
-        }),
-      );
-    vi.spyOn(
-      VegaDeviceCache.prototype,
-      "getPreviouslySentReceiptIds",
-    ).mockResolvedValue(new Set());
-    notifyFulfillment.mockResolvedValue({
-      responseCode: NotifyFulfillmentResponseCode.SUCCESSFUL,
-    });
-
-    await new AmazonBillingWrapper(backend, amazonApiKey).syncPendingPurchases(
-      "app-user-id",
-    );
-
-    expect(getPurchaseUpdates).toHaveBeenNthCalledWith(1, { reset: false });
-    expect(getPurchaseUpdates).toHaveBeenNthCalledWith(2, { reset: false });
-  });
-
   describe("product data requests", () => {
     test("loads and maps products from the Amazon IAP SDK", async () => {
       getProductData.mockResolvedValue(
@@ -848,37 +817,37 @@ describe("AmazonBillingWrapper", () => {
         "syncPurchases",
         PurchaseUpdatesResponseCode.NOT_SUPPORTED,
         ErrorCode.UnsupportedError,
-        "Fetching purchases is not supported.",
+        "Syncing purchases is not supported.",
       ],
       [
         "restorePurchases",
         PurchaseUpdatesResponseCode.NOT_SUPPORTED,
         ErrorCode.UnsupportedError,
-        "Fetching purchases is not supported.",
+        "Restoring purchases is not supported.",
       ],
       [
         "syncPurchases",
         PurchaseUpdatesResponseCode.FAILED,
         ErrorCode.StoreProblemError,
-        "Fetching purchases with the Amazon Store failed.",
+        "Syncing purchases with the Amazon Store failed.",
       ],
       [
         "restorePurchases",
         PurchaseUpdatesResponseCode.FAILED,
         ErrorCode.StoreProblemError,
-        "Fetching purchases with the Amazon Store failed.",
+        "Restoring purchases with the Amazon Store failed.",
       ],
       [
         "syncPurchases",
         999 as PurchaseUpdatesResponseCode,
         ErrorCode.StoreProblemError,
-        "Received an unexpected response code 999 from the Amazon Store while fetching purchases.",
+        "Received an unexpected response code from the Amazon Store while syncing purchases.",
       ],
       [
         "restorePurchases",
         999 as PurchaseUpdatesResponseCode,
         ErrorCode.StoreProblemError,
-        "Received an unexpected response code 999 from the Amazon Store while fetching purchases.",
+        "Received an unexpected response code from the Amazon Store while restoring purchases.",
       ],
     ] as const)(
       "%s maps response code %s to an error",
@@ -912,7 +881,7 @@ describe("AmazonBillingWrapper", () => {
           ),
         ).rejects.toMatchObject({
           errorCode: ErrorCode.StoreProblemError,
-          message: "Fetching purchases from the Amazon Store failed.",
+          message: `${method === "restorePurchases" ? "Restoring" : "Syncing"} purchases with the Amazon Store failed.`,
           underlyingErrorMessage: "Amazon IAP unavailable",
         });
 

--- a/src/tests/amazon/amazon-billing-wrapper.test.ts
+++ b/src/tests/amazon/amazon-billing-wrapper.test.ts
@@ -278,6 +278,37 @@ describe("AmazonBillingWrapper", () => {
     expect(debugLog).toHaveBeenCalledWith("Found no receipts to sync");
   });
 
+  test("does not reset purchase updates while syncing pending purchases", async () => {
+    const backend = createBackend();
+    vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
+    getPurchaseUpdates
+      .mockResolvedValueOnce(
+        purchaseUpdatesResponse({
+          hasMore: true,
+        }),
+      )
+      .mockResolvedValueOnce(
+        purchaseUpdatesResponse({
+          hasMore: false,
+          receiptList: [],
+        }),
+      );
+    vi.spyOn(
+      VegaDeviceCache.prototype,
+      "getPreviouslySentReceiptIds",
+    ).mockResolvedValue(new Set());
+    notifyFulfillment.mockResolvedValue({
+      responseCode: NotifyFulfillmentResponseCode.SUCCESSFUL,
+    });
+
+    await new AmazonBillingWrapper(backend, amazonApiKey).syncPendingPurchases(
+      "app-user-id",
+    );
+
+    expect(getPurchaseUpdates).toHaveBeenNthCalledWith(1, { reset: false });
+    expect(getPurchaseUpdates).toHaveBeenNthCalledWith(2, { reset: false });
+  });
+
   describe("product data requests", () => {
     test("loads and maps products from the Amazon IAP SDK", async () => {
       getProductData.mockResolvedValue(
@@ -817,37 +848,37 @@ describe("AmazonBillingWrapper", () => {
         "syncPurchases",
         PurchaseUpdatesResponseCode.NOT_SUPPORTED,
         ErrorCode.UnsupportedError,
-        "Syncing purchases is not supported.",
+        "Fetching purchases is not supported.",
       ],
       [
         "restorePurchases",
         PurchaseUpdatesResponseCode.NOT_SUPPORTED,
         ErrorCode.UnsupportedError,
-        "Restoring purchases is not supported.",
+        "Fetching purchases is not supported.",
       ],
       [
         "syncPurchases",
         PurchaseUpdatesResponseCode.FAILED,
         ErrorCode.StoreProblemError,
-        "Syncing purchases with the Amazon Store failed.",
+        "Fetching purchases with the Amazon Store failed.",
       ],
       [
         "restorePurchases",
         PurchaseUpdatesResponseCode.FAILED,
         ErrorCode.StoreProblemError,
-        "Restoring purchases with the Amazon Store failed.",
+        "Fetching purchases with the Amazon Store failed.",
       ],
       [
         "syncPurchases",
         999 as PurchaseUpdatesResponseCode,
         ErrorCode.StoreProblemError,
-        "Received an unexpected response code from the Amazon Store while syncing purchases.",
+        "Received an unexpected response code 999 from the Amazon Store while fetching purchases.",
       ],
       [
         "restorePurchases",
         999 as PurchaseUpdatesResponseCode,
         ErrorCode.StoreProblemError,
-        "Received an unexpected response code from the Amazon Store while restoring purchases.",
+        "Received an unexpected response code 999 from the Amazon Store while fetching purchases.",
       ],
     ] as const)(
       "%s maps response code %s to an error",
@@ -881,7 +912,7 @@ describe("AmazonBillingWrapper", () => {
           ),
         ).rejects.toMatchObject({
           errorCode: ErrorCode.StoreProblemError,
-          message: `${method === "restorePurchases" ? "Restoring" : "Syncing"} purchases with the Amazon Store failed.`,
+          message: "Fetching purchases from the Amazon Store failed.",
           underlyingErrorMessage: "Amazon IAP unavailable",
         });
 

--- a/src/tests/amazon/amazon-billing-wrapper.test.ts
+++ b/src/tests/amazon/amazon-billing-wrapper.test.ts
@@ -209,6 +209,75 @@ describe("AmazonBillingWrapper", () => {
     expect(getProductData).not.toHaveBeenCalled();
   });
 
+  test("syncs, fulfills, and caches only previously unsynced receipts in the background", async () => {
+    const backend = createBackend();
+    const debugLog = vi.spyOn(Logger, "debugLog");
+    vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
+    getPurchaseUpdates.mockResolvedValue(
+      purchaseUpdatesResponse({
+        receiptList: [
+          {
+            ...successfulPurchaseResponse().receipt,
+            receiptId: "already-synced",
+          },
+          {
+            ...successfulPurchaseResponse().receipt,
+            receiptId: "pending-receipt",
+          },
+        ],
+      }),
+    );
+    notifyFulfillment.mockResolvedValue({
+      responseCode: NotifyFulfillmentResponseCode.SUCCESSFUL,
+    });
+    vi.spyOn(
+      VegaDeviceCache.prototype,
+      "getPreviouslySentReceiptIds",
+    ).mockResolvedValue(new Set(["already-synced"]));
+
+    await new AmazonBillingWrapper(backend, amazonApiKey).syncPendingPurchases(
+      "app-user-id",
+    );
+
+    expect(backend.postReceipt).toHaveBeenCalledExactlyOnceWith(
+      "app-user-id",
+      "monthly",
+      null,
+      "pending-receipt",
+      null,
+      "unsynced_active_purchases",
+      undefined,
+      "amazon-store-user-id",
+      false,
+    );
+    expect(notifyFulfillment).toHaveBeenCalledExactlyOnceWith({
+      receiptId: "pending-receipt",
+      fulfillmentResult: FulfillmentResult.FULFILLED,
+    });
+    expect(
+      vi.mocked(VegaDeviceCache.prototype.addSuccessfullyPostedReceiptId),
+    ).toHaveBeenCalledExactlyOnceWith("pending-receipt");
+    expect(backend.getCustomerInfo).not.toHaveBeenCalled();
+    expect(debugLog).toHaveBeenCalledWith("Found 1 receipts to sync");
+  });
+
+  test("reports when all Amazon receipts have already been synced", async () => {
+    const backend = createBackend();
+    const debugLog = vi.spyOn(Logger, "debugLog");
+    getPurchaseUpdates.mockResolvedValue(successfulPurchaseUpdatesResponse());
+    vi.spyOn(
+      VegaDeviceCache.prototype,
+      "getPreviouslySentReceiptIds",
+    ).mockResolvedValue(new Set(["amazon-receipt-id"]));
+
+    await new AmazonBillingWrapper(backend, amazonApiKey).syncPendingPurchases(
+      "app-user-id",
+    );
+
+    expect(backend.postReceipt).not.toHaveBeenCalled();
+    expect(debugLog).toHaveBeenCalledWith("Found no receipts to sync");
+  });
+
   describe("product data requests", () => {
     test("loads and maps products from the Amazon IAP SDK", async () => {
       getProductData.mockResolvedValue(

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -331,6 +331,23 @@ describe("Purchases.configure()", () => {
 });
 
 describe("billing wrapper selection", () => {
+  test("syncs pending Amazon purchases at initialization", async () => {
+    const syncPendingPurchases = vi
+      .spyOn(AmazonBillingWrapper.prototype, "syncPendingPurchases")
+      .mockResolvedValue();
+    const purchases = configurePurchases(
+      testUserId,
+      "rcSource",
+      "amzn_valid_key",
+    );
+
+    await vi.waitFor(() => {
+      expect(syncPendingPurchases).toHaveBeenCalledExactlyOnceWith(testUserId);
+    });
+
+    purchases.close();
+  });
+
   test("requires the Vega entry point for offerings with an Amazon API key", async () => {
     const purchases = configurePurchases(
       testUserId,


### PR DESCRIPTION
## Changes introduced
Introduces a new capability to the SDK where when the SDK is configured, it queries purchases from the Amazon AppStore, and for any receipts that it finds that have not been successfully posted/fulfilled, it will post and fulfill them.

Ideally this could also be done automatically when the app is foregrounded, but I'm not 100% if that is possible for an SDK. This is because the [VegaAppState](https://developer.amazon.com/docs/react-native-vega/0.83/keplerappstate.html) utility provides lifecycle updates through a React hook - something that isn't available if you don't have a React component to attach it to. In future PRs, I'll explore if this is something that we might be able to use, or if we can provide a `onVegaAppForegrounded()` public API that developers can use to trigger this sync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automatically posts and fulfills Amazon receipts at SDK init, which is purchase/entitlement-sensitive. Failures are isolated and cached IDs skip already-synced receipts, but a cache miss could re-post receipts.
> 
> **Overview**
> On Amazon (Vega) configure, the SDK now automatically posts and fulfills receipts that this device has not already handled, so unfinished Appstore purchases can catch up without an explicit restore.
> 
> `AmazonBillingWrapper` kicks off a fire-and-forget `syncPendingPurchases` when an `appUserId` is provided. It loads Amazon purchase updates, skips receipt IDs already in the device cache, posts the rest with `PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES`, then fulfills and caches only successful ones. Failures are logged per receipt and do not block SDK init.
> 
> Receipt fetching is split out of restore/sync so the background path can reuse it without fetching customer info. Restore/sync posting behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76ba0fbe5be9f9a45f43282022d2ad9de01a5da6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->