### PR TITLE
Product-change checkout tweaks

### DIFF
--- a/src/ui/molecules/pricing-table.svelte
+++ b/src/ui/molecules/pricing-table.svelte
@@ -29,6 +29,7 @@
     onRemoveDiscountCode: (() => void | Promise<void>) | undefined;
     pendingTaxLabel?: string | null;
     totalRowLabel?: string | null;
+    detailsExpandedByDefault?: boolean;
   }
 
   let {
@@ -47,6 +48,7 @@
     onRemoveDiscountCode,
     pendingTaxLabel = null,
     totalRowLabel = null,
+    detailsExpandedByDefault = true,
   }: Props = $props();
 
   const trialEndDate = $derived(
@@ -303,7 +305,10 @@
 {/snippet}
 
 {#if showDetailsControls}
-  <PricingDropdown {showDiscountCodeField}>
+  <PricingDropdown
+    {showDiscountCodeField}
+    isExpanded={detailsExpandedByDefault}
+  >
     {@render pricingTable()}
   </PricingDropdown>
 {:else}

--- a/src/ui/organisms/upgrade-product-info.svelte
+++ b/src/ui/organisms/upgrade-product-info.svelte
@@ -148,6 +148,7 @@
       onRemoveDiscountCode={undefined}
       {pendingTaxLabel}
       {totalRowLabel}
+      detailsExpandedByDefault={false}
     />
   </div>
 

--- a/src/ui/pages/upgrade-confirm-page.svelte
+++ b/src/ui/pages/upgrade-confirm-page.svelte
@@ -198,7 +198,7 @@
   }
 
   .rcb-upgrade-header {
-    display: flex;
+    display: none;
     flex-direction: column;
     gap: var(--rc-spacing-gapMedium-mobile);
   }
@@ -239,6 +239,7 @@
     }
 
     .rcb-upgrade-header {
+      display: flex;
       gap: var(--rc-spacing-gapMedium-desktop);
     }
 


### PR DESCRIPTION
## Motivation / Description

In the product-change checkout:
- Default the "Show details" to hidden
- Hide the title+subtitle in the details section on mobile viewport width

## Changes introduced

Before:
<img width="435" height="940" alt="Screenshot 2026-08-28 at 16 19 21" src="https://github.com/user-attachments/assets/df75a274-c95f-44e9-8691-54a52e47326b" />

After:
<img width="430" height="934" alt="Screenshot 2026-08-28 at 16 20 32" src="https://github.com/user-attachments/assets/f57cf29f-e5f1-490b-848c-fac9e50e482c" />

https://github.com/user-attachments/assets/1031a70b-b1cd-4e9f-8ee7-1063e5a71f1d


## Linear ticket (if any)

## Additional comments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to upgrade checkout layout and pricing dropdown default state; no payment, auth, or pricing calculation logic touched.
> 
> **Overview**
> **Product-change checkout** is tightened on small screens: pricing line items start **collapsed** behind “Show details,” and the confirm step no longer shows its title/subtitle block until desktop width.
> 
> `PricingTable` gains optional `detailsExpandedByDefault` (default **true** elsewhere) and passes it to `PricingDropdown` as `isExpanded`. **Upgrade** product info sets `detailsExpandedByDefault={false}` so tax/breakdown stays hidden until expanded.
> 
> On `upgrade-confirm-page`, `.rcb-upgrade-header` is **`display: none`** by default and **`display: flex`** again inside the `>= 768px` container query, so mobile users see email/payment/CTA without the duplicate heading area.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3324f3458043f087df95793823e9608cb669b02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->