### PR TITLE
fix(vega): post product price for purchases

### DIFF
--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -5,11 +5,11 @@ import type {
   Receipt,
 } from "@amazon-devices/keplerscript-appstore-iap-lib";
 import { ErrorCode, PurchasesError } from "../entities/errors";
-import type {
-  NonSubscriptionOption,
-  Price,
-  PurchaseOption,
-  SubscriptionOption,
+import {
+  ProductType as RevenueCatProductType,
+  type NonSubscriptionOption,
+  type Price,
+  type SubscriptionOption,
 } from "../entities/offerings";
 import { Logger } from "../helpers/logger";
 import type { BillingWrapper } from "../helpers/billing-wrapper";
@@ -655,29 +655,12 @@ export class AmazonBillingWrapper implements BillingWrapper {
 }
 
 function priceForPurchaseParams(params: PurchaseParams): Price | null {
-  const purchaseOption =
-    params.purchaseOption ??
-    params.rcPackage.webBillingProduct.defaultPurchaseOption;
+  const product = params.rcPackage.webBillingProduct;
+  const purchaseOption = params.purchaseOption ?? product.defaultPurchaseOption;
 
-  if (isNonSubscriptionOption(purchaseOption)) {
-    return purchaseOption.basePrice;
-  }
-
-  return isSubscriptionOption(purchaseOption)
-    ? purchaseOption.base.price
-    : null;
-}
-
-function isNonSubscriptionOption(
-  purchaseOption: PurchaseOption,
-): purchaseOption is NonSubscriptionOption {
-  return "basePrice" in purchaseOption;
-}
-
-function isSubscriptionOption(
-  purchaseOption: PurchaseOption,
-): purchaseOption is SubscriptionOption {
-  return "base" in purchaseOption;
+  return product.productType === RevenueCatProductType.Subscription
+    ? (purchaseOption as SubscriptionOption).base.price
+    : (purchaseOption as NonSubscriptionOption).basePrice;
 }
 
 function formatCacheError(error: unknown): string {

--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -608,8 +608,15 @@ export class AmazonBillingWrapper implements BillingWrapper {
       };
     };
 
+    const productsForProductDataResponse = (
+      productDataResponse: ProductDataResponse,
+    ): ProductResponse[] =>
+      Array.from(productDataResponse.productData.values())
+        .map(productForAmazonProduct)
+        .filter((product): product is ProductResponse => product !== null);
+
     const uniqueProductIds = [...new Set(productIds)];
-    const productsById = new Map<string, Product>();
+    const productDetails: ProductResponse[] = [];
     const maximumProductsPerRequest = 100;
 
     for (
@@ -640,17 +647,10 @@ export class AmazonBillingWrapper implements BillingWrapper {
         throw purchasesError;
       }
 
-      for (const [productId, product] of response.productData) {
-        productsById.set(productId, product);
-      }
+      productDetails.push(...productsForProductDataResponse(response));
     }
 
-    return {
-      product_details: uniqueProductIds
-        .map((productId) => productsById.get(productId))
-        .map((product) => (product ? productForAmazonProduct(product) : null))
-        .filter((product): product is ProductResponse => product !== null),
-    };
+    return { product_details: productDetails };
   }
 }
 

--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -5,6 +5,12 @@ import type {
   Receipt,
 } from "@amazon-devices/keplerscript-appstore-iap-lib";
 import { ErrorCode, PurchasesError } from "../entities/errors";
