### PR TITLE
feat(vega): run sync on app foregrounding

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "devDependencies": {
     "@amazon-devices/kepler-file-system": "0.0.7",
     "@amazon-devices/keplerscript-appstore-iap-lib": "2.12.16",
+    "react-native": "0.72.0",
     "@eslint/js": "^9.16.0",
     "@microsoft/api-extractor": "^7.48.0",
     "@paddle/paddle-js": "^1.6.4",
@@ -114,13 +115,17 @@
   },
   "peerDependencies": {
     "@amazon-devices/kepler-file-system": "0.0.7",
-    "@amazon-devices/keplerscript-appstore-iap-lib": "2.12.16"
+    "@amazon-devices/keplerscript-appstore-iap-lib": "2.12.16",
+    "react-native": ">=0.72.0"
   },
   "peerDependenciesMeta": {
     "@amazon-devices/kepler-file-system": {
       "optional": true
     },
     "@amazon-devices/keplerscript-appstore-iap-lib": {
+      "optional": true
+    },
+    "react-native": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
       "@amazon-devices/keplerscript-appstore-iap-lib":
         specifier: 2.12.16
         version: 2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))
+      react-native:
+        specifier: 0.72.0
+        version: 0.72.0(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react@18.3.1)
       "@eslint/js":
         specifier: ^9.16.0
         version: 9.17.0

--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -32,6 +32,10 @@ import {
   type AmazonAppstoreIAPSDK,
 } from "./amazon-appstore-iap-sdk-loader";
 import { VegaDeviceCache } from "./vega-device-cache";
