### PR TITLE
fix(vega): set X-Platform header to "amazon" when configured with an amazon API key

### DIFF
--- a/src/networking/http-client.ts
+++ b/src/networking/http-client.ts
@@ -3,7 +3,10 @@ import type { BackendErrorCode } from "../entities/errors";
 import { ErrorCode, ErrorCodeUtils, PurchasesError } from "../entities/errors";
 import { RC_ENDPOINT, VERSION } from "../helpers/constants";
 import { StatusCodes } from "http-status-codes";
-import { isWebBillingSandboxApiKey } from "../helpers/api-key-helper";
+import {
+  isAmazonApiKey,
+  isWebBillingSandboxApiKey,
+} from "../helpers/api-key-helper";
 import type { HttpConfig } from "../entities/http-config";
 import { Purchases } from "../main";
 
@@ -152,7 +155,7 @@ export function getHeaders(
     [AUTHORIZATION_HEADER]: `Bearer ${apiKey}`,
     [CONTENT_TYPE_HEADER]: "application/json",
     [ACCEPT_HEADER]: "application/json",
-    [PLATFORM_HEADER]: "web",
+    [PLATFORM_HEADER]: isAmazonApiKey(apiKey) ? "amazon" : "web",
     [VERSION_HEADER]: VERSION,
     [IS_SANDBOX_HEADER]: `${isWebBillingSandboxApiKey(apiKey)}`,
   };

--- a/src/tests/behavioral-events/events-tracker.test.ts
+++ b/src/tests/behavioral-events/events-tracker.test.ts
@@ -136,6 +136,28 @@ describe("EventsTracker", (test) => {
     });
   });
 
+  test("uses the Amazon platform header for events when configured with an Amazon API key", async () => {
+    let requestPerformed: Request | undefined;
+    server.events.on("request:start", (req) => {
+      requestPerformed = req.request;
+    });
+    const eventsTracker = new EventsTracker({
+      apiKey: "amzn_valid_key",
+      appUserId: "someAppUserId",
+      rcSource: "rcSource",
+    });
+
+    eventsTracker.trackExternalEvent({
+      eventName: "external",
+      source: "sdk",
+    });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(requestPerformed?.headers.get("X-Platform")).toEqual("amazon");
+
+    eventsTracker.dispose();
+  });
+
   test<EventsTrackerFixtures>("passes the checkout trace id to the event", async ({
     eventsTracker,
   }) => {

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -131,6 +131,22 @@ describe("httpConfig is setup correctly", () => {
     expect(headers.get("X-Platform-Flavor")).toEqual("flutter");
     expect(headers.get("X-Platform-Flavor-Version")).toEqual("1.2.3");
   });
+
+  test("uses the Amazon platform header when configured with an Amazon API key", async () => {
+    setCustomerInfoResponse(
+      HttpResponse.json(customerInfoResponse, { status: 200 }),
+    );
+
+    let requestPerformed: Request | undefined;
+    server.events.on("request:start", (req) => {
+      requestPerformed = req.request;
+    });
+    backend = new Backend("amzn_valid_key");
+
+    await backend.getCustomerInfo("someAppUserId");
+
+    expect(requestPerformed?.headers.get("X-Platform")).toEqual("amazon");
+  });
 });
 
 describe("getCustomerInfo request", () => {


### PR DESCRIPTION
## Changes introduced
Sets the `X-Platform` header to `amazon` when using an Amazon API key to match the behavior in `purchases-android`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, conditional change to a request header with test coverage; no auth or payload logic changes.
> 
> **Overview**
> Outgoing SDK requests now send **`X-Platform: amazon`** when the configured API key is recognized as Amazon, instead of always using **`web`**. The logic lives in shared `getHeaders` in `http-client.ts`, so it applies to backend API calls and behavioral event posts alike.
> 
> This matches **`purchases-android`** so RevenueCat can route and attribute Amazon integrations correctly. Tests cover `Backend` customer-info requests and `EventsTracker` event flushes with an `amzn_valid_key`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f22122d2b3b3849b5e379484dbdd4a569aaa46b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->