### PR TITLE
fix: send X-Is-Sandbox header when using a Test Store API key

### DIFF
--- a/src/networking/http-client.ts
+++ b/src/networking/http-client.ts
@@ -3,7 +3,10 @@ import type { BackendErrorCode } from "../entities/errors";
 import { ErrorCode, ErrorCodeUtils, PurchasesError } from "../entities/errors";
 import { RC_ENDPOINT, VERSION } from "../helpers/constants";
 import { StatusCodes } from "http-status-codes";
-import { isWebBillingSandboxApiKey } from "../helpers/api-key-helper";
+import {
+  isSimulatedStoreApiKey,
+  isWebBillingSandboxApiKey,
+} from "../helpers/api-key-helper";
 import type { HttpConfig } from "../entities/http-config";
 import { Purchases } from "../main";
 
@@ -154,7 +157,7 @@ export function getHeaders(
     [ACCEPT_HEADER]: "application/json",
     [PLATFORM_HEADER]: "web",
     [VERSION_HEADER]: VERSION,
-    [IS_SANDBOX_HEADER]: `${isWebBillingSandboxApiKey(apiKey)}`,
+    [IS_SANDBOX_HEADER]: `${isWebBillingSandboxApiKey(apiKey) || isSimulatedStoreApiKey(apiKey)}`,
   };
   const platformInfo = Purchases.getPlatformInfo();
   if (platformInfo) {

--- a/src/tests/networking/backend.test.ts
+++ b/src/tests/networking/backend.test.ts
@@ -97,7 +97,7 @@ describe("httpConfig is setup correctly", () => {
     server.events.on("request:start", (req) => {
       requestPerformed = req.request;
     });
-    backend = new Backend("test_api_key");
+    backend = new Backend("rcb_api_key");
     await backend.getCustomerInfo("someAppUserId");
     const headers = requestPerformed?.headers;
     expect(headers).not.toBeNull();
@@ -107,6 +107,24 @@ describe("httpConfig is setup correctly", () => {
     expect(headers.get("X-Platform-Flavor")).toBeNull();
     expect(headers.get("X-Platform-Flavor-Version")).toBeNull();
     expect(headers.get("X-Is-Sandbox")).toEqual("false");
+  });
+
+  test.each([
+    ["rcb_sb_api_key", "true"],
+    ["test_api_key", "true"],
+    ["rcb_api_key", "false"],
+  ])("X-Is-Sandbox header for %s is %s", async (apiKey, expected) => {
+    setCustomerInfoResponse(
+      HttpResponse.json(customerInfoResponse, { status: 200 }),
+    );
+
+    let requestPerformed: Request | undefined;
+    server.events.on("request:start", (req) => {
+      requestPerformed = req.request;
+    });
+    backend = new Backend(apiKey);
+    await backend.getCustomerInfo("someAppUserId");
+    expect(requestPerformed?.headers.get("X-Is-Sandbox")).toEqual(expected);
   });
 
   test("expected platformInfo headers are sent", async () => {


### PR DESCRIPTION
Sends `X-Is-Sandbox: true` on every request when the SDK is configured with a Test Store API key, so backend integrations route those events to the sandbox project.

Part of SDK-4449

- [x] If applicable, unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small header logic change on all backend requests; misclassification would only affect sandbox routing, and behavior is covered by new unit tests.
> 
> **Overview**
> Outgoing HTTP requests now set **`X-Is-Sandbox: true`** when the configured API key is a **Test Store** key (`test_*`), in addition to existing Web Billing sandbox keys (`rcb_sb_*`).
> 
> `getHeaders` in `http-client.ts` uses `isSimulatedStoreApiKey` alongside `isWebBillingSandboxApiKey` for that header. Backend networking tests were updated to assert sandbox vs production keys, including `test_api_key` → `true` and `rcb_api_key` → `false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 564b954718d79183c0a236da944356f1efd80bd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->