+import type {
+  NonSubscriptionOption,
+  Price,
+  PurchaseOption,
+  SubscriptionOption,
+} from "../entities/offerings";
 import { Logger } from "../helpers/logger";
 import type { BillingWrapper } from "../helpers/billing-wrapper";
 import type {
@@ -39,7 +45,6 @@ type ReceiptWithStoreUserId = {
  */
 export class AmazonBillingWrapper implements BillingWrapper {
   private readonly deviceCache: VegaDeviceCache;
-  private readonly productsById = new Map<string, Product>();
 
   constructor(
     private readonly backend: Backend,
@@ -130,34 +135,19 @@ export class AmazonBillingWrapper implements BillingWrapper {
         ? receipt.termSku
         : receipt.sku;
 
-    let price: number | undefined = undefined;
-    try {
-      const { product_details: products } = await this.getProducts(appUserId, [
-        productIdentifier,
-      ]);
-      const productPrice = getBasePrice(
-        products.find((product) => product.identifier === productIdentifier),
-      );
-      if (productPrice) {
-        price = productPrice.amount_micros / 1_000_000;
-      }
-    } catch (error: unknown) {
-      Logger.warnLog(
-        `Failed to fetch Amazon product data for ${productIdentifier} before posting its receipt: ${String(error)}`,
-      );
-    }
+    const price = priceForPurchaseParams(params);
 
     const subscriberResponse = await this.backend.postReceipt(
       appUserId,
       productIdentifier,
-      rcPackage.webBillingProduct.price.currency,
+      price?.currency ?? null,
       receipt.receiptId,
       rcPackage.webBillingProduct.presentedOfferingContext,
       PostReceiptInitiationSource.PURCHASE,
       undefined,
       storeUserId,
       false,
-      price,
+      price ? price.amountMicros / 1_000_000 : undefined,
     );
 
     let fulfillmentSucceeded = false;
@@ -619,17 +609,15 @@ export class AmazonBillingWrapper implements BillingWrapper {
     };
 
     const uniqueProductIds = [...new Set(productIds)];
-    const missingProductIds = uniqueProductIds.filter(
-      (productId) => !this.productsById.has(productId),
-    );
+    const productsById = new Map<string, Product>();
     const maximumProductsPerRequest = 100;
 
     for (
       let startIndex = 0;
-      startIndex < missingProductIds.length;
+      startIndex < uniqueProductIds.length;
       startIndex += maximumProductsPerRequest
     ) {
-      const skus = missingProductIds.slice(
+      const skus = uniqueProductIds.slice(
         startIndex,
         startIndex + maximumProductsPerRequest,
       );
@@ -653,30 +641,43 @@ export class AmazonBillingWrapper implements BillingWrapper {
       }
 
       for (const [productId, product] of response.productData) {
-        this.productsById.set(productId, product);
+        productsById.set(productId, product);
       }
     }
 
     return {
       product_details: uniqueProductIds
-        .map((productId) => this.productsById.get(productId))
+        .map((productId) => productsById.get(productId))
         .map((product) => (product ? productForAmazonProduct(product) : null))
         .filter((product): product is ProductResponse => product !== null),
     };
   }
 }
 
-function getBasePrice(
-  product: ProductResponse | undefined,
-): PriceResponse | null {
-  const purchaseOption = product?.purchase_options.base_option;
-  if (purchaseOption == null) {
-    return null;
+function priceForPurchaseParams(params: PurchaseParams): Price | null {
+  const purchaseOption =
+    params.purchaseOption ??
+    params.rcPackage.webBillingProduct.defaultPurchaseOption;
+
+  if (isNonSubscriptionOption(purchaseOption)) {
+    return purchaseOption.basePrice;
   }
 
-  return "base_price" in purchaseOption
-    ? purchaseOption.base_price
-    : (purchaseOption.base?.price ?? null);
+  return isSubscriptionOption(purchaseOption)
+    ? purchaseOption.base.price
+    : null;
+}
+
+function isNonSubscriptionOption(
+  purchaseOption: PurchaseOption,
+): purchaseOption is NonSubscriptionOption {
+  return "basePrice" in purchaseOption;
+}
+
+function isSubscriptionOption(
+  purchaseOption: PurchaseOption,
+): purchaseOption is SubscriptionOption {
+  return "base" in purchaseOption;
 }
 
 function formatCacheError(error: unknown): string {

--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -39,6 +39,7 @@ type ReceiptWithStoreUserId = {
  */
 export class AmazonBillingWrapper implements BillingWrapper {
   private readonly deviceCache: VegaDeviceCache;
+  private readonly productsById = new Map<string, Product>();
 
   constructor(
     private readonly backend: Backend,
@@ -129,6 +130,23 @@ export class AmazonBillingWrapper implements BillingWrapper {
         ? receipt.termSku
         : receipt.sku;
 
+    let price: number | undefined = undefined;
+    try {
+      const { product_details: products } = await this.getProducts(appUserId, [
+        productIdentifier,
+      ]);
+      const productPrice = getBasePrice(
+        products.find((product) => product.identifier === productIdentifier),
+      );
+      if (productPrice) {
+        price = productPrice.amount_micros / 1_000_000;
+      }
+    } catch (error: unknown) {
+      Logger.warnLog(
+        `Failed to fetch Amazon product data for ${productIdentifier} before posting its receipt: ${String(error)}`,
+      );
+    }
+
     const subscriberResponse = await this.backend.postReceipt(
       appUserId,
       productIdentifier,
@@ -138,6 +156,8 @@ export class AmazonBillingWrapper implements BillingWrapper {
       PostReceiptInitiationSource.PURCHASE,
       undefined,
       storeUserId,
+      false,
+      price,
     );
 
     let fulfillmentSucceeded = false;
@@ -598,23 +618,18 @@ export class AmazonBillingWrapper implements BillingWrapper {
       };
     };
 
-    const productsForProductDataResponse = (
-      productDataResponse: ProductDataResponse,
-    ): ProductResponse[] =>
-      Array.from(productDataResponse.productData.values())
-        .map(productForAmazonProduct)
-        .filter((product): product is ProductResponse => product !== null);
-
     const uniqueProductIds = [...new Set(productIds)];
-    const productDetails: ProductResponse[] = [];
+    const missingProductIds = uniqueProductIds.filter(
+      (productId) => !this.productsById.has(productId),
+    );
     const maximumProductsPerRequest = 100;
 
     for (
       let startIndex = 0;
-      startIndex < uniqueProductIds.length;
+      startIndex < missingProductIds.length;
       startIndex += maximumProductsPerRequest
     ) {
-      const skus = uniqueProductIds.slice(
+      const skus = missingProductIds.slice(
         startIndex,
         startIndex + maximumProductsPerRequest,
       );
@@ -637,11 +652,31 @@ export class AmazonBillingWrapper implements BillingWrapper {
         throw purchasesError;
       }
 
-      productDetails.push(...productsForProductDataResponse(response));
+      for (const [productId, product] of response.productData) {
+        this.productsById.set(productId, product);
+      }
     }
 
-    return { product_details: productDetails };
+    return {
+      product_details: uniqueProductIds
+        .map((productId) => this.productsById.get(productId))
+        .map((product) => (product ? productForAmazonProduct(product) : null))
+        .filter((product): product is ProductResponse => product !== null),
+    };
   }
+}
+
+function getBasePrice(
+  product: ProductResponse | undefined,
+): PriceResponse | null {
+  const purchaseOption = product?.purchase_options.base_option;
+  if (purchaseOption == null) {
+    return null;
+  }
+
+  return "base_price" in purchaseOption
+    ? purchaseOption.base_price
+    : (purchaseOption.base?.price ?? null);
 }
 
 function formatCacheError(error: unknown): string {

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -556,6 +556,7 @@ export class Backend {
     paywallId?: string,
     storeUserId?: string,
     is_restore?: boolean,
+    price?: number,
   ): Promise<SubscriberResponse> {
     type PostReceiptTargetingRule = {
       rule_id: string;
@@ -576,6 +577,7 @@ export class Backend {
       };
       store_user_id?: string;
       is_restore?: boolean;
+      price: number | null;
     };
 
     let targetingInfo: PostReceiptTargetingRule | null = null;
@@ -601,6 +603,7 @@ export class Backend {
       initiation_source: initiationSource,
       store_user_id: storeUserId,
       is_restore: is_restore,
+      price: price ?? null,
     };
 
     if (paywallId) {

--- a/src/tests/amazon/amazon-billing-wrapper.test.ts
+++ b/src/tests/amazon/amazon-billing-wrapper.test.ts
@@ -413,22 +413,6 @@ describe("AmazonBillingWrapper", () => {
     });
   });
 
-  test("returns cached products without requesting Amazon product data again", async () => {
-    const wrapper = new AmazonBillingWrapper(createBackend(), amazonApiKey);
-    getProductData.mockResolvedValue(
-      responseForProducts([product({ sku: "monthly" })]),
-    );
-
-    await wrapper.getProducts("user", ["monthly"]);
-    const result = await wrapper.getProducts("user", ["monthly"]);
-
-    expect(getProductData).toHaveBeenCalledExactlyOnceWith({
-      skus: ["monthly"],
-    });
-    expect(result.product_details).toHaveLength(1);
-    expect(result.product_details[0].identifier).toBe("monthly");
-  });
-
   describe("product data response errors", () => {
     test("maps an unsupported response to an unsupported error", async () => {
       await expect(
@@ -942,8 +926,8 @@ describe("AmazonBillingWrapper", () => {
         "purchase",
         undefined,
         "amazon-store-user-id",
-        undefined,
-        undefined,
+        false,
+        3,
       );
       expect(notifyFulfillment).toHaveBeenCalledExactlyOnceWith({
         receiptId: "amazon-receipt-id",
@@ -960,21 +944,9 @@ describe("AmazonBillingWrapper", () => {
       });
     });
 
-    test("fetches and posts the Amazon product price when purchasing", async () => {
+    test("posts the price from the package in the purchase params", async () => {
       const backend = createBackend();
       vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
-      getProductData.mockResolvedValue(
-        responseForProducts([
-          product({
-            sku: "monthly",
-            price: {
-              priceStr: "$4.99",
-              priceCurrencyCode: "USD",
-              valueInMicros: 4_990_000n,
-            },
-          }),
-        ]),
-      );
       const wrapper = new AmazonBillingWrapper(backend, amazonApiKey);
 
       await wrapper.purchase(
@@ -982,9 +954,7 @@ describe("AmazonBillingWrapper", () => {
         appUserId,
       );
 
-      expect(getProductData).toHaveBeenCalledExactlyOnceWith({
-        skus: ["monthly"],
-      });
+      expect(getProductData).not.toHaveBeenCalled();
       expect(backend.postReceipt).toHaveBeenCalledWith(
         appUserId,
         "monthly",
@@ -994,38 +964,44 @@ describe("AmazonBillingWrapper", () => {
         "purchase",
         undefined,
         "amazon-store-user-id",
-        undefined,
-        4.99,
+        false,
+        3,
       );
     });
 
-    test("posts without a price when fetching the product fails", async () => {
+    test("posts the selected purchase option's price and currency", async () => {
       const backend = createBackend();
-      const warningLog = vi
-        .spyOn(Logger, "warnLog")
-        .mockImplementation(() => {});
       vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
-      getProductData.mockRejectedValue(new Error("Amazon IAP unavailable"));
+      const rcPackage = createMonthlyPackageMock();
+      const selectedPurchaseOption = {
+        ...rcPackage.webBillingProduct.defaultSubscriptionOption!,
+        base: {
+          ...rcPackage.webBillingProduct.defaultSubscriptionOption!.base,
+          price: {
+            amount: 499,
+            amountMicros: 4_990_000,
+            currency: "EUR",
+            formattedPrice: "€4.99",
+          },
+        },
+      };
 
       await new AmazonBillingWrapper(backend, amazonApiKey).purchase(
-        { rcPackage: createMonthlyPackageMock() },
+        { rcPackage, purchaseOption: selectedPurchaseOption },
         appUserId,
       );
 
-      expect(warningLog).toHaveBeenCalledWith(
-        "Failed to fetch Amazon product data for monthly before posting its receipt: Error: Amazon IAP unavailable",
-      );
       expect(backend.postReceipt).toHaveBeenCalledWith(
         appUserId,
         "monthly",
-        "USD",
+        "EUR",
         "amazon-receipt-id",
         expect.anything(),
         "purchase",
         undefined,
         "amazon-store-user-id",
-        undefined,
-        undefined,
+        false,
+        4.99,
       );
     });
 
@@ -1094,8 +1070,8 @@ describe("AmazonBillingWrapper", () => {
         "purchase",
         undefined,
         "amazon-store-user-id",
-        undefined,
-        undefined,
+        false,
+        3,
       );
       expect(result.storeTransaction.productIdentifier).toBe("coin-pack");
     });
@@ -1400,6 +1376,7 @@ describe("AmazonBillingWrapper", () => {
           product({ price: null as unknown as Product["price"] }),
           product({ sku: "available-product" }),
         ]),
+        ["product-id", "available-product"],
       );
 
       expect(warningLog).toHaveBeenCalledWith(

--- a/src/tests/amazon/amazon-billing-wrapper.test.ts
+++ b/src/tests/amazon/amazon-billing-wrapper.test.ts
@@ -102,12 +102,15 @@ const responseForProducts = (products: Product[]): ProductDataResponse => ({
   unavailableSkus: [],
 });
 
-async function getProducts(response: ProductDataResponse) {
+async function getProducts(
+  response: ProductDataResponse,
+  productIds = ["product-id"],
+) {
   getProductData.mockResolvedValue(response);
   return await new AmazonBillingWrapper(
     {} as Backend,
     amazonApiKey,
-  ).getProducts("app-user-id", ["product-id"]);
+  ).getProducts("app-user-id", productIds);
 }
 
 const successfulPurchaseResponse = (): PurchaseResponse => ({
@@ -408,6 +411,22 @@ describe("AmazonBillingWrapper", () => {
         skus: ["product-100"],
       });
     });
+  });
+
+  test("returns cached products without requesting Amazon product data again", async () => {
+    const wrapper = new AmazonBillingWrapper(createBackend(), amazonApiKey);
+    getProductData.mockResolvedValue(
+      responseForProducts([product({ sku: "monthly" })]),
+    );
+
+    await wrapper.getProducts("user", ["monthly"]);
+    const result = await wrapper.getProducts("user", ["monthly"]);
+
+    expect(getProductData).toHaveBeenCalledExactlyOnceWith({
+      skus: ["monthly"],
+    });
+    expect(result.product_details).toHaveLength(1);
+    expect(result.product_details[0].identifier).toBe("monthly");
   });
 
   describe("product data response errors", () => {
@@ -899,6 +918,7 @@ describe("AmazonBillingWrapper", () => {
       notifyFulfillment.mockResolvedValue({
         responseCode: NotifyFulfillmentResponseCode.SUCCESSFUL,
       });
+      getProductData.mockResolvedValue(responseForProducts([]));
     });
 
     test("uses a subscription receipt's term SKU when posting and returning the purchase", async () => {
@@ -922,6 +942,8 @@ describe("AmazonBillingWrapper", () => {
         "purchase",
         undefined,
         "amazon-store-user-id",
+        undefined,
+        undefined,
       );
       expect(notifyFulfillment).toHaveBeenCalledExactlyOnceWith({
         receiptId: "amazon-receipt-id",
@@ -936,6 +958,75 @@ describe("AmazonBillingWrapper", () => {
           storeTransactionId: "amazon-receipt-id",
         },
       });
+    });
+
+    test("fetches and posts the Amazon product price when purchasing", async () => {
+      const backend = createBackend();
+      vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
+      getProductData.mockResolvedValue(
+        responseForProducts([
+          product({
+            sku: "monthly",
+            price: {
+              priceStr: "$4.99",
+              priceCurrencyCode: "USD",
+              valueInMicros: 4_990_000n,
+            },
+          }),
+        ]),
+      );
+      const wrapper = new AmazonBillingWrapper(backend, amazonApiKey);
+
+      await wrapper.purchase(
+        { rcPackage: createMonthlyPackageMock() },
+        appUserId,
+      );
+
+      expect(getProductData).toHaveBeenCalledExactlyOnceWith({
+        skus: ["monthly"],
+      });
+      expect(backend.postReceipt).toHaveBeenCalledWith(
+        appUserId,
+        "monthly",
+        "USD",
+        "amazon-receipt-id",
+        expect.anything(),
+        "purchase",
+        undefined,
+        "amazon-store-user-id",
+        undefined,
+        4.99,
+      );
+    });
+
+    test("posts without a price when fetching the product fails", async () => {
+      const backend = createBackend();
+      const warningLog = vi
+        .spyOn(Logger, "warnLog")
+        .mockImplementation(() => {});
+      vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
+      getProductData.mockRejectedValue(new Error("Amazon IAP unavailable"));
+
+      await new AmazonBillingWrapper(backend, amazonApiKey).purchase(
+        { rcPackage: createMonthlyPackageMock() },
+        appUserId,
+      );
+
+      expect(warningLog).toHaveBeenCalledWith(
+        "Failed to fetch Amazon product data for monthly before posting its receipt: Error: Amazon IAP unavailable",
+      );
+      expect(backend.postReceipt).toHaveBeenCalledWith(
+        appUserId,
+        "monthly",
+        "USD",
+        "amazon-receipt-id",
+        expect.anything(),
+        "purchase",
+        undefined,
+        "amazon-store-user-id",
+        undefined,
+        undefined,
+      );
     });
 
     test("caches a receipt ID after Amazon successfully fulfills it", async () => {
@@ -1003,6 +1094,8 @@ describe("AmazonBillingWrapper", () => {
         "purchase",
         undefined,
         "amazon-store-user-id",
+        undefined,
+        undefined,
       );
       expect(result.storeTransaction.productIdentifier).toBe("coin-pack");
     });

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -1636,6 +1636,7 @@ describe("postReceipt request", () => {
       fetch_token: "test_fetch_token",
       product_id: "monthly",
       currency: "EUR",
+      price: null,
       app_user_id: "someAppUserId",
       presented_offering_identifier: "offering_1",
       presented_placement_identifier: null,
@@ -1666,6 +1667,48 @@ describe("postReceipt request", () => {
     expect(requestBody.currency).toBeNull();
   });
 
+  test("posts a null price when not provided", async () => {
+    setPostReceiptResponse(
+      HttpResponse.json(customerInfoResponse, { status: 200 }),
+    );
+
+    await backend.postReceipt(
+      "someAppUserId",
+      "monthly",
+      "USD",
+      "test_fetch_token",
+      null,
+      PostReceiptInitiationSource.PURCHASE,
+    );
+
+    const request = postReceiptAPIMock.mock.calls[0][0].request;
+    const requestBody = await request.json();
+    expect(requestBody.price).toBeNull();
+  });
+
+  test("posts a price when provided", async () => {
+    setPostReceiptResponse(
+      HttpResponse.json(customerInfoResponse, { status: 200 }),
+    );
+
+    await backend.postReceipt(
+      "someAppUserId",
+      "monthly",
+      "USD",
+      "test_fetch_token",
+      null,
+      PostReceiptInitiationSource.PURCHASE,
+      undefined,
+      undefined,
+      undefined,
+      4.99,
+    );
+
+    const request = postReceiptAPIMock.mock.calls[0][0].request;
+    const requestBody = await request.json();
+    expect(requestBody.price).toBe(4.99);
+  });
+
   test("includes targeting context when provided", async () => {
     setPostReceiptResponse(
       HttpResponse.json(customerInfoResponse, { status: 200 }),
@@ -1694,6 +1737,7 @@ describe("postReceipt request", () => {
       fetch_token: "test_fetch_token",
       product_id: "monthly",
       currency: "EUR",
+      price: null,
       app_user_id: "someAppUserId",
       presented_offering_identifier: "offering_1",
       presented_placement_identifier: "placement_1",

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -1667,25 +1667,6 @@ describe("postReceipt request", () => {
     expect(requestBody.currency).toBeNull();
   });
 
-  test("posts a null price when not provided", async () => {
-    setPostReceiptResponse(
-      HttpResponse.json(customerInfoResponse, { status: 200 }),
-    );
-
-    await backend.postReceipt(
-      "someAppUserId",
-      "monthly",
-      "USD",
-      "test_fetch_token",
-      null,
-      PostReceiptInitiationSource.PURCHASE,
-    );
-
-    const request = postReceiptAPIMock.mock.calls[0][0].request;
-    const requestBody = await request.json();
-    expect(requestBody.price).toBeNull();
-  });
-
   test("posts a price when provided", async () => {
     setPostReceiptResponse(
       HttpResponse.json(customerInfoResponse, { status: 200 }),


### PR DESCRIPTION
## Changes introduced
Before this PR, we weren't posting the product's price when calling POST /receipt. This means that if we don't already have a price for the product in the backend, the backend may never be able to get one.

This PR modifies the SDK to include the Amazon product's price when posting a receipt for a new purchase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches receipt posting for Amazon purchases, which feeds backend revenue/price data. Restore and other callers still send `price: null`.
> 
> **Overview**
> Amazon purchases now send **price and currency** on `POST /receipts` so the backend can record a product price when it does not already have one.
> 
> `postReceipt` takes an optional `price` (major units) and always includes `price` in the body (`null` if omitted). On purchase, the SDK uses the selected option’s (or default option’s) price from the package—currency from that price, amount from `amountMicros`—instead of the package’s web-billing currency alone. Restore/sync still omit price.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff12f3441ce9ccc6c41859c81841a25980661f05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->