### PR TITLE
DX-999 | bump purchases-ui-js version to 4.8.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@eslint/js": "^9.16.0",
     "@microsoft/api-extractor": "^7.48.0",
     "@paddle/paddle-js": "^1.6.4",
-    "@revenuecat/purchases-ui-js": "4.8.20",
+    "@revenuecat/purchases-ui-js": "4.8.21",
     "@storybook/addon-essentials": "^8.6.15",
     "@storybook/addon-interactions": "^8.6.15",
     "@storybook/addon-links": "^8.6.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^1.6.4
         version: 1.6.4
       "@revenuecat/purchases-ui-js":
-        specifier: 4.8.20
-        version: 4.8.20(svelte@5.46.4)
+        specifier: 4.8.21
+        version: 4.8.21(svelte@5.46.4)
       "@storybook/addon-essentials":
         specifier: ^8.6.15
         version: 8.6.15(@types/react@19.0.10)(storybook@8.6.15(prettier@3.4.2))
@@ -698,10 +698,10 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
 
-  "@revenuecat/purchases-ui-js@4.8.20":
+  "@revenuecat/purchases-ui-js@4.8.21":
     resolution:
       {
-        integrity: sha512-kO79gX2voMYn5xKy9n1km7vCx/YAcUSfkNHKLQsTH3mv6o+J7d9aU2f29b/ywUGzAM7s9jzSDXhDxdId3OYQoA==,
+        integrity: sha512-RfV372rroVFOyFs6rfENy6IdNCsWzv8V4GXe/Bn2H3mM7d7o0BVyT/eofVCw3liC2NUfJ2yyRAvk4InhkI98Lw==,
       }
     engines: { node: ^22.18 || ^24.11 }
     peerDependencies:
@@ -6128,7 +6128,7 @@ snapshots:
 
   "@pkgr/core@0.1.1": {}
 
-  "@revenuecat/purchases-ui-js@4.8.20(svelte@5.46.4)":
+  "@revenuecat/purchases-ui-js@4.8.21(svelte@5.46.4)":
     dependencies:
       "@revenuecat/workflow-web-components-sdk": 0.1.7
       qrcode: 1.5.4


### PR DESCRIPTION
## Motivation / Description

Bumps the version of purchases-ui-js to 4.8.21 to reflect changes from https://github.com/RevenueCat/purchases-ui-js/pull/380 - adding support for localized images in paywalls.

## Changes introduced

Updates the package version to 4.8.21 (from 4.8.19 - looks like main doesn't have 4.8.20 merged in yet):
* Looks up the override_source_lid in the localizations map if present, and returns the matching image. If not present, will fallback to the source. Prefers a matching override first, defaulting to the base image otherwise.

## Linear ticket (if any)

https://linear.app/revenuecat/issue/DX-999

## Additional comments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version bump with no direct code changes in purchases-js; risk is limited to paywall rendering behavior from the updated UI package.
> 
> **Overview**
> Updates the pinned **`@revenuecat/purchases-ui-js`** dev dependency from **4.8.20** to **4.8.21** and refreshes **`pnpm-lock.yaml`** accordingly. There are no application source changes in this repo—the bump pulls in upstream paywall UI behavior for **localized images** (locale overrides via `override_source_lid` in the localizations map, with fallback to the base image when no override exists).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52879009dfa8fd78c6fd389cec775787fbb24c56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->