### PR TITLE
feat: add five discount paywall variables

### DIFF
--- a/src/helpers/paywall-offer-helpers.ts
+++ b/src/helpers/paywall-offer-helpers.ts
@@ -6,6 +6,7 @@ import type {
   SubscriptionOption,
 } from "../entities/offerings";
 import { type Translator } from "../ui/localization/translator";
+import { LocalizationKeys } from "../ui/localization/supportedLanguages";
 import { getNextRenewalDate, type Period } from "./duration-helper";
 import { getPeriodVariables } from "./paywall-period-helpers";
 import { getPriceVariables } from "./paywall-price-helpers";
@@ -57,6 +58,82 @@ function getOfferEndDate(period: Period, translator: Translator): string {
     : "";
 }
 
+function isDiscountPhase(offer: OfferPhase): offer is DiscountPhase {
+  return "durationMode" in offer;
+}
+
+/**
+ * The offer's price, but only when it can be compared like-for-like against the
+ * standard renewal price: same billing period, and not free. Returns null otherwise
+ * so the discount variables render empty rather than a misleading number.
+ */
+function comparableOfferPriceMicros(
+  product: SubscriptionOption,
+  offer: OfferPhase,
+): number | null {
+  if (offer.price === null || offer.price.amountMicros <= 0) {
+    return null;
+  }
+
+  // A discount always replaces the base plan's own renewal price, so it is comparable by
+  // construction. Its `period` can't be compared directly: `toDiscountPhase` normalizes it
+  // to a single unit and moves the count into `cycleCount`, so a discount on a 3-month base
+  // plan carries `{number: 1, unit: Month}` and a raw comparison would wrongly reject it.
+  if (isDiscountPhase(offer)) {
+    return offer.price.amountMicros;
+  }
+
+  // Trials and intro prices bill on their own period, which only lines up with the standard
+  // price when it matches the base period exactly.
+  const basePeriod = product.base.period;
+  const offerPeriod = offer.period;
+
+  if (
+    basePeriod === null ||
+    offerPeriod === null ||
+    offerPeriod.number !== basePeriod.number ||
+    offerPeriod.unit !== basePeriod.unit
+  ) {
+    return null;
+  }
+
+  return offer.price.amountMicros;
+}
+
+function setOfferDiscountVariables(
+  product: SubscriptionOption,
+  offer: OfferPhase,
+  translator: Translator,
+  variables: VariableDictionary,
+) {
+  const standardPrice = product.base.price;
+  const offerPriceMicros = comparableOfferPriceMicros(product, offer);
+
+  if (
+    standardPrice === null ||
+    standardPrice.amountMicros <= 0 ||
+    offerPriceMicros === null
+  ) {
+    return;
+  }
+
+  const savingMicros = standardPrice.amountMicros - offerPriceMicros;
+  if (savingMicros <= 0) {
+    return;
+  }
+
+  variables["product.offer_absolute_discount"] = translator.formatPrice(
+    savingMicros,
+    standardPrice.currency,
+  );
+  variables["product.offer_relative_discount"] = translator.translate(
+    LocalizationKeys.PaywallVariablesSubRelativeDiscount,
+    {
+      discount: ((savingMicros * 100) / standardPrice.amountMicros).toFixed(0),
+    },
+  );
+}
+
 export function setOfferVariables(
   product: SubscriptionOption,
   translator: Translator,
@@ -69,6 +146,8 @@ export function setOfferVariables(
   if (primaryOffer === null) {
     return;
   }
+
+  setOfferDiscountVariables(product, primaryOffer, translator, variables);
 
   const offerDuration = getOfferDuration(primaryOffer);
   const offerPricingPeriod = getOfferPricingPeriod(product, primaryOffer);

--- a/src/helpers/paywall-offer-helpers.ts
+++ b/src/helpers/paywall-offer-helpers.ts
@@ -10,6 +10,7 @@ import { LocalizationKeys } from "../ui/localization/supportedLanguages";
 import { getNextRenewalDate, type Period } from "./duration-helper";
 import { getPeriodVariables } from "./paywall-period-helpers";
 import { getPriceVariables } from "./paywall-price-helpers";
+import { getPricePerPeriodFactors } from "./price-conversion-helper";
 
 export type OfferPhase = PricingPhase | DiscountPhase;
 
@@ -60,6 +61,68 @@ function getOfferEndDate(period: Period, translator: Translator): string {
 
 function isDiscountPhase(offer: OfferPhase): offer is DiscountPhase {
   return "durationMode" in offer;
+}
+
+/**
+ * The period an offer's price is quoted against. A discount replaces the base plan's own
+ * renewal price, so its rate is per base period; `toDiscountPhase` normalizes its own
+ * `period` to a single unit, which would misprice a discount on a multi-month plan.
+ * Trials and intro prices bill on their own period.
+ *
+ * Note this covers every discount phase, whereas `getOfferPricingPeriod` above only special-cases
+ * `time_window` ones. The two therefore disagree for a `forever` discount on a multi-unit base
+ * plan, where `offer_price_per_*` still uses the normalized period and so reports a different
+ * monthly rate than these variables do. That looks like a latent bug in `offer_price_per_*` rather
+ * than something to replicate here — tracked separately, since changing it would move a value
+ * already rendering on live paywalls.
+ */
+function offerRatePeriod(
+  product: SubscriptionOption,
+  offer: OfferPhase,
+): Period | null {
+  return isDiscountPhase(offer) ? product.base.period : offer.period;
+}
+
+/**
+ * The currently applicable offer expressed as a monthly rate plus the span it runs for, for
+ * the `*_with_offer` variables. Returns null when there is no usable offer, so callers fall
+ * back to the package's own base price and period.
+ *
+ * `durationInMonths` is null when the offer never reverts (a "forever" discount): there is no
+ * term over which a total saving accrues, so the absolute variant renders empty.
+ */
+export function getOfferRate(product: SubscriptionOption): {
+  ratePerMonthMicros: number;
+  durationInMonths: number | null;
+} | null {
+  const offer = product.discount ?? product.trial ?? product.introPrice;
+
+  // A free offer is treated as no offer: "100% off" isn't the claim these variables make.
+  if (offer === null || offer.price === null || offer.price.amountMicros <= 0) {
+    return null;
+  }
+
+  const ratePeriod = offerRatePeriod(product, offer);
+  if (ratePeriod === null) {
+    return null;
+  }
+
+  const rateFactor = getPricePerPeriodFactors(ratePeriod).perMonth;
+  if (rateFactor <= 0) {
+    return null;
+  }
+
+  const duration = getOfferDuration(offer);
+  const durationFactor = duration
+    ? getPricePerPeriodFactors(duration).perMonth
+    : 0;
+
+  return {
+    ratePerMonthMicros: offer.price.amountMicros * rateFactor,
+    // perMonth is "how many of this period fit in a month", so its reciprocal is the
+    // period expressed in months.
+    durationInMonths: durationFactor > 0 ? 1 / durationFactor : null,
+  };
 }
 
 /**

--- a/src/helpers/paywall-variables-helpers.ts
+++ b/src/helpers/paywall-variables-helpers.ts
@@ -14,6 +14,7 @@ import {
 import { LocalizationKeys } from "../ui/localization/supportedLanguages";
 import { getPeriodVariables } from "./paywall-period-helpers";
 import { getPricePerPeriodFactors } from "./price-conversion-helper";
+import { floorMicrosToCurrencyUnit } from "./price-labels";
 import { getPriceVariables } from "./paywall-price-helpers";
 import {
   setNonSubscriptionOfferVariables,
@@ -200,6 +201,9 @@ function parsePackageIntoVariables(
     "product.secondary_offer_period": "",
     "product.secondary_offer_period_abbreviated": "",
     "product.relative_discount": "",
+    "product.absolute_discount": "",
+    "product.offer_relative_discount": "",
+    "product.offer_absolute_discount": "",
   };
 
   if (productIsSubscription(productType, purchaseOption)) {
@@ -247,9 +251,14 @@ function parsePackageIntoVariables(
     }
 
     // Calculate discount based on monthly equivalent prices
-    if (highestPricePackage) {
+    const highestMonthlyPrice = highestPricePackage
+      ? getPackageMonthlyPrice(highestPricePackage)
+      : 0;
+
+    // A zero-priced anchor makes the ratio NaN, and `NaN < 1` is false, so the
+    // suppression below would fail open and render "NaN%".
+    if (highestMonthlyPrice > 0) {
       const packageMonthlyPrice = getPackageMonthlyPrice(pkg);
-      const highestMonthlyPrice = getPackageMonthlyPrice(highestPricePackage);
       const discount =
         ((highestMonthlyPrice - packageMonthlyPrice) * 100) /
         highestMonthlyPrice;
@@ -262,6 +271,28 @@ function parsePackageIntoVariables(
               {
                 discount: discount.toFixed(0),
               },
+            );
+
+      // The absolute saving is expressed over this package's own period rather than
+      // per month. A ratio is period-invariant so `relative_discount` can normalize
+      // on any unit, but a currency amount changes with whatever unit it's quoted in,
+      // so it's anchored to the term actually being purchased. `perMonth` converts a
+      // period total into a monthly price, so dividing by it converts the monthly
+      // delta back into this package's period.
+      const perMonth = basePeriod
+        ? getPricePerPeriodFactors(basePeriod).perMonth
+        : 0;
+      baseObject["product.absolute_discount"] =
+        discount < 1 || perMonth <= 0
+          ? ""
+          : translator.formatPrice(
+              // Floor rather than round, so a derived saving never overstates what the
+              // customer saves. Matches `getPriceVariables` and `toPricingPhase`.
+              floorMicrosToCurrencyUnit(
+                (highestMonthlyPrice - packageMonthlyPrice) / perMonth,
+                productPrice.currency,
+              ),
+              productPrice.currency,
             );
     }
 

--- a/src/helpers/paywall-variables-helpers.ts
+++ b/src/helpers/paywall-variables-helpers.ts
@@ -17,6 +17,7 @@ import { getPricePerPeriodFactors } from "./price-conversion-helper";
 import { floorMicrosToCurrencyUnit } from "./price-labels";
 import { getPriceVariables } from "./paywall-price-helpers";
 import {
+  getOfferRate,
   setNonSubscriptionOfferVariables,
   setOfferVariables,
 } from "./paywall-offer-helpers";
@@ -204,6 +205,8 @@ function parsePackageIntoVariables(
     "product.absolute_discount": "",
     "product.offer_relative_discount": "",
     "product.offer_absolute_discount": "",
+    "product.relative_discount_with_offer": "",
+    "product.absolute_discount_with_offer": "",
   };
 
   if (productIsSubscription(productType, purchaseOption)) {
@@ -290,6 +293,46 @@ function parsePackageIntoVariables(
               // customer saves. Matches `getPriceVariables` and `toPricingPhase`.
               floorMicrosToCurrencyUnit(
                 (highestMonthlyPrice - packageMonthlyPrice) / perMonth,
+                productPrice.currency,
+              ),
+              productPrice.currency,
+            );
+
+      // The `*_with_offer` pair is the same cross-package comparison, but priced off the
+      // offer the customer would actually get. With no usable offer the effective rate and
+      // term are the package's own, so these collapse to the two variables above.
+      const offerRate = getOfferRate(purchaseOption);
+      const effectiveRate =
+        offerRate?.ratePerMonthMicros ?? packageMonthlyPrice;
+      const effectiveMonths =
+        offerRate !== null
+          ? offerRate.durationInMonths
+          : perMonth > 0
+            ? 1 / perMonth
+            : null;
+
+      const offerDelta = highestMonthlyPrice - effectiveRate;
+      const offerDiscount = (offerDelta * 100) / highestMonthlyPrice;
+
+      baseObject["product.relative_discount_with_offer"] =
+        offerDiscount < 1
+          ? ""
+          : translator.translate(
+              LocalizationKeys.PaywallVariablesSubRelativeDiscount,
+              {
+                discount: offerDiscount.toFixed(0),
+              },
+            );
+
+      // A "forever" discount never reverts, so there is no term over which a total saving
+      // accrues and `effectiveMonths` is null. Render empty, as the bare variables already
+      // do for a package with no period.
+      baseObject["product.absolute_discount_with_offer"] =
+        offerDiscount < 1 || effectiveMonths === null
+          ? ""
+          : translator.formatPrice(
+              floorMicrosToCurrencyUnit(
+                offerDelta * effectiveMonths,
                 productPrice.currency,
               ),
               productPrice.currency,

--- a/src/tests/helpers/paywall-variables-helper.test.ts
+++ b/src/tests/helpers/paywall-variables-helper.test.ts
@@ -830,3 +830,325 @@ describe("getPaywallVariables", () => {
     });
   });
 });
+
+describe("discount variables", () => {
+  test("absolute_discount is expressed over the package's own period", () => {
+    /**
+     * Monthly €10.00/mo is the anchor. Annual €60.00/yr is €5.00/mo, so the
+     * per-month gap is €5.00 — but the annual buyer's actual saving over the
+     * year they're buying is (€10.00 × 12) − €60.00 = €60.00.
+     */
+    const off = toOffering([
+      {
+        packageIdentifier: "$rc_monthly",
+        identifier: "monthly_bingo",
+        title: "Monthly",
+        basePriceMicros: 10000000,
+      },
+      {
+        packageIdentifier: "$rc_annual",
+        identifier: "annual_bingo",
+        title: "Annual",
+        period: { unit: PeriodUnit.Year, number: 1 },
+        basePriceMicros: 60000000,
+      },
+    ]);
+
+    const variables = parseOfferingIntoVariables(off, enTranslator);
+
+    expect(variables.$rc_annual["product.absolute_discount"]).toBe("€60.00");
+    expect(variables.$rc_annual["product.relative_discount"]).toBe("50%");
+  });
+
+  test("absolute_discount is empty for the anchor package itself", () => {
+    const off = toOffering([
+      {
+        packageIdentifier: "$rc_monthly",
+        identifier: "monthly_bingo",
+        title: "Monthly",
+        basePriceMicros: 10000000,
+      },
+      {
+        packageIdentifier: "$rc_annual",
+        identifier: "annual_bingo",
+        title: "Annual",
+        period: { unit: PeriodUnit.Year, number: 1 },
+        basePriceMicros: 60000000,
+      },
+    ]);
+
+    const variables = parseOfferingIntoVariables(off, enTranslator);
+
+    expect(variables.$rc_monthly["product.absolute_discount"]).toBe("");
+    expect(variables.$rc_monthly["product.relative_discount"]).toBe("");
+  });
+
+  test("absolute_discount normalizes a weekly anchor to the package's period", () => {
+    /**
+     * Weekly €6.00/wk ≈ €26.07/mo is the anchor; the monthly package's own
+     * period is 1 month, so it saves ≈ €23.07 per month.
+     */
+    const off = toOffering([
+      {
+        packageIdentifier: "$rc_monthly",
+        identifier: "monthly_bingo",
+        title: "Monthly",
+        basePriceMicros: 3000000,
+      },
+      {
+        packageIdentifier: "$rc_weekly",
+        identifier: "weekly_bingo",
+        title: "Weekly",
+        period: { unit: PeriodUnit.Week, number: 1 },
+        basePriceMicros: 6000000,
+      },
+    ]);
+
+    const variables = parseOfferingIntoVariables(off, enTranslator);
+
+    expect(variables.$rc_monthly["product.absolute_discount"]).toBe("€23.07");
+    expect(variables.$rc_monthly["product.relative_discount"]).toBe("88%");
+  });
+
+  test("absolute_discount is empty for non-subscription packages", () => {
+    const off = toNonSubscriptionOffering([
+      {
+        packageIdentifier: "lifetime",
+        identifier: "lifetime_basic",
+        title: "Lifetime Basic",
+        basePriceMicros: 100000000,
+      },
+    ]);
+
+    const variables = parseOfferingIntoVariables(off, enTranslator);
+
+    expect(variables.lifetime["product.absolute_discount"]).toBe("");
+  });
+
+  test("offer discounts compare the offer price to the standard renewal price", () => {
+    // €9.00/mo base with a €1.99/mo intro for 3 cycles: saves €7.01, 78% off.
+    const off = toOffering([
+      {
+        packageIdentifier: "$rc_monthly",
+        identifier: "monthly_bingo",
+        title: "Monthly",
+        basePriceMicros: 9000000,
+        introPrice: {
+          periodDuration: "P1M",
+          period: { number: 1, unit: PeriodUnit.Month },
+          cycleCount: 3,
+          price: toPrice(1990000, "EUR"),
+          pricePerWeek: null,
+          pricePerMonth: null,
+          pricePerYear: null,
+        },
+      },
+    ]);
+
+    const variables = parseOfferingIntoVariables(off, enTranslator);
+
+    expect(variables.$rc_monthly["product.offer_absolute_discount"]).toBe(
+      "€7.01",
+    );
+    expect(variables.$rc_monthly["product.offer_relative_discount"]).toBe(
+      "78%",
+    );
+  });
+
+  test("offer discounts are empty when the offer period differs from the base period", () => {
+    // €15.00 for the first 3 months isn't comparable to a €9.00 monthly price.
+    const off = toOffering([
+      {
+        packageIdentifier: "$rc_monthly",
+        identifier: "monthly_bingo",
+        title: "Monthly",
+        basePriceMicros: 9000000,
+        introPrice: {
+          periodDuration: "P3M",
+          period: { number: 3, unit: PeriodUnit.Month },
+          cycleCount: 1,
+          price: toPrice(15000000, "EUR"),
+          pricePerWeek: null,
+          pricePerMonth: null,
+          pricePerYear: null,
+        },
+      },
+    ]);
+
+    const variables = parseOfferingIntoVariables(off, enTranslator);
+
+    expect(variables.$rc_monthly["product.offer_absolute_discount"]).toBe("");
+    expect(variables.$rc_monthly["product.offer_relative_discount"]).toBe("");
+  });
+
+  test("offer discounts are empty for a free offer", () => {
+    // A free month would otherwise render "100%" / the full price as a saving.
+    const off = toOffering([
+      {
+        packageIdentifier: "$rc_monthly",
+        identifier: "monthly_bingo",
+        title: "Monthly",
+        basePriceMicros: 9000000,
+        introPrice: {
+          periodDuration: "P1M",
+          period: { number: 1, unit: PeriodUnit.Month },
+          cycleCount: 1,
+          price: toPrice(0, "EUR"),
+          pricePerWeek: null,
+          pricePerMonth: null,
+          pricePerYear: null,
+        },
+      },
+    ]);
+
+    const variables = parseOfferingIntoVariables(off, enTranslator);
+
+    expect(variables.$rc_monthly["product.offer_absolute_discount"]).toBe("");
+    expect(variables.$rc_monthly["product.offer_relative_discount"]).toBe("");
+  });
+
+  test("offer discounts are empty when the package has no offer", () => {
+    const off = toOffering([
+      {
+        packageIdentifier: "$rc_monthly",
+        identifier: "monthly_bingo",
+        title: "Monthly",
+        basePriceMicros: 9000000,
+      },
+    ]);
+
+    const variables = parseOfferingIntoVariables(off, enTranslator);
+
+    expect(variables.$rc_monthly["product.offer_absolute_discount"]).toBe("");
+    expect(variables.$rc_monthly["product.offer_relative_discount"]).toBe("");
+  });
+});
+
+describe("discount variables - offer sources beyond introPrice", () => {
+  test("a time_window discount populates the offer discounts", () => {
+    // discountPhaseTimeWindow is $12.00 against a $14.99 monthly base: saves $2.99, 20% off.
+    const off = toOffering([
+      {
+        packageIdentifier: "$rc_monthly",
+        identifier: "monthly_bingo",
+        title: "Monthly",
+        currency: "USD",
+        basePriceMicros: 14990000,
+        discount: discountPhaseTimeWindow,
+      },
+    ]);
+
+    const variables = parseOfferingIntoVariables(off, enTranslator);
+
+    expect(variables.$rc_monthly["product.offer_absolute_discount"]).toBe(
+      "$2.99",
+    );
+    expect(variables.$rc_monthly["product.offer_relative_discount"]).toBe(
+      "20%",
+    );
+  });
+
+  test("a one_time discount on a multi-month base still compares against the base price", () => {
+    /**
+     * Regression: `toDiscountPhase` normalizes a discount's period to a single unit and
+     * moves the count into `cycleCount`, so a discount on a 3-month plan carries
+     * `{number: 1, unit: Month}`. Comparing that to the base period raw would wrongly
+     * suppress a discount that does apply to the base plan's own renewal.
+     */
+    const off = toOffering([
+      {
+        packageIdentifier: "$rc_three_month",
+        identifier: "quarterly_bingo",
+        title: "Quarterly",
+        currency: "USD",
+        period: { unit: PeriodUnit.Month, number: 3 },
+        basePriceMicros: 27000000,
+        discount: {
+          ...discountPhaseOneTime,
+          periodDuration: "P3M",
+          price: toPrice(15000000, "USD"),
+          period: { number: 1, unit: PeriodUnit.Month },
+          cycleCount: 3,
+        },
+      },
+    ]);
+
+    const variables = parseOfferingIntoVariables(off, enTranslator);
+
+    expect(variables.$rc_three_month["product.offer_absolute_discount"]).toBe(
+      "$12.00",
+    );
+    expect(variables.$rc_three_month["product.offer_relative_discount"]).toBe(
+      "44%",
+    );
+  });
+
+  test("a free trial phase leaves the offer discounts empty", () => {
+    // trialPhaseP2W carries `price: null`, a different guard branch from `price: 0`.
+    const off = toOffering([
+      {
+        packageIdentifier: "$rc_monthly",
+        identifier: "monthly_bingo",
+        title: "Monthly",
+        basePriceMicros: 9000000,
+        trial: trialPhaseP2W,
+      },
+    ]);
+
+    const variables = parseOfferingIntoVariables(off, enTranslator);
+
+    expect(variables.$rc_monthly["product.offer_absolute_discount"]).toBe("");
+    expect(variables.$rc_monthly["product.offer_relative_discount"]).toBe("");
+  });
+
+  test("absolute_discount is empty when every package is free", () => {
+    // A zero anchor makes the ratio NaN; the guard must not fall through to "€0".
+    const off = toOffering([
+      {
+        packageIdentifier: "$rc_monthly",
+        identifier: "monthly_bingo",
+        title: "Monthly",
+        basePriceMicros: 0,
+      },
+      {
+        packageIdentifier: "$rc_annual",
+        identifier: "annual_bingo",
+        title: "Annual",
+        period: { unit: PeriodUnit.Year, number: 1 },
+        basePriceMicros: 0,
+      },
+    ]);
+
+    const variables = parseOfferingIntoVariables(off, enTranslator);
+
+    expect(variables.$rc_monthly["product.absolute_discount"]).toBe("");
+    expect(variables.$rc_annual["product.absolute_discount"]).toBe("");
+    expect(variables.$rc_monthly["product.relative_discount"]).toBe("");
+    expect(variables.$rc_annual["product.relative_discount"]).toBe("");
+  });
+
+  test("absolute_discount normalizes onto a multi-month package period", () => {
+    // €10.00/mo anchor vs. a €21.00 quarterly package: saves (€10.00 x 3) - €21.00 = €9.00.
+    const off = toOffering([
+      {
+        packageIdentifier: "$rc_monthly",
+        identifier: "monthly_bingo",
+        title: "Monthly",
+        basePriceMicros: 10000000,
+      },
+      {
+        packageIdentifier: "$rc_three_month",
+        identifier: "quarterly_bingo",
+        title: "Quarterly",
+        period: { unit: PeriodUnit.Month, number: 3 },
+        basePriceMicros: 21000000,
+      },
+    ]);
+
+    const variables = parseOfferingIntoVariables(off, enTranslator);
+
+    expect(variables.$rc_three_month["product.absolute_discount"]).toBe(
+      "€9.00",
+    );
+  });
+});

