### PR TITLE
fix(vega): handle exists() function not available on OS

### DIFF
--- a/examples/amazonvega-demo/PurchaseTester/package.json
+++ b/examples/amazonvega-demo/PurchaseTester/package.json
@@ -19,6 +19,7 @@
     "release": "npm-run-all lint test build:app"
   },
   "dependencies": {
+    "@amazon-devices/kepler-compatibility": "1.0.5",
     "@amazon-devices/kepler-file-system": "0.0.7",
     "@amazon-devices/react-native-kepler": "^2.0.0",
     "@amazon-devices/keplerscript-appstore-iap-lib": "2.12.16",

--- a/examples/amazonvega-demo/PurchaseTester/pnpm-lock.yaml
+++ b/examples/amazonvega-demo/PurchaseTester/pnpm-lock.yaml
@@ -117,6 +117,12 @@ packages:
         integrity: sha512-SKdbd/Hv+mWgjhxj56y4U4Zmnq1krPOJMob5rL9kb0vxPhwCcweES0moC0NFjpauNxF5dy5FEjOouJ0JIkI1YA==,
       }
 
+  '@amazon-devices/kepler-compatibility@1.0.5':
+    resolution:
+      {
+        integrity: sha512-51JGeFW5W0J8vTz6XF1OBA+yNKz/N8NxH0OX89AulgPOLeZKnz4jjn2wSaISvoQIDqzrHe2dKapNK2NBcSD4Jg==,
+      }
+
   '@amazon-devices/kepler-file-system@0.0.7':
     resolution:
       {
@@ -7056,6 +7062,13 @@ snapshots:
       '@amazon-devices/keplerscript-commonmodules': 1.0.9000000000
 
   '@amazon-devices/kepler-compatibility-metro-config@0.0.7': {}
+
+  '@amazon-devices/kepler-compatibility@1.0.5(@babel/preset-env@7.29.7(@babel/core@7.29.7))':
+    dependencies:
+      '@amazon-devices/keplerscript-turbomodule-api': 1.2.5(@babel/preset-env@7.29.7(@babel/core@7.29.7))
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
 
   '@amazon-devices/kepler-file-system@0.0.7(@babel/preset-env@7.29.7(@babel/core@7.29.7))':
     dependencies:

--- a/examples/amazonvega-demo/PurchaseTester/pnpm-lock.yaml
+++ b/examples/amazonvega-demo/PurchaseTester/pnpm-lock.yaml
@@ -1831,9 +1831,12 @@ packages:
   '@revenuecat/purchases-js@file:../../..':
     resolution: {directory: ../../.., type: directory}
     peerDependencies:
+      '@amazon-devices/kepler-compatibility': 1.0.5
       '@amazon-devices/kepler-file-system': 0.0.7
       '@amazon-devices/keplerscript-appstore-iap-lib': 2.12.16
     peerDependenciesMeta:
+      '@amazon-devices/kepler-compatibility':
+        optional: true
       '@amazon-devices/kepler-file-system':
         optional: true
       '@amazon-devices/keplerscript-appstore-iap-lib':
@@ -8794,7 +8797,7 @@ snapshots:
       nullthrows: 1.1.1
       react-native: 0.72.0(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react@18.2.0)
 
-  '@revenuecat/purchases-js@file:../../..(@amazon-devices/kepler-file-system@0.0.7(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(@amazon-devices/keplerscript-appstore-iap-lib@2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))':
+  '@revenuecat/purchases-js@file:../../..(@amazon-devices/kepler-compatibility@1.0.5(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(@amazon-devices/kepler-file-system@0.0.7(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(@amazon-devices/keplerscript-appstore-iap-lib@2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))':
     optionalDependencies:
       '@amazon-devices/kepler-compatibility': 1.0.5(@babel/preset-env@7.29.7(@babel/core@7.29.7))
       '@amazon-devices/kepler-file-system': 0.0.7(@babel/preset-env@7.29.7(@babel/core@7.29.7))

--- a/examples/amazonvega-demo/PurchaseTester/pnpm-lock.yaml
+++ b/examples/amazonvega-demo/PurchaseTester/pnpm-lock.yaml
@@ -8783,6 +8783,7 @@ snapshots:
 
   '@revenuecat/purchases-js@file:../../..(@amazon-devices/kepler-file-system@0.0.7(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(@amazon-devices/keplerscript-appstore-iap-lib@2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))':
     optionalDependencies:
+      '@amazon-devices/kepler-compatibility': 1.0.5(@babel/preset-env@7.29.7(@babel/core@7.29.7))
       '@amazon-devices/kepler-file-system': 0.0.7(@babel/preset-env@7.29.7(@babel/core@7.29.7))
       '@amazon-devices/keplerscript-appstore-iap-lib': 2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))
 

