### PR TITLE
ci: bump external PR notifications workflow to v8

### DIFF
--- a/.github/workflows/external-pr-notifications.yml
+++ b/.github/workflows/external-pr-notifications.yml
@@ -8,6 +8,6 @@ permissions: {}
 
 jobs:
   notify:
-    uses: revenuecat/sdk-github-workflows/.github/workflows/external-pr-notifications.yml@3765ddb1c650fba52875e793217f737727425bdf # v7
+    uses: revenuecat/sdk-github-workflows/.github/workflows/external-pr-notifications.yml@b679120ce2931ac2e5c02166f84ad1f9b263fb96 # v8
     secrets:
       EXTERNAL_PR_SLACK_WEBHOOK_URL: ${{ secrets.EXTERNAL_PR_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Bumps the shared workflow to `v8`, which gates on `head.repo.fork` instead of `author_association` so PRs from org members with private membership stop being posted as external. See RevenueCat/sdk-github-workflows#11.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow pin bump with no application code or secret handling changes beyond the existing Slack webhook passthrough.
> 
> **Overview**
> Updates the **External PR Notifications** job to call the shared `revenuecat/sdk-github-workflows` workflow at **v8** (pinned commit `b679120…`) instead of **v7**.
> 
> That upstream release changes how “external” PRs are detected: it uses **`head.repo.fork`** rather than **`author_association`**, so Slack notifications for opened PRs no longer misclassify contributors whose org membership is private as external.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a26dda241c91a70ba367c87b588ba9f72c21c43a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->