### PR TITLE
Stabilize PaymentEntryPage Chromatic snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@storybook/addon-svelte-csf": "^5.0.6",
     "@storybook/svelte": "^8.6.15",
     "@storybook/sveltekit": "^8.6.15",
+    "@storybook/test": "^8.6.15",
     "@stripe/stripe-js": "^9.7.0",
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
     "@testing-library/jest-dom": "^6.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       "@storybook/sveltekit":
         specifier: ^8.6.15
         version: 8.6.15(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(jiti@2.7.0)(yaml@2.9.0)))(postcss-load-config@3.1.4(postcss@8.5.3))(postcss@8.5.3)(storybook@8.6.15(prettier@3.4.2))(svelte@5.46.4)(vite@6.4.1(@types/node@22.10.5)(jiti@2.7.0)(yaml@2.9.0))
+      "@storybook/test":
+        specifier: ^8.6.15
+        version: 8.6.15(storybook@8.6.15(prettier@3.4.2))
       "@stripe/stripe-js":
         specifier: ^9.7.0
         version: 9.7.0

--- a/src/stories/pages/payment-entry-page.stories.svelte
+++ b/src/stories/pages/payment-entry-page.stories.svelte
@@ -1,5 +1,6 @@
 <script module lang="ts">
   import { defineMeta, type StoryContext } from "@storybook/addon-svelte-csf";
+  import { expect, waitFor, within } from "@storybook/test";
   import PurchasesInner from "../../ui/purchases-ui-inner.svelte";
   import { brandingLanguageViewportModes } from "../../../.storybook/modes";
   import {
@@ -47,6 +48,16 @@
         modes: brandingLanguageViewportModes,
         diffThreshold: 0.49,
       },
+    },
+    play: async ({ canvasElement }) => {
+      const canvas = within(canvasElement);
+
+      await waitFor(
+        async () => {
+          await expect(canvas.getByTestId("PayButton")).toBeVisible();
+        },
+        { timeout: 10_000 },
+      );
     },
     // @ts-ignore ignore importing before initializing
     render: template,
@@ -101,15 +112,7 @@
   />
 {/snippet}
 
-<Story
-  name="Default"
-  args={{ ...defaultArgs, currentPage: "payment-entry" }}
-  parameters={{
-    chromatic: {
-      delay: 1000,
-    },
-  }}
-/>
+<Story name="Default" args={{ ...defaultArgs, currentPage: "payment-entry" }} />
 
 <Story
   name="With Checkout Consent"
@@ -119,21 +122,11 @@
     requireCheckoutConsent: true,
     termsAndConditionsUrl: "https://example.com/terms",
   }}
-  parameters={{
-    chromatic: {
-      delay: 1000,
-    },
-  }}
 />
 
 <Story
   name="With Sandbox Banner"
   args={{ ...defaultArgs, currentPage: "payment-entry", isSandbox: true }}
-  parameters={{
-    chromatic: {
-      delay: 1000,
-    },
-  }}
 />
 
 <Story
@@ -143,11 +136,6 @@
     currentPage: "payment-entry",
     showDiscountCodeField: true,
     isDiscountCodeControlsEnabled: true,
-  }}
-  parameters={{
-    chromatic: {
-      delay: 1000,
-    },
   }}
 />
 
@@ -160,11 +148,6 @@
     draftDiscountCode: "BADCODE",
     discountCodeError: "Invalid discount code.",
     isDiscountCodeControlsEnabled: true,
-  }}
-  parameters={{
-    chromatic: {
-      delay: 1000,
-    },
   }}
 />
 
@@ -206,11 +189,6 @@
     appliedDiscountCode: "SAVE10",
     isDiscountCodeControlsEnabled: true,
   }}
-  parameters={{
-    chromatic: {
-      delay: 1000,
-    },
-  }}
 />
 
 <Story
@@ -220,11 +198,6 @@
     currentPage: "payment-entry",
     isSandbox: true,
     customerEmail: "test@test.com",
-  }}
-  parameters={{
-    chromatic: {
-      delay: 1000,
-    },
   }}
 />
 
@@ -242,11 +215,6 @@
     },
     purchaseOptionToUse: subscriptionOptionWithTrial,
     defaultPurchaseOption: subscriptionOptionWithTrial,
-  }}
-  parameters={{
-    chromatic: {
-      delay: 1000,
-    },
   }}
 />
 
@@ -269,11 +237,6 @@
     purchaseOptionToUse: subscriptionOptionWithTrialAndIntroPricePaidUpfront,
     defaultPurchaseOption: subscriptionOptionWithTrialAndIntroPricePaidUpfront,
   }}
-  parameters={{
-    chromatic: {
-      delay: 1000,
-    },
-  }}
 />
 
 <Story