--- a/src/tests/helpers/paywall-variables-helper.test.ts
+++ b/src/tests/helpers/paywall-variables-helper.test.ts
@@ -1152,3 +1152,213 @@ describe("discount variables - offer sources beyond introPrice", () => {
     );
   });
 });
+
+describe("discount variables - with offer", () => {
+  /**
+   * The Yousician case: an Annual vs. Monthly paywall where annual carries a paid intro
+   * year. The badge should compare annual's *offer* price per month against monthly's
+   * price per month, which no other discount variable produces.
+   */
+  const annualWithPaidIntro = () =>
+    toOffering([
+      {
+        packageIdentifier: "$rc_monthly",
+        identifier: "monthly_bingo",
+        title: "Monthly",
+        currency: "USD",
+        basePriceMicros: 9990000,
+      },
+      {
+        packageIdentifier: "$rc_annual",
+        identifier: "annual_bingo",
+        title: "Annual",
+        currency: "USD",
+        period: { unit: PeriodUnit.Year, number: 1 },
+        basePriceMicros: 99990000,
+        introPrice: {
+          periodDuration: "P1Y",
+          period: { number: 1, unit: PeriodUnit.Year },
+          cycleCount: 1,
+          price: toPrice(52990000, "USD"),
+          pricePerWeek: null,
+          pricePerMonth: null,
+          pricePerYear: null,
+        },
+      },
+    ]);
+
+  test("relative_discount_with_offer prices the offer against the anchor", () => {
+    const variables = parseOfferingIntoVariables(
+      annualWithPaidIntro(),
+      enTranslator,
+    );
+
+    // $52.99/yr is $4.42/mo against a $9.99/mo anchor.
+    expect(variables.$rc_annual["product.relative_discount_with_offer"]).toBe(
+      "56%",
+    );
+    // The base-price comparison is a different, smaller number.
+    expect(variables.$rc_annual["product.relative_discount"]).toBe("17%");
+  });
+
+  test("absolute_discount_with_offer spans the offer's own duration", () => {
+    const variables = parseOfferingIntoVariables(
+      annualWithPaidIntro(),
+      enTranslator,
+    );
+
+    // ($9.99 - $4.4158) x 12 months of offer = $66.89.
+    expect(variables.$rc_annual["product.absolute_discount_with_offer"]).toBe(
+      "$66.89",
+    );
+  });
+
+  test("with_offer variables fall back to the base comparison when there is no offer", () => {
+    const off = toOffering([
+      {
+        packageIdentifier: "$rc_monthly",
+        identifier: "monthly_bingo",
+        title: "Monthly",
+        basePriceMicros: 10000000,
+      },
+      {
+        packageIdentifier: "$rc_annual",
+        identifier: "annual_bingo",
+        title: "Annual",
+        period: { unit: PeriodUnit.Year, number: 1 },
+        basePriceMicros: 60000000,
+      },
+    ]);
+
+    const variables = parseOfferingIntoVariables(off, enTranslator);
+
+    expect(variables.$rc_annual["product.relative_discount_with_offer"]).toBe(
+      variables.$rc_annual["product.relative_discount"],
+    );
+    expect(variables.$rc_annual["product.absolute_discount_with_offer"]).toBe(
+      variables.$rc_annual["product.absolute_discount"],
+    );
+  });
+
+  test("a free trial is treated as no offer rather than 100% off", () => {
+    const off = toOffering([
+      {
+        packageIdentifier: "$rc_monthly",
+        identifier: "monthly_bingo",
+        title: "Monthly",
+        basePriceMicros: 10000000,
+      },
+      {
+        packageIdentifier: "$rc_annual",
+        identifier: "annual_bingo",
+        title: "Annual",
+        period: { unit: PeriodUnit.Year, number: 1 },
+        basePriceMicros: 60000000,
+        trial: trialPhaseP2W,
+      },
+    ]);
+
+    const variables = parseOfferingIntoVariables(off, enTranslator);
+
+    expect(variables.$rc_annual["product.relative_discount_with_offer"]).toBe(
+      variables.$rc_annual["product.relative_discount"],
+    );
+  });
+
+  test("a multi-cycle offer spans every cycle", () => {
+    // 3 cycles at $5.99/mo against a $9.99/mo anchor: 40% off, $12.00 across the offer.
+    const off = toOffering([
+      {
+        packageIdentifier: "$rc_weekly",
+        identifier: "weekly_bingo",
+        title: "Weekly",
+        currency: "USD",
+        period: { unit: PeriodUnit.Week, number: 1 },
+        basePriceMicros: 2299000,
+      },
+      {
+        packageIdentifier: "$rc_monthly",
+        identifier: "monthly_bingo",
+        title: "Monthly",
+        currency: "USD",
+        basePriceMicros: 9990000,
+        introPrice: {
+          periodDuration: "P1M",
+          period: { number: 1, unit: PeriodUnit.Month },
+          cycleCount: 3,
+          price: toPrice(5990000, "USD"),
+          pricePerWeek: null,
+          pricePerMonth: null,
+          pricePerYear: null,
+        },
+      },
+    ]);
+
+    const variables = parseOfferingIntoVariables(off, enTranslator);
+
+    // Anchor is weekly at $2.299/wk ~= $9.99/mo, so the monthly offer saves ~$4.00/mo.
+    expect(variables.$rc_monthly["product.absolute_discount_with_offer"]).toBe(
+      "$12.00",
+    );
+  });
+
+  test("with_offer variables are empty when every package is free", () => {
+    // A zero anchor makes the ratio NaN, and `NaN < 1` is false, so the guard must not
+    // fall through for the new pair either.
+    const off = toOffering([
+      {
+        packageIdentifier: "$rc_monthly",
+        identifier: "monthly_bingo",
+        title: "Monthly",
+        basePriceMicros: 0,
+      },
+      {
+        packageIdentifier: "$rc_annual",
+        identifier: "annual_bingo",
+        title: "Annual",
+        period: { unit: PeriodUnit.Year, number: 1 },
+        basePriceMicros: 0,
+      },
+    ]);
+
+    const variables = parseOfferingIntoVariables(off, enTranslator);
+
+    expect(variables.$rc_annual["product.relative_discount_with_offer"]).toBe(
+      "",
+    );
+    expect(variables.$rc_annual["product.absolute_discount_with_offer"]).toBe(
+      "",
+    );
+  });
+
+  test("a forever discount leaves the absolute variant empty but keeps the relative one", () => {
+    const off = toOffering([
+      {
+        packageIdentifier: "$rc_monthly",
+        identifier: "monthly_bingo",
+        title: "Monthly",
+        currency: "USD",
+        basePriceMicros: 20000000,
+      },
+      {
+        packageIdentifier: "$rc_annual",
+        identifier: "annual_bingo",
+        title: "Annual",
+        currency: "USD",
+        basePriceMicros: 12000000,
+        discount: discountPhaseForever,
+      },
+    ]);
+
+    const variables = parseOfferingIntoVariables(off, enTranslator);
+
+    // A perpetual discount has a monthly rate but never reverts, so there is no term
+    // over which a total saving accrues.
+    expect(
+      variables.$rc_annual["product.relative_discount_with_offer"],
+    ).not.toBe("");
+    expect(variables.$rc_annual["product.absolute_discount_with_offer"]).toBe(
+      "",
+    );
+  });
+});


