### PR TITLE
[WEB-4656] Prepare Apple Pay before RC Billing checkout

### DIFF
--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -446,6 +446,7 @@ export interface PurchaseParams {
     showDiscountCodeField?: boolean;
     skipSuccessPage?: boolean;
     termsAndConditionsUrl?: string;
+    tryWithApplePay?: boolean;
     /* Excluded from this release type: productChangeInfo */
 }
 
@@ -475,6 +476,8 @@ export class Purchases {
     /* Excluded from this release type: _platformInfo */
     /* Excluded from this release type: inMemoryCache */
     /* Excluded from this release type: cachedCurrentOffering */
+    /* Excluded from this release type: preparedQuickPurchaseConfiguration */
+    /* Excluded from this release type: quickPurchasePreparationPromise */
     /* Excluded from this release type: instance */
     changeUser(newAppUserId: string): Promise<CustomerInfo>;
     close(): void;
@@ -498,6 +501,7 @@ export class Purchases {
     // (undocumented)
     isSandbox(): boolean;
     preload(): Promise<void>;
+    prepareForQuickPurchases(): Promise<void>;
     presentExpressPurchaseButton(params: PresentExpressPurchaseButtonParams): Promise<PurchaseResult>;
     presentPaywall(paywallParams: PresentPaywallParams): Promise<PaywallPurchaseResult>;
     purchase(params: PurchaseParams): Promise<PurchaseResult>;

--- a/examples/webbilling-demo/src/App.tsx
+++ b/examples/webbilling-demo/src/App.tsx
@@ -26,6 +26,7 @@ import RCPaywallSettingsPage from "./pages/rc_paywall_settings";
 import UpgradePage from "./pages/upgrade";
 import UpgradePaywallPage from "./pages/upgrade_paywall";
 import AppearanceOverridesPage from "./pages/appearance_overrides";
+import ApplePayPage from "./pages/apple_pay";
 
 const router = createBrowserRouter([
   {
@@ -48,6 +49,15 @@ const router = createBrowserRouter([
     element: (
       <WithoutEntitlement>
         <PaywallPage />
+      </WithoutEntitlement>
+    ),
+  },
+  {
+    path: "/apple_pay/:app_user_id",
+    loader: loadPurchases,
+    element: (
+      <WithoutEntitlement>
+        <ApplePayPage />
       </WithoutEntitlement>
     ),
   },

--- a/examples/webbilling-demo/src/pages/apple_pay/index.tsx
+++ b/examples/webbilling-demo/src/pages/apple_pay/index.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import PaywallPage from "../paywall";
+
+const ApplePayPage: React.FC = () => <PaywallPage tryWithApplePay />;
+
+export default ApplePayPage;

--- a/examples/webbilling-demo/src/pages/login/index.tsx
+++ b/examples/webbilling-demo/src/pages/login/index.tsx
@@ -16,7 +16,7 @@ const LoginPage: React.FC = () => {
 
   const navigateToAppUserIDPaywall = (
     appUserId?: string,
-    destination: "paywall" | "rc_paywall" = "paywall",
+    destination: "apple_pay" | "paywall" | "rc_paywall" = "paywall",
   ) => {
     if (appUserId) {
       const params = new URLSearchParams();
@@ -111,6 +111,12 @@ const LoginPage: React.FC = () => {
             caption="Continue (RC Paywall)"
             onClick={() => {
               navigateToAppUserIDPaywall(appUserId, "rc_paywall");
+            }}
+          />
+          <Button
+            caption="Continue (Apple Pay first)"
+            onClick={() => {
+              navigateToAppUserIDPaywall(appUserId, "apple_pay");
             }}
           />
           <Button

--- a/examples/webbilling-demo/src/pages/paywall/index.tsx
+++ b/examples/webbilling-demo/src/pages/paywall/index.tsx
@@ -8,7 +8,7 @@ import {
   PurchasesError,
   ReservedCustomerAttribute,
 } from "@revenuecat/purchases-js";
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import {
   usePurchasesLoaderData,
@@ -24,6 +24,10 @@ interface IPackageCardProps {
   pkg: Package;
   offering: Offering;
   onClick: () => void;
+}
+
+interface PaywallPageProps {
+  tryWithApplePay?: boolean;
 }
 
 const shortPeriodLabels: Record<string, string> = {
@@ -162,7 +166,9 @@ const PackageCard: React.FC<IPackageCardProps> = ({
   );
 };
 
-const PaywallPage: React.FC = () => {
+const PaywallPage: React.FC<PaywallPageProps> = ({
+  tryWithApplePay = false,
+}) => {
   const navigate = useNavigate();
   const { purchases, offering } = usePurchasesLoaderData();
   const [searchParams] = useSearchParams();
@@ -175,6 +181,9 @@ const PaywallPage: React.FC = () => {
   const showDiscountCodeField =
     searchParams.get("showDiscountCodeField") === "true";
   const attributesSetRef = useRef(false);
+  const [isPreparingApplePay, setIsPreparingApplePay] = useState(false);
+  const [isApplePayPrepared, setIsApplePayPrepared] = useState(false);
+  const packages: Package[] = offering?.availablePackages || [];
 
   useEffect(() => {
     const setAttributes = async () => {
@@ -202,11 +211,41 @@ const PaywallPage: React.FC = () => {
     setAttributes();
   }, [purchases, displayName, nickname]);
 
+  useEffect(() => {
+    if (!tryWithApplePay || !offering) {
+      setIsPreparingApplePay(false);
+      setIsApplePayPrepared(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsPreparingApplePay(true);
+    setIsApplePayPrepared(false);
+    void purchases
+      .prepareForQuickPurchases()
+      .then(() => {
+        if (!cancelled) {
+          setIsApplePayPrepared(true);
+        }
+      })
+      .catch((error) => {
+        console.error("Error preparing quick purchases:", error);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsPreparingApplePay(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [purchases, offering, tryWithApplePay]);
+
   if (!offering) {
     console.error("No offering found");
     return <>No offering found!</>;
   }
-  const packages: Package[] = offering?.availablePackages || [];
   if (packages.length == 0) {
     console.error("No packages found in current offering.");
   }
@@ -233,6 +272,11 @@ const PaywallPage: React.FC = () => {
 
     // How do we complete the purchase?
     try {
+      if (tryWithApplePay && isPreparingApplePay) {
+        console.log("Apple Pay is still preparing; try again in a moment");
+        return;
+      }
+
       const { customerInfo, redemptionInfo, storeTransaction } =
         await purchases.purchase({
           rcPackage: pkg,
@@ -242,6 +286,7 @@ const PaywallPage: React.FC = () => {
           customerEmail: email || undefined,
           externalPurchaseTokenId,
           skipSuccessPage: skipSuccessPage,
+          tryWithApplePay,
           // @ts-expect-error This method is marked as internal for now but it's public.'
           labelsOverride: {
             en: {
@@ -291,16 +336,27 @@ const PaywallPage: React.FC = () => {
             fontWeight: "500",
           }}
         >
-          {isPaddleApiKey
-            ? "Paddle demo"
-            : isStripeApiKey
-              ? "Stripe Checkout demo"
-              : "Web Billing demo"}
+          {tryWithApplePay
+            ? "Apple Pay first demo"
+            : isPaddleApiKey
+              ? "Paddle demo"
+              : isStripeApiKey
+                ? "Stripe Checkout demo"
+                : "Web Billing demo"}
         </div>
 
         <h1>
           Subscribe today and <em>save up to 25%!</em>
         </h1>
+        {tryWithApplePay ? (
+          <p className="notice">
+            {isPreparingApplePay
+              ? "Preparing Apple Pay before the purchase click…"
+              : isApplePayPrepared
+                ? "Apple Pay is prepared. The purchase click presents it before starting checkout."
+                : "Apple Pay preparation failed. Purchases use the normal checkout."}
+          </p>
+        ) : null}
         <div className="packages">
           {packages.map((pkg) =>
             pkg.webBillingProduct !== null ? (

--- a/src/entities/purchase-params.ts
+++ b/src/entities/purchase-params.ts
@@ -94,6 +94,14 @@ export interface PurchaseParams {
   externalPurchaseTokenId?: string;
 
   /**
+   * If set to true after {@link Purchases.prepareForQuickPurchases} completes,
+   * Web Billing will try to present Apple Pay before showing the regular
+   * checkout. If preparation is unavailable or Apple Pay cannot be presented,
+   * the regular checkout is shown instead. Defaults to `false`.
+   */
+  tryWithApplePay?: boolean;
+
+  /**
    * Workflow-specific context for this purchase.
    * @internal
    */

--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -32,7 +32,10 @@ import {
   type CheckoutPricingResponse,
 } from "../networking/responses/checkout-pricing-response";
 import { handleCheckoutSessionFailed } from "./checkout-error-handler";
-import type { CheckoutPrepareResponse } from "../networking/responses/checkout-prepare-response";
+import type {
+  CheckoutPrepareResponse,
+  QuickPurchasesPrepareResponse,
+} from "../networking/responses/checkout-prepare-response";
 import {
   isSubscriptionChangeCompleteResponse,
   type SubscriptionChangeCheckoutStartResponse,
@@ -263,6 +266,27 @@ export class PurchaseOperationHelper {
           errorMessage,
         );
       }
+    }
+  }
+
+  async prepareForQuickPurchases(): Promise<QuickPurchasesPrepareResponse> {
+    try {
+      return await this.backend.postCheckoutPrepare();
+    } catch (error) {
+      if (error instanceof PurchasesError) {
+        throw PurchaseFlowError.fromPurchasesError(
+          error,
+          PurchaseFlowErrorCode.ErrorSettingUpPurchase,
+        );
+      }
+
+      const errorMessage =
+        "Unknown error preparing quick purchases: " + String(error);
+      Logger.errorLog(errorMessage);
+      throw new PurchaseFlowError(
+        PurchaseFlowErrorCode.UnknownError,
+        errorMessage,
+      );
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1711,6 +1711,7 @@ export class Purchases {
       return null;
     }
 
+    this.preparedQuickPurchaseConfiguration = null;
     Logger.debugLog(
       "Apple Pay first is ready; calling paymentRequest.show() before /start",
     );
@@ -1822,6 +1823,13 @@ export class Purchases {
           }),
         );
         throw PurchasesError.getForPurchasesFlowError(purchaseFlowError);
+      })
+      .finally(() => {
+        void this.prepareForQuickPurchases().catch((error) => {
+          Logger.debugLog(
+            `Could not prepare Apple Pay for another purchase: ${String(error)}`,
+          );
+        });
       });
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,7 @@ import {
 import {
   type OperationSessionSuccessfulResult,
   type PurchaseFlowError,
+  PurchaseFlowErrorCode,
   PurchaseOperationHelper,
 } from "./helpers/purchase-operation-helper";
 import { PaddleService } from "./paddle/paddle-service";
@@ -59,7 +60,10 @@ import { validateCurrency } from "./helpers/validators";
 import { type BrandingInfoResponse } from "./networking/responses/branding-response";
 import type { BrandingAppearance } from "./entities/branding";
 import { requiresLoadedResources } from "./helpers/decorators";
-import { resolveTermsAndConditionsUrl } from "./helpers/checkout-consent-helper";
+import {
+  isCheckoutConsentRequired,
+  resolveTermsAndConditionsUrl,
+} from "./helpers/checkout-consent-helper";
 import {
   enrichPackagesWithPlacementContext,
   getOfferingIdForPlacement,
@@ -158,6 +162,15 @@ import {
   applyBrandingAppearanceOverride,
   mergeBrandingAppearanceOverrides,
 } from "./helpers/branding-appearance-helper";
+import { getInitialPriceFromPurchaseOption } from "./helpers/purchase-option-price-helper";
+import {
+  type PreparedApplePayConfiguration,
+  type PreparedApplePayPurchase,
+  prepareApplePayConfiguration,
+  prepareApplePayPurchaseForLater,
+  presentPreparedApplePayPurchase,
+  updatePreparedApplePayPurchase,
+} from "./stripe/apple-pay-purchase";
 
 type UIComponentInteractionFields = UIComponentInteractionData & {
   componentURL?: string;
@@ -305,6 +318,13 @@ export class Purchases {
 
   /** @internal */
   private cachedCurrentOffering: Offering | null = null;
+
+  /** @internal */
+  private preparedQuickPurchaseConfiguration: PreparedApplePayPurchase | null =
+    null;
+
+  /** @internal */
+  private quickPurchasePreparationPromise: Promise<void> | null = null;
 
   /** @internal */
   private static instance: Purchases | undefined = undefined;
@@ -1538,6 +1558,296 @@ export class Purchases {
   }
 
   /**
+   * Prepares the SDK to present Apple Pay synchronously from a later
+   * {@link Purchases.purchase} call.
+   *
+   * Call this before the customer interacts with a purchase button. The method
+   * is idempotent and concurrent calls share the same preparation.
+   */
+  @requiresLoadedResources
+  public async prepareForQuickPurchases(): Promise<void> {
+    if (!isWebBillingApiKey(this._API_KEY)) {
+      throw new PurchasesError(
+        ErrorCode.ConfigurationError,
+        "Quick purchases are only available with Web Billing API keys.",
+      );
+    }
+
+    if (this.preparedQuickPurchaseConfiguration) {
+      return;
+    }
+
+    if (!this.quickPurchasePreparationPromise) {
+      this.quickPurchasePreparationPromise =
+        this.prepareQuickPurchaseConfiguration()
+          .catch((error) => {
+            this.preparedQuickPurchaseConfiguration = null;
+            throw error;
+          })
+          .finally(() => {
+            this.quickPurchasePreparationPromise = null;
+          });
+    }
+
+    return await this.quickPurchasePreparationPromise;
+  }
+
+  /** @internal */
+  private async prepareQuickPurchaseConfiguration(): Promise<void> {
+    Logger.debugLog("Preparing quick purchases with /prepare");
+    const response =
+      await this.purchaseOperationHelper.prepareForQuickPurchases();
+    const configuration: PreparedApplePayConfiguration =
+      await prepareApplePayConfiguration({
+        gatewayParams: response.stripe_gateway_params,
+        managementUrl: response.management_url,
+      });
+    this.preparedQuickPurchaseConfiguration =
+      await prepareApplePayPurchaseForLater(configuration);
+    if (!this.preparedQuickPurchaseConfiguration) {
+      Logger.debugLog(
+        "Apple Pay is unavailable; quick purchases will use checkout",
+      );
+      return;
+    }
+    Logger.debugLog("Quick purchases are ready");
+  }
+
+  /** @internal */
+  private tryPreparedQuickPurchase(
+    params: PurchaseParams,
+  ): Promise<PurchaseResult> | null {
+    if (!isWebBillingApiKey(this._API_KEY)) {
+      return null;
+    }
+
+    const preparedPurchase = this.preparedQuickPurchaseConfiguration;
+    if (!preparedPurchase) {
+      Logger.debugLog(
+        "Apple Pay first requested without prepared quick-purchase state; using checkout",
+      );
+      return null;
+    }
+
+    const appearanceOverride = mergeBrandingAppearanceOverrides(
+      this._brandingAppearanceOverride,
+      params.brandingAppearanceOverride,
+    );
+    const effectiveParams = appearanceOverride
+      ? { ...params, brandingAppearanceOverride: appearanceOverride }
+      : params;
+    const brandingInfo = applyBrandingAppearanceOverride(
+      this._brandingInfo,
+      appearanceOverride,
+    );
+    const product = effectiveParams.rcPackage.webBillingProduct;
+    const purchaseOption =
+      effectiveParams.purchaseOption ?? product.defaultPurchaseOption;
+    const termsAndConditionsUrl = resolveTermsAndConditionsUrl({
+      brandingInfo,
+      termsAndConditionsUrl: effectiveParams.termsAndConditionsUrl,
+    });
+    const skipReasons: string[] = [];
+    if (this.resolveProductChange(effectiveParams)) {
+      skipReasons.push("product change requested");
+    }
+    if (effectiveParams.discountCode) {
+      skipReasons.push("discount code requested");
+    }
+    if (
+      isCheckoutConsentRequired({
+        brandingInfo,
+        termsAndConditionsUrl,
+        productDetails: product,
+      })
+    ) {
+      skipReasons.push("checkout consent required");
+    }
+    if (skipReasons.length > 0) {
+      Logger.debugLog(
+        `Apple Pay first skipped: ${skipReasons.join(", ")}; using checkout`,
+      );
+      return null;
+    }
+
+    const selectedLocale =
+      effectiveParams.selectedLocale ??
+      effectiveParams.defaultLocale ??
+      englishLocale;
+    const defaultLocale = effectiveParams.defaultLocale ?? englishLocale;
+    const translator = new Translator(
+      effectiveParams.labelsOverride ?? {},
+      selectedLocale,
+      defaultLocale,
+    );
+    const initialPrice = getInitialPriceFromPurchaseOption(
+      product,
+      purchaseOption,
+    );
+
+    let preparedApplePay: PreparedApplePayPurchase;
+    try {
+      preparedApplePay = updatePreparedApplePayPurchase({
+        preparedPurchase,
+        product,
+        purchaseOption,
+        priceBreakdown: {
+          currency: initialPrice.currency,
+          totalAmountInMicros: initialPrice.amountMicros,
+          totalExcludingTaxInMicros: initialPrice.amountMicros,
+          taxCalculationStatus: brandingInfo?.gateway_tax_collection_enabled
+            ? "unavailable"
+            : "disabled",
+          taxAmountInMicros: null,
+          taxBreakdown: null,
+        },
+        brandingInfo,
+        translator,
+      });
+    } catch (error) {
+      Logger.debugLog(
+        `Apple Pay setup failed, using checkout: ${String(error)}`,
+      );
+      return null;
+    }
+
+    Logger.debugLog(
+      "Apple Pay first is ready; calling paymentRequest.show() before /start",
+    );
+    const appUserId = this._appUserId;
+    const utmParamsMetadata = this._flags.autoCollectUTMAsMetadata
+      ? autoParseUTMParams()
+      : {};
+    const metadata = {
+      ...utmParamsMetadata,
+      ...(effectiveParams.metadata || {}),
+    };
+    const applePayAttempt = presentPreparedApplePayPurchase({
+      preparedPurchase: preparedApplePay,
+      customerEmail: effectiveParams.customerEmail,
+      brandingInfo,
+      translator,
+      purchaseOperationHelper: this.purchaseOperationHelper,
+      eventsTracker: this.eventsTracker,
+      onPresented: async () => {
+        Logger.debugLog("Apple Pay presented; starting checkout with /start");
+        this.eventsTracker.trackSDKEvent(
+          createCheckoutSessionStartEvent({
+            appearance: brandingInfo?.appearance,
+            rcPackage: effectiveParams.rcPackage,
+            purchaseOptionToUse: purchaseOption,
+            customerEmail: effectiveParams.customerEmail,
+          }),
+        );
+
+        const startParams = {
+          appUserId,
+          productId: product.identifier,
+          purchaseOption,
+          presentedOfferingContext: product.presentedOfferingContext,
+          customerEmail: effectiveParams.customerEmail,
+          metadata,
+          workflowPurchaseContext: effectiveParams.workflowPurchaseContext,
+          attributionMetadata: effectiveParams.attributionMetadata,
+          paywallId: effectiveParams.paywallId,
+          paywallSessionId: effectiveParams.paywallSessionId,
+          locale: selectedLocale,
+          ...(appearanceOverride ? { appearanceOverride } : {}),
+        };
+
+        try {
+          await this.purchaseOperationHelper.checkoutStart(startParams);
+        } catch (error) {
+          if (
+            (error as PurchaseFlowError).errorCode !==
+            PurchaseFlowErrorCode.MissingEmailError
+          ) {
+            throw error;
+          }
+          await this.purchaseOperationHelper.checkoutStart({
+            ...startParams,
+            customerEmail: undefined,
+          });
+        }
+      },
+    });
+
+    return applePayAttempt
+      .then(async (result) => {
+        if (result.status === "unavailable") {
+          Logger.debugLog(
+            "Apple Pay could not be presented; using the normal checkout",
+          );
+          return await this.purchaseAfterLoadingResources({
+            ...effectiveParams,
+            tryWithApplePay: false,
+          });
+        }
+        if (result.status === "cancelled") {
+          this.eventsTracker.trackSDKEvent(
+            createCheckoutSessionEndClosedEvent(),
+          );
+          throw new PurchasesError(ErrorCode.UserCancelledError);
+        }
+
+        this.eventsTracker.trackSDKEvent(
+          createCheckoutSessionEndFinishedEvent({
+            redemptionInfo: result.operationResult.redemptionInfo,
+          }),
+        );
+        this.inMemoryCache.invalidateAllCaches();
+        Logger.debugLog("Purchase finished");
+        return {
+          customerInfo: await this._getCustomerInfoForUserId(appUserId),
+          redemptionInfo: result.operationResult.redemptionInfo,
+          operationSessionId: result.operationResult.operationSessionId,
+          attributionMetadata: result.operationResult.attributionMetadata,
+          storeTransaction: {
+            storeTransactionId:
+              result.operationResult.storeTransactionIdentifier,
+            productIdentifier: product.identifier,
+            purchaseDate: result.operationResult.purchaseDate,
+          },
+        };
+      })
+      .catch((error: unknown) => {
+        if (error instanceof PurchasesError) {
+          throw error;
+        }
+        const purchaseFlowError = error as PurchaseFlowError;
+        this.eventsTracker.trackSDKEvent(
+          createCheckoutSessionEndErroredEvent({
+            errorCode: purchaseFlowError.errorCode?.toString(),
+            errorMessage: purchaseFlowError.message,
+          }),
+        );
+        throw PurchasesError.getForPurchasesFlowError(purchaseFlowError);
+      });
+  }
+
+  /**
+   * Method to perform a purchase for a given package. This method preserves
+   * browser user activation by presenting a prepared Apple Pay request before
+   * awaiting any asynchronous work.
+   *
+   * @param params - The parameters object to customise the purchase flow. Check {@link PurchaseParams}
+   * @returns a Promise for the customer and redemption info after the purchase is completed successfully.
+   */
+  public async purchase(params: PurchaseParams): Promise<PurchaseResult> {
+    if (params.tryWithApplePay) {
+      const quickPurchase = this.tryPreparedQuickPurchase(params);
+      if (quickPurchase) {
+        return quickPurchase;
+      }
+    }
+
+    return this.purchaseAfterLoadingResources({
+      ...params,
+      tryWithApplePay: false,
+    });
+  }
+
+  /**
    * Method to perform a purchase for a given package. You can obtain the
    * package from {@link Purchases.getOfferings}. This method will present the purchase
    * form on your site, using the given HTML element as the mount point, if
@@ -1752,7 +2062,9 @@ export class Purchases {
    * @throws {@link PurchasesError} if there is an error while performing the purchase. If the {@link PurchasesError.errorCode} is {@link ErrorCode.UserCancelledError}, the user cancelled the purchase.
    */
   @requiresLoadedResources
-  public async purchase(params: PurchaseParams): Promise<PurchaseResult> {
+  private async purchaseAfterLoadingResources(
+    params: PurchaseParams,
+  ): Promise<PurchaseResult> {
     const appearanceOverride = mergeBrandingAppearanceOverrides(
       this._brandingAppearanceOverride,
       params.brandingAppearanceOverride,

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -43,7 +43,10 @@ import type { CheckoutCompleteResponse } from "./responses/checkout-complete-res
 import type { CheckoutPricingResponse } from "./responses/checkout-pricing-response";
 import { isWebBillingSandboxApiKey } from "../helpers/api-key-helper";
 import type { IdentifyResponse } from "./responses/identify-response";
-import type { CheckoutPrepareResponse } from "./responses/checkout-prepare-response";
+import type {
+  CheckoutPrepareResponse,
+  QuickPurchasesPrepareResponse,
+} from "./responses/checkout-prepare-response";
 import type { AttributionMetadata } from "../entities/purchase-params";
 import type { BrandingAppearance } from "../entities/branding";
 
@@ -253,20 +256,26 @@ export class Backend {
 
   async postCheckoutPrepare<
     T extends CheckoutPrepareResponse = CheckoutPrepareResponse,
-  >(productId: string, purchaseOption: PurchaseOption): Promise<T> {
+  >(productId: string, purchaseOption: PurchaseOption): Promise<T>;
+  async postCheckoutPrepare(): Promise<QuickPurchasesPrepareResponse>;
+  async postCheckoutPrepare<T>(
+    productId?: string,
+    purchaseOption?: PurchaseOption,
+  ): Promise<T> {
     type CheckoutPrepareRequestBody = {
-      product_id: string;
-      price_id: string;
+      product_id?: string;
+      price_id?: string;
       offer_id?: string;
     };
 
-    const requestBody: CheckoutPrepareRequestBody = {
-      product_id: productId,
-      price_id: purchaseOption.priceId,
-    };
+    const requestBody: CheckoutPrepareRequestBody = {};
 
-    if (purchaseOption.id !== "base_option") {
-      requestBody.offer_id = purchaseOption.id;
+    if (productId && purchaseOption) {
+      requestBody.product_id = productId;
+      requestBody.price_id = purchaseOption.priceId;
+      if (purchaseOption.id !== "base_option") {
+        requestBody.offer_id = purchaseOption.id;
+      }
     }
 
     return (await performRequest<CheckoutPrepareRequestBody, T>(

--- a/src/networking/responses/checkout-prepare-response.ts
+++ b/src/networking/responses/checkout-prepare-response.ts
@@ -18,3 +18,8 @@ export interface CheckoutPrepareResponse {
   paypal_gateway_params: CheckoutPreparePayPalGatewayParams | null;
   paddle_billing_params: CheckoutPreparePaddleBillingParams | null;
 }
+
+export interface QuickPurchasesPrepareResponse {
+  stripe_gateway_params: CheckoutPrepareStripeGatewayParams;
+  management_url: string;
+}

--- a/src/networking/responses/stripe-elements.ts
+++ b/src/networking/responses/stripe-elements.ts
@@ -19,5 +19,6 @@ export interface StripeElementsConfiguration {
 export interface GatewayParams {
   stripe_account_id?: string;
   publishable_api_key?: string;
+  account_country?: string | null;
   elements_configuration?: StripeElementsConfiguration;
 }

--- a/src/stripe/apple-pay-purchase.ts
+++ b/src/stripe/apple-pay-purchase.ts
@@ -1,0 +1,607 @@
+import type {
+  PaymentIntentResult,
+  PaymentRequestOptions,
+  PaymentRequestPaymentMethodEvent,
+  PaymentRequestUpdateOptions,
+  SetupIntentResult,
+  Stripe,
+} from "@stripe/stripe-js";
+
+import type { IEventsTracker } from "../behavioural-events/events-tracker";
+import {
+  createCheckoutPaymentGatewayErrorEvent,
+  createCheckoutPaymentFormSubmitEvent,
+  createCheckoutPaymentTaxCalculationEvent,
+} from "../behavioural-events/sdk-event-helpers";
+import {
+  ProductType,
+  type Product,
+  type PurchaseOption,
+  type SubscriptionOption,
+} from "../entities/offerings";
+import {
+  PurchaseFlowError,
+  PurchaseFlowErrorCode,
+  type OperationSessionSuccessfulResult,
+  type PurchaseOperationHelper,
+} from "../helpers/purchase-operation-helper";
+import { resolveDiscountBreakdownForPurchaseOption } from "../helpers/discount-breakdown-helper";
+import { Logger } from "../helpers/logger";
+import type { BrandingInfoResponse } from "../networking/responses/branding-response";
+import type { GatewayParams } from "../networking/responses/stripe-elements";
+import type { Translator } from "../ui/localization/translator";
+import type { PriceBreakdown } from "../ui/ui-types";
+import { StripeService, StripeServiceError } from "./stripe-service";
+
+export type ApplePayPurchaseAttemptResult =
+  | { status: "unavailable" }
+  | { status: "cancelled" }
+  | {
+      status: "finished";
+      operationResult: OperationSessionSuccessfulResult;
+    };
+
+interface TryApplePayPurchaseParams {
+  gatewayParams: GatewayParams;
+  managementUrl: string;
+  product: Product;
+  purchaseOption: PurchaseOption;
+  priceBreakdown: PriceBreakdown;
+  brandingInfo: BrandingInfoResponse | null;
+  translator: Translator;
+  customerEmail?: string;
+  purchaseOperationHelper: PurchaseOperationHelper;
+  eventsTracker: IEventsTracker;
+}
+
+export interface PreparedApplePayPurchase {
+  stripe: Stripe;
+  paymentRequest: ReturnType<Stripe["paymentRequest"]>;
+  managementUrl: string;
+}
+
+export interface PreparedApplePayConfiguration {
+  stripe: Stripe;
+  accountCountry: string;
+  managementUrl: string;
+}
+
+type PrepareApplePayPurchaseParams = Omit<
+  TryApplePayPurchaseParams,
+  "customerEmail" | "purchaseOperationHelper" | "eventsTracker"
+>;
+
+type CompletePaymentRequestUpdateOptions = PaymentRequestUpdateOptions & {
+  currency: string;
+  total: NonNullable<PaymentRequestUpdateOptions["total"]>;
+};
+
+export async function tryApplePayPurchase({
+  gatewayParams,
+  managementUrl,
+  product,
+  purchaseOption,
+  priceBreakdown,
+  brandingInfo,
+  translator,
+  customerEmail,
+  purchaseOperationHelper,
+  eventsTracker,
+}: TryApplePayPurchaseParams): Promise<ApplePayPurchaseAttemptResult> {
+  const preparedPurchase = await prepareApplePayPurchase({
+    gatewayParams,
+    managementUrl,
+    product,
+    purchaseOption,
+    priceBreakdown,
+    brandingInfo,
+    translator,
+  });
+
+  if (!preparedPurchase) {
+    return { status: "unavailable" };
+  }
+
+  return await presentPreparedApplePayPurchase({
+    preparedPurchase,
+    customerEmail,
+    brandingInfo,
+    translator,
+    purchaseOperationHelper,
+    eventsTracker,
+  });
+}
+
+export async function prepareApplePayPurchase({
+  gatewayParams,
+  managementUrl,
+  product,
+  purchaseOption,
+  priceBreakdown,
+  brandingInfo,
+  translator,
+}: PrepareApplePayPurchaseParams): Promise<PreparedApplePayPurchase | null> {
+  try {
+    const configuration = await prepareApplePayConfiguration({
+      gatewayParams,
+      managementUrl,
+    });
+    const preparedPurchase = createPreparedApplePayPurchase({
+      configuration,
+      product,
+      purchaseOption,
+      priceBreakdown,
+      brandingInfo,
+      translator,
+    });
+
+    const canMakePayment =
+      await preparedPurchase.paymentRequest.canMakePayment();
+    if (!canMakePayment?.applePay) {
+      return null;
+    }
+
+    return preparedPurchase;
+  } catch (error) {
+    Logger.debugLog(`Apple Pay setup failed, using checkout: ${String(error)}`);
+    return null;
+  }
+}
+
+export async function prepareApplePayConfiguration({
+  gatewayParams,
+  managementUrl,
+}: {
+  gatewayParams: GatewayParams;
+  managementUrl: string;
+}): Promise<PreparedApplePayConfiguration> {
+  const stripeAccountId = gatewayParams.stripe_account_id;
+  const publishableApiKey = gatewayParams.publishable_api_key;
+  const accountCountry = gatewayParams.account_country;
+  if (!stripeAccountId || !publishableApiKey || !accountCountry) {
+    throw new PurchaseFlowError(
+      PurchaseFlowErrorCode.ErrorSettingUpPurchase,
+      "Apple Pay configuration is incomplete.",
+    );
+  }
+
+  const { stripe } = await StripeService.getStripeClient(
+    stripeAccountId,
+    publishableApiKey,
+  );
+  return { stripe, accountCountry, managementUrl };
+}
+
+export async function prepareApplePayPurchaseForLater(
+  configuration: PreparedApplePayConfiguration,
+): Promise<PreparedApplePayPurchase | null> {
+  const { stripe, accountCountry, managementUrl } = configuration;
+  // Stripe requires canMakePayment() to run on the same request that is shown.
+  // The real purchase details replace these placeholders synchronously on click.
+  const paymentRequest = stripe.paymentRequest({
+    country: accountCountry.toUpperCase(),
+    currency: "usd",
+    total: {
+      label: "RevenueCat",
+      amount: 1,
+    },
+    requestPayerName: true,
+    requestPayerEmail: true,
+    disableWallets: ["googlePay", "link", "browserCard"],
+  });
+  const canMakePayment = await paymentRequest.canMakePayment();
+  if (!canMakePayment?.applePay) {
+    return null;
+  }
+
+  return { stripe, paymentRequest, managementUrl };
+}
+
+export function createPreparedApplePayPurchase({
+  configuration,
+  product,
+  purchaseOption,
+  priceBreakdown,
+  brandingInfo,
+  translator,
+}: {
+  configuration: PreparedApplePayConfiguration;
+  product: Product;
+  purchaseOption: PurchaseOption;
+  priceBreakdown: PriceBreakdown;
+  brandingInfo: BrandingInfoResponse | null;
+  translator: Translator;
+}): PreparedApplePayPurchase {
+  const { stripe, accountCountry, managementUrl } = configuration;
+  const paymentRequest = stripe.paymentRequest(
+    buildPaymentRequestOptions({
+      accountCountry,
+      managementUrl,
+      product,
+      purchaseOption,
+      priceBreakdown,
+      brandingInfo,
+      translator,
+    }),
+  );
+  return { stripe, paymentRequest, managementUrl };
+}
+
+export function updatePreparedApplePayPurchase({
+  preparedPurchase,
+  product,
+  purchaseOption,
+  priceBreakdown,
+  brandingInfo,
+  translator,
+}: {
+  preparedPurchase: PreparedApplePayPurchase;
+  product: Product;
+  purchaseOption: PurchaseOption;
+  priceBreakdown: PriceBreakdown;
+  brandingInfo: BrandingInfoResponse | null;
+  translator: Translator;
+}): PreparedApplePayPurchase {
+  preparedPurchase.paymentRequest.update(
+    buildPaymentRequestUpdateOptions({
+      managementUrl: preparedPurchase.managementUrl,
+      product,
+      purchaseOption,
+      priceBreakdown,
+      brandingInfo,
+      translator,
+    }),
+  );
+  return preparedPurchase;
+}
+
+function buildPaymentRequestOptions({
+  accountCountry,
+  managementUrl,
+  product,
+  purchaseOption,
+  priceBreakdown,
+  brandingInfo,
+  translator,
+}: {
+  accountCountry: string;
+  managementUrl: string;
+  product: Product;
+  purchaseOption: PurchaseOption;
+  priceBreakdown: PriceBreakdown;
+  brandingInfo: BrandingInfoResponse | null;
+  translator: Translator;
+}): PaymentRequestOptions {
+  return {
+    country: accountCountry.toUpperCase(),
+    requestPayerName: true,
+    requestPayerEmail: true,
+    disableWallets: ["googlePay", "link", "browserCard"],
+    ...buildPaymentRequestUpdateOptions({
+      managementUrl,
+      product,
+      purchaseOption,
+      priceBreakdown,
+      brandingInfo,
+      translator,
+    }),
+  };
+}
+
+function buildPaymentRequestUpdateOptions({
+  managementUrl,
+  product,
+  purchaseOption,
+  priceBreakdown,
+  brandingInfo,
+  translator,
+}: Omit<
+  Parameters<typeof buildPaymentRequestOptions>[0],
+  "accountCountry"
+>): CompletePaymentRequestUpdateOptions {
+  const resolvedDiscount = resolveDiscountBreakdownForPurchaseOption({
+    priceBreakdown,
+    productDetails: product,
+    purchaseOption,
+    translator,
+  });
+  const expressCheckoutOptions =
+    product.productType === ProductType.Subscription
+      ? StripeService.buildStripeExpressCheckoutOptionsForSubscription(
+          product,
+          priceBreakdown,
+          getSubscriptionOption(product, purchaseOption),
+          translator,
+          managementUrl,
+          resolvedDiscount,
+        )
+      : StripeService.buildStripeExpressCheckoutOptionsForNonSubscription(
+          product,
+          priceBreakdown,
+          resolvedDiscount,
+        );
+
+  return {
+    currency: priceBreakdown.currency.toLowerCase(),
+    total: {
+      label: brandingInfo?.app_name ?? product.title,
+      amount: StripeService.microsToMinimumAmountPrice(
+        priceBreakdown.totalAmountInMicros,
+        priceBreakdown.currency,
+      ),
+    },
+    displayItems: expressCheckoutOptions.lineItems?.map((lineItem) => ({
+      label: lineItem.name,
+      amount: lineItem.amount,
+    })),
+    applePay: expressCheckoutOptions.applePay,
+  };
+}
+
+function getSubscriptionOption(
+  product: Product,
+  purchaseOption: PurchaseOption,
+): SubscriptionOption {
+  const subscriptionOption =
+    product.subscriptionOptions?.[purchaseOption.id] ??
+    product.defaultSubscriptionOption;
+  if (!subscriptionOption) {
+    throw new PurchaseFlowError(PurchaseFlowErrorCode.ErrorSettingUpPurchase);
+  }
+  return subscriptionOption;
+}
+
+export function presentPreparedApplePayPurchase({
+  preparedPurchase,
+  customerEmail,
+  brandingInfo,
+  translator,
+  purchaseOperationHelper,
+  eventsTracker,
+  onPresented,
+}: {
+  preparedPurchase: PreparedApplePayPurchase;
+  customerEmail?: string;
+  brandingInfo: BrandingInfoResponse | null;
+  translator: Translator;
+  purchaseOperationHelper: PurchaseOperationHelper;
+  eventsTracker: IEventsTracker;
+  onPresented?: () => Promise<void>;
+}): Promise<ApplePayPurchaseAttemptResult> {
+  const { stripe, paymentRequest } = preparedPurchase;
+
+  return new Promise((resolve, reject) => {
+    let paymentAuthorized = false;
+    let settled = false;
+    let checkoutReadyPromise: Promise<void> = Promise.resolve();
+
+    const cleanup = () => {
+      paymentRequest.off("cancel", cancelHandler);
+      paymentRequest.off("paymentmethod", paymentMethodHandler);
+    };
+    const cancelHandler = () => {
+      if (paymentAuthorized || settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve({ status: "cancelled" });
+    };
+
+    const paymentMethodHandler = (event: PaymentRequestPaymentMethodEvent) => {
+      if (settled) {
+        return;
+      }
+      paymentAuthorized = true;
+      void checkoutReadyPromise
+        .then(() =>
+          completeApplePayPurchase({
+            stripe,
+            event,
+            customerEmail,
+            brandingInfo,
+            translator,
+            purchaseOperationHelper,
+            eventsTracker,
+          }),
+        )
+        .then((operationResult) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          cleanup();
+          resolve({ status: "finished", operationResult });
+        })
+        .catch((error) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          cleanup();
+          reject(toPurchaseFlowError(error));
+        });
+    };
+
+    paymentRequest.on("cancel", cancelHandler);
+    paymentRequest.on("paymentmethod", paymentMethodHandler);
+
+    try {
+      paymentRequest.show();
+    } catch (error) {
+      Logger.debugLog(
+        `Apple Pay presentation failed, using checkout: ${String(error)}`,
+      );
+      settled = true;
+      cleanup();
+      resolve({ status: "unavailable" });
+      return;
+    }
+
+    if (onPresented) {
+      checkoutReadyPromise = onPresented();
+      void checkoutReadyPromise.catch((error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        try {
+          paymentRequest.abort();
+        } catch {
+          // The payment sheet can already be closing when checkout start fails.
+        }
+        reject(toPurchaseFlowError(error));
+      });
+    }
+  });
+}
+
+async function completeApplePayPurchase({
+  stripe,
+  event,
+  customerEmail,
+  brandingInfo,
+  translator,
+  purchaseOperationHelper,
+  eventsTracker,
+}: {
+  stripe: Stripe;
+  event: PaymentRequestPaymentMethodEvent;
+  customerEmail?: string;
+  brandingInfo: BrandingInfoResponse | null;
+  translator: Translator;
+  purchaseOperationHelper: PurchaseOperationHelper;
+  eventsTracker: IEventsTracker;
+}): Promise<OperationSessionSuccessfulResult> {
+  eventsTracker.trackSDKEvent(
+    createCheckoutPaymentFormSubmitEvent({
+      selectedPaymentMethod: "apple_pay",
+    }),
+  );
+
+  let paymentRequestCompleted = false;
+
+  try {
+    const email =
+      customerEmail ??
+      event.payerEmail ??
+      event.paymentMethod.billing_details.email ??
+      undefined;
+    const completeResponse = await purchaseOperationHelper.checkoutComplete({
+      email,
+      locale: translator.selectedLocale,
+    });
+    const clientSecret = completeResponse.gateway_params?.client_secret;
+    if (!clientSecret) {
+      throw new PurchaseFlowError(
+        PurchaseFlowErrorCode.ErrorChargingPayment,
+        "The payment could not be initialized.",
+      );
+    }
+
+    if (brandingInfo?.gateway_tax_collection_enabled) {
+      const billingAddress = event.paymentMethod.billing_details.address;
+      const customerDetails = {
+        countryCode: billingAddress?.country ?? undefined,
+        postalCode: billingAddress?.postal_code ?? undefined,
+        state: billingAddress?.state ?? undefined,
+        city: billingAddress?.city ?? undefined,
+        addressLine1: billingAddress?.line1 ?? undefined,
+        addressLine2: billingAddress?.line2 ?? undefined,
+      };
+      const taxCalculation =
+        await purchaseOperationHelper.checkoutRefreshPricing(customerDetails);
+      eventsTracker.trackSDKEvent(
+        createCheckoutPaymentTaxCalculationEvent({
+          taxCalculation,
+          taxCustomerDetails: customerDetails,
+        }),
+      );
+    }
+
+    const result = await confirmApplePayPayment(
+      stripe,
+      clientSecret,
+      event.paymentMethod.id,
+    );
+    event.complete("success");
+    paymentRequestCompleted = true;
+    await handleRequiredAction(stripe, clientSecret, result);
+    return await purchaseOperationHelper.pollCurrentPurchaseForCompletion();
+  } catch (error) {
+    if (!paymentRequestCompleted) {
+      event.complete("fail");
+    }
+    if (error instanceof StripeServiceError) {
+      eventsTracker.trackSDKEvent(
+        createCheckoutPaymentGatewayErrorEvent({
+          errorCode: error.gatewayErrorCode ?? null,
+          errorMessage: error.message ?? "",
+        }),
+      );
+    }
+    throw error;
+  }
+}
+
+async function confirmApplePayPayment(
+  stripe: Stripe,
+  clientSecret: string,
+  paymentMethodId: string,
+): Promise<PaymentIntentResult | SetupIntentResult> {
+  const data = { payment_method: paymentMethodId };
+  const options = { handleActions: false };
+  const result = clientSecret.startsWith("seti_")
+    ? await stripe.confirmCardSetup(clientSecret, data, options)
+    : await stripe.confirmCardPayment(clientSecret, data, options);
+
+  if (result.error) {
+    throw StripeService.mapError(result.error);
+  }
+  return result;
+}
+
+async function handleRequiredAction(
+  stripe: Stripe,
+  clientSecret: string,
+  result: PaymentIntentResult | SetupIntentResult,
+): Promise<void> {
+  if (
+    "paymentIntent" in result &&
+    result.paymentIntent?.status === "requires_action"
+  ) {
+    const actionResult = await stripe.confirmCardPayment(clientSecret);
+    if (actionResult.error) {
+      throw StripeService.mapError(actionResult.error);
+    }
+  }
+
+  if (
+    "setupIntent" in result &&
+    result.setupIntent?.status === "requires_action"
+  ) {
+    const actionResult = await stripe.confirmCardSetup(clientSecret);
+    if (actionResult.error) {
+      throw StripeService.mapError(actionResult.error);
+    }
+  }
+}
+
+function toPurchaseFlowError(error: unknown): PurchaseFlowError {
+  if (error instanceof PurchaseFlowError) {
+    return error;
+  }
+  if (error instanceof StripeServiceError) {
+    return new PurchaseFlowError(
+      PurchaseFlowErrorCode.ErrorChargingPayment,
+      "The Apple Pay payment failed.",
+      error.message,
+    );
+  }
+  return new PurchaseFlowError(
+    PurchaseFlowErrorCode.UnknownError,
+    "The Apple Pay payment failed.",
+    error instanceof Error ? error.message : String(error),
+  );
+}

--- a/src/tests/helpers/purchase-operation-helper.test.ts
+++ b/src/tests/helpers/purchase-operation-helper.test.ts
@@ -24,6 +24,7 @@ import {
 import { type IEventsTracker } from "../../behavioural-events/events-tracker";
 import {
   checkoutPrepareResponse,
+  quickPurchasesPrepareResponse,
   checkoutStartResponse,
 } from "../test-responses";
 import { BackendErrorCode, ErrorCode } from "../../entities/errors";
@@ -360,6 +361,18 @@ describe("PurchaseOperationHelper", () => {
       { id: "base_option", priceId: "test-price-id" },
     );
     expect(response).toEqual(checkoutPrepareResponse);
+  });
+
+  test("prepareForQuickPurchases returns the backend response", async () => {
+    setCheckoutPrepareResponse(
+      HttpResponse.json(quickPurchasesPrepareResponse, {
+        status: StatusCodes.OK,
+      }),
+    );
+
+    const response = await purchaseOperationHelper.prepareForQuickPurchases();
+
+    expect(response).toEqual(quickPurchasesPrepareResponse);
   });
 
   test("prepareCheckout fails if /checkout/prepare fails", async () => {

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -7,6 +7,7 @@ import {
   Purchases,
   type PurchasesConfig,
   type PurchaseParams,
+  type PurchaseResult,
   PurchasesError,
   ReservedCustomerAttribute,
 } from "../main";
@@ -579,7 +580,7 @@ describe("Purchases.preload()", () => {
 });
 
 describe("Purchases.prepareForQuickPurchases()", () => {
-  test("shares preparation and presents Apple Pay before checkout start", async () => {
+  test("shares preparation, consumes it once, and prepares the next request", async () => {
     const purchases = configurePurchases();
     const handlers: { cancel?: () => void } = {};
     const order: string[] = [];
@@ -603,8 +604,19 @@ describe("Purchases.prepareForQuickPurchases()", () => {
       }),
       abort: vi.fn(),
     } as unknown as PaymentRequest;
+    const nextPaymentRequest = {
+      canMakePayment: vi.fn(async () => ({ applePay: true })),
+      on: vi.fn(),
+      off: vi.fn(),
+      update: vi.fn(),
+      show: vi.fn(),
+      abort: vi.fn(),
+    } as unknown as PaymentRequest;
     const stripe = {
-      paymentRequest: vi.fn(() => paymentRequest),
+      paymentRequest: vi
+        .fn()
+        .mockReturnValueOnce(paymentRequest)
+        .mockReturnValueOnce(nextPaymentRequest),
     } as unknown as Stripe;
     const prepareSpy = vi
       .spyOn(purchases["purchaseOperationHelper"], "prepareForQuickPurchases")
@@ -643,6 +655,58 @@ describe("Purchases.prepareForQuickPurchases()", () => {
       "errorCode",
       ErrorCode.UserCancelledError,
     );
+
+    await waitFor(() => {
+      expect(prepareSpy).toHaveBeenCalledTimes(2);
+      expect(nextPaymentRequest.canMakePayment).toHaveBeenCalledOnce();
+    });
+
+    await purchases.prepareForQuickPurchases();
+    expect(prepareSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("keeps prepared state when the purchase is not eligible", async () => {
+    const purchases = configurePurchases();
+    const paymentRequest = {
+      canMakePayment: vi.fn(async () => ({ applePay: true })),
+      on: vi.fn(),
+      off: vi.fn(),
+      update: vi.fn(),
+      show: vi.fn(),
+      abort: vi.fn(),
+    } as unknown as PaymentRequest;
+    const stripe = {
+      paymentRequest: vi.fn(() => paymentRequest),
+    } as unknown as Stripe;
+    const prepareSpy = vi
+      .spyOn(purchases["purchaseOperationHelper"], "prepareForQuickPurchases")
+      .mockResolvedValue(quickPurchasesPrepareResponse);
+    vi.spyOn(StripeService, "getStripeClient").mockResolvedValue({ stripe });
+    const fallbackResult = {} as PurchaseResult;
+    const purchasesInternal = purchases as unknown as {
+      purchaseAfterLoadingResources: (
+        params: PurchaseParams,
+      ) => Promise<PurchaseResult>;
+    };
+    const fallbackSpy = vi
+      .spyOn(purchasesInternal, "purchaseAfterLoadingResources")
+      .mockResolvedValue(fallbackResult);
+
+    await purchases.prepareForQuickPurchases();
+
+    await expect(
+      purchases.purchase({
+        rcPackage: createMonthlyPackageMock(),
+        discountCode: "SAVE10",
+        tryWithApplePay: true,
+      }),
+    ).resolves.toBe(fallbackResult);
+
+    expect(paymentRequest.show).not.toHaveBeenCalled();
+    expect(fallbackSpy).toHaveBeenCalledOnce();
+
+    await purchases.prepareForQuickPurchases();
+    expect(prepareSpy).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/tests/main.test.ts
+++ b/src/tests/main.test.ts
@@ -21,13 +21,20 @@ import {
   testApiKey,
   testUserId,
 } from "./base.purchases_test";
-import { APIGetRequest, type GetRequest } from "./test-responses";
+import {
+  APIGetRequest,
+  checkoutStartResponse,
+  type GetRequest,
+  quickPurchasesPrepareResponse,
+} from "./test-responses";
 import { createMonthlyPackageMock } from "./mocks/offering-mock-provider";
 import { waitFor } from "@testing-library/svelte";
 import { http, HttpResponse } from "msw";
 import { expectPromiseToError } from "./test-helpers";
 import { StatusCodes } from "http-status-codes";
 import type { BrandingInfoResponse } from "../networking/responses/branding-response";
+import { StripeService } from "../stripe/stripe-service";
+import type { PaymentRequest, Stripe } from "@stripe/stripe-js";
 
 describe("Purchases.configure() legacy", () => {
   test("throws error if given invalid api key", () => {
@@ -568,6 +575,74 @@ describe("Purchases.preload()", () => {
   test("can initialize without failing", async () => {
     const purchases = configurePurchases();
     await purchases.preload();
+  });
+});
+
+describe("Purchases.prepareForQuickPurchases()", () => {
+  test("shares preparation and presents Apple Pay before checkout start", async () => {
+    const purchases = configurePurchases();
+    const handlers: { cancel?: () => void } = {};
+    const order: string[] = [];
+    const paymentRequest = {
+      canMakePayment: vi.fn(async () => {
+        order.push("canMakePayment");
+        return { applePay: true };
+      }),
+      on: vi.fn((eventName: string, handler: () => void) => {
+        if (eventName === "cancel") {
+          handlers.cancel = handler;
+        }
+      }),
+      off: vi.fn(),
+      update: vi.fn(() => {
+        order.push("update");
+      }),
+      show: vi.fn(() => {
+        order.push("show");
+        queueMicrotask(() => handlers.cancel?.());
+      }),
+      abort: vi.fn(),
+    } as unknown as PaymentRequest;
+    const stripe = {
+      paymentRequest: vi.fn(() => paymentRequest),
+    } as unknown as Stripe;
+    const prepareSpy = vi
+      .spyOn(purchases["purchaseOperationHelper"], "prepareForQuickPurchases")
+      .mockResolvedValue(quickPurchasesPrepareResponse);
+    vi.spyOn(StripeService, "getStripeClient").mockResolvedValue({ stripe });
+
+    await Promise.all([
+      purchases.prepareForQuickPurchases(),
+      purchases.prepareForQuickPurchases(),
+    ]);
+
+    expect(prepareSpy).toHaveBeenCalledOnce();
+    expect(order).toEqual(["canMakePayment"]);
+
+    vi.spyOn(
+      purchases["purchaseOperationHelper"],
+      "checkoutStart",
+    ).mockImplementation(async () => {
+      order.push("start");
+      return checkoutStartResponse;
+    });
+
+    const purchasePromise = purchases.purchase({
+      rcPackage: createMonthlyPackageMock(),
+      tryWithApplePay: true,
+    });
+
+    expect(order).toEqual(["canMakePayment", "update", "show", "start"]);
+    expect(paymentRequest.canMakePayment).toHaveBeenCalledOnce();
+    expect(paymentRequest.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currency: "usd",
+      }),
+    );
+    await expect(purchasePromise).rejects.toHaveProperty(
+      "errorCode",
+      ErrorCode.UserCancelledError,
+    );
   });
 });
 

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -5,6 +5,7 @@ import {
   checkoutStartResponse,
   checkoutCompleteResponse,
   checkoutPrepareResponse,
+  quickPurchasesPrepareResponse,
   customerInfoResponse,
   offeringsArray,
   productsResponse,
@@ -711,6 +712,26 @@ describe("postCheckoutPrepare request", () => {
       priceId: "test_price_id",
     });
     expect(backendResponse).toEqual(checkoutPrepareResponse);
+  });
+
+  test("can prepare quick purchases without product data", async () => {
+    let requestBody: unknown;
+    server.use(
+      http.post(
+        "http://localhost:8000/rcbilling/v1/checkout/prepare",
+        async ({ request }) => {
+          requestBody = await request.json();
+          return HttpResponse.json(quickPurchasesPrepareResponse, {
+            status: 200,
+          });
+        },
+      ),
+    );
+
+    const backendResponse = await backend.postCheckoutPrepare();
+
+    expect(requestBody).toEqual({});
+    expect(backendResponse).toEqual(quickPurchasesPrepareResponse);
   });
 
   test("throws an error if the backend returns a server error", async () => {

--- a/src/tests/stripe/apple-pay-purchase.test.ts
+++ b/src/tests/stripe/apple-pay-purchase.test.ts
@@ -1,0 +1,366 @@
+import type {
+  PaymentRequest,
+  PaymentRequestPaymentMethodEvent,
+  Stripe,
+} from "@stripe/stripe-js";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import type { PurchaseOperationHelper } from "../../helpers/purchase-operation-helper";
+import { StripeService } from "../../stripe/stripe-service";
+import {
+  prepareApplePayPurchase,
+  prepareApplePayPurchaseForLater,
+  presentPreparedApplePayPurchase,
+  tryApplePayPurchase,
+  updatePreparedApplePayPurchase,
+} from "../../stripe/apple-pay-purchase";
+import {
+  brandingInfo,
+  checkoutPricingResponse,
+  rcPackage,
+  subscriptionOption,
+} from "../../stories/fixtures";
+import { Translator } from "../../ui/localization/translator";
+import { createEventsTrackerMock } from "../mocks/events-tracker-mock-provider";
+
+type PaymentRequestHandlers = {
+  cancel?: () => void;
+  paymentmethod?: (event: PaymentRequestPaymentMethodEvent) => void;
+};
+
+const operationResult = {
+  redemptionInfo: null,
+  operationSessionId: "operation-session-id",
+  storeTransactionIdentifier: "transaction-id",
+  productIdentifier: "product-id",
+  purchaseDate: new Date("2026-08-31T00:00:00Z"),
+};
+
+const createPurchaseOperationHelper = () =>
+  ({
+    checkoutComplete: vi.fn().mockResolvedValue({
+      operation_session_id: "operation-session-id",
+      gateway_params: { client_secret: "pi_secret" },
+      checkout_mode: "purchase",
+    }),
+    checkoutRefreshPricing: vi.fn().mockResolvedValue(checkoutPricingResponse),
+    pollCurrentPurchaseForCompletion: vi
+      .fn()
+      .mockResolvedValue(operationResult),
+  }) as unknown as PurchaseOperationHelper;
+
+const createStripeMocks = ({
+  canMakePayment = { applePay: true },
+  onShow,
+}: {
+  canMakePayment?: { applePay: boolean } | null;
+  onShow?: (handlers: PaymentRequestHandlers) => void;
+} = {}) => {
+  const handlers: PaymentRequestHandlers = {};
+  const paymentRequest = {
+    canMakePayment: vi.fn().mockResolvedValue(canMakePayment),
+    on: vi.fn(
+      (
+        eventName: keyof PaymentRequestHandlers,
+        handler: PaymentRequestHandlers[typeof eventName],
+      ) => {
+        handlers[eventName] = handler as never;
+      },
+    ),
+    off: vi.fn(),
+    update: vi.fn(),
+    show: vi.fn(() => onShow?.(handlers)),
+    abort: vi.fn(),
+  } as unknown as PaymentRequest;
+  const stripe = {
+    paymentRequest: vi.fn(() => paymentRequest),
+    confirmCardPayment: vi.fn().mockResolvedValue({
+      paymentIntent: { status: "succeeded" },
+    }),
+    confirmCardSetup: vi.fn(),
+  } as unknown as Stripe;
+
+  return { handlers, paymentRequest, stripe };
+};
+
+const createPaymentMethodEvent = (): PaymentRequestPaymentMethodEvent =>
+  ({
+    payerEmail: "wallet@example.com",
+    paymentMethod: {
+      id: "pm_apple_pay",
+      billing_details: {
+        email: "billing@example.com",
+        address: {
+          country: "US",
+          postal_code: "94107",
+          state: "CA",
+          city: "San Francisco",
+          line1: "123 Main Street",
+          line2: null,
+        },
+      },
+    },
+    complete: vi.fn(),
+  }) as unknown as PaymentRequestPaymentMethodEvent;
+
+const createParams = (
+  purchaseOperationHelper: PurchaseOperationHelper,
+  accountCountry: string | null = "US",
+) => ({
+  gatewayParams: {
+    stripe_account_id: "acct_123",
+    publishable_api_key: "pk_test_123",
+    account_country: accountCountry,
+  },
+  managementUrl: "https://pay.revenuecat.com/manage/session",
+  product: rcPackage.webBillingProduct,
+  purchaseOption: subscriptionOption,
+  priceBreakdown: {
+    currency: checkoutPricingResponse.currency,
+    totalAmountInMicros: checkoutPricingResponse.total_amount_in_micros,
+    totalExcludingTaxInMicros:
+      checkoutPricingResponse.total_excluding_tax_in_micros,
+    taxCalculationStatus: "disabled" as const,
+    taxAmountInMicros: null,
+    taxBreakdown: null,
+  },
+  brandingInfo: null,
+  translator: new Translator(),
+  customerEmail: undefined,
+  purchaseOperationHelper,
+  eventsTracker: createEventsTrackerMock(),
+});
+
+describe("tryApplePayPurchase", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("falls back before loading Stripe when the account country is missing", async () => {
+    const getStripeClientSpy = vi.spyOn(StripeService, "getStripeClient");
+
+    const result = await tryApplePayPurchase(
+      createParams(createPurchaseOperationHelper(), null),
+    );
+
+    expect(result).toEqual({ status: "unavailable" });
+    expect(getStripeClientSpy).not.toHaveBeenCalled();
+  });
+
+  test("falls back when Apple Pay is unavailable", async () => {
+    const { paymentRequest, stripe } = createStripeMocks({
+      canMakePayment: null,
+    });
+    vi.spyOn(StripeService, "getStripeClient").mockResolvedValue({ stripe });
+
+    const result = await tryApplePayPurchase(
+      createParams(createPurchaseOperationHelper()),
+    );
+
+    expect(result).toEqual({ status: "unavailable" });
+    expect(paymentRequest.show).not.toHaveBeenCalled();
+  });
+
+  test("falls back when Apple Pay cannot be presented", async () => {
+    const { paymentRequest, stripe } = createStripeMocks();
+    vi.mocked(paymentRequest.show).mockImplementation(() => {
+      throw new Error("User activation is no longer available");
+    });
+    vi.spyOn(StripeService, "getStripeClient").mockResolvedValue({ stripe });
+
+    const result = await tryApplePayPurchase(
+      createParams(createPurchaseOperationHelper()),
+    );
+
+    expect(result).toEqual({ status: "unavailable" });
+  });
+
+  test("returns cancellation without falling back to checkout", async () => {
+    const { paymentRequest, stripe } = createStripeMocks({
+      onShow: (handlers) => queueMicrotask(() => handlers.cancel?.()),
+    });
+    vi.spyOn(StripeService, "getStripeClient").mockResolvedValue({ stripe });
+
+    const result = await tryApplePayPurchase(
+      createParams(createPurchaseOperationHelper()),
+    );
+
+    expect(result).toEqual({ status: "cancelled" });
+    expect(paymentRequest.off).toHaveBeenCalledWith(
+      "cancel",
+      expect.any(Function),
+    );
+    expect(paymentRequest.off).toHaveBeenCalledWith(
+      "paymentmethod",
+      expect.any(Function),
+    );
+  });
+
+  test("shows the prepared payment request before starting checkout", async () => {
+    const order: string[] = [];
+    const { handlers, paymentRequest, stripe } = createStripeMocks();
+    vi.mocked(paymentRequest.show).mockImplementation(() => {
+      order.push("show");
+      queueMicrotask(() => handlers.cancel?.());
+    });
+    vi.spyOn(StripeService, "getStripeClient").mockResolvedValue({ stripe });
+    const params = createParams(createPurchaseOperationHelper());
+    const preparedPurchase = await prepareApplePayPurchase(params);
+
+    expect(preparedPurchase).not.toBeNull();
+    if (!preparedPurchase) {
+      return;
+    }
+
+    const resultPromise = presentPreparedApplePayPurchase({
+      preparedPurchase,
+      customerEmail: params.customerEmail,
+      brandingInfo: params.brandingInfo,
+      translator: params.translator,
+      purchaseOperationHelper: params.purchaseOperationHelper,
+      eventsTracker: params.eventsTracker,
+      onPresented: async () => {
+        order.push("start");
+      },
+    });
+
+    expect(order).toEqual(["show", "start"]);
+    await expect(resultPromise).resolves.toEqual({ status: "cancelled" });
+  });
+
+  test("completes the checkout with the Apple Pay payment method", async () => {
+    const paymentMethodEvent = createPaymentMethodEvent();
+    const { paymentRequest, stripe } = createStripeMocks({
+      onShow: (handlers) =>
+        queueMicrotask(() => handlers.paymentmethod?.(paymentMethodEvent)),
+    });
+    vi.spyOn(StripeService, "getStripeClient").mockResolvedValue({ stripe });
+    const purchaseOperationHelper = createPurchaseOperationHelper();
+
+    const result = await tryApplePayPurchase(
+      createParams(purchaseOperationHelper),
+    );
+
+    expect(result).toEqual({ status: "finished", operationResult });
+    expect(stripe.paymentRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        country: "US",
+        currency: "usd",
+        disableWallets: ["googlePay", "link", "browserCard"],
+        applePay: expect.objectContaining({
+          recurringPaymentRequest: expect.objectContaining({
+            managementURL: "https://pay.revenuecat.com/manage/session",
+          }),
+        }),
+      }),
+    );
+    expect(purchaseOperationHelper.checkoutComplete).toHaveBeenCalledWith({
+      email: "wallet@example.com",
+      locale: "en",
+    });
+    expect(stripe.confirmCardPayment).toHaveBeenCalledWith(
+      "pi_secret",
+      { payment_method: "pm_apple_pay" },
+      { handleActions: false },
+    );
+    expect(paymentMethodEvent.complete).toHaveBeenCalledOnce();
+    expect(paymentMethodEvent.complete).toHaveBeenCalledWith("success");
+    expect(paymentRequest.on).toHaveBeenCalledWith(
+      "paymentmethod",
+      expect.any(Function),
+    );
+    expect(
+      purchaseOperationHelper.pollCurrentPurchaseForCompletion,
+    ).toHaveBeenCalledOnce();
+  });
+
+  test("refreshes taxes with the Apple Pay billing address", async () => {
+    const paymentMethodEvent = createPaymentMethodEvent();
+    const { stripe } = createStripeMocks({
+      onShow: (handlers) =>
+        queueMicrotask(() => handlers.paymentmethod?.(paymentMethodEvent)),
+    });
+    vi.spyOn(StripeService, "getStripeClient").mockResolvedValue({ stripe });
+    const purchaseOperationHelper = createPurchaseOperationHelper();
+    const params = createParams(purchaseOperationHelper);
+
+    await tryApplePayPurchase({
+      ...params,
+      brandingInfo: {
+        ...brandingInfo,
+        gateway_tax_collection_enabled: true,
+      },
+    });
+
+    expect(purchaseOperationHelper.checkoutRefreshPricing).toHaveBeenCalledWith(
+      {
+        countryCode: "US",
+        postalCode: "94107",
+        state: "CA",
+        city: "San Francisco",
+        addressLine1: "123 Main Street",
+        addressLine2: undefined,
+      },
+    );
+  });
+});
+
+describe("prepareApplePayPurchaseForLater", () => {
+  test("checks availability before updating and presenting the same request", async () => {
+    const { paymentRequest, stripe } = createStripeMocks();
+    const preparedPurchase = await prepareApplePayPurchaseForLater({
+      stripe,
+      accountCountry: "US",
+      managementUrl: "https://pay.revenuecat.com/manage/session",
+    });
+
+    expect(preparedPurchase).not.toBeNull();
+    expect(paymentRequest.canMakePayment).toHaveBeenCalledOnce();
+    expect(stripe.paymentRequest).toHaveBeenCalledWith({
+      country: "US",
+      currency: "usd",
+      total: {
+        label: "RevenueCat",
+        amount: 1,
+      },
+      requestPayerName: true,
+      requestPayerEmail: true,
+      disableWallets: ["googlePay", "link", "browserCard"],
+    });
+
+    if (!preparedPurchase) {
+      return;
+    }
+    updatePreparedApplePayPurchase({
+      preparedPurchase,
+      product: rcPackage.webBillingProduct,
+      purchaseOption: subscriptionOption,
+      priceBreakdown: createParams(createPurchaseOperationHelper())
+        .priceBreakdown,
+      brandingInfo: null,
+      translator: new Translator(),
+    });
+
+    expect(stripe.paymentRequest).toHaveBeenCalledOnce();
+    expect(paymentRequest.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currency: "usd",
+        total: expect.objectContaining({
+          amount: expect.any(Number),
+        }),
+      }),
+    );
+  });
+
+  test("returns null when Apple Pay is unavailable", async () => {
+    const { stripe } = createStripeMocks({ canMakePayment: null });
+
+    await expect(
+      prepareApplePayPurchaseForLater({
+        stripe,
+        accountCountry: "US",
+        managementUrl: "https://pay.revenuecat.com/manage/session",
+      }),
+    ).resolves.toBeNull();
+  });
+});

--- a/src/tests/test-responses.ts
+++ b/src/tests/test-responses.ts
@@ -5,11 +5,14 @@ import type {
   ProductResponse,
   ProductsResponse,
 } from "../networking/responses/products-response";
-import { type CheckoutStartResponse } from "../networking/responses/checkout-start-response";
+import { type WebBillingCheckoutStartResponse } from "../networking/responses/checkout-start-response";
 import type { CheckoutCompleteResponse } from "../networking/responses/checkout-complete-response";
 import { StripeElementsSetupFutureUsage } from "../networking/responses/stripe-elements";
 import { StripeElementsMode } from "../networking/responses/stripe-elements";
-import type { CheckoutPrepareResponse } from "../networking/responses/checkout-prepare-response";
+import type {
+  CheckoutPrepareResponse,
+  QuickPurchasesPrepareResponse,
+} from "../networking/responses/checkout-prepare-response";
 import type { SubscriberResponse } from "../networking/responses/subscriber-response";
 
 const monthlyProductResponse: ProductResponse = {
@@ -620,6 +623,15 @@ export const checkoutPrepareResponse: CheckoutPrepareResponse = {
   },
 };
 
+export const quickPurchasesPrepareResponse: QuickPurchasesPrepareResponse = {
+  stripe_gateway_params: {
+    publishable_api_key: "test_publishable_api_key",
+    stripe_account_id: "test_stripe_account_id",
+    account_country: "US",
+  },
+  management_url: "https://api.revenuecat.com/quick-purchase-management",
+};
+
 export const customerInfoResponse: SubscriberResponse = {
   request_date: "2024-01-22T13:23:07Z",
   request_date_ms: 1705929787636,
@@ -927,7 +939,7 @@ const brandingInfoResponse = {
   support_email: "test-rcbilling-support@revenuecat.com",
 };
 
-export const checkoutStartResponse: CheckoutStartResponse = {
+export const checkoutStartResponse: WebBillingCheckoutStartResponse = {
   operation_session_id: "test-operation-session-id",
   gateway_params: {
     stripe_account_id: "test-stripe-account-id",

--- a/src/tests/ui/purchases-ui.test.ts
+++ b/src/tests/ui/purchases-ui.test.ts
@@ -18,10 +18,7 @@ import {
 import { createEventsTrackerMock } from "../mocks/events-tracker-mock-provider";
 import type { CheckoutStartResponse } from "../../networking/responses/checkout-start-response";
 import type { CheckoutPricingResponse } from "../../networking/responses/checkout-pricing-response";
-import {
-  checkoutCompleteResponse,
-  checkoutPrepareResponse,
-} from "../test-responses";
+import { checkoutCompleteResponse } from "../test-responses";
 import type { CheckoutCompleteResponse } from "../../networking/responses/checkout-complete-response";
 import type { SubscriptionOptionResponse } from "../../networking/responses/products-response";
 
@@ -146,7 +143,6 @@ const sessionForeverFreePurchaseOption =
   });
 
 const purchaseOperationHelperMock: PurchaseOperationHelper = {
-  prepareCheckout: async () => Promise.resolve(checkoutPrepareResponse),
   checkoutStart: async () =>
     Promise.resolve(checkoutStartResponse as CheckoutStartResponse),
   checkoutComplete: async () =>


### PR DESCRIPTION
Apple Pay must be presented from the original customer click, but the previous `.purchase()` flow waited for RC Billing checkout setup before attempting to show it. Safari can reject the presentation after that asynchronous work.

This adds `prepareForQuickPurchases()` to load and cache package-independent Stripe configuration before the click. When `.purchase({ tryWithApplePay: true })` is called with prepared state, the SDK shows Apple Pay synchronously and starts the normal RC Billing checkout immediately afterwards.

The existing checkout remains the default and is used when preparation is missing, Apple Pay cannot be presented, or the purchase requires the checkout UI. Express Purchase Button behavior is unchanged. The Web Billing demo includes a dedicated Apple Pay-first page.
