### PR TITLE
[EXTERNAL] Allow Paddle checkout settings to carry non-boolean values (unblocks express checkout)

### DIFF
--- a/src/networking/responses/checkout-prepare-response.ts
+++ b/src/networking/responses/checkout-prepare-response.ts
@@ -1,4 +1,5 @@
 import type { GatewayParams } from "./stripe-elements";
+import type { PaddleCheckoutSettings } from "./paddle-checkout-settings";
 
 export type CheckoutPrepareStripeGatewayParams = GatewayParams;
 
@@ -9,7 +10,7 @@ export interface CheckoutPreparePayPalGatewayParams {
 export interface CheckoutPreparePaddleBillingParams {
   client_side_token: string;
   is_sandbox: boolean;
-  checkout_settings?: Record<string, boolean>;
+  checkout_settings?: PaddleCheckoutSettings;
 }
 
 export interface CheckoutPrepareResponse {

--- a/src/networking/responses/checkout-start-response.ts
+++ b/src/networking/responses/checkout-start-response.ts
@@ -1,4 +1,5 @@
 import type { GatewayParams } from "./stripe-elements";
+import type { PaddleCheckoutSettings } from "./paddle-checkout-settings";
 
 export interface StripeBillingParams {
   client_secret: string;
@@ -26,7 +27,7 @@ export interface PaddleCheckoutStartResponse {
     client_side_token: string;
     is_sandbox: boolean;
     transaction_id: string;
-    checkout_settings?: Record<string, boolean>;
+    checkout_settings?: PaddleCheckoutSettings;
     /**
      * Per-project gate for the Paddle inline checkout rollout. When `true`,
      * present Paddle's checkout inline (embedded in our own container); when

--- a/src/networking/responses/paddle-checkout-settings.ts
+++ b/src/networking/responses/paddle-checkout-settings.ts
@@ -2,12 +2,7 @@
  * Checkout settings configured on the RevenueCat dashboard and forwarded by the
  * backend, merged over the SDK's defaults before being handed to Paddle's
  * `Checkout.open({ settings })`.
- *
- * Keys and values map 1:1 to Paddle's own checkout settings, which are not all
- * booleans: `variant`, for example, is `"one-page" | "multi-page" | "express"`,
- * so express checkout can only be expressed once strings are allowed here.
- * Kept as an open record (rather than a closed union of the settings we know
- * about today) so the backend can forward newly supported Paddle settings
+ * Intentionally an open record so we can forward newly supported Paddle settings
  * without requiring an SDK release.
  */
 export type PaddleCheckoutSettings = Record<string, boolean | string>;

--- a/src/networking/responses/paddle-checkout-settings.ts
+++ b/src/networking/responses/paddle-checkout-settings.ts
@@ -1,0 +1,13 @@
+/**
+ * Checkout settings configured on the RevenueCat dashboard and forwarded by the
+ * backend, merged over the SDK's defaults before being handed to Paddle's
+ * `Checkout.open({ settings })`.
+ *
+ * Keys and values map 1:1 to Paddle's own checkout settings, which are not all
+ * booleans: `variant`, for example, is `"one-page" | "multi-page" | "express"`,
+ * so express checkout can only be expressed once strings are allowed here.
+ * Kept as an open record (rather than a closed union of the settings we know
+ * about today) so the backend can forward newly supported Paddle settings
+ * without requiring an SDK release.
+ */
+export type PaddleCheckoutSettings = Record<string, boolean | string>;

--- a/src/paddle/paddle-service.ts
+++ b/src/paddle/paddle-service.ts
@@ -33,6 +33,7 @@ import { toRedemptionInfo } from "../entities/redemption-info";
 import type { OperationSessionSuccessfulResult } from "../helpers/purchase-operation-helper";
 import { handleCheckoutSessionFailed } from "../helpers/checkout-error-handler";
 import type { PaddleCheckoutStartResponse } from "../networking/responses/checkout-start-response";
+import type { PaddleCheckoutSettings } from "../networking/responses/paddle-checkout-settings";
 import type { IEventsTracker } from "../behavioural-events/events-tracker";
 
 interface PaddlePurchaseParams {
@@ -89,7 +90,7 @@ interface BuildPaddleCheckoutOptionsParams {
   transactionId: string;
   locale: string;
   customerEmail?: string;
-  checkoutSettings?: Record<string, boolean>;
+  checkoutSettings?: PaddleCheckoutSettings;
   displayMode?: PaddleCheckoutDisplayMode;
   theme?: PaddleCheckoutTheme;
 }
@@ -146,7 +147,7 @@ interface PaddlePurchase {
   onCheckoutLoaded: () => void;
   params: PaddlePurchaseParams;
   onClose: () => void;
-  checkoutSettings?: Record<string, boolean>;
+  checkoutSettings?: PaddleCheckoutSettings;
   displayMode?: PaddleCheckoutDisplayMode;
   theme?: PaddleCheckoutTheme;
   /**

--- a/src/tests/paddle/paddle-service.test.ts
+++ b/src/tests/paddle/paddle-service.test.ts
@@ -163,6 +163,36 @@ describe("buildPaddleCheckoutOptions", () => {
     );
   });
 
+  test("lets checkout settings override the default variant", () => {
+    const options = buildPaddleCheckoutOptions({
+      transactionId,
+      locale: "en",
+      checkoutSettings: { variant: "express" },
+    });
+
+    expect(options.settings).toEqual(
+      expect.objectContaining({ variant: "express" }),
+    );
+  });
+
+  test("forwards unknown checkout settings to Paddle untouched", () => {
+    const options = buildPaddleCheckoutOptions({
+      transactionId,
+      locale: "en",
+      checkoutSettings: {
+        variant: "express",
+        showNonExpressPaymentMethods: false,
+      },
+    });
+
+    expect(options.settings).toEqual(
+      expect.objectContaining({
+        variant: "express",
+        showNonExpressPaymentMethods: false,
+      }),
+    );
+  });
+
   test("keeps SDK-controlled layout settings", () => {
     const options = buildPaddleCheckoutOptions({
       transactionId,
@@ -636,6 +666,31 @@ describe("PaddleService", () => {
         purchasePromise.catch(() => {});
       },
     );
+
+    test("passes the express checkout settings to Paddle", async () => {
+      const purchasePromise = paddleService.purchase({
+        operationSessionId,
+        transactionId,
+        onCheckoutLoaded: vi.fn(),
+        onClose: vi.fn(),
+        params: purchaseParams,
+        checkoutSettings: {
+          variant: "express",
+          showNonExpressPaymentMethods: false,
+        },
+      });
+
+      expect(mockPaddleInstance.Checkout?.open).toHaveBeenCalledWith(
+        expect.objectContaining({
+          settings: expect.objectContaining({
+            variant: "express",
+            showNonExpressPaymentMethods: false,
+          }),
+        }),
+      );
+
+      purchasePromise.catch(() => {});
+    });
 
     test("forwards order totals on checkout.loaded and checkout.updated", async () => {
       const onCheckoutTotals = vi.fn();


### PR DESCRIPTION
## Motivation / Description

Fixes #1072.

Paddle supports [express checkout](https://developer.paddle.com/concepts/sell/express-checkout), which leads with Apple Pay / Google Pay and takes customer details from the wallet instead of a form. Because `purchases-js` owns the Paddle.js integration, apps can't turn it on themselves — it has to come through `checkout_settings`.

The passthrough mechanism is already correct: `buildPaddleCheckoutOptions` spreads `...checkoutSettings` *after* the SDK defaults, so a backend-supplied `variant` already wins over the hardcoded `"one-page"`. The only thing in the way is the type — `checkout_settings` / `checkoutSettings` are `Record<string, boolean>`, and Paddle's `variant` is `"one-page" | "multi-page" | "express"`, so express checkout can't be expressed at all.

This PR is the SDK half only: it makes the setting representable. Actually forwarding it from the dashboard's Paddle checkout settings (alongside the existing `showAddDiscounts` passthrough) is the backend/dashboard half, which only RevenueCat can do.

## Changes introduced

- Added `PaddleCheckoutSettings` (`Record<string, boolean | string>`) in `src/networking/responses/paddle-checkout-settings.ts`, mirroring how `stripe-elements.ts` holds gateway-specific types shared between the prepare and start responses.
- Used it for `checkout_settings` in `CheckoutPreparePaddleBillingParams` and `PaddleCheckoutStartResponse`, and for the `checkoutSettings` params in `paddle-service.ts`.
- Tests covering `variant: "express"` overriding the default, and an unknown setting (`showNonExpressPaymentMethods`) reaching `Checkout.open()` untouched — both through `buildPaddleCheckoutOptions` and through `PaddleService.purchase`.

Notes on the shape of the type:

- It stays an **open** record rather than a closed union of the settings known today, so the backend can start forwarding a newly supported Paddle setting without waiting on an SDK release. `showNonExpressPaymentMethods` is a concrete example: it's documented by Paddle but isn't in `@paddle/paddle-js@1.6.4`'s `CheckoutSettings` type yet.
- Type safety on the settings the SDK controls is unchanged. The explicit defaults (`theme`, `locale`) and the layout settings (`displayMode`, `frameTarget`, `frameInitialHeight`, `frameStyle`) keep their exact types and are still checked against Paddle's `CheckoutSettings` — I verified that a bad `theme` literal still fails to compile after the widening.
- No public API surface change; `api-report/` is unchanged.

Happy to adjust the direction — e.g. a closed union of the settings you intend to support, or `Partial<CheckoutSettings>` from `@paddle/paddle-js` — if you'd rather constrain it.

## Linear ticket (if any)

N/A — external contribution.

## Additional comments

- `pnpm typecheck`, `pnpm test:typecheck`, `pnpm lint`, `pnpm svelte-check` (0 errors), `pnpm build` and `pnpm test` (816 passing) all pass locally.
- Apple Pay domain verification is a Paddle-side prerequisite for the one-click experience and is independent of this change.
- `presentExpressPurchaseButton` is Stripe-backed, so it isn't an alternative for Paddle Billing apps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only widening of an existing passthrough; merge order and SDK-controlled layout settings are unchanged. No public API or payment-flow logic change.
> 
> **Overview**
> Widens Paddle `checkout_settings` so dashboard/backend values can include strings (e.g. `variant: "express"`), unblocking express checkout without an SDK release for each new Paddle setting.
> 
> Adds shared `PaddleCheckoutSettings` (`Record<string, boolean | string>`) and uses it on prepare/start responses and in `buildPaddleCheckoutOptions`. Settings still spread after SDK defaults, so a backend `variant` overrides `"one-page"`. Tests cover express override and forwarding unknown keys like `showNonExpressPaymentMethods`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 432e24e756aa7cdb0ba68931d33b55c02521013b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->