+import {
+  loadReactNativeAppState,
+  type AppStateSubscription,
+} from "./react-native-app-state-loader";
 
 type ReceiptWithStoreUserId = {
   receipt: Receipt;
@@ -45,25 +49,29 @@ type ReceiptWithStoreUserId = {
  */
 export class AmazonBillingWrapper implements BillingWrapper {
   private readonly deviceCache: VegaDeviceCache;
+  private appStateSubscription: AppStateSubscription | undefined;
+  private pendingSync: Promise<void> | undefined;
+  private closed = false;
 
   constructor(
     private readonly backend: Backend,
     apiKey: string,
-    appUserId?: string,
+    private readonly getAppUserId: () => string | undefined,
   ) {
     this.deviceCache = new VegaDeviceCache(apiKey);
-    if (appUserId !== undefined) {
-      void this.syncPendingPurchases(appUserId).catch((error: unknown) => {
-        Logger.warnLog(
-          `Failed to sync pending Amazon purchases in the background: ${String(error)}`,
-        );
-      });
-    }
+    void this.triggerSyncPendingPurchases();
+    void this.observeAppState();
   }
 
   private amazonAppstoreIAPSDKPromise:
     | Promise<AmazonAppstoreIAPSDK>
     | undefined;
+
+  public close(): void {
+    this.closed = true;
+    this.appStateSubscription?.remove();
+    this.appStateSubscription = undefined;
+  }
 
   public async getProducts(
     _appUserId: string,
@@ -189,13 +197,33 @@ export class AmazonBillingWrapper implements BillingWrapper {
     };
   }
 
-  /**
-   * Posts and fulfills receipts which have not been successfully handled on
-   * this device. This is intended for the background automatic sync performed
-   * when the app starts or returns to the foreground.
-   * @internal
-   */
-  public async syncPendingPurchases(appUserId: string): Promise<void> {
+  private async triggerSyncPendingPurchases(): Promise<void> {
+    if (this.pendingSync !== undefined) {
+      await this.pendingSync;
+      return;
+    }
+
+    const appUserId = this.getAppUserId();
+    if (appUserId === undefined) {
+      return;
+    }
+
+    const pendingSync = this.syncPendingPurchases(appUserId);
+    this.pendingSync = pendingSync;
+    try {
+      await pendingSync;
+    } catch (error: unknown) {
+      Logger.warnLog(
+        `Failed to sync pending Amazon purchases in the background: ${String(error)}`,
+      );
+    } finally {
+      if (this.pendingSync === pendingSync) {
+        this.pendingSync = undefined;
+      }
+    }
+  }
+
+  private async syncPendingPurchases(appUserId: string): Promise<void> {
     Logger.debugLog("Syncing pending purchases with the Amazon Store.");
 
     let previouslySentReceiptIds: Set<string>;
@@ -651,6 +679,35 @@ export class AmazonBillingWrapper implements BillingWrapper {
     }
 
     return { product_details: productDetails };
+  }
+
+  private async observeAppState(): Promise<void> {
+    try {
+      const appState = await loadReactNativeAppState();
+      if (this.closed) return;
+
+      let previousState = appState.currentState;
+      this.appStateSubscription = appState.addEventListener(
+        "change",
+        (nextState) => {
+          const enteredForeground =
+            (previousState === "background" || previousState === "inactive") &&
+            nextState === "active";
+          previousState = nextState;
+
+          if (enteredForeground) {
+            Logger.debugLog(
+              "App has entered the foreground. Will sync any pending purchases.",
+            );
+            void this.triggerSyncPendingPurchases();
+          }
+        },
+      );
+    } catch (error: unknown) {
+      Logger.warnLog(
+        `Failed to observe Vega app state for Amazon purchase syncing: ${String(error)}`,
+      );
+    }
   }
 }
 

--- a/src/amazon/amazon-billing-wrapper.ts
+++ b/src/amazon/amazon-billing-wrapper.ts
@@ -59,7 +59,7 @@ export class AmazonBillingWrapper implements BillingWrapper {
     private readonly getAppUserId: () => string | undefined,
   ) {
     this.deviceCache = new VegaDeviceCache(apiKey);
-    void this.triggerSyncPendingPurchases();
+    void this.syncPendingPurchasesInBackground();
     void this.observeAppState();
   }
 
@@ -197,7 +197,10 @@ export class AmazonBillingWrapper implements BillingWrapper {
     };
   }
 
-  private async triggerSyncPendingPurchases(): Promise<void> {
+  // Starts the automatic pending-purchase sync used on initialization and
+  // foregrounding. Calls coalesce onto a handled in-flight promise, so
+  // fire-and-forget callers do not surface unhandled rejections.
+  private async syncPendingPurchasesInBackground(): Promise<void> {
     if (this.pendingSync !== undefined) {
       await this.pendingSync;
       return;
@@ -208,21 +211,23 @@ export class AmazonBillingWrapper implements BillingWrapper {
       return;
     }
 
-    const pendingSync = this.syncPendingPurchases(appUserId);
-    this.pendingSync = pendingSync;
-    try {
-      await pendingSync;
-    } catch (error: unknown) {
-      Logger.warnLog(
-        `Failed to sync pending Amazon purchases in the background: ${String(error)}`,
-      );
-    } finally {
-      if (this.pendingSync === pendingSync) {
+    const pendingSync = (async () => {
+      try {
+        await this.syncPendingPurchases(appUserId);
+      } catch (error: unknown) {
+        Logger.warnLog(
+          `Failed to sync pending Amazon purchases in the background: ${String(error)}`,
+        );
+      } finally {
         this.pendingSync = undefined;
       }
-    }
+    })();
+    this.pendingSync = pendingSync;
+    await pendingSync;
   }
 
+  // Performs the actual automatic sync work: fetch Amazon receipts, post only
+  // receipt IDs not present in the device cache, then fulfill and cache them.
   private async syncPendingPurchases(appUserId: string): Promise<void> {
     Logger.debugLog("Syncing pending purchases with the Amazon Store.");
 
@@ -699,7 +704,7 @@ export class AmazonBillingWrapper implements BillingWrapper {
             Logger.debugLog(
               "App has entered the foreground. Will sync any pending purchases.",
             );
-            void this.triggerSyncPendingPurchases();
+            void this.syncPendingPurchasesInBackground();
           }
         },
       );

--- a/src/amazon/react-native-app-state-loader.ts
+++ b/src/amazon/react-native-app-state-loader.ts
@@ -1,0 +1,46 @@
+import type { AppStateStatus } from "react-native";
+import { ErrorCode, PurchasesError } from "../entities/errors";
+
+/** A subscription returned by React Native's AppState listener. */
+export interface AppStateSubscription {
+  remove(): void;
+}
+
+/** The small portion of React Native AppState used by the Amazon BillingWrapper. */
+export interface ReactNativeAppState {
+  currentState: AppStateStatus | null;
+  addEventListener(
+    type: "change",
+    listener: (nextState: AppStateStatus) => void,
+  ): AppStateSubscription;
+}
+
+export type ReactNativeAppStateLoader = () => Promise<ReactNativeAppState>;
+
+const missingReactNativeAppStateLoader: ReactNativeAppStateLoader =
+  async () => {
+    throw new PurchasesError(
+      ErrorCode.ConfigurationError,
+      "React Native AppState is supported only by the @revenuecat/purchases-js/vega entry point.",
+    );
+  };
+
+let reactNativeAppStateLoader: ReactNativeAppStateLoader =
+  missingReactNativeAppStateLoader;
+
+/** Installs the Vega runtime's React Native AppState implementation. */
+export function setReactNativeAppStateLoader(
+  loader: ReactNativeAppStateLoader,
+): void {
+  reactNativeAppStateLoader = loader;
+}
+
+/** Restores the default loader. Primarily useful for tests. */
+export function resetReactNativeAppStateLoader(): void {
+  reactNativeAppStateLoader = missingReactNativeAppStateLoader;
+}
+
+/** Gets React Native AppState through the implementation selected by the entry point. */
+export function loadReactNativeAppState(): Promise<ReactNativeAppState> {
+  return reactNativeAppStateLoader();
+}

--- a/src/helpers/billing-wrapper.ts
+++ b/src/helpers/billing-wrapper.ts
@@ -12,6 +12,11 @@ import type { SyncPurchasesResult } from "src/entities/sync-purchases-result";
  */
 export interface BillingWrapper {
   /**
+   * Releases resources held by the billing implementation.
+   */
+  close(): void;
+
+  /**
    * Fetches product details (prices) for the given product IDs from the store.
    * @param appUserId - The app user ID.
    * @param productIds - The product IDs to fetch.

--- a/src/main.ts
+++ b/src/main.ts
@@ -477,6 +477,10 @@ export class Purchases {
       Logger.enableConsoleLogForDebugMessages();
     }
 
+    // Reconfiguring replaces the singleton instance. Close the old Amazon
+    // wrapper first so its AppState listener does not keep syncing in the
+    // background after it is no longer reachable.
+    Purchases.instance?.amazonBillingWrapper?.close();
     Purchases.instance = new Purchases(
       apiKey,
       appUserId,

--- a/src/main.ts
+++ b/src/main.ts
@@ -621,7 +621,7 @@ export class Purchases {
       this.amazonBillingWrapper = new AmazonBillingWrapper(
         this.backend,
         this._API_KEY,
-        this._appUserId,
+        () => this._appUserId,
       );
     }
   }
@@ -2570,6 +2570,7 @@ export class Purchases {
       if (this.eventsTracker) {
         this.eventsTracker.dispose();
       }
+      this.amazonBillingWrapper?.close();
       if (this._flags.applePayBrandingLogoEnabled) {
         const doc = getNullableDocument();
         if (doc) {

--- a/src/tests/amazon/amazon-billing-wrapper.test.ts
+++ b/src/tests/amazon/amazon-billing-wrapper.test.ts
@@ -61,6 +61,10 @@ import {
   resetAmazonAppstoreIAPSDKLoader,
   setAmazonAppstoreIAPSDKLoader,
 } from "../../amazon/amazon-appstore-iap-sdk-loader";
+import {
+  resetReactNativeAppStateLoader,
+  setReactNativeAppStateLoader,
+} from "../../amazon/react-native-app-state-loader";
 import { AmazonBillingWrapper } from "../../amazon/amazon-billing-wrapper";
 import { VegaDeviceCache } from "../../amazon/vega-device-cache";
 import { ErrorCode } from "../../entities/errors";
@@ -71,6 +75,7 @@ import { customerInfoResponse } from "../test-responses";
 import { createMonthlyPackageMock } from "../mocks/offering-mock-provider";
 
 const amazonApiKey = "amazon-api-key";
+const getNoAppUserId = () => undefined;
 
 const responseForCode = (
   responseCode: ProductDataResponseCode,
@@ -110,6 +115,7 @@ async function getProducts(
   return await new AmazonBillingWrapper(
     {} as Backend,
     amazonApiKey,
+    getNoAppUserId,
   ).getProducts("app-user-id", productIds);
 }
 
@@ -166,6 +172,7 @@ const createBackend = () =>
 describe("AmazonBillingWrapper", () => {
   beforeEach(() => {
     setAmazonAppstoreIAPSDKLoader(async () => AmazonVegaSdk);
+    resetReactNativeAppStateLoader();
     getProductData.mockReset();
     getPurchaseUpdates.mockReset();
     notifyFulfillment.mockReset();
@@ -178,7 +185,11 @@ describe("AmazonBillingWrapper", () => {
   });
 
   test("initializes the Vega device cache with its API key", () => {
-    const wrapper = new AmazonBillingWrapper(createBackend(), "amazon-api-key");
+    const wrapper = new AmazonBillingWrapper(
+      createBackend(),
+      "amazon-api-key",
+      getNoAppUserId,
+    );
 
     const deviceCache = (wrapper as unknown as { deviceCache: VegaDeviceCache })
       .deviceCache;
@@ -195,14 +206,93 @@ describe("AmazonBillingWrapper", () => {
     ).toBe("/data/com.revenuecat.purchases.amazon-api-key.tokens");
   });
 
+  test("syncs pending receipts when the Vega app returns to the foreground", async () => {
+    let onAppStateChange: ((state: string) => void) | undefined;
+    const subscription = { remove: vi.fn() };
+    const appState = {
+      currentState: "background",
+      addEventListener: vi.fn(
+        (_type: "change", listener: (state: string) => void) => {
+          onAppStateChange = listener;
+          return subscription;
+        },
+      ),
+    };
+    setReactNativeAppStateLoader(async () => appState);
+    getPurchaseUpdates.mockResolvedValue(
+      purchaseUpdatesResponse({ receiptList: [] }),
+    );
+
+    const wrapper = new AmazonBillingWrapper(
+      createBackend(),
+      amazonApiKey,
+      () => "app-user-id",
+    );
+
+    await vi.waitFor(() => {
+      expect(appState.addEventListener).toHaveBeenCalledOnce();
+      expect(getPurchaseUpdates).toHaveBeenCalledOnce();
+    });
+
+    onAppStateChange?.("active");
+
+    await vi.waitFor(() => {
+      expect(getPurchaseUpdates).toHaveBeenCalledTimes(2);
+    });
+
+    wrapper.close();
+    expect(subscription.remove).toHaveBeenCalledOnce();
+  });
+
+  test("reuses an in-flight pending-purchase sync", async () => {
+    let onAppStateChange: ((state: string) => void) | undefined;
+    setReactNativeAppStateLoader(async () => ({
+      currentState: "background",
+      addEventListener: vi.fn(
+        (_type: "change", listener: (state: string) => void) => {
+          onAppStateChange = listener;
+          return { remove: vi.fn() };
+        },
+      ),
+    }));
+    let resolvePurchaseUpdates:
+      | ((value: ReturnType<typeof purchaseUpdatesResponse>) => void)
+      | undefined;
+    getPurchaseUpdates.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePurchaseUpdates = resolve;
+      }),
+    );
+
+    const wrapper = new AmazonBillingWrapper(
+      createBackend(),
+      amazonApiKey,
+      () => "app-user-id",
+    );
+
+    await vi.waitFor(() => {
+      expect(getPurchaseUpdates).toHaveBeenCalledOnce();
+    });
+
+    onAppStateChange?.("active");
+    expect(getPurchaseUpdates).toHaveBeenCalledOnce();
+
+    resolvePurchaseUpdates?.(purchaseUpdatesResponse({ receiptList: [] }));
+    await vi.waitFor(() => {
+      expect(getPurchaseUpdates).toHaveBeenCalledOnce();
+    });
+    wrapper.close();
+  });
+
   test("fails clearly when the Amazon SDK loader has not been wired up", async () => {
     resetAmazonAppstoreIAPSDKLoader();
 
     await expect(
-      new AmazonBillingWrapper(createBackend(), amazonApiKey).getProducts(
-        "user",
-        ["monthly"],
-      ),
+      new AmazonBillingWrapper(
+        createBackend(),
+        amazonApiKey,
+        getNoAppUserId,
+      ).getProducts("user", ["monthly"]),
     ).rejects.toMatchObject({
       errorCode: ErrorCode.ConfigurationError,
       message:
@@ -238,9 +328,11 @@ describe("AmazonBillingWrapper", () => {
       "getPreviouslySentReceiptIds",
     ).mockResolvedValue(new Set(["already-synced"]));
 
-    await new AmazonBillingWrapper(backend, amazonApiKey).syncPendingPurchases(
-      "app-user-id",
-    );
+    new AmazonBillingWrapper(backend, amazonApiKey, () => "app-user-id");
+
+    await vi.waitFor(() => {
+      expect(backend.postReceipt).toHaveBeenCalledOnce();
+    });
 
     expect(backend.postReceipt).toHaveBeenCalledExactlyOnceWith(
       "app-user-id",
@@ -273,9 +365,11 @@ describe("AmazonBillingWrapper", () => {
       "getPreviouslySentReceiptIds",
     ).mockResolvedValue(new Set(["amazon-receipt-id"]));
 
-    await new AmazonBillingWrapper(backend, amazonApiKey).syncPendingPurchases(
-      "app-user-id",
-    );
+    new AmazonBillingWrapper(backend, amazonApiKey, () => "app-user-id");
+
+    await vi.waitFor(() => {
+      expect(debugLog).toHaveBeenCalledWith("Found no receipts to sync");
+    });
 
     expect(backend.postReceipt).not.toHaveBeenCalled();
     expect(debugLog).toHaveBeenCalledWith("Found no receipts to sync");
@@ -299,6 +393,7 @@ describe("AmazonBillingWrapper", () => {
       const result = await new AmazonBillingWrapper(
         createBackend(),
         amazonApiKey,
+        getNoAppUserId,
       ).getProducts("user", ["monthly"]);
 
       expect(getProductData).toHaveBeenCalledExactlyOnceWith({
@@ -321,10 +416,11 @@ describe("AmazonBillingWrapper", () => {
         responseForProducts([product({ sku: "monthly" })]),
       );
 
-      await new AmazonBillingWrapper(createBackend(), amazonApiKey).getProducts(
-        "user",
-        ["monthly", "yearly", "monthly", "yearly"],
-      );
+      await new AmazonBillingWrapper(
+        createBackend(),
+        amazonApiKey,
+        getNoAppUserId,
+      ).getProducts("user", ["monthly", "yearly", "monthly", "yearly"]);
 
       expect(getProductData).toHaveBeenCalledExactlyOnceWith({
         skus: ["monthly", "yearly"],
@@ -338,10 +434,11 @@ describe("AmazonBillingWrapper", () => {
       );
       getProductData.mockResolvedValue(responseForProducts([]));
 
-      await new AmazonBillingWrapper(createBackend(), amazonApiKey).getProducts(
-        "user",
-        productIds,
-      );
+      await new AmazonBillingWrapper(
+        createBackend(),
+        amazonApiKey,
+        getNoAppUserId,
+      ).getProducts("user", productIds);
 
       expect(getProductData).toHaveBeenCalledExactlyOnceWith({
         skus: productIds,
@@ -367,6 +464,7 @@ describe("AmazonBillingWrapper", () => {
       const result = await new AmazonBillingWrapper(
         createBackend(),
         amazonApiKey,
+        getNoAppUserId,
       ).getProducts("user", productIds);
 
       expect(getProductData).toHaveBeenNthCalledWith(1, {
@@ -398,10 +496,11 @@ describe("AmazonBillingWrapper", () => {
         .mockResolvedValueOnce(responseForProducts([]))
         .mockResolvedValueOnce(responseForProducts([]));
 
-      await new AmazonBillingWrapper(createBackend(), amazonApiKey).getProducts(
-        "user",
-        requestedProductIds,
-      );
+      await new AmazonBillingWrapper(
+        createBackend(),
+        amazonApiKey,
+        getNoAppUserId,
+      ).getProducts("user", requestedProductIds);
 
       expect(getProductData).toHaveBeenCalledTimes(2);
       expect(getProductData).toHaveBeenNthCalledWith(1, {
@@ -453,9 +552,9 @@ describe("AmazonBillingWrapper", () => {
           successfulPurchaseUpdatesResponse(),
         );
 
-        await new AmazonBillingWrapper(backend, amazonApiKey)[method](
-          "app-user-id",
-        );
+        await new AmazonBillingWrapper(backend, amazonApiKey, getNoAppUserId)[
+          method
+        ]("app-user-id");
 
         expect(getPurchaseUpdates).toHaveBeenCalledExactlyOnceWith({
           reset: true,
@@ -473,7 +572,11 @@ describe("AmazonBillingWrapper", () => {
       const getPreviouslySentReceiptIds = vi
         .spyOn(VegaDeviceCache.prototype, "getPreviouslySentReceiptIds")
         .mockResolvedValue(new Set(["amazon-receipt-id"]));
-      const wrapper = new AmazonBillingWrapper(backend, amazonApiKey);
+      const wrapper = new AmazonBillingWrapper(
+        backend,
+        amazonApiKey,
+        getNoAppUserId,
+      );
 
       await wrapper.syncPurchases("app-user-id");
       await wrapper.syncPurchases("app-user-id");
@@ -537,9 +640,11 @@ describe("AmazonBillingWrapper", () => {
       vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
       getPurchaseUpdates.mockResolvedValue(successfulPurchaseUpdatesResponse());
 
-      await new AmazonBillingWrapper(backend, amazonApiKey).syncPurchases(
-        "app-user-id",
-      );
+      await new AmazonBillingWrapper(
+        backend,
+        amazonApiKey,
+        getNoAppUserId,
+      ).syncPurchases("app-user-id");
 
       expect(backend.postReceipt).toHaveBeenCalledBefore(
         backend.getCustomerInfo as ReturnType<typeof vi.fn>,
@@ -573,9 +678,11 @@ describe("AmazonBillingWrapper", () => {
         }),
       );
 
-      await new AmazonBillingWrapper(backend, amazonApiKey).syncPurchases(
-        "app-user-id",
-      );
+      await new AmazonBillingWrapper(
+        backend,
+        amazonApiKey,
+        getNoAppUserId,
+      ).syncPurchases("app-user-id");
 
       expect(backend.postReceipt).toHaveBeenCalledTimes(2);
       expect(backend.postReceipt).toHaveBeenNthCalledWith(
@@ -612,9 +719,11 @@ describe("AmazonBillingWrapper", () => {
       });
       getPurchaseUpdates.mockResolvedValue(successfulPurchaseUpdatesResponse());
 
-      await new AmazonBillingWrapper(backend, amazonApiKey).restorePurchases(
-        "app-user-id",
-      );
+      await new AmazonBillingWrapper(
+        backend,
+        amazonApiKey,
+        getNoAppUserId,
+      ).restorePurchases("app-user-id");
 
       expect(notifyFulfillment).toHaveBeenCalledOnce();
       expect(warningLog).toHaveBeenCalledWith(
@@ -659,9 +768,9 @@ describe("AmazonBillingWrapper", () => {
             }),
           );
 
-        await new AmazonBillingWrapper(backend, amazonApiKey)[method](
-          "app-user-id",
-        );
+        await new AmazonBillingWrapper(backend, amazonApiKey, getNoAppUserId)[
+          method
+        ]("app-user-id");
 
         expect(getPurchaseUpdates).toHaveBeenCalledTimes(2);
         expect(getPurchaseUpdates).toHaveBeenNthCalledWith(1, { reset: true });
@@ -724,9 +833,9 @@ describe("AmazonBillingWrapper", () => {
             }),
           );
 
-        await new AmazonBillingWrapper(backend, amazonApiKey)[method](
-          "app-user-id",
-        );
+        await new AmazonBillingWrapper(backend, amazonApiKey, getNoAppUserId)[
+          method
+        ]("app-user-id");
 
         expect(backend.postReceipt).toHaveBeenNthCalledWith(
           1,
@@ -763,9 +872,9 @@ describe("AmazonBillingWrapper", () => {
           purchaseUpdatesResponse({ receiptList: [] }),
         );
 
-        await new AmazonBillingWrapper(backend, amazonApiKey)[method](
-          "app-user-id",
-        );
+        await new AmazonBillingWrapper(backend, amazonApiKey, getNoAppUserId)[
+          method
+        ]("app-user-id");
 
         expect(backend.postReceipt).not.toHaveBeenCalled();
         expect(backend.getCustomerInfo).toHaveBeenCalledExactlyOnceWith(
@@ -782,9 +891,9 @@ describe("AmazonBillingWrapper", () => {
           purchaseUpdatesResponse({ hasMore: true, receiptList: [] }),
         );
 
-        await new AmazonBillingWrapper(backend, amazonApiKey)[method](
-          "app-user-id",
-        );
+        await new AmazonBillingWrapper(backend, amazonApiKey, getNoAppUserId)[
+          method
+        ]("app-user-id");
 
         expect(getPurchaseUpdates).toHaveBeenCalledExactlyOnceWith({
           reset: true,
@@ -806,7 +915,11 @@ describe("AmazonBillingWrapper", () => {
         getPurchaseUpdates.mockResolvedValue(
           successfulPurchaseUpdatesResponse(),
         );
-        const wrapper = new AmazonBillingWrapper(backend, amazonApiKey);
+        const wrapper = new AmazonBillingWrapper(
+          backend,
+          amazonApiKey,
+          getNoAppUserId,
+        );
 
         await expect(wrapper[method]("app-user-id")).rejects.toBe(error);
         await wrapper[method]("app-user-id");
@@ -861,9 +974,9 @@ describe("AmazonBillingWrapper", () => {
         );
 
         await expect(
-          new AmazonBillingWrapper(backend, amazonApiKey)[method](
-            "app-user-id",
-          ),
+          new AmazonBillingWrapper(backend, amazonApiKey, getNoAppUserId)[
+            method
+          ]("app-user-id"),
         ).rejects.toMatchObject({ errorCode, message });
 
         expect(backend.postReceipt).not.toHaveBeenCalled();
@@ -879,9 +992,9 @@ describe("AmazonBillingWrapper", () => {
         getPurchaseUpdates.mockRejectedValue(error);
 
         await expect(
-          new AmazonBillingWrapper(backend, amazonApiKey)[method](
-            "app-user-id",
-          ),
+          new AmazonBillingWrapper(backend, amazonApiKey, getNoAppUserId)[
+            method
+          ]("app-user-id"),
         ).rejects.toMatchObject({
           errorCode: ErrorCode.StoreProblemError,
           message: `${method === "restorePurchases" ? "Restoring" : "Syncing"} purchases with the Amazon Store failed.`,
@@ -914,6 +1027,7 @@ describe("AmazonBillingWrapper", () => {
       const result = await new AmazonBillingWrapper(
         backend,
         amazonApiKey,
+        getNoAppUserId,
       ).purchase(params, appUserId);
 
       expect(purchase).toHaveBeenCalledExactlyOnceWith({ sku: "monthly" });
@@ -947,7 +1061,11 @@ describe("AmazonBillingWrapper", () => {
     test("posts the price from the package in the purchase params", async () => {
       const backend = createBackend();
       vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
-      const wrapper = new AmazonBillingWrapper(backend, amazonApiKey);
+      const wrapper = new AmazonBillingWrapper(
+        backend,
+        amazonApiKey,
+        getNoAppUserId,
+      );
 
       await wrapper.purchase(
         { rcPackage: createMonthlyPackageMock() },
@@ -986,7 +1104,11 @@ describe("AmazonBillingWrapper", () => {
         },
       };
 
-      await new AmazonBillingWrapper(backend, amazonApiKey).purchase(
+      await new AmazonBillingWrapper(
+        backend,
+        amazonApiKey,
+        getNoAppUserId,
+      ).purchase(
         { rcPackage, purchaseOption: selectedPurchaseOption },
         appUserId,
       );
@@ -1009,10 +1131,11 @@ describe("AmazonBillingWrapper", () => {
       const backend = createBackend();
       vi.mocked(backend.postReceipt).mockResolvedValue(customerInfoResponse);
 
-      await new AmazonBillingWrapper(backend, amazonApiKey).purchase(
-        { rcPackage: createMonthlyPackageMock() },
-        appUserId,
-      );
+      await new AmazonBillingWrapper(
+        backend,
+        amazonApiKey,
+        getNoAppUserId,
+      ).purchase({ rcPackage: createMonthlyPackageMock() }, appUserId);
 
       expect(
         vi.mocked(VegaDeviceCache.prototype.addSuccessfullyPostedReceiptId),
@@ -1030,10 +1153,11 @@ describe("AmazonBillingWrapper", () => {
       ).mockRejectedValueOnce(new Error("disk unavailable"));
 
       await expect(
-        new AmazonBillingWrapper(backend, amazonApiKey).purchase(
-          { rcPackage: createMonthlyPackageMock() },
-          appUserId,
-        ),
+        new AmazonBillingWrapper(
+          backend,
+          amazonApiKey,
+          getNoAppUserId,
+        ).purchase({ rcPackage: createMonthlyPackageMock() }, appUserId),
       ).resolves.toMatchObject({ operationSessionId: "amazon-receipt-id" });
 
       expect(notifyFulfillment).toHaveBeenCalledOnce();
@@ -1059,6 +1183,7 @@ describe("AmazonBillingWrapper", () => {
       const result = await new AmazonBillingWrapper(
         backend,
         amazonApiKey,
+        getNoAppUserId,
       ).purchase(params, appUserId);
 
       expect(backend.postReceipt).toHaveBeenCalledWith(
@@ -1107,10 +1232,11 @@ describe("AmazonBillingWrapper", () => {
         });
 
         await expect(
-          new AmazonBillingWrapper(backend, amazonApiKey).purchase(
-            { rcPackage: createMonthlyPackageMock() },
-            appUserId,
-          ),
+          new AmazonBillingWrapper(
+            backend,
+            amazonApiKey,
+            getNoAppUserId,
+          ).purchase({ rcPackage: createMonthlyPackageMock() }, appUserId),
         ).rejects.toMatchObject({ errorCode, message });
 
         expect(backend.postReceipt).not.toHaveBeenCalled();
@@ -1129,10 +1255,11 @@ describe("AmazonBillingWrapper", () => {
       });
 
       await expect(
-        new AmazonBillingWrapper(backend, amazonApiKey).purchase(
-          { rcPackage: createMonthlyPackageMock() },
-          appUserId,
-        ),
+        new AmazonBillingWrapper(
+          backend,
+          amazonApiKey,
+          getNoAppUserId,
+        ).purchase({ rcPackage: createMonthlyPackageMock() }, appUserId),
       ).rejects.toMatchObject({
         errorCode: ErrorCode.StoreProblemError,
         message: "Amazon purchase failed",
@@ -1152,10 +1279,11 @@ describe("AmazonBillingWrapper", () => {
       vi.mocked(backend.postReceipt).mockRejectedValue(postReceiptError);
 
       await expect(
-        new AmazonBillingWrapper(backend, amazonApiKey).purchase(
-          { rcPackage: createMonthlyPackageMock() },
-          appUserId,
-        ),
+        new AmazonBillingWrapper(
+          backend,
+          amazonApiKey,
+          getNoAppUserId,
+        ).purchase({ rcPackage: createMonthlyPackageMock() }, appUserId),
       ).rejects.toBe(postReceiptError);
 
       expect(notifyFulfillment).not.toHaveBeenCalled();
@@ -1167,10 +1295,11 @@ describe("AmazonBillingWrapper", () => {
       purchase.mockRejectedValue(amazonError);
 
       await expect(
-        new AmazonBillingWrapper(backend, amazonApiKey).purchase(
-          { rcPackage: createMonthlyPackageMock() },
-          appUserId,
-        ),
+        new AmazonBillingWrapper(
+          backend,
+          amazonApiKey,
+          getNoAppUserId,
+        ).purchase({ rcPackage: createMonthlyPackageMock() }, appUserId),
       ).rejects.toBe(amazonError);
 
       expect(backend.postReceipt).not.toHaveBeenCalled();
@@ -1206,10 +1335,11 @@ describe("AmazonBillingWrapper", () => {
         notifyFulfillment.mockResolvedValue({ responseCode });
 
         await expect(
-          new AmazonBillingWrapper(backend, amazonApiKey).purchase(
-            { rcPackage: createMonthlyPackageMock() },
-            appUserId,
-          ),
+          new AmazonBillingWrapper(
+            backend,
+            amazonApiKey,
+            getNoAppUserId,
+          ).purchase({ rcPackage: createMonthlyPackageMock() }, appUserId),
         ).resolves.toMatchObject({ operationSessionId: "amazon-receipt-id" });
 
         expect(notifyFulfillment).toHaveBeenCalledOnce();
@@ -1230,10 +1360,11 @@ describe("AmazonBillingWrapper", () => {
       notifyFulfillment.mockRejectedValue(fulfillmentError);
 
       await expect(
-        new AmazonBillingWrapper(backend, amazonApiKey).purchase(
-          { rcPackage: createMonthlyPackageMock() },
-          appUserId,
-        ),
+        new AmazonBillingWrapper(
+          backend,
+          amazonApiKey,
+          getNoAppUserId,
+        ).purchase({ rcPackage: createMonthlyPackageMock() }, appUserId),
       ).resolves.toMatchObject({ operationSessionId: "amazon-receipt-id" });
 
       expect(backend.postReceipt).toHaveBeenCalledOnce();

--- a/src/tests/amazon/amazon-billing-wrapper.test.ts
+++ b/src/tests/amazon/amazon-billing-wrapper.test.ts
@@ -285,6 +285,83 @@ describe("AmazonBillingWrapper", () => {
     wrapper.close();
   });
 
+  test("handles failures from a coalesced pending-purchase sync once", async () => {
+    let onAppStateChange: ((state: string) => void) | undefined;
+    setReactNativeAppStateLoader(async () => ({
+      currentState: "background",
+      addEventListener: vi.fn(
+        (_type: "change", listener: (state: string) => void) => {
+          onAppStateChange = listener;
+          return { remove: vi.fn() };
+        },
+      ),
+    }));
+    let rejectPurchaseUpdates: ((reason?: unknown) => void) | undefined;
+    getPurchaseUpdates.mockReturnValue(
+      new Promise((_, reject) => {
+        rejectPurchaseUpdates = reject;
+      }),
+    );
+    vi.spyOn(
+      VegaDeviceCache.prototype,
+      "getPreviouslySentReceiptIds",
+    ).mockResolvedValue(new Set());
+    const warnLog = vi.spyOn(Logger, "warnLog");
+
+    const wrapper = new AmazonBillingWrapper(
+      createBackend(),
+      amazonApiKey,
+      () => "app-user-id",
+    );
+
+    await vi.waitFor(() => {
+      expect(getPurchaseUpdates).toHaveBeenCalledOnce();
+    });
+
+    onAppStateChange?.("active");
+    rejectPurchaseUpdates?.(new Error("fetch failed"));
+
+    await vi.waitFor(() => {
+      expect(warnLog).toHaveBeenCalledExactlyOnceWith(
+        "Failed to sync pending Amazon purchases in the background: PurchasesError(code: StoreProblemError, message: Syncing purchases with the Amazon Store failed.)",
+      );
+    });
+    wrapper.close();
+  });
+
+  test("does not throw when a pending-purchase sync fails", async () => {
+    let rejectPurchaseUpdates: ((reason?: unknown) => void) | undefined;
+    getPurchaseUpdates.mockReturnValue(
+      new Promise((_, reject) => {
+        rejectPurchaseUpdates = reject;
+      }),
+    );
+    vi.spyOn(
+      VegaDeviceCache.prototype,
+      "getPreviouslySentReceiptIds",
+    ).mockResolvedValue(new Set());
+
+    const wrapper = new AmazonBillingWrapper(
+      createBackend(),
+      amazonApiKey,
+      () => "app-user-id",
+    );
+
+    await vi.waitFor(() => {
+      expect(getPurchaseUpdates).toHaveBeenCalledOnce();
+    });
+
+    const pendingSync = (
+      wrapper as unknown as { pendingSync: Promise<void> | undefined }
+    ).pendingSync;
+    expect(pendingSync).toBeDefined();
+
+    rejectPurchaseUpdates?.(new Error("fetch failed"));
+
+    await expect(pendingSync).resolves.toBeUndefined();
+    wrapper.close();
+  });
+
   test("fails clearly when the Amazon SDK loader has not been wired up", async () => {
     resetAmazonAppstoreIAPSDKLoader();
 

--- a/src/tests/amazon/amazon-billing-wrapper.test.ts
+++ b/src/tests/amazon/amazon-billing-wrapper.test.ts
@@ -64,6 +64,7 @@ import {
 import {
   resetReactNativeAppStateLoader,
   setReactNativeAppStateLoader,
+  type ReactNativeAppState,
 } from "../../amazon/react-native-app-state-loader";
 import { AmazonBillingWrapper } from "../../amazon/amazon-billing-wrapper";
 import { VegaDeviceCache } from "../../amazon/vega-device-cache";
@@ -209,7 +210,7 @@ describe("AmazonBillingWrapper", () => {
   test("syncs pending receipts when the Vega app returns to the foreground", async () => {
     let onAppStateChange: ((state: string) => void) | undefined;
     const subscription = { remove: vi.fn() };
-    const appState = {
+    const appState: ReactNativeAppState = {
       currentState: "background",
       addEventListener: vi.fn(
         (_type: "change", listener: (state: string) => void) => {

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -332,8 +332,13 @@ describe("Purchases.configure()", () => {
 
 describe("billing wrapper selection", () => {
   test("syncs pending Amazon purchases at initialization", async () => {
-    const syncPendingPurchases = vi
-      .spyOn(AmazonBillingWrapper.prototype, "syncPendingPurchases")
+    const triggerSyncPendingPurchases = vi
+      .spyOn(
+        AmazonBillingWrapper.prototype as unknown as {
+          triggerSyncPendingPurchases: () => Promise<void>;
+        },
+        "triggerSyncPendingPurchases",
+      )
       .mockResolvedValue();
     const purchases = configurePurchases(
       testUserId,
@@ -342,7 +347,7 @@ describe("billing wrapper selection", () => {
     );
 
     await vi.waitFor(() => {
-      expect(syncPendingPurchases).toHaveBeenCalledExactlyOnceWith(testUserId);
+      expect(triggerSyncPendingPurchases).toHaveBeenCalledOnce();
     });
 
     purchases.close();

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -353,6 +353,23 @@ describe("billing wrapper selection", () => {
     purchases.close();
   });
 
+  test("closes the existing Amazon billing wrapper when reconfiguring", () => {
+    vi.spyOn(
+      AmazonBillingWrapper.prototype as unknown as {
+        syncPendingPurchasesInBackground: () => Promise<void>;
+      },
+      "syncPendingPurchasesInBackground",
+    ).mockResolvedValue();
+    const close = vi.spyOn(AmazonBillingWrapper.prototype, "close");
+
+    configurePurchases(testUserId, "rcSource", "amzn_valid_key");
+    const purchases = configurePurchases(testUserId, "rcSource", testApiKey);
+
+    expect(close).toHaveBeenCalledOnce();
+
+    purchases.close();
+  });
+
   test("requires the Vega entry point for offerings with an Amazon API key", async () => {
     const purchases = configurePurchases(
       testUserId,

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -332,12 +332,12 @@ describe("Purchases.configure()", () => {
 
 describe("billing wrapper selection", () => {
   test("syncs pending Amazon purchases at initialization", async () => {
-    const triggerSyncPendingPurchases = vi
+    const syncPendingPurchasesInBackground = vi
       .spyOn(
         AmazonBillingWrapper.prototype as unknown as {
-          triggerSyncPendingPurchases: () => Promise<void>;
+          syncPendingPurchasesInBackground: () => Promise<void>;
         },
-        "triggerSyncPendingPurchases",
+        "syncPendingPurchasesInBackground",
       )
       .mockResolvedValue();
     const purchases = configurePurchases(
@@ -347,7 +347,7 @@ describe("billing wrapper selection", () => {
     );
 
     await vi.waitFor(() => {
-      expect(triggerSyncPendingPurchases).toHaveBeenCalledOnce();
+      expect(syncPendingPurchasesInBackground).toHaveBeenCalledOnce();
     });
 
     purchases.close();

--- a/src/tests/vega.test.ts
+++ b/src/tests/vega.test.ts
@@ -8,6 +8,10 @@ const { keplerFileSystem } = vi.hoisted(() => ({
   keplerFileSystem: { readFileAsString: vi.fn(), writeStringToFile: vi.fn() },
 }));
 
+const { appState } = vi.hoisted(() => ({
+  appState: { currentState: "active", addEventListener: vi.fn() },
+}));
+
 vi.mock("@amazon-devices/keplerscript-appstore-iap-lib", () => ({
   ProductDataResponseCode: { SUCCESSFUL: 1, NOT_SUPPORTED: 2, FAILED: 3 },
   ProductType: { CONSUMABLE: 1, ENTITLED: 2, SUBSCRIPTION: 3 },
@@ -18,8 +22,13 @@ vi.mock("@amazon-devices/kepler-file-system", () => ({
   KeplerFileSystem: keplerFileSystem,
 }));
 
+vi.mock("react-native", () => ({
+  AppState: appState,
+}));
+
 import { loadAmazonAppstoreIAPSDK } from "../amazon/amazon-appstore-iap-sdk-loader";
 import { loadKeplerFileSystem } from "../amazon/kepler-file-system-loader";
+import { loadReactNativeAppState } from "../amazon/react-native-app-state-loader";
 import { defaultHttpConfig } from "../entities/http-config";
 import { Purchases } from "../vega";
 import { testUserId } from "./base.purchases_test";
@@ -43,6 +52,10 @@ describe("Vega entry point", () => {
 
   test("wires the Kepler File System loader", async () => {
     expect(await loadKeplerFileSystem()).toBe(keplerFileSystem);
+  });
+
+  test("wires the React Native AppState loader", async () => {
+    expect(await loadReactNativeAppState()).toBe(appState);
   });
 
   test("configures with an Amazon API key", () => {

--- a/src/vega.ts
+++ b/src/vega.ts
@@ -14,12 +14,15 @@
  */
 import * as AmazonVegaSdk from "@amazon-devices/keplerscript-appstore-iap-lib";
 import { KeplerFileSystem } from "@amazon-devices/kepler-file-system";
+import { AppState } from "react-native";
 import { setAmazonAppstoreIAPSDKLoader } from "./amazon/amazon-appstore-iap-sdk-loader";
 import { setKeplerFileSystemLoader } from "./amazon/kepler-file-system-loader";
+import { setReactNativeAppStateLoader } from "./amazon/react-native-app-state-loader";
 import { activateVegaEntryPoint } from "./vega-entry-point";
 
 setAmazonAppstoreIAPSDKLoader(async () => AmazonVegaSdk);
 setKeplerFileSystemLoader(async () => KeplerFileSystem);
+setReactNativeAppStateLoader(async () => AppState);
 activateVegaEntryPoint();
 
 export * from "./main";

--- a/vite.vega.config.js
+++ b/vite.vega.config.js
@@ -26,6 +26,7 @@ export default defineConfig({
       external: [
         "@amazon-devices/kepler-file-system",
         "@amazon-devices/keplerscript-appstore-iap-lib",
+        "react-native",
       ],
     },
   },


### PR DESCRIPTION
## Changes introduced
Runs the unposted receipt sync whenever the vega app is foregrounded in addition to when the SDK is configured. This is a crucial step in supporting Quick Subscribe.

The foregrounding transition is detected using the React Native `AppState` APIs, which means that we needed to add React Native as a dependency for the `AmazonBillingWrapper`, while keeping it out of the base `purchases-js` module.

If the sync triggered by foregrounding occurs while a sync is ongoing from the SDK being configured (or vise versa), the existing promise is awaited so that we don't run to sync operations at the same time.

### Testing
- Added a few unit tests
- Manually verified behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes automatic Amazon receipt posting and backend sync timing on foreground; mistakes could duplicate work or miss receipts, though coalescing and cache checks limit overlap.
> 
> **Overview**
> **Amazon / Vega billing** now re-syncs unposted receipts when the app returns to the foreground, in addition to the existing sync at SDK initialization. That foreground path is meant to support Quick Subscribe flows where purchases may need posting after the user comes back to the app.
> 
> Foreground detection uses React Native **`AppState`** through a new **`react-native-app-state-loader`** (same pluggable pattern as the Amazon IAP loader). **`react-native`** is added as an optional peer dependency and wired only from the **`@revenuecat/purchases-js/vega`** entry point so the default web bundle stays unchanged.
> 
> **`AmazonBillingWrapper`** takes a **`getAppUserId`** callback instead of a fixed user id, coalesces overlapping background syncs onto one in-flight promise, and swallows sync failures into **`warnLog`** so fire-and-forget callers don’t get unhandled rejections. **`close()`** on the billing wrapper (and **`Purchases.configure` / `Purchases.close`**) removes the AppState listener so reconfiguration doesn’t leave stale background syncs running.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4024945ad8f48d8d371f12e6e590b574c8bd430. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->