### PR TITLE
DX-999 | bump purchases-ui-js version to 4.8.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@eslint/js": "^9.16.0",
     "@microsoft/api-extractor": "^7.48.0",
     "@paddle/paddle-js": "^1.6.4",
-    "@revenuecat/purchases-ui-js": "4.8.19",
+    "@revenuecat/purchases-ui-js": "4.8.21",
     "@storybook/addon-essentials": "^8.6.15",
     "@storybook/addon-interactions": "^8.6.15",
     "@storybook/addon-links": "^8.6.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^1.6.4
         version: 1.6.4
       "@revenuecat/purchases-ui-js":
-        specifier: 4.8.19
-        version: 4.8.19(svelte@5.46.4)
+        specifier: 4.8.21
+        version: 4.8.21(svelte@5.46.4)
       "@storybook/addon-essentials":
         specifier: ^8.6.15
         version: 8.6.15(@types/react@19.0.10)(storybook@8.6.15(prettier@3.4.2))
@@ -698,19 +698,19 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
 
-  "@revenuecat/purchases-ui-js@4.8.19":
+  "@revenuecat/purchases-ui-js@4.8.21":
     resolution:
       {
-        integrity: sha512-MJ9kLnekG9nFvQchqQe556R1DHn1g4krXgwd9CBZvMo8PPga4cRIzU1rjgkSESK18KMWw/wiUQ1pTcNAAC5SYg==,
+        integrity: sha512-RfV372rroVFOyFs6rfENy6IdNCsWzv8V4GXe/Bn2H3mM7d7o0BVyT/eofVCw3liC2NUfJ2yyRAvk4InhkI98Lw==,
       }
     engines: { node: ^22.18 || ^24.11 }
     peerDependencies:
       svelte: ^5.46.4
 
-  "@revenuecat/workflow-web-components-sdk@0.1.4":
+  "@revenuecat/workflow-web-components-sdk@0.1.8":
     resolution:
       {
-        integrity: sha512-8LGZkqNNE7MgziVSnH6s6yjVkK32g6Rzi92UYy9o5bhtBuYwtz5+qRVh+QG5cU+AVfaUCAMjm2Ep7iBwHNW7mw==,
+        integrity: sha512-c3CbxzyHVB7GWLFSaY9RCm0tXF2Wq8mDXNG9924N6r6CxecAsDVcvwTPurs8OaslSr0hkvYNEj4/OOjG1e32BA==,
       }
     engines: { node: ">=18" }
 
@@ -6128,13 +6128,13 @@ snapshots:
 
   "@pkgr/core@0.1.1": {}
 
-  "@revenuecat/purchases-ui-js@4.8.19(svelte@5.46.4)":
+  "@revenuecat/purchases-ui-js@4.8.21(svelte@5.46.4)":
     dependencies:
-      "@revenuecat/workflow-web-components-sdk": 0.1.4
+      "@revenuecat/workflow-web-components-sdk": 0.1.8
       qrcode: 1.5.4
       svelte: 5.46.4
 
-  "@revenuecat/workflow-web-components-sdk@0.1.4": {}
+  "@revenuecat/workflow-web-components-sdk@0.1.8": {}
 
   "@rollup/pluginutils@5.1.4(rollup@4.41.1)":
     dependencies:


### PR DESCRIPTION
## Motivation / Description

Bumps the version of purchases-ui-js to 4.8.21 to reflect changes from https://github.com/RevenueCat/purchases-ui-js/pull/380 - adding support for localized images in paywalls.

## Changes introduced

Updates the package version to 4.8.21 (from 4.8.19 - looks like main doesn't have 4.8.20 merged in yet):
* Looks up the override_source_lid in the localizations map if present, and returns the matching image. If not present, will fallback to the source. Prefers a matching override first, defaulting to the base image otherwise.

## Linear ticket (if any)

https://linear.app/revenuecat/issue/DX-999

## Additional comments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version and lockfile-only change with no edits to purchases-js runtime code; risk is limited to paywall UI behavior from the upgraded purchases-ui-js package.
> 
> **Overview**
> Bumps the pinned dev dependency **`@revenuecat/purchases-ui-js`** from **4.8.19** to **4.8.21** and refreshes **`pnpm-lock.yaml`**. The lockfile also pulls in **`@revenuecat/workflow-web-components-sdk` 0.1.8** (from 0.1.4) as a transitive dependency of purchases-ui-js.
> 
> This aligns local builds and Storybook with purchases-ui-js **4.8.21**, which adds **localized paywall images**: when `override_source_lid` is set in the localizations map, the UI prefers that image and otherwise falls back to the base source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99e1a7a1e8b8f1f1558b2df9576d066779816ecf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->