### PR TITLE
fix(vega): suppress generic web billing events on vega

### DIFF
--- a/src/behavioural-events/events-tracker.ts
+++ b/src/behavioural-events/events-tracker.ts
@@ -2,6 +2,7 @@ import { generateUUID } from "../helpers/uuid-helper";
 import { RC_ANALYTICS_ENDPOINT } from "../helpers/constants";
 import { HttpMethods } from "msw";
 import { getHeaders } from "../networking/http-client";
+import { isAmazonApiKey } from "../helpers/api-key-helper";
 import { FlushManager, type FlushOptions } from "./flush-manager";
 import { Logger } from "../helpers/logger";
 import { defaultPurchaseMode, Event, type EventProperties } from "./event";
@@ -70,6 +71,7 @@ export default class EventsTracker implements IEventsTracker {
   private readonly traceId: string;
   private appUserId: string;
   private readonly isSilent: boolean;
+  private readonly suppressGenericEvents: boolean;
   private rcSource: string | null;
   private readonly workflowContext?: WorkflowContext;
   private isDisposed: boolean = false;
@@ -81,6 +83,7 @@ export default class EventsTracker implements IEventsTracker {
     this.eventsUrl = `${props.httpConfig?.eventsURL ?? RC_ANALYTICS_ENDPOINT}/v1/events`;
     this.appUserId = props.appUserId;
     this.isSilent = props.silent || false;
+    this.suppressGenericEvents = isAmazonApiKey(props.apiKey);
     this.rcSource = props.rcSource;
     this.workflowContext = props.workflowContext;
     this.traceId = props.trace_id || generateUUID();
@@ -163,6 +166,9 @@ export default class EventsTracker implements IEventsTracker {
   private trackEvent(props: TrackEventProps) {
     if (this.isSilent) {
       Logger.verboseLog("Skipping event tracking, the EventsTracker is silent");
+      return;
+    }
+    if (this.suppressGenericEvents) {
       return;
     }
     try {

--- a/src/tests/behavioral-events/events-tracker.test.ts
+++ b/src/tests/behavioral-events/events-tracker.test.ts
@@ -152,11 +152,7 @@ describe("EventsTracker", (test) => {
     });
   });
 
-  test("uses the Amazon platform header for events when configured with an Amazon API key", async () => {
-    let requestPerformed: Request | undefined;
-    server.events.on("request:start", (req) => {
-      requestPerformed = req.request;
-    });
+  test("does not track generic web billing events with an Amazon API key", async () => {
     const eventsTracker = new EventsTracker({
       apiKey: "amzn_valid_key",
       appUserId: "someAppUserId",
@@ -169,7 +165,68 @@ describe("EventsTracker", (test) => {
     });
     await vi.advanceTimersToNextTimerAsync();
 
-    expect(requestPerformed?.headers.get("X-Platform")).toEqual("amazon");
+    expect(APIPostRequest).not.toHaveBeenCalled();
+
+    eventsTracker.dispose();
+  });
+
+  test("tracks custom paywall impressions with an Amazon API key", async () => {
+    const eventsTracker = new EventsTracker({
+      apiKey: "amzn_valid_key",
+      appUserId: "someAppUserId",
+      rcSource: "rcSource",
+    });
+
+    eventsTracker.trackCustomPaywallImpression({
+      offeringId: "offering-789",
+    });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(APIPostRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        json: expect.objectContaining({
+          events: expect.arrayContaining([
+            expect.objectContaining({
+              type: "custom_paywall_impression",
+              offering_id: "offering-789",
+            }),
+          ]),
+        }),
+      }),
+    );
+
+    eventsTracker.dispose();
+  });
+
+  test("tracks standard paywall events with an Amazon API key", async () => {
+    const eventsTracker = new EventsTracker({
+      apiKey: "amzn_valid_key",
+      appUserId: "someAppUserId",
+      rcSource: "rcSource",
+    });
+
+    eventsTracker.trackPaywallEvent({
+      type: "paywall_impression",
+      appUserId: "someAppUserId",
+      sessionId: "paywall-session",
+      offeringId: "offering-789",
+      paywallRevision: 1,
+      paywallRcPublicId: "pw-123",
+    });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(APIPostRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        json: expect.objectContaining({
+          events: expect.arrayContaining([
+            expect.objectContaining({
+              type: "paywall_impression",
+              offering_id: "offering-789",
+            }),
+          ]),
+        }),
+      }),
+    );
 
     eventsTracker.dispose();
   });

--- a/src/tests/purchase.events.test.ts
+++ b/src/tests/purchase.events.test.ts
@@ -70,7 +70,7 @@ describe("Purchases.configure()", () => {
     });
   });
 
-  test("does not track SDKInitialized when configured with an Amazon API key", async () => {
+  test("does not track sdk_initialized event when configured with an Amazon API key", async () => {
     Purchases.getSharedInstance().close();
     APIPostRequest.mockReset();
 

--- a/src/tests/purchase.events.test.ts
+++ b/src/tests/purchase.events.test.ts
@@ -70,6 +70,19 @@ describe("Purchases.configure()", () => {
     });
   });
 
+  test("does not track SDKInitialized when configured with an Amazon API key", async () => {
+    Purchases.getSharedInstance().close();
+    APIPostRequest.mockReset();
+
+    Purchases.configure({
+      apiKey: "amzn_valid_key",
+      appUserId: testUserId,
+    });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(APIPostRequest).not.toHaveBeenCalled();
+  });
+
   test("tracks the CheckoutSessionStarted event upon starting a purchase", async () => {
     const purchases = Purchases.getSharedInstance();
     const offerings = await purchases.getOfferings();


### PR DESCRIPTION
## Motivation / Description
The JS SDK emits many events that are web-billing specific, and that the backend classifies as RCBilling events. We were incorrectly emitting these events when running on Vega. This caused events to be emitted by Vega apps that got classified as web billing events by the backend.

## Changes introduced
Prevents the SDK from emitting generic web billing events (including sdk_initialized) when the SDK is initialized with an Amazon API key. Paywall events are still emitted, as they aren't classified as web billing events in the backend.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only behavior gated on API key prefix; purchase and paywall event paths are explicitly preserved in tests.
> 
> **Overview**
> **Stops generic web billing analytics** (e.g. `sdk_initialized`, external/SDK `web_billing` events) when `EventsTracker` is constructed with an **Amazon API key** (`isAmazonApiKey`), so Vega apps no longer send events the backend misclassifies as RCBilling.
> 
> The guard lives in private `trackEvent` via a new `suppressGenericEvents` flag set in the constructor. **Paywall and custom paywall impression events are unchanged** and still flush to `/v1/events`.
> 
> Tests replace the old Amazon `X-Platform` header expectation with coverage that generic tracking is skipped while paywall paths still post, plus a `Purchases.configure` case asserting no `sdk_initialized` for `amzn_valid_key`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd13f185e869cad9ccfcbb87549b3e23d6579e68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->