### PR TITLE
[WEB-4653] Forward external purchase token IDs to checkout

### DIFF
--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -325,6 +325,7 @@ export interface PresentedOfferingContext {
 export interface PresentExpressPurchaseButtonParams {
     customerEmail?: string;
     defaultLocale?: string;
+    externalPurchaseTokenId?: string;
     htmlTarget: HTMLElement;
     listener?: PurchaseListener;
     metadata?: PurchaseMetadata;
@@ -341,6 +342,7 @@ export interface PresentPaywallParams {
     readonly customerEmail?: string;
     readonly customVariables?: CustomVariables;
     readonly discountCode?: string;
+    readonly externalPurchaseTokenId?: string;
     readonly hideBackButtons?: boolean;
     readonly htmlTarget?: HTMLElement;
     readonly listener?: PaywallListener;
@@ -434,6 +436,7 @@ export interface PurchaseParams {
     customerEmail?: string;
     defaultLocale?: string;
     discountCode?: string;
+    externalPurchaseTokenId?: string;
     htmlTarget?: HTMLElement;
     metadata?: PurchaseMetadata;
     onDiscountCodeChanged?: (discountCode: string | null) => void;

--- a/examples/webbilling-demo/src/pages/appearance_overrides/index.tsx
+++ b/examples/webbilling-demo/src/pages/appearance_overrides/index.tsx
@@ -1,11 +1,13 @@
 import type { Package } from "@revenuecat/purchases-js";
 import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import LogoutButton from "../../components/LogoutButton";
 import { usePurchasesLoaderData } from "../../util/PurchasesLoader";
 import {
   configuredAppearanceOverride,
   operationAppearanceOverride,
 } from "../../util/runtime-appearance-overrides";
+import { getExternalPurchaseTokenId } from "../../util/external-purchase-token";
 
 type DemoStatus = {
   kind: "idle" | "running" | "success" | "error";
@@ -31,6 +33,8 @@ const getErrorMessage = (error: unknown) =>
 
 const AppearanceOverridesPage = () => {
   const { purchases, defaultPurchases, offering } = usePurchasesLoaderData();
+  const [searchParams] = useSearchParams();
+  const externalPurchaseTokenId = getExternalPurchaseTokenId(searchParams);
   const packages =
     offering?.availablePackages.filter((pkg) => pkg.webBillingProduct) ?? [];
   const [selectedPackageId, setSelectedPackageId] = useState(
@@ -67,6 +71,7 @@ const AppearanceOverridesPage = () => {
     return runFlow(purchaseLabels[appearanceMode], () =>
       purchaseInstance.purchase({
         rcPackage: pkg,
+        externalPurchaseTokenId,
         ...(appearanceMode === "operation"
           ? { brandingAppearanceOverride: operationAppearanceOverride }
           : {}),
@@ -83,6 +88,7 @@ const AppearanceOverridesPage = () => {
     return runFlow(paywallLabels[appearanceMode], () =>
       purchaseInstance.presentPaywall({
         offering,
+        externalPurchaseTokenId,
         ...(appearanceMode === "operation"
           ? { brandingAppearanceOverride: operationAppearanceOverride }
           : {}),

--- a/examples/webbilling-demo/src/pages/login/index.tsx
+++ b/examples/webbilling-demo/src/pages/login/index.tsx
@@ -3,6 +3,7 @@ import Button from "../../components/Button";
 import { useNavigate } from "react-router-dom";
 import { Purchases } from "@revenuecat/purchases-js";
 import { isPaddleApiKey, isStripeApiKey } from "../../util/PurchasesLoader";
+import { appendExternalPurchaseTokenId } from "../../util/external-purchase-token";
 
 const LoginPage: React.FC = () => {
   const navigate = useNavigate();
@@ -10,6 +11,7 @@ const LoginPage: React.FC = () => {
   const [nickname, setNickname] = useState("");
   const [appUserId, setAppUserId] = useState("");
   const [offeringId, setOfferingId] = useState("");
+  const [externalPurchaseTokenId, setExternalPurchaseTokenId] = useState("");
   const [useCustomLogger, setUseCustomLogger] = useState(true);
 
   const navigateToAppUserIDPaywall = (
@@ -27,6 +29,7 @@ const LoginPage: React.FC = () => {
       if (offeringId.trim()) {
         params.append("offeringId", offeringId.trim());
       }
+      appendExternalPurchaseTokenId(params, externalPurchaseTokenId);
       // Add custom logger preference
       params.append("useCustomLogger", useCustomLogger.toString());
 
@@ -59,6 +62,13 @@ const LoginPage: React.FC = () => {
               placeholder="Offering identifier (leave blank for default offering)"
               value={offeringId}
               onChange={(e) => setOfferingId(e.target.value)}
+              className="input-field"
+            />
+            <input
+              type="text"
+              placeholder="External purchase token ID (optional)"
+              value={externalPurchaseTokenId}
+              onChange={(e) => setExternalPurchaseTokenId(e.target.value)}
               className="input-field"
             />
             <input
@@ -112,6 +122,7 @@ const LoginPage: React.FC = () => {
               if (offeringId.trim()) {
                 params.append("offeringId", offeringId.trim());
               }
+              appendExternalPurchaseTokenId(params, externalPurchaseTokenId);
               const queryString = params.toString();
               window.location.assign(
                 `/appearance-overrides/${encodeURIComponent(userId)}${queryString ? `?${queryString}` : ""}`,

--- a/examples/webbilling-demo/src/pages/paywall/index.tsx
+++ b/examples/webbilling-demo/src/pages/paywall/index.tsx
@@ -18,6 +18,7 @@ import {
 import { getLongPeriodLabel, pluralizePeriod } from "../../util/period-label";
 import Button from "../../components/Button";
 import LogoutButton from "../../components/LogoutButton";
+import { getExternalPurchaseTokenId } from "../../util/external-purchase-token";
 
 interface IPackageCardProps {
   pkg: Package;
@@ -169,6 +170,7 @@ const PaywallPage: React.FC = () => {
   const email = searchParams.get("email");
   const displayName = searchParams.get("$displayName");
   const nickname = searchParams.get("nickname");
+  const externalPurchaseTokenId = getExternalPurchaseTokenId(searchParams);
   const skipSuccessPage = searchParams.get("skipSuccessPage") === "true";
   const showDiscountCodeField =
     searchParams.get("showDiscountCodeField") === "true";
@@ -238,6 +240,7 @@ const PaywallPage: React.FC = () => {
           showDiscountCodeField,
           selectedLocale: lang || navigator.language,
           customerEmail: email || undefined,
+          externalPurchaseTokenId,
           skipSuccessPage: skipSuccessPage,
           // @ts-expect-error This method is marked as internal for now but it's public.'
           labelsOverride: {

--- a/examples/webbilling-demo/src/pages/rc_paywall/index.tsx
+++ b/examples/webbilling-demo/src/pages/rc_paywall/index.tsx
@@ -5,6 +5,7 @@ import { usePurchasesLoaderData } from "../../util/PurchasesLoader";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { usePaywallSettings } from "../../hooks/usePaywallSettings";
 import SettingsGearButton from "../../components/SettingsGearButton";
+import { getExternalPurchaseTokenId } from "../../util/external-purchase-token";
 
 const RCPaywallPage: React.FC = () => {
   const { offering } = usePurchasesLoaderData();
@@ -12,6 +13,7 @@ const RCPaywallPage: React.FC = () => {
   const [searchParams] = useSearchParams();
   const lang = searchParams.get("lang");
   const email = searchParams.get("email");
+  const externalPurchaseTokenId = getExternalPurchaseTokenId(searchParams);
   const hideBackButtons = searchParams.get("hideBackButtons") === "true";
   const showDiscountCodeField =
     searchParams.get("showDiscountCodeField") === "true";
@@ -37,6 +39,7 @@ const RCPaywallPage: React.FC = () => {
         hideBackButtons: hideBackButtons,
         customVariables,
         customerEmail: email || undefined,
+        externalPurchaseTokenId,
       })
       .then((purchaseResult: PurchaseResult) => {
         const { customerInfo, redemptionInfo } = purchaseResult;
@@ -55,7 +58,15 @@ const RCPaywallPage: React.FC = () => {
         );
       })
       .catch((err: Error) => console.log(`Error: ${err}`));
-  }, [offering, navigate, lang, hideBackButtons, customVariables, email]);
+  }, [
+    offering,
+    navigate,
+    lang,
+    hideBackButtons,
+    customVariables,
+    email,
+    externalPurchaseTokenId,
+  ]);
 
   if (!offering) {
     console.error("No offering found");

--- a/examples/webbilling-demo/src/pages/rc_paywall_no_offering_passed/index.tsx
+++ b/examples/webbilling-demo/src/pages/rc_paywall_no_offering_passed/index.tsx
@@ -4,6 +4,7 @@ import React, { useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { usePaywallSettings } from "../../hooks/usePaywallSettings";
 import SettingsGearButton from "../../components/SettingsGearButton";
+import { getExternalPurchaseTokenId } from "../../util/external-purchase-token";
 
 // This page is used to test the case where no offering is passed to the paywall.
 // We expect the sdk to be smart enough to pick the .current offering autonomously.
@@ -12,6 +13,7 @@ const RCPaywallNoOfferingPassedPage: React.FC = () => {
   const [searchParams] = useSearchParams();
   const lang = searchParams.get("lang");
   const email = searchParams.get("email");
+  const externalPurchaseTokenId = getExternalPurchaseTokenId(searchParams);
   const {
     openSettings,
     settings: { customVariables },
@@ -31,6 +33,7 @@ const RCPaywallNoOfferingPassedPage: React.FC = () => {
         selectedLocale: lang || undefined,
         customVariables,
         customerEmail: email || undefined,
+        externalPurchaseTokenId,
       })
       .then((purchaseResult: PurchaseResult) => {
         const { customerInfo, redemptionInfo } = purchaseResult;
@@ -49,7 +52,7 @@ const RCPaywallNoOfferingPassedPage: React.FC = () => {
         );
       })
       .catch((err: Error) => console.log(`Error: ${err}`));
-  }, [navigate, lang, customVariables, email]);
+  }, [navigate, lang, customVariables, email, externalPurchaseTokenId]);
 
   return (
     <>

--- a/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
+++ b/examples/webbilling-demo/src/tests/helpers/test-helpers.ts
@@ -1,5 +1,10 @@
 import type { APIResponse } from "@playwright/test";
-import { type Page, type Locator, expect } from "@playwright/test";
+import {
+  type Page,
+  type Locator,
+  type Request,
+  expect,
+} from "@playwright/test";
 import type { StoreLoadTime } from "@revenuecat/purchases-js";
 import { BASE_URL, NON_TAX_TEST_API_KEY } from "./fixtures";
 import type { integrationTest } from "./integration-test";
@@ -26,6 +31,7 @@ export const getBackButtons = (page: Page) =>
 export const CARD_SELECTOR = ".packages div.card";
 export const PACKAGE_SELECTOR = "button.rc-pw-package";
 export const TAX_SKELETON_SELECTOR = "div[data-testid='tax-loading-skeleton']";
+export const EXTERNAL_PURCHASE_TOKEN_ID = "rcat_external_purchase_token_123";
 
 export const skipPaywallsTestIfDisabled = (test: typeof integrationTest) => {
   test.skip(
@@ -101,6 +107,7 @@ export async function navigateToLandingUrl(
     hideBackButtons?: boolean;
     discountCode?: string;
     storeLoadTime?: StoreLoadTime;
+    rc_external_purchase_token_id?: string;
   },
   apiKey?: string,
 ) {
@@ -125,6 +132,7 @@ export async function navigateToLandingUrl(
     hideCheckoutBackButton,
     discountCode,
     storeLoadTime,
+    rc_external_purchase_token_id,
   } = queryString ?? {};
 
   const params = new URLSearchParams();
@@ -173,6 +181,12 @@ export async function navigateToLandingUrl(
   if (storeLoadTime) {
     params.append("storeLoadTime", storeLoadTime);
   }
+  if (rc_external_purchase_token_id) {
+    params.append(
+      "rc_external_purchase_token_id",
+      rc_external_purchase_token_id,
+    );
+  }
 
   const rcPaywallPath = offeringId ? "rc_paywall" : "rc_paywall_no_offering";
 
@@ -181,6 +195,12 @@ export async function navigateToLandingUrl(
 
   return page;
 }
+
+export const waitForCheckoutStartRequest = (page: Page): Promise<Request> =>
+  page.waitForRequest(
+    (request) =>
+      request.method() === "POST" && request.url().includes("/checkout/start"),
+  );
 
 async function getAllElementsByLocator(
   locator: Locator,

--- a/examples/webbilling-demo/src/tests/paddle/purchase-flow.test.ts
+++ b/examples/webbilling-demo/src/tests/paddle/purchase-flow.test.ts
@@ -88,6 +88,33 @@ integrationTest.describe("Paddle flow", () => {
   );
 
   integrationTest(
+    "Purchases a product with an external purchase token",
+    async ({ page, userId, email }) => {
+      const fullName = `E2E ${userId.replace(/_/g, " ")}`;
+
+      page = await navigateToPaddleLandingUrl(page, userId, {
+        rc_external_purchase_token_id: EXTERNAL_PURCHASE_TOKEN_ID,
+      });
+      await forcePaddleCheckoutMode(page, "overlay");
+
+      await expect(page.getByText("Paddle demo")).toBeVisible({
+        timeout: PADDLE_UI_STEP_TIMEOUT_MS,
+      });
+
+      const packageCards = await getPackageCards(page);
+      expect(packageCards.length).toBeGreaterThan(0);
+
+      await startPurchaseFlow(packageCards[0]);
+
+      const checkoutFrame = getPaddleOverlayFrame(page);
+      await confirmPaddleCheckoutFormVisible(checkoutFrame);
+      await completePaddleCheckoutForm(checkoutFrame, email, fullName);
+
+      await confirmSuccessPage(page);
+    },
+  );
+
+  integrationTest(
     "Forwards the external purchase token from an RC Paywall",
     async ({ page, userId }) => {
       skipPaywallsTestIfDisabled(integrationTest);
@@ -115,6 +142,39 @@ integrationTest.describe("Paddle flow", () => {
       expect(request.postDataJSON().external_purchase_token_id).toBe(
         EXTERNAL_PURCHASE_TOKEN_ID,
       );
+    },
+  );
+
+  integrationTest(
+    "Purchases from an RC Paywall with an external purchase token",
+    async ({ page, userId, email }) => {
+      skipPaywallsTestIfDisabled(integrationTest);
+
+      const fullName = `E2E ${userId.replace(/_/g, " ")}`;
+
+      page = await navigateToPaddleLandingUrl(page, userId, {
+        useRcPaywall: true,
+        lang: "en",
+        email,
+        rc_external_purchase_token_id: EXTERNAL_PURCHASE_TOKEN_ID,
+      });
+      await forcePaddleCheckoutMode(page, "overlay");
+
+      const packageButton = page
+        .getByRole("button", { name: /days|months|lifetime/i })
+        .first();
+      await expect(packageButton).toBeVisible({
+        timeout: PADDLE_UI_STEP_TIMEOUT_MS,
+      });
+      await packageButton.click();
+
+      await page.getByRole("button", { name: /^continue$/i }).click();
+
+      const checkoutFrame = getPaddleOverlayFrame(page);
+      await confirmPaddleCheckoutFormVisible(checkoutFrame);
+      await completePaddleCheckoutForm(checkoutFrame, email, fullName, false);
+
+      await confirmSuccessPage(page);
     },
   );
 

--- a/examples/webbilling-demo/src/tests/paddle/purchase-flow.test.ts
+++ b/examples/webbilling-demo/src/tests/paddle/purchase-flow.test.ts
@@ -4,10 +4,12 @@ import { integrationTest } from "../helpers/integration-test";
 import {
   confirmPaymentComplete,
   confirmPaymentError,
+  EXTERNAL_PURCHASE_TOKEN_ID,
   getPackageCards,
   skipPaddleTestsIfDisabled,
   skipPaywallsTestIfDisabled,
   startPurchaseFlow,
+  waitForCheckoutStartRequest,
 } from "../helpers/test-helpers";
 import {
   completePaddleCheckoutForm,
@@ -59,6 +61,61 @@ integrationTest.describe("Paddle flow", () => {
   integrationTest.skip(
     !PADDLE_TEST_API_KEY,
     "Paddle E2E tests require VITE_RC_PADDLE_E2E_API_KEY.",
+  );
+
+  integrationTest(
+    "Forwards the external purchase token for a direct purchase",
+    async ({ page, userId }) => {
+      page = await navigateToPaddleLandingUrl(page, userId, {
+        rc_external_purchase_token_id: EXTERNAL_PURCHASE_TOKEN_ID,
+      });
+
+      await expect(page.getByText("Paddle demo")).toBeVisible({
+        timeout: PADDLE_UI_STEP_TIMEOUT_MS,
+      });
+
+      const packageCards = await getPackageCards(page);
+      expect(packageCards.length).toBeGreaterThan(0);
+      const requestPromise = waitForCheckoutStartRequest(page);
+
+      await startPurchaseFlow(packageCards[0]);
+
+      const request = await requestPromise;
+      expect(request.postDataJSON().external_purchase_token_id).toBe(
+        EXTERNAL_PURCHASE_TOKEN_ID,
+      );
+    },
+  );
+
+  integrationTest(
+    "Forwards the external purchase token from an RC Paywall",
+    async ({ page, userId }) => {
+      skipPaywallsTestIfDisabled(integrationTest);
+
+      page = await navigateToPaddleLandingUrl(page, userId, {
+        useRcPaywall: true,
+        lang: "en",
+        rc_external_purchase_token_id: EXTERNAL_PURCHASE_TOKEN_ID,
+      });
+
+      const packageButton = page
+        .getByRole("button", { name: /days|months|lifetime/i })
+        .first();
+      await expect(packageButton).toBeVisible({
+        timeout: PADDLE_UI_STEP_TIMEOUT_MS,
+      });
+      await packageButton.click();
+
+      const purchaseButton = page.getByRole("button", { name: /^continue$/i });
+      const requestPromise = waitForCheckoutStartRequest(page);
+
+      await purchaseButton.click();
+
+      const request = await requestPromise;
+      expect(request.postDataJSON().external_purchase_token_id).toBe(
+        EXTERNAL_PURCHASE_TOKEN_ID,
+      );
+    },
   );
 
   (["inline", "overlay"] as const).forEach((mode) => {

--- a/examples/webbilling-demo/src/tests/paddle/test-helpers.ts
+++ b/examples/webbilling-demo/src/tests/paddle/test-helpers.ts
@@ -29,6 +29,7 @@ type LandingQuery = {
   nickname?: string;
   hideBackButtons?: boolean;
   discountCode?: string;
+  rc_external_purchase_token_id?: string;
 };
 
 export async function navigateToPaddleLandingUrl(

--- a/examples/webbilling-demo/src/tests/purchase-flow.test.ts
+++ b/examples/webbilling-demo/src/tests/purchase-flow.test.ts
@@ -56,6 +56,18 @@ test.describe("Purchase flow", () => {
   );
 
   integrationTest(
+    "Purchases a subscription product with an external purchase token",
+    async ({ page, userId, email }) => {
+      page = await navigateToLandingUrl(page, userId, {
+        rc_external_purchase_token_id: EXTERNAL_PURCHASE_TOKEN_ID,
+      });
+      const packageCards = await getPackageCards(page);
+
+      await performPurchase(page, packageCards[1], email);
+    },
+  );
+
+  integrationTest(
     "Purchase a subscription product with deferred store load on regular paywall",
     async ({ page, userId, email }) => {
       page = await navigateToLandingUrl(page, userId, {
@@ -152,6 +164,29 @@ test.describe("Purchase flow", () => {
       expect(request.postDataJSON().external_purchase_token_id).toBe(
         EXTERNAL_PURCHASE_TOKEN_ID,
       );
+    },
+  );
+
+  integrationTest(
+    "Purchases from an RC Paywall with an external purchase token",
+    async ({ page, userId, email }) => {
+      skipPaywallsTestIfDisabled(integrationTest);
+
+      page = await navigateToLandingUrl(page, userId, {
+        offeringId: RC_PAYWALL_TEST_OFFERING_ID_WITH_VARIABLES,
+        useRcPaywall: true,
+        rc_external_purchase_token_id: EXTERNAL_PURCHASE_TOKEN_ID,
+      });
+      const title = page.getByText("E2E Tests for Purchases JS");
+      await expect(title).toBeVisible();
+
+      const weekly = page.getByText("weekly", { exact: true });
+      await weekly.click();
+
+      const purchaseButton = page.getByText("PURCHASE weekly", { exact: true });
+      await expect(purchaseButton).toBeVisible();
+
+      await performPurchase(page, purchaseButton.locator("../../.."), email);
     },
   );
 

--- a/examples/webbilling-demo/src/tests/purchase-flow.test.ts
+++ b/examples/webbilling-demo/src/tests/purchase-flow.test.ts
@@ -10,6 +10,7 @@ import {
   confirmStripeEmailFieldVisible,
   enterCreditCardDetails,
   enterEmail,
+  EXTERNAL_PURCHASE_TOKEN_ID,
   getBackButtons,
   getEmailFromUserId,
   getPackageCards,
@@ -17,6 +18,7 @@ import {
   performPurchase,
   skipPaywallsTestIfDisabled,
   startPurchaseFlow,
+  waitForCheckoutStartRequest,
 } from "./helpers/test-helpers";
 import { integrationTest } from "./helpers/integration-test";
 import {
@@ -32,6 +34,24 @@ test.describe("Purchase flow", () => {
       page = await navigateToLandingUrl(page, userId);
       const packageCards = await getPackageCards(page);
       await performPurchase(page, packageCards[1], email);
+    },
+  );
+
+  integrationTest(
+    "Forwards the external purchase token for a direct purchase",
+    async ({ page, userId }) => {
+      page = await navigateToLandingUrl(page, userId, {
+        rc_external_purchase_token_id: EXTERNAL_PURCHASE_TOKEN_ID,
+      });
+      const packageCards = await getPackageCards(page);
+      const requestPromise = waitForCheckoutStartRequest(page);
+
+      await startPurchaseFlow(packageCards[1]);
+
+      const request = await requestPromise;
+      expect(request.postDataJSON().external_purchase_token_id).toBe(
+        EXTERNAL_PURCHASE_TOKEN_ID,
+      );
     },
   );
 
@@ -103,6 +123,35 @@ test.describe("Purchase flow", () => {
 
       // Target the parent element of the purchase button since the function targets the button itself
       await performPurchase(page, purchaseButton.locator("../../.."), email);
+    },
+  );
+
+  integrationTest(
+    "Forwards the external purchase token from an RC Paywall",
+    async ({ page, userId }) => {
+      skipPaywallsTestIfDisabled(integrationTest);
+
+      page = await navigateToLandingUrl(page, userId, {
+        offeringId: RC_PAYWALL_TEST_OFFERING_ID_WITH_VARIABLES,
+        useRcPaywall: true,
+        rc_external_purchase_token_id: EXTERNAL_PURCHASE_TOKEN_ID,
+      });
+      const title = page.getByText("E2E Tests for Purchases JS");
+      await expect(title).toBeVisible();
+
+      const weekly = page.getByText("weekly", { exact: true });
+      await weekly.click();
+
+      const purchaseButton = page.getByText("PURCHASE weekly", { exact: true });
+      await expect(purchaseButton).toBeVisible();
+      const requestPromise = waitForCheckoutStartRequest(page);
+
+      await purchaseButton.click();
+
+      const request = await requestPromise;
+      expect(request.postDataJSON().external_purchase_token_id).toBe(
+        EXTERNAL_PURCHASE_TOKEN_ID,
+      );
     },
   );
 

--- a/examples/webbilling-demo/src/tests/stripe-checkout/purchase-flow.test.ts
+++ b/examples/webbilling-demo/src/tests/stripe-checkout/purchase-flow.test.ts
@@ -109,6 +109,48 @@ integrationTest.describe("Stripe Checkout flow", () => {
   );
 
   integrationTest(
+    "Purchases a product with an external purchase token",
+    async ({ page, userId, email }) => {
+      const fullName = `E2E ${userId.replace(/_/g, " ")}`;
+
+      page = await navigateToStripeCheckoutLandingUrl(page, userId, {
+        rc_external_purchase_token_id: EXTERNAL_PURCHASE_TOKEN_ID,
+      });
+
+      await expect(page.getByText("Stripe Checkout demo")).toBeVisible({
+        timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
+      });
+
+      const packageCards = await getPackageCards(page);
+      expect(packageCards.length).toBeGreaterThan(0);
+
+      await startPurchaseFlow(packageCards[0]);
+      await completeStripeCheckoutEmbeddedForm(page, email, fullName);
+      await confirmPaymentCompleteOrSkipOnCaptcha(
+        integrationTest,
+        page,
+        STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
+      );
+
+      const continueButton = page.getByRole("button", { name: /continue/i });
+      await expect(continueButton).toBeVisible({
+        timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
+      });
+
+      await Promise.all([
+        page.waitForURL(/\/success\//, {
+          timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
+        }),
+        continueButton.click(),
+      ]);
+
+      await expect(
+        page.getByText("Enjoy your premium experience."),
+      ).toBeVisible({ timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS });
+    },
+  );
+
+  integrationTest(
     "Purchases a product with embedded Stripe Checkout passing the email as query parameter",
     async ({ page, userId, email }) => {
       const fullName = `E2E ${userId.replace(/_/g, " ")}`;
@@ -277,6 +319,63 @@ integrationTest.describe("Stripe Checkout flow", () => {
       expect(request.postDataJSON().external_purchase_token_id).toBe(
         EXTERNAL_PURCHASE_TOKEN_ID,
       );
+    },
+  );
+
+  integrationTest(
+    "Purchases from an RC Paywall with an external purchase token",
+    async ({ page, userId, email }) => {
+      skipPaywallsTestIfDisabled(integrationTest);
+
+      const fullName = `E2E ${userId.replace(/_/g, " ")}`;
+
+      page = await navigateToStripeCheckoutLandingUrl(page, userId, {
+        useRcPaywall: true,
+        lang: "en",
+        email,
+        rc_external_purchase_token_id: EXTERNAL_PURCHASE_TOKEN_ID,
+      });
+
+      await expect(page.getByText("E2E Tests for Purchases JS")).toBeVisible({
+        timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
+      });
+      await expect(
+        page.getByText(
+          "Testing current Offering is picked when no offering is passed",
+        ),
+      ).toBeVisible({ timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS });
+
+      const monthlyPackage = page.getByText("monthly", { exact: true });
+      await monthlyPackage.click();
+
+      const purchaseButton = page.getByText(/Subscribe/i);
+      await expect(purchaseButton).toBeVisible({
+        timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
+      });
+      await purchaseButton.click();
+
+      await completeStripeCheckoutEmbeddedForm(page, email, fullName, false);
+      await confirmPaymentCompleteOrSkipOnCaptcha(
+        integrationTest,
+        page,
+        STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
+      );
+
+      const continueButton = page.getByRole("button", { name: /continue/i });
+      await expect(continueButton).toBeVisible({
+        timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
+      });
+
+      await Promise.all([
+        page.waitForURL(/\/success\//, {
+          timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
+        }),
+        continueButton.click(),
+      ]);
+
+      await expect(
+        page.getByText("Enjoy your premium experience."),
+      ).toBeVisible({ timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS });
     },
   );
 

--- a/examples/webbilling-demo/src/tests/stripe-checkout/purchase-flow.test.ts
+++ b/examples/webbilling-demo/src/tests/stripe-checkout/purchase-flow.test.ts
@@ -3,10 +3,12 @@ import { STRIPE_CHECKOUT_TEST_API_KEY } from "../helpers/fixtures";
 import { integrationTest } from "../helpers/integration-test";
 import {
   confirmPaymentError,
+  EXTERNAL_PURCHASE_TOKEN_ID,
   getPackageCards,
   skipPaywallsTestIfDisabled,
   skipStripeTestsIfDisabled,
   startPurchaseFlow,
+  waitForCheckoutStartRequest,
 } from "../helpers/test-helpers";
 import {
   confirmStripeCheckoutEmailPrefilled,
@@ -79,6 +81,30 @@ integrationTest.describe("Stripe Checkout flow", () => {
       await expect(
         page.getByText("Enjoy your premium experience."),
       ).toBeVisible({ timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS });
+    },
+  );
+
+  integrationTest(
+    "Forwards the external purchase token for a direct purchase",
+    async ({ page, userId }) => {
+      page = await navigateToStripeCheckoutLandingUrl(page, userId, {
+        rc_external_purchase_token_id: EXTERNAL_PURCHASE_TOKEN_ID,
+      });
+
+      await expect(page.getByText("Stripe Checkout demo")).toBeVisible({
+        timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
+      });
+
+      const packageCards = await getPackageCards(page);
+      expect(packageCards.length).toBeGreaterThan(0);
+      const requestPromise = waitForCheckoutStartRequest(page);
+
+      await startPurchaseFlow(packageCards[0]);
+
+      const request = await requestPromise;
+      expect(request.postDataJSON().external_purchase_token_id).toBe(
+        EXTERNAL_PURCHASE_TOKEN_ID,
+      );
     },
   );
 
@@ -218,6 +244,39 @@ integrationTest.describe("Stripe Checkout flow", () => {
       await expect(
         page.getByText("Enjoy your premium experience."),
       ).toBeVisible({ timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS });
+    },
+  );
+
+  integrationTest(
+    "Forwards the external purchase token from an RC Paywall",
+    async ({ page, userId }) => {
+      skipPaywallsTestIfDisabled(integrationTest);
+
+      page = await navigateToStripeCheckoutLandingUrl(page, userId, {
+        useRcPaywall: true,
+        lang: "en",
+        rc_external_purchase_token_id: EXTERNAL_PURCHASE_TOKEN_ID,
+      });
+
+      await expect(page.getByText("E2E Tests for Purchases JS")).toBeVisible({
+        timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
+      });
+
+      const monthlyPackage = page.getByText("monthly", { exact: true });
+      await monthlyPackage.click();
+
+      const purchaseButton = page.getByText(/Subscribe/i);
+      await expect(purchaseButton).toBeVisible({
+        timeout: STRIPE_CHECKOUT_UI_STEP_TIMEOUT_MS,
+      });
+      const requestPromise = waitForCheckoutStartRequest(page);
+
+      await purchaseButton.click();
+
+      const request = await requestPromise;
+      expect(request.postDataJSON().external_purchase_token_id).toBe(
+        EXTERNAL_PURCHASE_TOKEN_ID,
+      );
     },
   );
 

--- a/examples/webbilling-demo/src/tests/stripe-checkout/test-helpers.ts
+++ b/examples/webbilling-demo/src/tests/stripe-checkout/test-helpers.ts
@@ -24,6 +24,7 @@ type LandingQuery = {
   nickname?: string;
   hideBackButtons?: boolean;
   discountCode?: string;
+  rc_external_purchase_token_id?: string;
 };
 
 export async function navigateToStripeCheckoutLandingUrl(

--- a/examples/webbilling-demo/src/util/external-purchase-token.ts
+++ b/examples/webbilling-demo/src/util/external-purchase-token.ts
@@ -1,0 +1,20 @@
+export const RC_EXTERNAL_PURCHASE_TOKEN_ID_QUERY_PARAMETER =
+  "rc_external_purchase_token_id";
+
+export const appendExternalPurchaseTokenId = (
+  searchParams: URLSearchParams,
+  externalPurchaseTokenId: string,
+) => {
+  const normalizedTokenId = externalPurchaseTokenId.trim();
+  if (normalizedTokenId) {
+    searchParams.append(
+      RC_EXTERNAL_PURCHASE_TOKEN_ID_QUERY_PARAMETER,
+      normalizedTokenId,
+    );
+  }
+};
+
+export const getExternalPurchaseTokenId = (
+  searchParams: URLSearchParams,
+): string | undefined =>
+  searchParams.get(RC_EXTERNAL_PURCHASE_TOKEN_ID_QUERY_PARAMETER) || undefined;

--- a/examples/webbilling-demo/src/util/external-purchase-token.unit.test.ts
+++ b/examples/webbilling-demo/src/util/external-purchase-token.unit.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+import {
+  appendExternalPurchaseTokenId,
+  getExternalPurchaseTokenId,
+  RC_EXTERNAL_PURCHASE_TOKEN_ID_QUERY_PARAMETER,
+} from "./external-purchase-token";
+
+describe("external purchase token query parameter", () => {
+  test("appends a trimmed token ID", () => {
+    const searchParams = new URLSearchParams();
+
+    appendExternalPurchaseTokenId(
+      searchParams,
+      "  rcat_external_purchase_token_123  ",
+    );
+
+    expect(
+      searchParams.get(RC_EXTERNAL_PURCHASE_TOKEN_ID_QUERY_PARAMETER),
+    ).toBe("rcat_external_purchase_token_123");
+  });
+
+  test("omits an empty token ID", () => {
+    const searchParams = new URLSearchParams();
+
+    appendExternalPurchaseTokenId(searchParams, "   ");
+
+    expect(
+      searchParams.has(RC_EXTERNAL_PURCHASE_TOKEN_ID_QUERY_PARAMETER),
+    ).toBe(false);
+  });
+
+  test("reads the SDK token ID from the public URL parameter", () => {
+    const searchParams = new URLSearchParams({
+      [RC_EXTERNAL_PURCHASE_TOKEN_ID_QUERY_PARAMETER]:
+        "rcat_external_purchase_token_123",
+    });
+
+    expect(getExternalPurchaseTokenId(searchParams)).toBe(
+      "rcat_external_purchase_token_123",
+    );
+  });
+});

--- a/src/entities/present-express-purchase-button-params.ts
+++ b/src/entities/present-express-purchase-button-params.ts
@@ -70,6 +70,10 @@ export interface PresentExpressPurchaseButtonParams {
    */
   customerEmail?: string;
   /**
+   * The RevenueCat public identifier for an Apple external purchase token.
+   */
+  externalPurchaseTokenId?: string;
+  /**
    * The locale to use for the purchase flow. If not specified, English will be used
    */
   selectedLocale?: string;

--- a/src/entities/present-paywall-params.ts
+++ b/src/entities/present-paywall-params.ts
@@ -39,6 +39,11 @@ export interface PresentPaywallParams {
   readonly customerEmail?: string;
 
   /**
+   * The RevenueCat public identifier for an Apple external purchase token.
+   */
+  readonly externalPurchaseTokenId?: string;
+
+  /**
    * The purchase metadata to be passed to the backend when a purchase is started
    * from the paywall.
    * Any information provided here will be propagated to the payment gateway and

--- a/src/entities/purchase-params.ts
+++ b/src/entities/purchase-params.ts
@@ -89,6 +89,11 @@ export interface PurchaseParams {
   customerEmail?: string;
 
   /**
+   * The RevenueCat public identifier for an Apple external purchase token.
+   */
+  externalPurchaseTokenId?: string;
+
+  /**
    * Workflow-specific context for this purchase.
    * @internal
    */

--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -304,7 +304,7 @@ export class PurchaseOperationHelper {
         paywallId,
         paywallSessionId,
         customerEmail,
-        ...(externalPurchaseTokenId ? { externalPurchaseTokenId } : {}),
+        externalPurchaseTokenId,
         metadata,
         locale,
         attributionMetadata,

--- a/src/helpers/purchase-operation-helper.ts
+++ b/src/helpers/purchase-operation-helper.ts
@@ -134,6 +134,7 @@ interface CheckoutStartParams {
 
   // Customer data
   customerEmail?: string;
+  externalPurchaseTokenId?: string;
   metadata?: PurchaseMetadata;
   // Resolved from selectedLocale/defaultLocale at the public API layer.
   // Future: consider adding localeSource?: "selected" | "browser".
@@ -274,6 +275,7 @@ export class PurchaseOperationHelper {
     paywallId,
     paywallSessionId,
     customerEmail,
+    externalPurchaseTokenId,
     metadata,
     locale,
     attributionMetadata,
@@ -302,6 +304,7 @@ export class PurchaseOperationHelper {
         paywallId,
         paywallSessionId,
         customerEmail,
+        ...(externalPurchaseTokenId ? { externalPurchaseTokenId } : {}),
         metadata,
         locale,
         attributionMetadata,

--- a/src/main.ts
+++ b/src/main.ts
@@ -834,6 +834,11 @@ export class Purchases {
         rcPackage: pkg,
         htmlTarget: paywallParams.purchaseHtmlTarget,
         customerEmail: paywallParams.customerEmail,
+        ...(paywallParams.externalPurchaseTokenId
+          ? {
+              externalPurchaseTokenId: paywallParams.externalPurchaseTokenId,
+            }
+          : {}),
         metadata: paywallParams.metadata,
         brandingAppearanceOverride: paywallParams.brandingAppearanceOverride,
         showDiscountCodeField: paywallParams.showDiscountCodeField,
@@ -1165,6 +1170,7 @@ export class Purchases {
         onError("Error presenting express purchase button"),
         listener,
         paywallParams.metadata,
+        paywallParams.externalPurchaseTokenId,
       );
 
       certainHTMLTarget.innerHTML = "";
@@ -1551,6 +1557,7 @@ export class Purchases {
       purchaseOption,
       htmlTarget,
       customerEmail,
+      externalPurchaseTokenId,
       selectedLocale = englishLocale,
       defaultLocale = englishLocale,
       onButtonReady = () => {},
@@ -1620,6 +1627,7 @@ export class Purchases {
         eventsTracker: this.eventsTracker,
         brandingInfo: this._brandingInfo,
         purchaseOperationHelper: this.purchaseOperationHelper,
+        ...(externalPurchaseTokenId ? { externalPurchaseTokenId } : {}),
         metadata: metadata,
         customTranslations: params.labelsOverride,
         translator,
@@ -1642,6 +1650,7 @@ export class Purchases {
    * @param onPurchaseError - The callback to be called when the purchase fails.
    * @param listener - Optional paywall listener for purchase lifecycle events.
    * @param metadata - Optional purchase metadata forwarded to express checkout.
+   * @param externalPurchaseTokenId - Optional RevenueCat public identifier for an Apple external purchase token.
    * @returns Function that renders the wallet button.
    */
   public getWalletButtonRender(
@@ -1651,6 +1660,7 @@ export class Purchases {
     onError?: (error: Error) => void,
     listener?: PaywallListener,
     metadata?: PurchaseMetadata,
+    externalPurchaseTokenId?: string,
   ): WalletButtonRender | undefined {
     if (!isWebBillingApiKey(this._API_KEY)) {
       return undefined;
@@ -1673,6 +1683,7 @@ export class Purchases {
         customerEmail: customerEmail,
         htmlTarget: element,
         metadata,
+        ...(externalPurchaseTokenId ? { externalPurchaseTokenId } : {}),
         onButtonReady: (updater, walletsAvailable) => {
           buttonUpdater = updater;
           onReady?.(walletsAvailable);
@@ -1867,6 +1878,9 @@ export class Purchases {
           brandingInfo,
           appearanceOverride: params.brandingAppearanceOverride,
           purchaseOperationHelper: this.purchaseOperationHelper,
+          ...(params.externalPurchaseTokenId
+            ? { externalPurchaseTokenId: params.externalPurchaseTokenId }
+            : {}),
           selectedLocale: localeToBeUsed,
           metadata: metadata,
           defaultLocale,
@@ -2011,6 +2025,9 @@ export class Purchases {
           brandingInfo,
           appearanceOverride: params.brandingAppearanceOverride,
           purchaseOperationHelper: this.purchaseOperationHelper,
+          ...(params.externalPurchaseTokenId
+            ? { externalPurchaseTokenId: params.externalPurchaseTokenId }
+            : {}),
           selectedLocale: localeToBeUsed,
           metadata: metadata,
           defaultLocale,
@@ -2135,6 +2152,9 @@ export class Purchases {
             discountCode,
             attributionMetadata,
             workflowPurchaseContext,
+            ...(params.externalPurchaseTokenId
+              ? { externalPurchaseTokenId: params.externalPurchaseTokenId }
+              : {}),
             metadata,
             unmountPaddlePurchaseUi,
             paddleService,

--- a/src/main.ts
+++ b/src/main.ts
@@ -834,11 +834,7 @@ export class Purchases {
         rcPackage: pkg,
         htmlTarget: paywallParams.purchaseHtmlTarget,
         customerEmail: paywallParams.customerEmail,
-        ...(paywallParams.externalPurchaseTokenId
-          ? {
-              externalPurchaseTokenId: paywallParams.externalPurchaseTokenId,
-            }
-          : {}),
+        externalPurchaseTokenId: paywallParams.externalPurchaseTokenId,
         metadata: paywallParams.metadata,
         brandingAppearanceOverride: paywallParams.brandingAppearanceOverride,
         showDiscountCodeField: paywallParams.showDiscountCodeField,
@@ -1627,7 +1623,7 @@ export class Purchases {
         eventsTracker: this.eventsTracker,
         brandingInfo: this._brandingInfo,
         purchaseOperationHelper: this.purchaseOperationHelper,
-        ...(externalPurchaseTokenId ? { externalPurchaseTokenId } : {}),
+        externalPurchaseTokenId,
         metadata: metadata,
         customTranslations: params.labelsOverride,
         translator,
@@ -1683,7 +1679,7 @@ export class Purchases {
         customerEmail: customerEmail,
         htmlTarget: element,
         metadata,
-        ...(externalPurchaseTokenId ? { externalPurchaseTokenId } : {}),
+        externalPurchaseTokenId,
         onButtonReady: (updater, walletsAvailable) => {
           buttonUpdater = updater;
           onReady?.(walletsAvailable);
@@ -1790,6 +1786,7 @@ export class Purchases {
       attributionMetadata,
       paywallId,
       paywallSessionId,
+      externalPurchaseTokenId,
       selectedLocale = englishLocale,
       defaultLocale = englishLocale,
       skipSuccessPage = false,
@@ -1878,9 +1875,7 @@ export class Purchases {
           brandingInfo,
           appearanceOverride: params.brandingAppearanceOverride,
           purchaseOperationHelper: this.purchaseOperationHelper,
-          ...(params.externalPurchaseTokenId
-            ? { externalPurchaseTokenId: params.externalPurchaseTokenId }
-            : {}),
+          externalPurchaseTokenId,
           selectedLocale: localeToBeUsed,
           metadata: metadata,
           defaultLocale,
@@ -1903,6 +1898,7 @@ export class Purchases {
       customerEmail,
       workflowPurchaseContext,
       attributionMetadata,
+      externalPurchaseTokenId,
       selectedLocale = englishLocale,
       defaultLocale = englishLocale,
       skipSuccessPage = false,
@@ -2025,9 +2021,7 @@ export class Purchases {
           brandingInfo,
           appearanceOverride: params.brandingAppearanceOverride,
           purchaseOperationHelper: this.purchaseOperationHelper,
-          ...(params.externalPurchaseTokenId
-            ? { externalPurchaseTokenId: params.externalPurchaseTokenId }
-            : {}),
+          externalPurchaseTokenId,
           selectedLocale: localeToBeUsed,
           metadata: metadata,
           defaultLocale,
@@ -2054,6 +2048,7 @@ export class Purchases {
       discountCode,
       attributionMetadata,
       workflowPurchaseContext,
+      externalPurchaseTokenId,
       selectedLocale = englishLocale,
       defaultLocale = englishLocale,
       skipSuccessPage = false,
@@ -2152,9 +2147,7 @@ export class Purchases {
             discountCode,
             attributionMetadata,
             workflowPurchaseContext,
-            ...(params.externalPurchaseTokenId
-              ? { externalPurchaseTokenId: params.externalPurchaseTokenId }
-              : {}),
+            externalPurchaseTokenId,
             metadata,
             unmountPaddlePurchaseUi,
             paddleService,

--- a/src/networking/backend.ts
+++ b/src/networking/backend.ts
@@ -65,6 +65,7 @@ interface CheckoutStartRequestParams {
 
   // Customer data
   customerEmail?: string;
+  externalPurchaseTokenId?: string;
   metadata?: PurchaseMetadata;
   // Locale for lifecycle emails.
   locale?: string;
@@ -293,6 +294,7 @@ export class Backend {
     paywallId,
     paywallSessionId,
     customerEmail,
+    externalPurchaseTokenId,
     metadata,
     locale,
     attributionMetadata,
@@ -314,6 +316,7 @@ export class Backend {
         revision: number;
       };
       email?: string;
+      external_purchase_token_id?: string;
       metadata?: PurchaseMetadata;
       trace_id: string;
       locale?: string;
@@ -342,6 +345,10 @@ export class Backend {
 
     if (metadata) {
       requestBody.metadata = metadata;
+    }
+
+    if (externalPurchaseTokenId) {
+      requestBody.external_purchase_token_id = externalPurchaseTokenId;
     }
 
     if (purchaseOption.id !== "base_option") {

--- a/src/paddle/paddle-service.ts
+++ b/src/paddle/paddle-service.ts
@@ -282,7 +282,7 @@ export class PaddleService {
           presentedStepId,
           urlParameters,
           customerEmail: customerEmail ?? undefined,
-          ...(externalPurchaseTokenId ? { externalPurchaseTokenId } : {}),
+          externalPurchaseTokenId,
           metadata,
           locale,
           attributionMetadata,

--- a/src/paddle/paddle-service.ts
+++ b/src/paddle/paddle-service.ts
@@ -175,6 +175,7 @@ interface PaddleStartCheckoutParams {
   presentedOfferingContext: PresentedOfferingContext;
   purchaseOption: PurchaseOption;
   customerEmail?: string;
+  externalPurchaseTokenId?: string;
   metadata?: PurchaseMetadata;
   locale?: string;
   attributionMetadata?: AttributionMetadata;
@@ -261,6 +262,7 @@ export class PaddleService {
     presentedOfferingContext,
     purchaseOption,
     customerEmail,
+    externalPurchaseTokenId,
     metadata,
     locale,
     attributionMetadata,
@@ -280,6 +282,7 @@ export class PaddleService {
           presentedStepId,
           urlParameters,
           customerEmail: customerEmail ?? undefined,
+          ...(externalPurchaseTokenId ? { externalPurchaseTokenId } : {}),
           metadata,
           locale,
           attributionMetadata,

--- a/src/tests/helpers/purchase-operation-helper.test.ts
+++ b/src/tests/helpers/purchase-operation-helper.test.ts
@@ -246,6 +246,30 @@ describe("PurchaseOperationHelper", () => {
     });
   });
 
+  test("checkoutStart passes an external purchase token ID to the backend", async () => {
+    const mockPostCheckoutStart = vi
+      .spyOn(backend, "postCheckoutStart")
+      .mockResolvedValue(checkoutStartResponse);
+
+    await purchaseOperationHelper.checkoutStart({
+      appUserId: "test-app-user-id",
+      productId: "test-product-id",
+      purchaseOption: { id: "test-option-id", priceId: "test-price-id" },
+      presentedOfferingContext: {
+        offeringIdentifier: "test-offering-id",
+        targetingContext: null,
+        placementIdentifier: null,
+      },
+      externalPurchaseTokenId: "rcat_external_purchase_token_123",
+    });
+
+    expect(mockPostCheckoutStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        externalPurchaseTokenId: "rcat_external_purchase_token_123",
+      }),
+    );
+  });
+
   test("checkoutStart passes an appearance override to the backend", async () => {
     const mockPostCheckoutStart = vi
       .spyOn(backend, "postCheckoutStart")

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -820,6 +820,33 @@ describe("postCheckoutStart request", () => {
     expect(result).toEqual(checkoutStartResponse);
   });
 
+  test("includes an external purchase token ID when provided", async () => {
+    setCheckoutStartResponse(
+      HttpResponse.json(checkoutStartResponse, { status: 200 }),
+    );
+
+    await backend.postCheckoutStart({
+      appUserId: "someAppUserId",
+      productId: "monthly",
+      presentedOfferingContext: {
+        offeringIdentifier: "offering_1",
+        targetingContext: null,
+        placementIdentifier: null,
+      },
+      purchaseOption: { id: "base_option", priceId: "test_price_id" },
+      traceId: "test-trace-id",
+      externalPurchaseTokenId: "rcat_external_purchase_token_123",
+    });
+
+    const request = purchaseMethodAPIMock.mock.calls[0][0].request;
+    const requestBody = await request.json();
+    expect(requestBody).toEqual(
+      expect.objectContaining({
+        external_purchase_token_id: "rcat_external_purchase_token_123",
+      }),
+    );
+  });
+
   test("includes a partial appearance override when provided", async () => {
     setCheckoutStartResponse(
       HttpResponse.json(checkoutStartResponse, { status: 200 }),

--- a/src/tests/paddle/paddle-service.test.ts
+++ b/src/tests/paddle/paddle-service.test.ts
@@ -462,6 +462,25 @@ describe("PaddleService", () => {
       });
     });
 
+    test("passes an external purchase token ID to the backend", async () => {
+      vi.mocked(initPaddle).mockResolvedValue(mockPaddleInstance);
+
+      const mockPostCheckoutStart = vi
+        .spyOn(backend, "postCheckoutStart")
+        .mockResolvedValue(paddleCheckoutStartResponse);
+
+      await paddleService.startCheckout({
+        ...startCheckoutArgs,
+        externalPurchaseTokenId: "rcat_external_purchase_token_123",
+      });
+
+      expect(mockPostCheckoutStart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          externalPurchaseTokenId: "rcat_external_purchase_token_123",
+        }),
+      );
+    });
+
     test("omits url_parameters and presented_step_id without workflowPurchaseContext", async () => {
       vi.mocked(initPaddle).mockResolvedValue(mockPaddleInstance);
       let capturedBody: Record<string, unknown> | undefined;

--- a/src/tests/present-paywall.events.test.ts
+++ b/src/tests/present-paywall.events.test.ts
@@ -126,57 +126,6 @@ describe("Purchases.presentPaywall() paywall events", () => {
     });
   });
 
-  test("passes an external purchase token ID to purchases started from the paywall", async () => {
-    const purchases = configurePurchases();
-    const offering = createOfferingWithPaywall();
-    const packageId = offering.availablePackages[0]!.identifier;
-    const purchaseSpy = vi
-      .spyOn(purchases, "purchase")
-      .mockResolvedValue({} as PurchaseResult);
-
-    void purchases.presentPaywall({
-      offering,
-      externalPurchaseTokenId: "rcat_external_purchase_token_123",
-    });
-
-    await vi.waitFor(() => expect(paywallProps).toBeDefined());
-    paywallProps!.onPurchaseClicked(packageId);
-
-    await vi.waitFor(() => {
-      expect(purchaseSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          externalPurchaseTokenId: "rcat_external_purchase_token_123",
-        }),
-      );
-    });
-  });
-
-  test("passes an external purchase token ID to paywall express checkout", async () => {
-    const purchases = configurePurchases();
-    const offering = createOfferingWithPaywall();
-    const getWalletButtonRenderSpy = vi.spyOn(
-      purchases,
-      "getWalletButtonRender",
-    );
-
-    void purchases.presentPaywall({
-      offering,
-      externalPurchaseTokenId: "rcat_external_purchase_token_123",
-    });
-
-    await vi.waitFor(() => {
-      expect(getWalletButtonRenderSpy).toHaveBeenCalledWith(
-        offering,
-        expect.any(Function),
-        undefined,
-        expect.any(Function),
-        undefined,
-        undefined,
-        "rcat_external_purchase_token_123",
-      );
-    });
-  });
-
   test("fires paywall_cancel and paywall_close when purchase is cancelled and paywall is dismissed", async () => {
     const purchases = configurePurchases();
     const offering = createOfferingWithPaywall();

--- a/src/tests/present-paywall.events.test.ts
+++ b/src/tests/present-paywall.events.test.ts
@@ -126,6 +126,57 @@ describe("Purchases.presentPaywall() paywall events", () => {
     });
   });
 
+  test("passes an external purchase token ID to purchases started from the paywall", async () => {
+    const purchases = configurePurchases();
+    const offering = createOfferingWithPaywall();
+    const packageId = offering.availablePackages[0]!.identifier;
+    const purchaseSpy = vi
+      .spyOn(purchases, "purchase")
+      .mockResolvedValue({} as PurchaseResult);
+
+    void purchases.presentPaywall({
+      offering,
+      externalPurchaseTokenId: "rcat_external_purchase_token_123",
+    });
+
+    await vi.waitFor(() => expect(paywallProps).toBeDefined());
+    paywallProps!.onPurchaseClicked(packageId);
+
+    await vi.waitFor(() => {
+      expect(purchaseSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          externalPurchaseTokenId: "rcat_external_purchase_token_123",
+        }),
+      );
+    });
+  });
+
+  test("passes an external purchase token ID to paywall express checkout", async () => {
+    const purchases = configurePurchases();
+    const offering = createOfferingWithPaywall();
+    const getWalletButtonRenderSpy = vi.spyOn(
+      purchases,
+      "getWalletButtonRender",
+    );
+
+    void purchases.presentPaywall({
+      offering,
+      externalPurchaseTokenId: "rcat_external_purchase_token_123",
+    });
+
+    await vi.waitFor(() => {
+      expect(getWalletButtonRenderSpy).toHaveBeenCalledWith(
+        offering,
+        expect.any(Function),
+        undefined,
+        expect.any(Function),
+        undefined,
+        undefined,
+        "rcat_external_purchase_token_123",
+      );
+    });
+  });
+
   test("fires paywall_cancel and paywall_close when purchase is cancelled and paywall is dismissed", async () => {
     const purchases = configurePurchases();
     const offering = createOfferingWithPaywall();

--- a/src/tests/present-paywall.test.ts
+++ b/src/tests/present-paywall.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { mount } from "svelte";
+import type { Offering } from "../entities/offerings";
+import type { PurchaseResult } from "../entities/purchase-result";
+import { configurePurchases } from "./base.purchases_test";
+import { createMonthlyPackageMock } from "./mocks/offering-mock-provider";
+
+vi.mock("svelte", () => ({
+  mount: vi.fn(),
+  unmount: vi.fn(),
+}));
+
+type PaywallMountProps = {
+  onPurchaseClicked: (selectedPackageId: string) => void;
+};
+
+const createOfferingWithPaywall = (): Offering => {
+  const monthlyPackage = createMonthlyPackageMock();
+
+  return {
+    identifier: "paywall-offering-id",
+    serverDescription: "paywall offering",
+    metadata: null,
+    packagesById: {
+      [monthlyPackage.identifier]: monthlyPackage,
+    },
+    availablePackages: [monthlyPackage],
+    lifetime: null,
+    annual: null,
+    sixMonth: null,
+    threeMonth: null,
+    twoMonth: null,
+    monthly: monthlyPackage,
+    weekly: null,
+    hasPaywall: true,
+    paywallComponents: {
+      id: "paywall-public-id",
+      default_locale: "en_US",
+      components_localizations: {
+        en_US: {},
+      },
+    } as unknown as Offering["paywallComponents"],
+    uiConfig: {} as Offering["uiConfig"],
+  };
+};
+
+describe("Purchases.presentPaywall()", () => {
+  let paywallProps: PaywallMountProps | undefined;
+
+  beforeEach(() => {
+    paywallProps = undefined;
+    vi.mocked(mount).mockImplementation((_component, options) => {
+      paywallProps = options.props as PaywallMountProps;
+      (options.target as Element).innerHTML =
+        "<div data-testid='paywall-root'></div>";
+      return {} as ReturnType<typeof mount>;
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  test("forwards an external purchase token ID to purchases started from the paywall", async () => {
+    const purchases = configurePurchases();
+    const offering = createOfferingWithPaywall();
+    const packageId = offering.availablePackages[0]!.identifier;
+    const purchaseSpy = vi
+      .spyOn(purchases, "purchase")
+      .mockResolvedValue({} as PurchaseResult);
+
+    void purchases.presentPaywall({
+      offering,
+      externalPurchaseTokenId: "rcat_external_purchase_token_123",
+    });
+
+    await vi.waitFor(() => expect(paywallProps).toBeDefined());
+    paywallProps!.onPurchaseClicked(packageId);
+
+    await vi.waitFor(() => {
+      expect(purchaseSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          externalPurchaseTokenId: "rcat_external_purchase_token_123",
+        }),
+      );
+    });
+  });
+
+  test("forwards an external purchase token ID to paywall express checkout", async () => {
+    const purchases = configurePurchases();
+    const offering = createOfferingWithPaywall();
+    const getWalletButtonRenderSpy = vi.spyOn(
+      purchases,
+      "getWalletButtonRender",
+    );
+
+    void purchases.presentPaywall({
+      offering,
+      externalPurchaseTokenId: "rcat_external_purchase_token_123",
+    });
+
+    await vi.waitFor(() => {
+      expect(getWalletButtonRenderSpy).toHaveBeenCalledWith(
+        offering,
+        expect.any(Function),
+        undefined,
+        expect.any(Function),
+        undefined,
+        undefined,
+        "rcat_external_purchase_token_123",
+      );
+    });
+  });
+});

--- a/src/tests/purchase.events.test.ts
+++ b/src/tests/purchase.events.test.ts
@@ -122,31 +122,6 @@ describe("Purchases.configure()", () => {
     });
   });
 
-  test("forwards an external purchase token ID from purchase", async () => {
-    let purchaseProps: Record<string, unknown> | undefined;
-    vi.mocked(mount).mockImplementation((_component, options) => {
-      purchaseProps = options.props as Record<string, unknown>;
-      return vi.fn();
-    });
-
-    const purchases = Purchases.getSharedInstance();
-    const offerings = await purchases.getOfferings();
-    const packageToBuy = offerings.current?.availablePackages[0];
-
-    void purchases.purchase({
-      rcPackage: packageToBuy!,
-      externalPurchaseTokenId: "rcat_external_purchase_token_123",
-    });
-
-    await vi.waitFor(() => {
-      expect(purchaseProps).toEqual(
-        expect.objectContaining({
-          externalPurchaseTokenId: "rcat_external_purchase_token_123",
-        }),
-      );
-    });
-  });
-
   test("tracks the CheckoutSessionEnded event upon finishing a purchase", async () => {
     vi.mocked(mount).mockImplementation((_component, options) => {
       options.props?.onFinished("test-operation-session-id", null);
@@ -318,11 +293,6 @@ describe("Purchases.configure()", () => {
 
   test("tracks the CheckoutSessionEnded event upon finishing an express purchase", async () => {
     vi.mocked(mount).mockImplementation((_component, options) => {
-      expect(options.props).toEqual(
-        expect.objectContaining({
-          externalPurchaseTokenId: "rcat_external_purchase_token_123",
-        }),
-      );
       options.props?.onFinished({
         redemptionInfo: null,
         operationSessionId: "op-id",
@@ -342,7 +312,6 @@ describe("Purchases.configure()", () => {
     await purchases.presentExpressPurchaseButton({
       rcPackage: packageToBuy!,
       htmlTarget,
-      externalPurchaseTokenId: "rcat_external_purchase_token_123",
     });
 
     await vi.advanceTimersToNextTimerAsync();

--- a/src/tests/purchase.events.test.ts
+++ b/src/tests/purchase.events.test.ts
@@ -122,6 +122,31 @@ describe("Purchases.configure()", () => {
     });
   });
 
+  test("forwards an external purchase token ID from purchase", async () => {
+    let purchaseProps: Record<string, unknown> | undefined;
+    vi.mocked(mount).mockImplementation((_component, options) => {
+      purchaseProps = options.props as Record<string, unknown>;
+      return vi.fn();
+    });
+
+    const purchases = Purchases.getSharedInstance();
+    const offerings = await purchases.getOfferings();
+    const packageToBuy = offerings.current?.availablePackages[0];
+
+    void purchases.purchase({
+      rcPackage: packageToBuy!,
+      externalPurchaseTokenId: "rcat_external_purchase_token_123",
+    });
+
+    await vi.waitFor(() => {
+      expect(purchaseProps).toEqual(
+        expect.objectContaining({
+          externalPurchaseTokenId: "rcat_external_purchase_token_123",
+        }),
+      );
+    });
+  });
+
   test("tracks the CheckoutSessionEnded event upon finishing a purchase", async () => {
     vi.mocked(mount).mockImplementation((_component, options) => {
       options.props?.onFinished("test-operation-session-id", null);
@@ -293,6 +318,11 @@ describe("Purchases.configure()", () => {
 
   test("tracks the CheckoutSessionEnded event upon finishing an express purchase", async () => {
     vi.mocked(mount).mockImplementation((_component, options) => {
+      expect(options.props).toEqual(
+        expect.objectContaining({
+          externalPurchaseTokenId: "rcat_external_purchase_token_123",
+        }),
+      );
       options.props?.onFinished({
         redemptionInfo: null,
         operationSessionId: "op-id",
@@ -312,6 +342,7 @@ describe("Purchases.configure()", () => {
     await purchases.presentExpressPurchaseButton({
       rcPackage: packageToBuy!,
       htmlTarget,
+      externalPurchaseTokenId: "rcat_external_purchase_token_123",
     });
 
     await vi.advanceTimersToNextTimerAsync();

--- a/src/tests/purchase.test.ts
+++ b/src/tests/purchase.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { mount } from "svelte";
 import {
   configurePurchases,
   server,
@@ -11,12 +12,68 @@ import { buildAssetURL } from "../networking/assets";
 
 const applePayBrandingLogoFlags = { applePayBrandingLogoEnabled: true };
 
+vi.mock("svelte", () => ({
+  mount: vi.fn(),
+  unmount: vi.fn(),
+}));
+
 beforeEach(() => {
   document.head.innerHTML = "";
   document.body.innerHTML = "";
 });
 
 describe("purchase", () => {
+  test("forwards an external purchase token ID to the purchase UI", async () => {
+    let purchaseProps: Record<string, unknown> | undefined;
+    vi.mocked(mount).mockImplementation((_component, options) => {
+      purchaseProps = options.props as Record<string, unknown>;
+      return vi.fn();
+    });
+
+    const purchases = configurePurchases();
+    const offerings = await purchases.getOfferings();
+    const packageToBuy = offerings.current?.availablePackages[0];
+
+    void purchases.purchase({
+      rcPackage: packageToBuy!,
+      externalPurchaseTokenId: "rcat_external_purchase_token_123",
+    });
+
+    await vi.waitFor(() => {
+      expect(purchaseProps).toEqual(
+        expect.objectContaining({
+          externalPurchaseTokenId: "rcat_external_purchase_token_123",
+        }),
+      );
+    });
+  });
+
+  test("forwards an external purchase token ID to the express purchase UI", async () => {
+    let purchaseProps: Record<string, unknown> | undefined;
+    vi.mocked(mount).mockImplementation((_component, options) => {
+      purchaseProps = options.props as Record<string, unknown>;
+      return vi.fn();
+    });
+
+    const purchases = configurePurchases();
+    const offerings = await purchases.getOfferings();
+    const packageToBuy = offerings.current?.availablePackages[0];
+
+    void purchases.presentExpressPurchaseButton({
+      rcPackage: packageToBuy!,
+      htmlTarget: document.createElement("div"),
+      externalPurchaseTokenId: "rcat_external_purchase_token_123",
+    });
+
+    await vi.waitFor(() => {
+      expect(purchaseProps).toEqual(
+        expect.objectContaining({
+          externalPurchaseTokenId: "rcat_external_purchase_token_123",
+        }),
+      );
+    });
+  });
+
   test("purchase loads branding if not preloaded", async () => {
     const purchases = configurePurchases();
     const expectedRequest: GetRequest = {

--- a/src/tests/ui/purchases-ui.test.ts
+++ b/src/tests/ui/purchases-ui.test.ts
@@ -327,6 +327,27 @@ describe("PurchasesUI", () => {
     });
   });
 
+  test("passes an external purchase token ID to checkoutStart", async () => {
+    const checkoutStartSpy = vi
+      .spyOn(purchaseOperationHelperMock, "checkoutStart")
+      .mockResolvedValue(checkoutStartResponse);
+
+    render(PurchasesUI, {
+      props: {
+        ...basicProps,
+        externalPurchaseTokenId: "rcat_external_purchase_token_123",
+      },
+    });
+
+    await new Promise(process.nextTick);
+
+    expect(checkoutStartSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        externalPurchaseTokenId: "rcat_external_purchase_token_123",
+      }),
+    );
+  });
+
   test("passes undefined workflowPurchaseContext to checkoutStart when not provided", async () => {
     const checkoutStartSpy = vi
       .spyOn(purchaseOperationHelperMock, "checkoutStart")

--- a/src/tests/ui/stripe-checkout-purchases-ui.test.ts
+++ b/src/tests/ui/stripe-checkout-purchases-ui.test.ts
@@ -120,6 +120,27 @@ describe("StripeCheckoutPurchasesUi", () => {
     });
   });
 
+  test("passes an external purchase token ID to checkoutStart", async () => {
+    const checkoutStartSpy = vi
+      .spyOn(purchaseOperationHelperMock, "checkoutStart")
+      .mockResolvedValue(checkoutStartResponseWithoutStripeParams);
+
+    render(StripeCheckoutPurchasesUi, {
+      props: {
+        ...baseProps,
+        externalPurchaseTokenId: "rcat_external_purchase_token_123",
+      },
+    });
+
+    await waitFor(() => {
+      expect(checkoutStartSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          externalPurchaseTokenId: "rcat_external_purchase_token_123",
+        }),
+      );
+    });
+  });
+
   test("passes an appearance override to checkoutStart", async () => {
     const checkoutStartSpy = vi
       .spyOn(purchaseOperationHelperMock, "checkoutStart")

--- a/src/tests/wallet-button-render.test.ts
+++ b/src/tests/wallet-button-render.test.ts
@@ -116,4 +116,24 @@ describe("Purchases.getWalletButtonRender()", () => {
     await vi.waitFor(() => expect(buttonProps).toBeDefined());
     expect(buttonProps!.metadata).toEqual(metadata);
   });
+
+  test("forwards an external purchase token ID to the express purchase button", async () => {
+    const render = purchases.getWalletButtonRender(
+      offering,
+      onSuccess,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "rcat_external_purchase_token_123",
+    );
+    render!(document.createElement("div"), {
+      selectedPackageId: monthlyPackage.identifier,
+      onReady: vi.fn(),
+    });
+    await vi.waitFor(() => expect(buttonProps).toBeDefined());
+    expect(buttonProps!.externalPurchaseTokenId).toBe(
+      "rcat_external_purchase_token_123",
+    );
+  });
 });

--- a/src/ui/express-purchase-button/express-purchase-button-props.ts
+++ b/src/ui/express-purchase-button/express-purchase-button-props.ts
@@ -23,6 +23,7 @@ export interface ExpressPurchaseButtonProps {
   appUserId: string;
   rcPackage: Package;
   purchaseOption: PurchaseOption;
+  externalPurchaseTokenId?: string;
   metadata: PurchaseMetadata | undefined;
   brandingInfo: BrandingInfoResponse | null;
   purchases: Purchases;

--- a/src/ui/express-purchase-button/express-purchase-button.svelte
+++ b/src/ui/express-purchase-button/express-purchase-button.svelte
@@ -299,7 +299,7 @@
         presentedOfferingContext:
           rcPackage.webBillingProduct.presentedOfferingContext,
         customerEmail,
-        ...(externalPurchaseTokenId ? { externalPurchaseTokenId } : {}),
+        externalPurchaseTokenId,
         metadata,
         locale: translator.selectedLocale,
       });

--- a/src/ui/express-purchase-button/express-purchase-button.svelte
+++ b/src/ui/express-purchase-button/express-purchase-button.svelte
@@ -45,6 +45,7 @@
     appUserId,
     rcPackage,
     purchaseOption,
+    externalPurchaseTokenId,
     metadata,
     brandingInfo,
     eventsTracker,
@@ -298,6 +299,7 @@
         presentedOfferingContext:
           rcPackage.webBillingProduct.presentedOfferingContext,
         customerEmail,
+        ...(externalPurchaseTokenId ? { externalPurchaseTokenId } : {}),
         metadata,
         locale: translator.selectedLocale,
       });

--- a/src/ui/paddle-purchases-ui.svelte
+++ b/src/ui/paddle-purchases-ui.svelte
@@ -47,6 +47,7 @@
     appUserId: string;
     purchaseOption: PurchaseOption;
     customerEmail: string | undefined;
+    externalPurchaseTokenId?: string;
     discountCode?: string;
     metadata: PurchaseMetadata | undefined;
     attributionMetadata?: AttributionMetadata;
@@ -72,6 +73,7 @@
     appUserId,
     purchaseOption,
     customerEmail,
+    externalPurchaseTokenId,
     discountCode,
     metadata,
     attributionMetadata,
@@ -202,6 +204,7 @@
         presentedOfferingContext,
         purchaseOption,
         customerEmail,
+        ...(externalPurchaseTokenId ? { externalPurchaseTokenId } : {}),
         metadata,
         locale: selectedLocale,
         attributionMetadata,

--- a/src/ui/paddle-purchases-ui.svelte
+++ b/src/ui/paddle-purchases-ui.svelte
@@ -204,7 +204,7 @@
         presentedOfferingContext,
         purchaseOption,
         customerEmail,
-        ...(externalPurchaseTokenId ? { externalPurchaseTokenId } : {}),
+        externalPurchaseTokenId,
         metadata,
         locale: selectedLocale,
         attributionMetadata,

--- a/src/ui/purchases-ui.svelte
+++ b/src/ui/purchases-ui.svelte
@@ -53,6 +53,7 @@
     appUserId: string;
     rcPackage: Package;
     purchaseOption: PurchaseOption;
+    externalPurchaseTokenId?: string;
     metadata: PurchaseMetadata | undefined;
     brandingInfo: BrandingInfoResponse | null;
     purchases: Purchases;
@@ -89,6 +90,7 @@
     appUserId,
     rcPackage,
     purchaseOption,
+    externalPurchaseTokenId,
     metadata,
     brandingInfo,
     purchases,
@@ -242,6 +244,7 @@
         purchaseOption: nextPurchaseOption,
         presentedOfferingContext: nextProductDetails.presentedOfferingContext,
         customerEmail: nextEmail,
+        ...(externalPurchaseTokenId ? { externalPurchaseTokenId } : {}),
         metadata,
         workflowPurchaseContext,
         attributionMetadata,
@@ -271,6 +274,7 @@
             presentedOfferingContext:
               nextProductDetails.presentedOfferingContext,
             customerEmail: undefined,
+            ...(externalPurchaseTokenId ? { externalPurchaseTokenId } : {}),
             metadata,
             workflowPurchaseContext,
             attributionMetadata,

--- a/src/ui/purchases-ui.svelte
+++ b/src/ui/purchases-ui.svelte
@@ -244,7 +244,7 @@
         purchaseOption: nextPurchaseOption,
         presentedOfferingContext: nextProductDetails.presentedOfferingContext,
         customerEmail: nextEmail,
-        ...(externalPurchaseTokenId ? { externalPurchaseTokenId } : {}),
+        externalPurchaseTokenId,
         metadata,
         workflowPurchaseContext,
         attributionMetadata,
@@ -274,7 +274,7 @@
             presentedOfferingContext:
               nextProductDetails.presentedOfferingContext,
             customerEmail: undefined,
-            ...(externalPurchaseTokenId ? { externalPurchaseTokenId } : {}),
+            externalPurchaseTokenId,
             metadata,
             workflowPurchaseContext,
             attributionMetadata,

--- a/src/ui/stripe-checkout-purchases-ui.svelte
+++ b/src/ui/stripe-checkout-purchases-ui.svelte
@@ -42,6 +42,7 @@
     appUserId: string;
     purchaseOption: PurchaseOption;
     customerEmail: string | undefined;
+    externalPurchaseTokenId?: string;
     metadata: PurchaseMetadata | undefined;
     purchaseOperationHelper: PurchaseOperationHelper;
     workflowPurchaseContext?: WorkflowPurchaseContext;
@@ -65,6 +66,7 @@
     appUserId,
     purchaseOption,
     customerEmail,
+    externalPurchaseTokenId,
     metadata,
     purchaseOperationHelper,
     workflowPurchaseContext,
@@ -177,6 +179,7 @@
         presentedOfferingContext:
           rcPackage.webBillingProduct.presentedOfferingContext,
         customerEmail: email,
+        ...(externalPurchaseTokenId ? { externalPurchaseTokenId } : {}),
         metadata,
         workflowPurchaseContext,
         attributionMetadata,

--- a/src/ui/stripe-checkout-purchases-ui.svelte
+++ b/src/ui/stripe-checkout-purchases-ui.svelte
@@ -179,7 +179,7 @@
         presentedOfferingContext:
           rcPackage.webBillingProduct.presentedOfferingContext,
         customerEmail: email,
-        ...(externalPurchaseTokenId ? { externalPurchaseTokenId } : {}),
+        externalPurchaseTokenId,
         metadata,
         workflowPurchaseContext,
         attributionMetadata,


### PR DESCRIPTION
## Description

Expose an optional RevenueCat external purchase token ID on the purchases-js purchase APIs and forward it to Khepri when checkout starts.

## Changes

- [WEB-4653](https://linear.app/revenuecat/issue/WEB-4653)
- Add `externalPurchaseTokenId` to `PurchaseParams`, `PresentPaywallParams`, and `PresentExpressPurchaseButtonParams`.
- Preserve the value through direct purchases, paywall purchases, paywall express checkout, and direct express-purchase buttons.
- Forward it through Web Billing, Stripe, and Paddle checkout paths.
- Serialize non-empty values as `external_purchase_token_id` on `/checkout/start`.
- Omit the field when unavailable so existing request bodies remain unchanged.
- Update the checked-in public API report and add boundary coverage.

## Dependency

Depends on [RevenueCat/khepri#24610](https://github.com/RevenueCat/khepri/pull/24610) being deployed before this SDK starts sending the field.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shared checkout-start contract across all payment paths; risk is mitigated by making the field optional and requiring a coordinated Khepri deploy.
> 
> **Overview**
> Adds optional **`externalPurchaseTokenId`** on **`purchase`**, **`presentPaywall`**, and **`presentExpressPurchaseButton`**, documented as RevenueCat’s public Apple external purchase token identifier.
> 
> The value is threaded through paywall purchases, wallet/express checkout, and Web Billing, Stripe Checkout, and Paddle UIs into **`checkoutStart`**, which sends **`external_purchase_token_id`** on **`POST /checkout/start`** only when non-empty so existing clients are unchanged.
> 
> The web billing demo reads **`rc_external_purchase_token_id`** from the URL and passes it into those APIs. Playwright and unit tests assert the field on checkout start and cover end-to-end purchases with a token across Stripe, Paddle, and RC Paywall paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 098b1230a113092261e7093e3abb2a41feeeb8b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->