@@ -287,11 +250,6 @@
     purchaseOptionToUse: nonSubscriptionOption,
     defaultPurchaseOption: nonSubscriptionOption,
   }}
-  parameters={{
-    chromatic: {
-      delay: 1000,
-    },
-  }}
 />
 
 <Story
@@ -301,11 +259,6 @@
     currentPage: "payment-entry",
     withTaxes: true,
   }}
-  parameters={{
-    chromatic: {
-      delay: 1000,
-    },
-  }}
 />
 
 <Story
@@ -314,11 +267,6 @@
     ...defaultArgs,
     currentPage: "payment-entry",
     fullAddressCollectionMode: "always",
-  }}
-  parameters={{
-    chromatic: {
-      delay: 1000,
-    },
   }}
 />
 
@@ -337,11 +285,6 @@
     purchaseOptionToUse: subscriptionOptionWithTrial,
     defaultPurchaseOption: subscriptionOptionWithTrial,
     withTaxes: true,
-  }}
-  parameters={{
-    chromatic: {
-      delay: 1000,
-    },
   }}
 />
 
@@ -364,11 +307,6 @@
     defaultPurchaseOption: subscriptionOptionWithTrialAndIntroPricePaidUpfront,
     withTaxes: true,
   }}
-  parameters={{
-    chromatic: {
-      delay: 1000,
-    },
-  }}
 />
 
 <Story
@@ -389,11 +327,6 @@
     purchaseOptionToUse: subscriptionOptionWithTrialAndIntroPriceRecurring,
     defaultPurchaseOption: subscriptionOptionWithTrialAndIntroPriceRecurring,
     withTaxes: true,
-  }}
-  parameters={{
-    chromatic: {
-      delay: 1000,
-    },
   }}
 />
 
@@ -416,11 +349,6 @@
     defaultPurchaseOption: subscriptionOptionWithIntroPricePaidUpfront,
     withTaxes: true,
   }}
-  parameters={{
-    chromatic: {
-      delay: 1000,
-    },
-  }}
 />
 
 <Story
@@ -442,11 +370,6 @@
     defaultPurchaseOption: subscriptionOptionWithIntroPriceRecurring,
     withTaxes: true,
   }}
-  parameters={{
-    chromatic: {
-      delay: 1000,
-    },
-  }}
 />
 
 <Story
@@ -460,11 +383,6 @@
       taxCalculationStatus: "miss-match",
     },
   }}
-  parameters={{
-    chromatic: {
-      delay: 1000,
-    },
-  }}
 />
 
 <Story
@@ -474,11 +392,6 @@
     currentPage: "payment-entry",
     termsAndConditionsUrl: "https://www.revenuecat.com/terms",
   }}
-  parameters={{
-    chromatic: {
-      delay: 1000,
-    },
-  }}
 />
 
 <Story
@@ -487,10 +400,5 @@
     ...defaultArgs,
     currentPage: "payment-entry",
     forceEnableWalletMethods: true,
-  }}
-  parameters={{
-    chromatic: {
-      delay: 1000,
-    },
   }}
 />

--- a/src/stories/pages/payment-entry-page.stories.svelte
+++ b/src/stories/pages/payment-entry-page.stories.svelte
@@ -56,7 +56,7 @@
         async () => {
           await expect(canvas.getByTestId("PayButton")).toBeVisible();
         },
-        { timeout: 30_000 },
+        { timeout: 14_000 },
       );
     },
     // @ts-ignore ignore importing before initializing

--- a/src/stories/pages/payment-entry-page.stories.svelte
+++ b/src/stories/pages/payment-entry-page.stories.svelte
@@ -161,7 +161,7 @@
       originalAmountInMicros: 9900000,
       totalAmountInMicros: 8900000,
       totalExcludingTaxInMicros: 8900000,
-      taxCalculationStatus: "unavailable",
+      taxCalculationStatus: "disabled",
       taxAmountInMicros: 0,
       taxBreakdown: null,
       appliedDiscounts: [

--- a/src/stories/pages/payment-entry-page.stories.svelte
+++ b/src/stories/pages/payment-entry-page.stories.svelte
@@ -56,7 +56,7 @@
         async () => {
           await expect(canvas.getByTestId("PayButton")).toBeVisible();
         },
-        { timeout: 10_000 },
+        { timeout: 30_000 },
       );
     },
     // @ts-ignore ignore importing before initializing


### PR DESCRIPTION
## Summary

- wait for the PaymentEntryPage form to become visible in a shared Storybook play function before Chromatic captures it
- remove the fixed one-second delay from every PaymentEntryPage story
- declare the Storybook testing utilities as a direct development dependency

## Why

Stripe Elements can take longer than one second to finish loading, so Chromatic could capture the form while its contents were still hidden. The play function now waits for the payment button to become visible, which happens only after the required Stripe Elements report that they are ready and the application reveals the form.