### PR DESCRIPTION
Adds five Paywalls V2 variables. Part of [Paywall variables: discounts & secondary offer parity](https://app.notion.com/p/361cb1a108b08189a94def9fab1e8752) — Milestone 1 of 2; the secondary-offer variables are Milestone 2.

Pairs with [purchases-ui-js#376](https://github.com/RevenueCat/purchases-ui-js/pull/376) for autocomplete only — not a build dependency.

## Two comparison axes

| Variable | Compares | Example |
|---|---|---|
| `absolute_discount` | this package vs. the most expensive package | `$60.00` |
| `offer_relative_discount` / `offer_absolute_discount` | an offer vs. **its own package's** standard price | `40%` / `$4.00` |
| `relative_discount_with_offer` / `absolute_discount_with_offer` | this package **with its offer applied** vs. the most expensive package | `56%` / `$66.89` |

All five select the same anchor — most-expensive per-month base price — so they never disagree about which packages are being compared.

## `absolute_discount`

```
(mostExpensivePricePerMonth × thisPackagePeriodInMonths) − thisPackagePrice
```

The anchor is *selected* by per-month price, exactly as `relative_discount` does. The saving is then expressed over **the purchased package's own period**, not per month. A ratio is period-invariant so the unit `relative_discount` normalises on is arbitrary; a currency amount changes with whatever unit you quote it in, so it's anchored to the term actually being bought — and that avoids shipping an `absolute_discount_per_day/_week/_month/_year` family just to disambiguate.

## `offer_relative_discount` / `offer_absolute_discount`

The primary offer's price against the same package's standard renewal price, compared raw. Both render empty unless the offer's billing period matches the base period **and** the offer price is above zero, so a 7-day trial on a monthly product doesn't read as a full month's saving.

Discount phases are exempt from the period check: they always replace the base plan's own renewal price, and `toDiscountPhase` normalises their period to a single unit with the count moved into `cycleCount`, so a discount on a 3-month plan carries `{number: 1, unit: Month}` and a raw comparison would wrongly reject it. There's a regression test for that.

## `relative_discount_with_offer` / `absolute_discount_with_offer`

The same cross-package comparison as the first two, but priced off the offer the customer would actually get. This is the "56% off annual" badge on a paywall where annual carries a paid intro offer — `offer_relative_discount` does **not** produce that number, since it compares annual's offer to annual's own base.

- The absolute variant spans the offer's **full duration** (billing period × cycles), since that's the term being purchased.
- When the offer never reverts (`durationMode: "forever"`) there is no such term, so the absolute variant renders empty — matching what `relative_discount` already does for a lifetime product. The relative variant still works, since a perpetual discount has a well-defined monthly rate.
- With no usable offer both collapse to the bare variables, so they can be used unconditionally rather than behind show/hide rules. A free trial counts as no offer rather than "100% off".

## Notes

- **No locale changes.** Percentages reuse `paywall_variables.sub_relative_discount`, so none of the 30+ locale files are touched.
- **Derived amounts are floored** via `floorMicrosToCurrencyUnit`, so a saving is never overstated — matching `getPriceVariables` and `toPricingPhase`.
- **Drive-by fix:** the existing per-month discount ratio divided by zero when every package was free, producing `NaN`; `NaN < 1` is false, so the suppression failed open and rendered `"NaN%"`. Now guarded.
- **Latent bug flagged, not fixed:** `offerRatePeriod` handles every discount phase, whereas the pre-existing `getOfferPricingPeriod` only special-cases `time_window`. They disagree for a `forever` discount on a multi-unit base plan, where `offer_price_per_*` still uses the normalised period. Documented in a comment — changing it would move a value already rendering on live paywalls.
- **No `<1%` suppression on `offer_relative_discount`**, unlike the package-level `relative_discount`, to keep it consistent with iOS and Android. Happy to add it to all three if reviewers prefer.
- **Known limitation:** the `offer_*` pair renders empty for products with a free trial *and* a discounted intro phase, because `primaryOffer` resolves to the trial. That needs `secondary_offer_*_discount`, which is Milestone 2.

## Verification

- `pnpm test` — 851 passed (52 files), including 21 new tests
- `pnpm run typecheck` — clean
- `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)