### PR TITLE
feat(vega): fetch customer info/display action results

### DIFF
--- a/examples/amazonvega-demo/PurchaseTester/src/components/AllOfferingsList.tsx
+++ b/examples/amazonvega-demo/PurchaseTester/src/components/AllOfferingsList.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {Modal, ScrollView, Text, View} from 'react-native';
+import {ScrollView, Text, View} from 'react-native';
 import {
   Purchases,
   type Offering,
@@ -8,13 +8,12 @@ import {
 } from '@revenuecat/purchases-js/vega';
 import {styles} from './AllOfferingsList.styles';
 import {Button} from './Button';
+import {formatJsonData, DataModal} from './DataModal';
 
-const formatProduct = (product: Product): string =>
-  JSON.stringify(
-    product,
-    (_key, value) => (typeof value === 'bigint' ? value.toString() : value),
-    2,
-  );
+type ModalData = {
+  formattedData: string;
+  title: string;
+};
 
 const formatDuration = (product: Product): string => {
   if (product.period === null) {
@@ -27,7 +26,7 @@ const formatDuration = (product: Product): string => {
 
 export const AllOfferingsList = () => {
   const [offerings, setOfferings] = useState<Offering[]>([]);
-  const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+  const [modalData, setModalData] = useState<ModalData | null>(null);
   const [purchasingPackageId, setPurchasingPackageId] = useState<string | null>(
     null,
   );
@@ -63,7 +62,13 @@ export const AllOfferingsList = () => {
     console.log(`Purchasing ${pkg.webBillingProduct.identifier}...`);
 
     try {
-      await Purchases.getSharedInstance().purchase({rcPackage: pkg});
+      const result = await Purchases.getSharedInstance().purchase({
+        rcPackage: pkg,
+      });
+      setModalData({
+        formattedData: formatJsonData(result),
+        title: 'Purchase result',
+      });
       console.log(
         `Successfully purchased ${pkg.webBillingProduct.identifier}.`,
       );
@@ -72,6 +77,10 @@ export const AllOfferingsList = () => {
         `Failed to purchase ${pkg.webBillingProduct.identifier}:`,
         purchaseError,
       );
+      setModalData({
+        formattedData: String(purchaseError),
+        title: 'Purchase failed',
+      });
     } finally {
       setPurchasingPackageId(null);
     }
@@ -112,7 +121,12 @@ export const AllOfferingsList = () => {
                     />
                     <Button
                       label="View details"
-                      onPress={() => setSelectedProduct(product)}
+                      onPress={() =>
+                        setModalData({
+                          formattedData: formatJsonData(product),
+                          title: 'Product details',
+                        })
+                      }
                       variant="secondary"
                     />
                   </View>
@@ -126,30 +140,11 @@ export const AllOfferingsList = () => {
         )}
       </ScrollView>
 
-      <Modal
-        animationType="slide"
-        onRequestClose={() => setSelectedProduct(null)}
-        transparent
-        visible={selectedProduct !== null}>
-        <View style={styles.sheetBackdrop}>
-          <View style={styles.sheet}>
-            <View style={styles.sheetHeader}>
-              <Text style={styles.sheetTitle}>Product details</Text>
-              <Button
-                hasTVPreferredFocus
-                label="Close"
-                onPress={() => setSelectedProduct(null)}
-                variant="secondary"
-              />
-            </View>
-            <ScrollView style={styles.jsonScroll}>
-              <Text style={styles.productFields}>
-                {selectedProduct === null ? '' : formatProduct(selectedProduct)}
-              </Text>
-            </ScrollView>
-          </View>
-        </View>
-      </Modal>
+      <DataModal
+        formattedData={modalData?.formattedData ?? null}
+        onClose={() => setModalData(null)}
+        title={modalData?.title ?? ''}
+      />
     </>
   );
 };

--- a/examples/amazonvega-demo/PurchaseTester/src/components/DataModal.tsx
+++ b/examples/amazonvega-demo/PurchaseTester/src/components/DataModal.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import {Modal, ScrollView, Text, View} from 'react-native';
+import {styles} from './AllOfferingsList.styles';
+import {Button} from './Button';
+
+export const formatJsonData = (data: unknown): string =>
+  JSON.stringify(
+    data,
+    (_key, value) => {
+      if (typeof value === 'bigint') {
+        return value.toString();
+      }
+      if (value instanceof Set) {
+        return Array.from(value);
+      }
+      return value;
+    },
+    2,
+  );
+
+type DataModalProps = {
+  title: string;
+  formattedData: string | null;
+  onClose: () => void;
+};
+
+export const DataModal = ({title, formattedData, onClose}: DataModalProps) => (
+  <Modal
+    animationType="slide"
+    onRequestClose={onClose}
+    transparent
+    visible={formattedData !== null}>
+    <View style={styles.sheetBackdrop}>
+      <View style={styles.sheet}>
+        <View style={styles.sheetHeader}>
+          <Text style={styles.sheetTitle}>{title}</Text>
+          <Button
+            hasTVPreferredFocus
+            label="Close"
+            onPress={onClose}
+            variant="secondary"
+          />
+        </View>
+        <ScrollView style={styles.jsonScroll}>
+          <Text style={styles.productFields}>{formattedData ?? ''}</Text>
+        </ScrollView>
+      </View>
+    </View>
+  </Modal>
+);

--- a/examples/amazonvega-demo/PurchaseTester/src/screens/HomeScreen.tsx
+++ b/examples/amazonvega-demo/PurchaseTester/src/screens/HomeScreen.tsx
@@ -3,30 +3,80 @@ import {View} from 'react-native';
 import {Purchases} from '@revenuecat/purchases-js/vega';
 import {AllOfferingsList} from '../components/AllOfferingsList';
 import {Button} from '../components/Button';
+import {formatJsonData, DataModal} from '../components/DataModal';
 import {ScreenContainer} from '../ScreenContainer';
 import {LogsScreen} from './LogsScreen';
 import {styles} from './LogsScreen.styles';
 
+type ModalData = {
+  formattedData: string;
+  title: string;
+};
+
 export const HomeScreen = () => {
   const [isShowingLogs, setIsShowingLogs] = useState(false);
+  const [isFetchingCustomerInfo, setIsFetchingCustomerInfo] = useState(false);
+  const [modalData, setModalData] = useState<ModalData | null>(null);
 
   const syncPurchases = async () => {
     console.log('Syncing purchases...');
     try {
-      await Purchases.getSharedInstance().syncPurchases();
+      const result = await Purchases.getSharedInstance().syncPurchases();
+      setModalData({
+        formattedData: formatJsonData(result),
+        title: 'Sync purchases result',
+      });
       console.log('Successfully synced purchases.');
     } catch (error) {
       console.error('Failed to sync purchases:', error);
+      setModalData({
+        formattedData: String(error),
+        title: 'Sync purchases failed',
+      });
     }
   };
 
   const restorePurchases = async () => {
     console.log('Restoring purchases...');
     try {
-      await Purchases.getSharedInstance().restorePurchases();
+      const result = await Purchases.getSharedInstance().restorePurchases();
+      setModalData({
+        formattedData: formatJsonData(result),
+        title: 'Restore purchases result',
+      });
       console.log('Successfully restored purchases.');
     } catch (error) {
       console.error('Failed to restore purchases:', error);
+      setModalData({
+        formattedData: String(error),
+        title: 'Restore purchases failed',
+      });
+    }
+  };
+
+  const fetchCustomerInfo = async () => {
+    if (isFetchingCustomerInfo) {
+      return;
+    }
+
+    setIsFetchingCustomerInfo(true);
+    console.log('Fetching customer info...');
+    try {
+      const customerInfo =
+        await Purchases.getSharedInstance().getCustomerInfo();
+      setModalData({
+        formattedData: formatJsonData(customerInfo),
+        title: 'Customer info',
+      });
+      console.log('Successfully fetched customer info.');
+    } catch (error) {
+      console.error('Failed to fetch customer info:', error);
+      setModalData({
+        formattedData: String(error),
+        title: 'Customer info failed',
+      });
+    } finally {
+      setIsFetchingCustomerInfo(false);
     }
   };
 
@@ -43,12 +93,23 @@ export const HomeScreen = () => {
           onPress={() => void restorePurchases()}
         />
         <Button
+          label={
+            isFetchingCustomerInfo ? 'Fetching customer info…' : 'Customer info'
+          }
+          onPress={() => void fetchCustomerInfo()}
+        />
+        <Button
           hasTVPreferredFocus
           label="View app logs"
           onPress={() => setIsShowingLogs(true)}
         />
       </View>
       <AllOfferingsList />
+      <DataModal
+        formattedData={modalData?.formattedData ?? null}
+        onClose={() => setModalData(null)}
+        title={modalData?.title ?? ''}
+      />
     </ScreenContainer>
   );
 };


### PR DESCRIPTION
## Changes introduced
Introduces a few QoL features to the Vega Purchase Tester app:
- You can now call getCustomerInfo() from the home screen. The results are shown in a modal
- The results of syncPurchases()/restorePurchases()/purchase() function calls are now displayed in a modal

### Screenshots

<img width="1000" height="683" alt="Screenshot 2026-08-21 at 9 52 56 AM" src="https://github.com/user-attachments/assets/3fa240b4-c380-443a-9ea3-b96c4d4c0606" />

<img width="1000" height="584" alt="Screenshot 2026-08-21 at 9 53 59 AM" src="https://github.com/user-attachments/assets/ba7aab3b-ee37-4ff2-8506-d3e4b78f1ae3" />

<img width="1000" height="603" alt="Screenshot 2026-08-21 at 9 54 50 AM" src="https://github.com/user-attachments/assets/f35cbb46-994a-4547-8d0f-38232a4e5b40" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Demo-only UI changes in the Vega Purchase Tester; no SDK or production logic is modified.
> 
> **Overview**
> Makes the Vega Purchase Tester easier to inspect by showing SDK action results in a shared `DataModal` instead of console-only output.
> 
> Adds a **Customer info** button that calls `getCustomerInfo()`. Purchase, sync, restore, and product-detail flows now display success JSON or error text in the modal. JSON formatting also handles `Set` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25f8f8ed91e5ad10fa80e5ad3b0cd32268f81583. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->