### PR TITLE
ci: notify external PRs feed on PRs from outside the org

### DIFF
--- a/.github/workflows/external-pr-notifications.yml
+++ b/.github/workflows/external-pr-notifications.yml
@@ -1,0 +1,13 @@
+name: External PR Notifications
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  notify:
+    uses: revenuecat/sdk-github-workflows/.github/workflows/external-pr-notifications.yml@3765ddb1c650fba52875e793217f737727425bdf # v7
+    secrets:
+      EXTERNAL_PR_SLACK_WEBHOOK_URL: ${{ secrets.EXTERNAL_PR_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
- Adds a workflow that posts to an internal Slack feed when a PR is opened by someone outside the RevenueCat org.
- Uses `pull_request_target` so the job has the webhook secret on fork PRs; it never checks out or runs PR code and holds a `GITHUB_TOKEN` with no permissions.


### Checklist

- [x] `actionlint` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Slack notification with no repo token permissions and no PR code execution; `pull_request_target` is used deliberately for fork secret access.
> 
> **Overview**
> Adds a new GitHub Actions workflow that **notifies an internal Slack feed** when a pull request is **opened by someone outside the RevenueCat org**.
> 
> The workflow runs on `pull_request_target` (opened only) so fork PRs can use the webhook secret without checking out or executing PR code. It sets **`permissions: {}`** on the job token and delegates to the shared **`revenuecat/sdk-github-workflows`** reusable workflow (pinned at v7), passing `EXTERNAL_PR_SLACK_WEBHOOK_URL` from repo secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bb88983047487678fcd967e22102d8616222e57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->