### PR TITLE
fix(vega): don't include X-Is-Sandbox header for Amazon store

### DIFF
--- a/src/networking/http-client.ts
+++ b/src/networking/http-client.ts
@@ -151,13 +151,16 @@ export function getHeaders(
   headers?: { [key: string]: string },
   additionalHeaders?: { [key: string]: string },
 ): { [key: string]: string } {
+  const isAmazon = isAmazonApiKey(apiKey);
   let all_headers = {
     [AUTHORIZATION_HEADER]: `Bearer ${apiKey}`,
     [CONTENT_TYPE_HEADER]: "application/json",
     [ACCEPT_HEADER]: "application/json",
-    [PLATFORM_HEADER]: isAmazonApiKey(apiKey) ? "amazon" : "web",
+    [PLATFORM_HEADER]: isAmazon ? "amazon" : "web",
     [VERSION_HEADER]: VERSION,
-    [IS_SANDBOX_HEADER]: `${isWebBillingSandboxApiKey(apiKey)}`,
+    ...(!isAmazon && {
+      [IS_SANDBOX_HEADER]: `${isWebBillingSandboxApiKey(apiKey)}`,
+    }),
   };
   const platformInfo = Purchases.getPlatformInfo();
   if (platformInfo) {
@@ -174,6 +177,11 @@ export function getHeaders(
     // The order here is intentional, so we don't allow overriding the SDK
     // headers with additional headers.
     all_headers = { ...additionalHeaders, ...all_headers };
+  }
+  if (isAmazon) {
+    // Amazon does not expose whether the app is running in a sandbox environment.
+    // Do not allow caller-provided headers to send an inaccurate value either.
+    delete all_headers[IS_SANDBOX_HEADER];
   }
   return all_headers;
 }

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -109,6 +109,37 @@ describe("httpConfig is setup correctly", () => {
     expect(headers.get("X-Is-Sandbox")).toEqual("false");
   });
 
+  test("includes the sandbox header for non-Amazon API key types", async () => {
+    server.use(
+      http.get("http://localhost:8000/v1/subscribers/someAppUserId", () =>
+        HttpResponse.json(customerInfoResponse, { status: 200 }),
+      ),
+    );
+
+    const requests: Request[] = [];
+    server.events.on("request:start", (req) => {
+      requests.push(req.request);
+    });
+    const apiKeys = [
+      { apiKey: "rcb_valid_key", isSandbox: false },
+      { apiKey: "rcb_sb_valid_key", isSandbox: true },
+      { apiKey: "pdl_valid_key", isSandbox: false },
+      { apiKey: "strp_valid_key", isSandbox: false },
+      { apiKey: "strp_sb_valid_key", isSandbox: true },
+      { apiKey: "test_valid_key", isSandbox: false },
+    ];
+
+    for (const { apiKey, isSandbox } of apiKeys) {
+      backend = new Backend(apiKey);
+      await backend.getCustomerInfo("someAppUserId");
+
+      const latestRequest = requests.at(-1);
+      expect(latestRequest?.headers.get("X-Is-Sandbox")).toEqual(
+        `${isSandbox}`,
+      );
+    }
+  });
+
   test("expected platformInfo headers are sent", async () => {
     setCustomerInfoResponse(
       HttpResponse.json(customerInfoResponse, { status: 200 }),
@@ -146,6 +177,26 @@ describe("httpConfig is setup correctly", () => {
     await backend.getCustomerInfo("someAppUserId");
 
     expect(requestPerformed?.headers.get("X-Platform")).toEqual("amazon");
+  });
+
+  test("omits the sandbox header when configured with an Amazon API key", async () => {
+    setCustomerInfoResponse(
+      HttpResponse.json(customerInfoResponse, { status: 200 }),
+    );
+
+    let requestPerformed: Request | undefined;
+    server.events.on("request:start", (req) => {
+      requestPerformed = req.request;
+    });
+    backend = new Backend("amzn_valid_key", {
+      additionalHeaders: {
+        "X-Is-Sandbox": "false",
+      },
+    });
+
+    await backend.getCustomerInfo("someAppUserId");
+
+    expect(requestPerformed?.headers.get("X-Is-Sandbox")).toBeNull();
   });
 });
 

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -125,7 +125,6 @@ describe("httpConfig is setup correctly", () => {
       { apiKey: "rcb_sb_valid_key", isSandbox: true },
       { apiKey: "pdl_valid_key", isSandbox: false },
       { apiKey: "strp_valid_key", isSandbox: false },
-      { apiKey: "strp_sb_valid_key", isSandbox: true },
       { apiKey: "test_valid_key", isSandbox: false },
     ];
 


### PR DESCRIPTION
## Motivation / Description
The Amazon store doesn't provide a way for us to determine at runtime if a Vega app is running in the AppTest, DevTest, Live App Test, or production environments. Thus, we can't tell if we're running in sandbox mode or not. The JS SDK was always including the `X-Is-Sandbox` header in all HTTP requests, which was inaccurately always sending `true` when running a Vega app. This causes unintended consequences in the backend, primarily events that have the wrong sandbox value. Luckily, the value isn't used for processing receipts :)

## Changes introduced
The SDK no longer includes the `X-Is-Sandbox` header in HTTP requests when the SDK is configured with an Amazon API key. This matches the behavior in `purchases-android`, where `X-Is-Sandbox` is never included in HTTP requests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to request headers for Amazon only; aligns with purchases-android and fixes incorrect sandbox signaling without touching receipt processing logic.
> 
> **Overview**
> Stops sending **`X-Is-Sandbox`** on backend HTTP requests when the SDK is configured with an **Amazon API key**, because Vega/Amazon apps cannot reliably know sandbox vs production at runtime and the header was misleading backend events.
> 
> In `getHeaders`, the sandbox header is only added for non-Amazon keys (still derived from web billing sandbox key detection). For Amazon, the header is **removed after** merging caller and `additionalHeaders` so nothing can reintroduce a false sandbox value. Non-Amazon behavior is unchanged.
> 
> Tests cover sandbox header values across several key types and assert Amazon requests omit the header even when `additionalHeaders` try to set it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8215218a01992ba1b8840a43762de3424ed61b5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->