--- a/examples/amazonvega-demo/PurchaseTester/pnpm-lock.yaml
+++ b/examples/amazonvega-demo/PurchaseTester/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 importers:
   .:
     dependencies:
+      '@amazon-devices/kepler-compatibility':
+        specifier: 1.0.5
+        version: 1.0.5(@babel/preset-env@7.29.7(@babel/core@7.29.7))
       '@amazon-devices/kepler-file-system':
         specifier: 0.0.7
         version: 0.0.7(@babel/preset-env@7.29.7(@babel/core@7.29.7))
@@ -18,7 +21,7 @@ importers:
         version: 2.0.9000000000(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react-native@0.72.0(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(react@18.2.0))(react@18.2.0)
       '@revenuecat/purchases-js':
         specifier: file:../../..
-        version: file:../../..(@amazon-devices/kepler-file-system@0.0.7(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(@amazon-devices/keplerscript-appstore-iap-lib@2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))
+        version: file:../../..(@amazon-devices/kepler-compatibility@1.0.5(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(@amazon-devices/kepler-file-system@0.0.7(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(@amazon-devices/keplerscript-appstore-iap-lib@2.12.16(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))
       react:
         specifier: 18.2.0
         version: 18.2.0

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "prepare": "husky"
   },
   "devDependencies": {
+    "@amazon-devices/kepler-compatibility": "1.0.5",
     "@amazon-devices/kepler-file-system": "0.0.7",
     "@amazon-devices/keplerscript-appstore-iap-lib": "2.12.16",
     "@eslint/js": "^9.16.0",
@@ -113,10 +114,14 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
+    "@amazon-devices/kepler-compatibility": "1.0.5",
     "@amazon-devices/kepler-file-system": "0.0.7",
     "@amazon-devices/keplerscript-appstore-iap-lib": "2.12.16"
   },
   "peerDependenciesMeta": {
+    "@amazon-devices/kepler-compatibility": {
+      "optional": true
+    },
     "@amazon-devices/kepler-file-system": {
       "optional": true
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 importers:
   .:
     devDependencies:
+      "@amazon-devices/kepler-compatibility":
+        specifier: 1.0.5
+        version: 1.0.5(@babel/preset-env@7.29.7(@babel/core@7.29.7))
       "@amazon-devices/kepler-file-system":
         specifier: 0.0.7
         version: 0.0.7(@babel/preset-env@7.29.7(@babel/core@7.29.7))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,12 @@ packages:
         integrity: sha512-12WGKBQzjUAI4ayyF4IAtfw2QR/IDoqk6jTddXDhtYTJF9ASmoE1zst7cVtP0aL/F1jUJL5r+JxKXKEgHNbEUQ==,
       }
 
+  "@amazon-devices/kepler-compatibility@1.0.5":
+    resolution:
+      {
+        integrity: sha512-51JGeFW5W0J8vTz6XF1OBA+yNKz/N8NxH0OX89AulgPOLeZKnz4jjn2wSaISvoQIDqzrHe2dKapNK2NBcSD4Jg==,
+      }
+
   "@amazon-devices/keplerscript-appstore-iap-lib@2.12.16":
     resolution:
       {
@@ -9308,6 +9314,13 @@ packages:
 
 snapshots:
   "@adobe/css-tools@4.4.1": {}
+
+  "@amazon-devices/kepler-compatibility@1.0.5(@babel/preset-env@7.29.7(@babel/core@7.29.7))":
+    dependencies:
+      "@amazon-devices/keplerscript-turbomodule-api": 1.2.5(@babel/preset-env@7.29.7(@babel/core@7.29.7))
+    transitivePeerDependencies:
+      - "@babel/preset-env"
+      - supports-color
 
   "@amazon-devices/kepler-file-system@0.0.7(@babel/preset-env@7.29.7(@babel/core@7.29.7))":
     dependencies:

--- a/src/amazon/kepler-compatibility-loader.ts
+++ b/src/amazon/kepler-compatibility-loader.ts
@@ -1,41 +1,41 @@
-import type { isPresentOnOS as amazonIsPresentOnOS } from "@amazon-devices/kepler-compatibility";
 import { ErrorCode, PurchasesError } from "../entities/errors";
 
 /**
- * Shared Kepler compatibility API contract used by VegaDeviceCache.
+ * Shared Kepler File System compatibility contract used by VegaDeviceCache.
  *
- * Keeping this as an injected dependency lets the default purchases-js module
- * avoid importing the Vega-only compatibility package. The Vega entry point
- * installs the native implementation before re-exporting the public SDK API.
+ * The Vega entry point installs the OS-specific version check. Keeping the
+ * package name and version there prevents the default entry point from
+ * including Vega-only File System support.
  */
-export type IsPresentOnOS = typeof amazonIsPresentOnOS;
+export type KeplerFileSystemExistsSupportCheck = () => boolean;
 
-const missingIsPresentOnOS: IsPresentOnOS = () => {
-  throw new PurchasesError(
-    ErrorCode.ConfigurationError,
-    "Kepler compatibility APIs are supported only by the @revenuecat/purchases-js/vega entry point.",
-  );
-};
+const missingKeplerFileSystemExistsSupportCheck: KeplerFileSystemExistsSupportCheck =
+  () => {
+    throw new PurchasesError(
+      ErrorCode.ConfigurationError,
+      "Kepler compatibility APIs are supported only by the @revenuecat/purchases-js/vega entry point.",
+    );
+  };
 
-let isPresentOnOS: IsPresentOnOS = missingIsPresentOnOS;
+let keplerFileSystemExistsSupportCheck: KeplerFileSystemExistsSupportCheck =
+  missingKeplerFileSystemExistsSupportCheck;
 
 /**
- * Installs the runtime-specific Kepler compatibility implementation.
+ * Installs the Vega OS version check for Kepler File System's `exists` API.
  *
  * @internal
  */
-export function setIsPresentOnOS(implementation: IsPresentOnOS): void {
-  isPresentOnOS = implementation;
+export function setKeplerFileSystemExistsSupportCheck(
+  supportCheck: KeplerFileSystemExistsSupportCheck,
+): void {
+  keplerFileSystemExistsSupportCheck = supportCheck;
 }
 
 /**
- * Checks whether the running Vega OS provides a library version.
+ * Checks whether the running Vega OS provides Kepler File System's `exists` API.
  *
  * @internal
  */
-export function isKeplerLibraryPresentOnOS(
-  libraryName: string,
-  version: string,
-): boolean {
-  return isPresentOnOS(libraryName, version);
+export function isKeplerFileSystemExistsSupported(): boolean {
+  return keplerFileSystemExistsSupportCheck();
 }

--- a/src/amazon/kepler-compatibility-loader.ts
+++ b/src/amazon/kepler-compatibility-loader.ts
@@ -1,0 +1,41 @@
+import type { isPresentOnOS as amazonIsPresentOnOS } from "@amazon-devices/kepler-compatibility";
+import { ErrorCode, PurchasesError } from "../entities/errors";
+
+/**
+ * Shared Kepler compatibility API contract used by VegaDeviceCache.
+ *
+ * Keeping this as an injected dependency lets the default purchases-js module
+ * avoid importing the Vega-only compatibility package. The Vega entry point
+ * installs the native implementation before re-exporting the public SDK API.
+ */
+export type IsPresentOnOS = typeof amazonIsPresentOnOS;
+
+const missingIsPresentOnOS: IsPresentOnOS = () => {
+  throw new PurchasesError(
+    ErrorCode.ConfigurationError,
+    "Kepler compatibility APIs are supported only by the @revenuecat/purchases-js/vega entry point.",
+  );
+};
+
+let isPresentOnOS: IsPresentOnOS = missingIsPresentOnOS;
+
+/**
+ * Installs the runtime-specific Kepler compatibility implementation.
+ *
+ * @internal
+ */
+export function setIsPresentOnOS(implementation: IsPresentOnOS): void {
+  isPresentOnOS = implementation;
+}
+
+/**
+ * Checks whether the running Vega OS provides a library version.
+ *
+ * @internal
+ */
+export function isKeplerLibraryPresentOnOS(
+  libraryName: string,
+  version: string,
+): boolean {
+  return isPresentOnOS(libraryName, version);
+}

--- a/src/amazon/vega-device-cache.ts
+++ b/src/amazon/vega-device-cache.ts
@@ -1,7 +1,12 @@
 import {
   loadKeplerFileSystem,
+  type KeplerFileSystem,
   type KeplerFileSystemLoader,
 } from "./kepler-file-system-loader";
+import {
+  isKeplerLibraryPresentOnOS,
+  type IsPresentOnOS,
+} from "./kepler-compatibility-loader";
 
 type ReceiptCache = string[];
 
@@ -27,6 +32,7 @@ export class VegaDeviceCache {
   public constructor(
     private readonly apiKey: string,
     private readonly fileSystemLoader: KeplerFileSystemLoader = loadKeplerFileSystem,
+    private readonly isPresentOnOS: IsPresentOnOS = isKeplerLibraryPresentOnOS,
   ) {
     // As of KeplerFileSystem SDK version 0.24, there is no way to create a directory, and any attempts
     // to write to one throw a com.amazon.kepler.file_system.NotFoundError error. Therefore, we write
@@ -51,7 +57,7 @@ export class VegaDeviceCache {
 
       const fileSystem = await this.fileSystemLoader();
       const updatedReceiptIds = [...receiptIds, receiptId];
-      if (await fileSystem.exists(this.tokensCachePath)) {
+      if (await this.safeExists(fileSystem)) {
         await fileSystem.removeFile(this.tokensCachePath);
       }
       try {
@@ -79,10 +85,26 @@ export class VegaDeviceCache {
     await operation;
   }
 
+  /**
+   * `exists` arrived in Kepler File System 0.0.7. On older Vega OS versions,
+   * use a read attempt to determine whether the cache file is present.
+   */
+  private async safeExists(fileSystem: KeplerFileSystem): Promise<boolean> {
+    if (this.isPresentOnOS("@amazon-devices/kepler-file-system", "0.0.7")) {
+      return await fileSystem.exists(this.tokensCachePath);
+    }
+
+    try {
+      await fileSystem.readFileAsString(this.tokensCachePath, "UTF-8");
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   private async getReceiptIds(): Promise<ReceiptCache> {
     const fileSystem = await this.fileSystemLoader();
-    const cacheExists = await fileSystem.exists(this.tokensCachePath);
-    if (!cacheExists) {
+    if (!(await this.safeExists(fileSystem))) {
       return [];
     }
 

--- a/src/amazon/vega-device-cache.ts
+++ b/src/amazon/vega-device-cache.ts
@@ -95,6 +95,7 @@ export class VegaDeviceCache {
     }
 
     try {
+      // Throws if the file isn't found
       await fileSystem.readFileAsString(this.tokensCachePath, "UTF-8");
       return true;
     } catch {

--- a/src/amazon/vega-device-cache.ts
+++ b/src/amazon/vega-device-cache.ts
@@ -4,8 +4,8 @@ import {
   type KeplerFileSystemLoader,
 } from "./kepler-file-system-loader";
 import {
-  isKeplerLibraryPresentOnOS,
-  type IsPresentOnOS,
+  isKeplerFileSystemExistsSupported as defaultKeplerFileSystemExistsSupportCheck,
+  type KeplerFileSystemExistsSupportCheck,
 } from "./kepler-compatibility-loader";
 
 type ReceiptCache = string[];
@@ -32,7 +32,7 @@ export class VegaDeviceCache {
   public constructor(
     private readonly apiKey: string,
     private readonly fileSystemLoader: KeplerFileSystemLoader = loadKeplerFileSystem,
-    private readonly isPresentOnOS: IsPresentOnOS = isKeplerLibraryPresentOnOS,
+    private readonly isKeplerFileSystemExistsSupported: KeplerFileSystemExistsSupportCheck = defaultKeplerFileSystemExistsSupportCheck,
   ) {
     // As of KeplerFileSystem SDK version 0.24, there is no way to create a directory, and any attempts
     // to write to one throw a com.amazon.kepler.file_system.NotFoundError error. Therefore, we write
@@ -90,7 +90,7 @@ export class VegaDeviceCache {
    * use a read attempt to determine whether the cache file is present.
    */
   private async safeExists(fileSystem: KeplerFileSystem): Promise<boolean> {
-    if (this.isPresentOnOS("@amazon-devices/kepler-file-system", "0.0.7")) {
+    if (this.isKeplerFileSystemExistsSupported()) {
       return await fileSystem.exists(this.tokensCachePath);
     }
 

--- a/src/amazon/vega-device-cache.ts
+++ b/src/amazon/vega-device-cache.ts
@@ -57,7 +57,7 @@ export class VegaDeviceCache {
 
       const fileSystem = await this.fileSystemLoader();
       const updatedReceiptIds = [...receiptIds, receiptId];
-      if (await this.safeExists(fileSystem)) {
+      if (await this.doesCacheFileExist(fileSystem)) {
         await fileSystem.removeFile(this.tokensCachePath);
       }
       try {
@@ -85,11 +85,11 @@ export class VegaDeviceCache {
     await operation;
   }
 
-  /**
-   * `exists` arrived in Kepler File System 0.0.7. On older Vega OS versions,
-   * use a read attempt to determine whether the cache file is present.
-   */
-  private async safeExists(fileSystem: KeplerFileSystem): Promise<boolean> {
+  private async doesCacheFileExist(
+    fileSystem: KeplerFileSystem,
+  ): Promise<boolean> {
+    // `exists` arrived in Kepler File System 0.0.7. On older Vega OS versions,
+    // use a read attempt to determine whether the cache file is present.
     if (this.isKeplerFileSystemExistsSupported()) {
       return await fileSystem.exists(this.tokensCachePath);
     }
@@ -105,7 +105,7 @@ export class VegaDeviceCache {
 
   private async getReceiptIds(): Promise<ReceiptCache> {
     const fileSystem = await this.fileSystemLoader();
-    if (!(await this.safeExists(fileSystem))) {
+    if (!(await this.doesCacheFileExist(fileSystem))) {
       return [];
     }
 

--- a/src/amazon/vega-device-cache.ts
+++ b/src/amazon/vega-device-cache.ts
@@ -26,6 +26,7 @@ export class VegaDeviceCache {
   // More info: https://developer.amazon.com/docs/vega-api/0.24/README.amazon-devices_kepler-file-system.html
   private readonly dataDirectory = "data";
   private readonly rcStoragePrefix = "com.revenuecat.purchases";
+  private readonly cacheFileEncoding = "UTF-8";
   private readonly tokensCachePath: string;
   private writeQueue: Promise<void> = Promise.resolve();
 
@@ -64,7 +65,7 @@ export class VegaDeviceCache {
         await fileSystem.writeStringToFile(
           this.tokensCachePath,
           JSON.stringify(updatedReceiptIds),
-          "UTF-8",
+          this.cacheFileEncoding,
         );
       } catch {
         const currentReceiptIds = await this.getReceiptIds();
@@ -76,7 +77,7 @@ export class VegaDeviceCache {
         await fileSystem.writeStringToFile(
           this.tokensCachePath,
           JSON.stringify([...currentReceiptIds, receiptId]),
-          "UTF-8",
+          this.cacheFileEncoding,
         );
       }
     });
@@ -96,7 +97,10 @@ export class VegaDeviceCache {
 
     try {
       // Throws if the file isn't found
-      await fileSystem.readFileAsString(this.tokensCachePath, "UTF-8");
+      await fileSystem.readFileAsString(
+        this.tokensCachePath,
+        this.cacheFileEncoding,
+      );
       return true;
     } catch {
       return false;
@@ -112,7 +116,7 @@ export class VegaDeviceCache {
     try {
       const serializedReceiptIds = await fileSystem.readFileAsString(
         this.tokensCachePath,
-        "UTF-8",
+        this.cacheFileEncoding,
       );
       const receiptIds: unknown = JSON.parse(serializedReceiptIds);
 

--- a/src/tests/amazon/vega-device-cache.test.ts
+++ b/src/tests/amazon/vega-device-cache.test.ts
@@ -4,7 +4,7 @@ import type { KeplerFileSystem } from "../../amazon/kepler-file-system-loader";
 
 const cachePath = "/data/com.revenuecat.purchases.amzn_api_key.tokens";
 
-function createCache() {
+function createCache(supportsFileSystemExists = true) {
   const files = new Map<string, string>();
   const fileSystem = {
     exists: vi.fn(async (path: string) => files.has(path)),
@@ -26,6 +26,7 @@ function createCache() {
   const cache = new VegaDeviceCache(
     "amzn_api_key",
     async () => fileSystem as unknown as KeplerFileSystem,
+    vi.fn(() => supportsFileSystemExists),
   );
 
   return { cache, fileSystem, files };
@@ -40,6 +41,20 @@ describe("VegaDeviceCache", () => {
     );
     expect(fileSystem.exists).toHaveBeenCalledExactlyOnceWith(cachePath);
     expect(fileSystem.readFileAsString).not.toHaveBeenCalled();
+  });
+
+  test("reads the cache directly when the OS lacks exists", async () => {
+    const { cache, fileSystem, files } = createCache(false);
+    files.set(cachePath, JSON.stringify(["receipt-id"]));
+
+    await expect(cache.getPreviouslySentReceiptIds()).resolves.toEqual(
+      new Set(["receipt-id"]),
+    );
+    expect(fileSystem.readFileAsString).toHaveBeenCalledTimes(2);
+    expect(fileSystem.readFileAsString).toHaveBeenCalledWith(
+      cachePath,
+      "UTF-8",
+    );
   });
 
   test("stores raw receipt IDs", async () => {

--- a/src/tests/vega.test.ts
+++ b/src/tests/vega.test.ts
@@ -1,38 +1,38 @@
-// import { beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
-// const { purchasingService } = vi.hoisted(() => ({
-//   purchasingService: { getProductData: vi.fn() },
-// }));
+const { purchasingService } = vi.hoisted(() => ({
+  purchasingService: { getProductData: vi.fn() },
+}));
 
-// const { keplerFileSystem } = vi.hoisted(() => ({
-//   keplerFileSystem: { readFileAsString: vi.fn(), writeStringToFile: vi.fn() },
-// }));
+const { keplerFileSystem } = vi.hoisted(() => ({
+  keplerFileSystem: { readFileAsString: vi.fn(), writeStringToFile: vi.fn() },
+}));
 
-// const { isPresentOnOS } = vi.hoisted(() => ({
-//   isPresentOnOS: vi.fn(() => true),
-// }));
+const { isPresentOnOS } = vi.hoisted(() => ({
+  isPresentOnOS: vi.fn(() => true),
+}));
 
-// const { appState } = vi.hoisted(() => ({
-//   appState: { currentState: "active", addEventListener: vi.fn() },
-// }));
+const { appState } = vi.hoisted(() => ({
+  appState: { currentState: "active", addEventListener: vi.fn() },
+}));
 
-// vi.mock("@amazon-devices/keplerscript-appstore-iap-lib", () => ({
-//   ProductDataResponseCode: { SUCCESSFUL: 1, NOT_SUPPORTED: 2, FAILED: 3 },
-//   ProductType: { CONSUMABLE: 1, ENTITLED: 2, SUBSCRIPTION: 3 },
-//   PurchasingService: purchasingService,
-// }));
+vi.mock("@amazon-devices/keplerscript-appstore-iap-lib", () => ({
+  ProductDataResponseCode: { SUCCESSFUL: 1, NOT_SUPPORTED: 2, FAILED: 3 },
+  ProductType: { CONSUMABLE: 1, ENTITLED: 2, SUBSCRIPTION: 3 },
+  PurchasingService: purchasingService,
+}));
 
-// vi.mock("@amazon-devices/kepler-file-system", () => ({
-//   KeplerFileSystem: keplerFileSystem,
-// }));
+vi.mock("@amazon-devices/kepler-file-system", () => ({
+  KeplerFileSystem: keplerFileSystem,
+}));
 
-// vi.mock("@amazon-devices/kepler-compatibility", () => ({
-//   isPresentOnOS,
-// }));
+vi.mock("@amazon-devices/kepler-compatibility", () => ({
+  isPresentOnOS,
+}));
 
-// vi.mock("react-native", () => ({
-//   AppState: appState,
-// }));
+vi.mock("react-native", () => ({
+  AppState: appState,
+}));
 
 import { loadAmazonAppstoreIAPSDK } from "../amazon/amazon-appstore-iap-sdk-loader";
 import { loadKeplerFileSystem } from "../amazon/kepler-file-system-loader";

--- a/src/tests/vega.test.ts
+++ b/src/tests/vega.test.ts
@@ -8,6 +8,10 @@ const { keplerFileSystem } = vi.hoisted(() => ({
   keplerFileSystem: { readFileAsString: vi.fn(), writeStringToFile: vi.fn() },
 }));
 
+const { isPresentOnOS } = vi.hoisted(() => ({
+  isPresentOnOS: vi.fn(() => true),
+}));
+
 vi.mock("@amazon-devices/keplerscript-appstore-iap-lib", () => ({
   ProductDataResponseCode: { SUCCESSFUL: 1, NOT_SUPPORTED: 2, FAILED: 3 },
   ProductType: { CONSUMABLE: 1, ENTITLED: 2, SUBSCRIPTION: 3 },
@@ -16,6 +20,10 @@ vi.mock("@amazon-devices/keplerscript-appstore-iap-lib", () => ({
 
 vi.mock("@amazon-devices/kepler-file-system", () => ({
   KeplerFileSystem: keplerFileSystem,
+}));
+
+vi.mock("@amazon-devices/kepler-compatibility", () => ({
+  isPresentOnOS,
 }));
 
 import { loadAmazonAppstoreIAPSDK } from "../amazon/amazon-appstore-iap-sdk-loader";

--- a/src/vega.ts
+++ b/src/vega.ts
@@ -16,13 +16,15 @@ import * as AmazonVegaSdk from "@amazon-devices/keplerscript-appstore-iap-lib";
 import { isPresentOnOS } from "@amazon-devices/kepler-compatibility";
 import { KeplerFileSystem } from "@amazon-devices/kepler-file-system";
 import { setAmazonAppstoreIAPSDKLoader } from "./amazon/amazon-appstore-iap-sdk-loader";
-import { setIsPresentOnOS } from "./amazon/kepler-compatibility-loader";
+import { setKeplerFileSystemExistsSupportCheck } from "./amazon/kepler-compatibility-loader";
 import { setKeplerFileSystemLoader } from "./amazon/kepler-file-system-loader";
 import { activateVegaEntryPoint } from "./vega-entry-point";
 
 setAmazonAppstoreIAPSDKLoader(async () => AmazonVegaSdk);
 setKeplerFileSystemLoader(async () => KeplerFileSystem);
-setIsPresentOnOS(isPresentOnOS);
+setKeplerFileSystemExistsSupportCheck(() =>
+  isPresentOnOS("@amazon-devices/kepler-file-system", "0.0.7"),
+);
 activateVegaEntryPoint();
 
 export * from "./main";

--- a/src/vega.ts
+++ b/src/vega.ts
@@ -13,13 +13,16 @@
  * imports or CSP-sensitive runtime code generation.
  */
 import * as AmazonVegaSdk from "@amazon-devices/keplerscript-appstore-iap-lib";
+import { isPresentOnOS } from "@amazon-devices/kepler-compatibility";
 import { KeplerFileSystem } from "@amazon-devices/kepler-file-system";
 import { setAmazonAppstoreIAPSDKLoader } from "./amazon/amazon-appstore-iap-sdk-loader";
+import { setIsPresentOnOS } from "./amazon/kepler-compatibility-loader";
 import { setKeplerFileSystemLoader } from "./amazon/kepler-file-system-loader";
 import { activateVegaEntryPoint } from "./vega-entry-point";
 
 setAmazonAppstoreIAPSDKLoader(async () => AmazonVegaSdk);
 setKeplerFileSystemLoader(async () => KeplerFileSystem);
+setIsPresentOnOS(isPresentOnOS);
 activateVegaEntryPoint();
 
 export * from "./main";

--- a/vite.vega.config.js
+++ b/vite.vega.config.js
@@ -24,6 +24,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        "@amazon-devices/kepler-compatibility",
         "@amazon-devices/kepler-file-system",
         "@amazon-devices/keplerscript-appstore-iap-lib",
       ],


### PR DESCRIPTION
## Motivation / Description
The file system's `exist()` function wasn't introduced until the most recent version of the Kepler file system, `0.0.7`. This library is baked in to the Vega OS, so if the SDK is running on an OS version with a file system version <0.0.7, then the `exists()` function will be `undefined` at runtime, causing issues.

## Changes introduced
- We introduce a new `safeExists()` function that serves as a wrapper around `exists()`. It checks to see if `exists()` is available, and if so, uses it. If it isn't available, it gracefully falls back to attempting to read the file, while throws if the file isn't present on the disk.
- This introduces a dependency on `@amazon-devices/kepler-compatibility`, which is safely injected to the `purchases-js` SDK in the same manner as other dependencies to ensure that it won't be included for web/hybrid users of the SDK.

## Additional comments
I audited other dependencies' function calls that we use and couldn't find any other instances of functions be introduced that we need to work around.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Vega on-device receipt cache behavior on older OS versions; incorrect fallback could affect duplicate receipt handling, but scope is limited to the Vega Amazon path.
> 
> **Overview**
> Fixes **Vega receipt token caching** on OS builds where Kepler File System predates **`exists`** (added in **0.0.7**). `VegaDeviceCache` no longer calls `exists` unconditionally; it routes through **`doesCacheFileExist`**, which uses `exists` when the runtime reports support and otherwise infers presence via a **`readFileAsString`** attempt.
> 
> A new **`kepler-compatibility-loader`** holds an injectable OS capability check (default entry point still errors if used without the Vega bundle). The **`@revenuecat/purchases-js/vega`** entry registers **`isPresentOnOS("@amazon-devices/kepler-file-system", "0.0.7")`** from **`@amazon-devices/kepler-compatibility`**, added as an **optional peer** and demo dev dependency, with the Vega Vite build marking that package **external**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2892e94e2c6b1a65edf59d4835687b480033bcc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->