### PR TITLE
fix(paddle): localize hardcoded strings in the inline checkout

### DIFF
--- a/src/tests/ui/paddle-purchases-ui.test.ts
+++ b/src/tests/ui/paddle-purchases-ui.test.ts
@@ -936,6 +936,23 @@ describe("PaddlePurchasesUI", () => {
         ).toBeInTheDocument();
       });
 
+      test("translates the summary labels for a non-English locale", async () => {
+        // "Due on" and "billed" used to be hardcoded English, so a French
+        // checkout rendered "Due on 14 août 2026" and "billed mensuel".
+        renderWithTotals({
+          purchaseOption: subscriptionOptionWithSingleWeekIntroPriceRecurring,
+          selectedLocale: "fr",
+        });
+
+        expect(
+          await screen.findByText("Dû le 14 août 2026"),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText("premier 1 semaine, puis 20,00 $ mensuel"),
+        ).toBeInTheDocument();
+        expect(screen.queryByText(/^Due on /)).not.toBeInTheDocument();
+      });
+
       test("describes a same-length intro that only differs in price", async () => {
         // A first month at $3 against a $20 monthly base: the durations match,
         // so only the amounts reveal the step-up.

--- a/src/ui/localization/keys_context.json
+++ b/src/ui/localization/keys_context.json
@@ -75,5 +75,10 @@
   "paywall_variables.total_price_and_per_month": "Combines total price information with an equivalent monthly price. {{formattedPrice}} is replaced by the total price, {{formattedPricePerMonth}} is the monthly breakdown, and {{monthPeriod}} is the time unit for the monthly breakdown.",
   "navbar_header.details": "Text for a button that displays more information about the product.",
   "navbar_header.back_button": "Text for a button that allows the user to go back.",
-  "apple_pay.free_trial": "A 'Free Trial' label"
+  "apple_pay.free_trial": "A 'Free Trial' label",
+  "paddle_checkout.return_to": "Text for a back button in the checkout that returns the user to the seller's app. {{appName}} is replaced with the app name.",
+  "paddle_order_summary.billed_frequency": "Shown under the price in the order summary. {{frequency}} is replaced with a translated billing frequency such as 'monthly' or 'yearly'.",
+  "paddle_order_summary.intro_then_recurring": "Shown under the price when an introductory offer applies. {{firstPeriod}} is a duration like 'week' or '3 months', {{price}} is the recurring price, {{frequency}} is a translated billing frequency such as 'monthly'.",
+  "paddle_order_summary.inc_tax": "Short label next to a price meaning that tax is included.",
+  "paddle_order_summary.due_on": "Label for the next charge row in the order summary. {{date}} is replaced with a formatted date."
 }

--- a/src/ui/localization/locale/ar.json
+++ b/src/ui/localization/locale/ar.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "تأكيد الجدولة",
   "upgrade_confirm_page.on_file": "المحفوظة",
   "credit_for_unused_time.title": "رصيد للوقت غير المستخدم",
-  "credit_for_unused_time.message": "سيتم خصم المبلغ من طريقة الدفع الخاصة بك مقابل الفرق بين الاشتراكات، مع رصيد للوقت غير المستخدم في اشتراكك في {{previousProductName}}."
+  "credit_for_unused_time.message": "سيتم خصم المبلغ من طريقة الدفع الخاصة بك مقابل الفرق بين الاشتراكات، مع رصيد للوقت غير المستخدم في اشتراكك في {{previousProductName}}.",
+  "paddle_checkout.return_to": "العودة إلى {{appName}}",
+  "paddle_order_summary.billed_frequency": "تُحصّل {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "أول {{firstPeriod}}، ثم {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "شامل الضريبة",
+  "paddle_order_summary.due_on": "مستحق في {{date}}"
 }

--- a/src/ui/localization/locale/ca.json
+++ b/src/ui/localization/locale/ca.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Confirmar programació",
   "upgrade_confirm_page.on_file": "Registrat",
   "credit_for_unused_time.title": "Crèdit pel temps no utilitzat",
-  "credit_for_unused_time.message": "El vostre mètode de pagament es carregarà amb la diferència entre les subscripcions, amb un crèdit pel temps no utilitzat de la vostra subscripció a {{previousProductName}}."
+  "credit_for_unused_time.message": "El vostre mètode de pagament es carregarà amb la diferència entre les subscripcions, amb un crèdit pel temps no utilitzat de la vostra subscripció a {{previousProductName}}.",
+  "paddle_checkout.return_to": "Tornar a {{appName}}",
+  "paddle_order_summary.billed_frequency": "facturat {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "primer {{firstPeriod}}, després {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "impostos inclosos",
+  "paddle_order_summary.due_on": "Venciment el {{date}}"
 }

--- a/src/ui/localization/locale/cs.json
+++ b/src/ui/localization/locale/cs.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Potvrdit plán",
   "upgrade_confirm_page.on_file": "Uloženo",
   "credit_for_unused_time.title": "Kredit za nevyužitý čas",
-  "credit_for_unused_time.message": "Vaše platební metoda bude naúčtována za rozdíl mezi předplatnými, s kreditem za nevyužitý čas z vašeho předplatného {{previousProductName}}."
+  "credit_for_unused_time.message": "Vaše platební metoda bude naúčtována za rozdíl mezi předplatnými, s kreditem za nevyužitý čas z vašeho předplatného {{previousProductName}}.",
+  "paddle_checkout.return_to": "Zpět na {{appName}}",
+  "paddle_order_summary.billed_frequency": "účtováno {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "první {{firstPeriod}}, poté {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "vč. daně",
+  "paddle_order_summary.due_on": "Splatné {{date}}"
 }

--- a/src/ui/localization/locale/da.json
+++ b/src/ui/localization/locale/da.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Bekræft tidsplan",
   "upgrade_confirm_page.on_file": "Registreret",
   "credit_for_unused_time.title": "Tilgodehavende for ubrugt tid",
-  "credit_for_unused_time.message": "Din betalingsmetode vil blive opkrævet for forskellen mellem abonnementerne, med et tilgodehavende for ubrugt tid på dit {{previousProductName}}-abonnement."
+  "credit_for_unused_time.message": "Din betalingsmetode vil blive opkrævet for forskellen mellem abonnementerne, med et tilgodehavende for ubrugt tid på dit {{previousProductName}}-abonnement.",
+  "paddle_checkout.return_to": "Tilbage til {{appName}}",
+  "paddle_order_summary.billed_frequency": "faktureres {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "første {{firstPeriod}}, derefter {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "inkl. moms",
+  "paddle_order_summary.due_on": "Forfalder den {{date}}"
 }

--- a/src/ui/localization/locale/de.json
+++ b/src/ui/localization/locale/de.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Zeitplan bestätigen",
   "upgrade_confirm_page.on_file": "Hinterlegt",
   "credit_for_unused_time.title": "Gutschrift für ungenutzte Zeit",
-  "credit_for_unused_time.message": "Ihre Zahlungsmethode wird für die Differenz zwischen den Abonnements belastet, mit einer Gutschrift für ungenutzte Zeit für Ihr {{previousProductName}}-Abonnement."
+  "credit_for_unused_time.message": "Ihre Zahlungsmethode wird für die Differenz zwischen den Abonnements belastet, mit einer Gutschrift für ungenutzte Zeit für Ihr {{previousProductName}}-Abonnement.",
+  "paddle_checkout.return_to": "Zurück zu {{appName}}",
+  "paddle_order_summary.billed_frequency": "Abrechnung {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "erste(r) {{firstPeriod}}, danach {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "inkl. Steuern",
+  "paddle_order_summary.due_on": "Fällig am {{date}}"
 }

--- a/src/ui/localization/locale/el.json
+++ b/src/ui/localization/locale/el.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Επιβεβαίωση προγράμματος",
   "upgrade_confirm_page.on_file": "Καταχωρημένο",
   "credit_for_unused_time.title": "Πίστωση για αχρησιμοποίητο χρόνο",
-  "credit_for_unused_time.message": "Η μέθοδος πληρωμής σας θα χρεωθεί για τη διαφορά μεταξύ των συνδρομών, με πίστωση για τον αχρησιμοποίητο χρόνο της συνδρομής σας {{previousProductName}}."
+  "credit_for_unused_time.message": "Η μέθοδος πληρωμής σας θα χρεωθεί για τη διαφορά μεταξύ των συνδρομών, με πίστωση για τον αχρησιμοποίητο χρόνο της συνδρομής σας {{previousProductName}}.",
+  "paddle_checkout.return_to": "Επιστροφή στο {{appName}}",
+  "paddle_order_summary.billed_frequency": "χρέωση {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "πρώτο διάστημα {{firstPeriod}}, μετά {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "συμπ. φόρου",
+  "paddle_order_summary.due_on": "Πληρωτέο στις {{date}}"
 }

--- a/src/ui/localization/locale/en.json
+++ b/src/ui/localization/locale/en.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.on_file": "On file",
   "upgrade_confirm_page.email": "Email",
   "upgrade_confirm_page.payment_method": "Payment method",
-  "upgrade_confirm_page.billing_address": "Billing address"
+  "upgrade_confirm_page.billing_address": "Billing address",
+  "paddle_checkout.return_to": "Return to {{appName}}",
+  "paddle_order_summary.billed_frequency": "billed {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "first {{firstPeriod}}, then {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "inc. tax",
+  "paddle_order_summary.due_on": "Due on {{date}}"
 }

--- a/src/ui/localization/locale/es.json
+++ b/src/ui/localization/locale/es.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Confirmar programación",
   "upgrade_confirm_page.on_file": "Registrado",
   "credit_for_unused_time.title": "Crédito por tiempo no utilizado",
-  "credit_for_unused_time.message": "Se cargará a tu método de pago la diferencia entre suscripciones, con un crédito por el tiempo no utilizado de tu suscripción a {{previousProductName}}."
+  "credit_for_unused_time.message": "Se cargará a tu método de pago la diferencia entre suscripciones, con un crédito por el tiempo no utilizado de tu suscripción a {{previousProductName}}.",
+  "paddle_checkout.return_to": "Volver a {{appName}}",
+  "paddle_order_summary.billed_frequency": "facturado {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "primer {{firstPeriod}}, después {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "impuestos incl.",
+  "paddle_order_summary.due_on": "Vence el {{date}}"
 }

--- a/src/ui/localization/locale/fi.json
+++ b/src/ui/localization/locale/fi.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Vahvista aikataulu",
   "upgrade_confirm_page.on_file": "Tallennettu",
   "credit_for_unused_time.title": "Hyvitys käyttämättömästä ajasta",
-  "credit_for_unused_time.message": "Maksutapaasi veloitetaan tilausten välinen erotus, huomioiden hyvitys {{previousProductName}}-tilauksesi käyttämättömästä ajasta."
+  "credit_for_unused_time.message": "Maksutapaasi veloitetaan tilausten välinen erotus, huomioiden hyvitys {{previousProductName}}-tilauksesi käyttämättömästä ajasta.",
+  "paddle_checkout.return_to": "Takaisin: {{appName}}",
+  "paddle_order_summary.billed_frequency": "laskutetaan {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "ensimmäinen {{firstPeriod}}, sen jälkeen {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "sis. verot",
+  "paddle_order_summary.due_on": "Eräpäivä {{date}}"
 }

--- a/src/ui/localization/locale/fr.json
+++ b/src/ui/localization/locale/fr.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Confirmer la planification",
   "upgrade_confirm_page.on_file": "Enregistré",
   "credit_for_unused_time.title": "Crédit pour temps non utilisé",
-  "credit_for_unused_time.message": "Votre mode de paiement sera débité de la différence entre les abonnements, avec un crédit pour le temps non utilisé sur votre abonnement {{previousProductName}}."
+  "credit_for_unused_time.message": "Votre mode de paiement sera débité de la différence entre les abonnements, avec un crédit pour le temps non utilisé sur votre abonnement {{previousProductName}}.",
+  "paddle_checkout.return_to": "Retour à {{appName}}",
+  "paddle_order_summary.billed_frequency": "facturé {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "premier {{firstPeriod}}, puis {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "TTC",
+  "paddle_order_summary.due_on": "Dû le {{date}}"
 }

--- a/src/ui/localization/locale/he.json
+++ b/src/ui/localization/locale/he.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "אשר שינוי מועד",
   "upgrade_confirm_page.on_file": "שמור",
   "credit_for_unused_time.title": "זיכוי על זמן שלא נוצל",
-  "credit_for_unused_time.message": "אמצעי התשלום שלך יחויב על ההפרש בין המנויים, תוך התחשבות בזיכוי על זמן שלא נוצל במנוי ה-{{previousProductName}} שלך."
+  "credit_for_unused_time.message": "אמצעי התשלום שלך יחויב על ההפרש בין המנויים, תוך התחשבות בזיכוי על זמן שלא נוצל במנוי ה-{{previousProductName}} שלך.",
+  "paddle_checkout.return_to": "חזרה אל {{appName}}",
+  "paddle_order_summary.billed_frequency": "חיוב {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "{{firstPeriod}} ראשון, לאחר מכן {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "כולל מס",
+  "paddle_order_summary.due_on": "לתשלום ב-{{date}}"
 }

--- a/src/ui/localization/locale/hi.json
+++ b/src/ui/localization/locale/hi.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "शेड्यूल की पुष्टि करें",
   "upgrade_confirm_page.on_file": "फाइल पर",
   "credit_for_unused_time.title": "अप्रयुक्त समय का क्रेडिट",
-  "credit_for_unused_time.message": "आपकी भुगतान विधि से सब्सक्रिप्शन के बीच के अंतर के लिए शुल्क लिया जाएगा, जिसमें आपकी {{previousProductName}} सब्सक्रिप्शन के अप्रयुक्त समय का क्रेडिट शामिल होगा।"
+  "credit_for_unused_time.message": "आपकी भुगतान विधि से सब्सक्रिप्शन के बीच के अंतर के लिए शुल्क लिया जाएगा, जिसमें आपकी {{previousProductName}} सब्सक्रिप्शन के अप्रयुक्त समय का क्रेडिट शामिल होगा।",
+  "paddle_checkout.return_to": "{{appName}} पर वापस जाएँ",
+  "paddle_order_summary.billed_frequency": "बिलिंग {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "पहला {{firstPeriod}}, फिर {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "कर सहित",
+  "paddle_order_summary.due_on": "{{date}} को देय"
 }

--- a/src/ui/localization/locale/hr.json
+++ b/src/ui/localization/locale/hr.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Potvrdite raspored",
   "upgrade_confirm_page.on_file": "U evidenciji",
   "credit_for_unused_time.title": "Kredit za neiskorišteno vrijeme",
-  "credit_for_unused_time.message": "Vaš način plaćanja bit će naplaćen za razliku između pretplata, uz kredit za neiskorišteno vrijeme na vašoj pretplati {{previousProductName}}."
+  "credit_for_unused_time.message": "Vaš način plaćanja bit će naplaćen za razliku između pretplata, uz kredit za neiskorišteno vrijeme na vašoj pretplati {{previousProductName}}.",
+  "paddle_checkout.return_to": "Natrag na {{appName}}",
+  "paddle_order_summary.billed_frequency": "naplaćuje se {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "prvi {{firstPeriod}}, zatim {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "uklj. porez",
+  "paddle_order_summary.due_on": "Dospijeva {{date}}"
 }

--- a/src/ui/localization/locale/hu.json
+++ b/src/ui/localization/locale/hu.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Ütemezés megerősítése",
   "upgrade_confirm_page.on_file": "Rögzítve",
   "credit_for_unused_time.title": "Jóváírás fel nem használt időre",
-  "credit_for_unused_time.message": "Fizetési módját az előfizetések közötti különbséggel terheljük meg, jóváírással a(z) {{previousProductName}} előfizetésén fel nem használt időért."
+  "credit_for_unused_time.message": "Fizetési módját az előfizetések közötti különbséggel terheljük meg, jóváírással a(z) {{previousProductName}} előfizetésén fel nem használt időért.",
+  "paddle_checkout.return_to": "Vissza: {{appName}}",
+  "paddle_order_summary.billed_frequency": "számlázás {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "első {{firstPeriod}}, majd {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "adóval",
+  "paddle_order_summary.due_on": "Esedékes: {{date}}"
 }

--- a/src/ui/localization/locale/id.json
+++ b/src/ui/localization/locale/id.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Konfirmasi jadwal",
   "upgrade_confirm_page.on_file": "Tersimpan",
   "credit_for_unused_time.title": "Kredit Waktu Tidak Terpakai",
-  "credit_for_unused_time.message": "Metode pembayaran Anda akan ditagih untuk selisih antara langganan, dengan kredit untuk waktu yang tidak terpakai pada langganan {{previousProductName}} Anda."
+  "credit_for_unused_time.message": "Metode pembayaran Anda akan ditagih untuk selisih antara langganan, dengan kredit untuk waktu yang tidak terpakai pada langganan {{previousProductName}} Anda.",
+  "paddle_checkout.return_to": "Kembali ke {{appName}}",
+  "paddle_order_summary.billed_frequency": "ditagih {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "{{firstPeriod}} pertama, lalu {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "termasuk pajak",
+  "paddle_order_summary.due_on": "Jatuh tempo {{date}}"
 }

--- a/src/ui/localization/locale/it.json
+++ b/src/ui/localization/locale/it.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Conferma pianificazione",
   "upgrade_confirm_page.on_file": "In archivio",
   "credit_for_unused_time.title": "Credito per il tempo inutilizzato",
-  "credit_for_unused_time.message": "Il tuo metodo di pagamento verrà addebitato per la differenza tra gli abbonamenti, con un credito per il tempo inutilizzato sul tuo abbonamento {{previousProductName}}."
+  "credit_for_unused_time.message": "Il tuo metodo di pagamento verrà addebitato per la differenza tra gli abbonamenti, con un credito per il tempo inutilizzato sul tuo abbonamento {{previousProductName}}.",
+  "paddle_checkout.return_to": "Torna a {{appName}}",
+  "paddle_order_summary.billed_frequency": "fatturato {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "primo {{firstPeriod}}, poi {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "tasse incl.",
+  "paddle_order_summary.due_on": "In scadenza il {{date}}"
 }

--- a/src/ui/localization/locale/ja.json
+++ b/src/ui/localization/locale/ja.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "スケジュールを確定",
   "upgrade_confirm_page.on_file": "登録済み",
   "credit_for_unused_time.title": "未使用期間分のクレジット",
-  "credit_for_unused_time.message": "お客様の{{previousProductName}}サブスクリプションの未使用期間分のクレジットが適用され、サブスクリプション間の差額がお支払い方法に請求されます。"
+  "credit_for_unused_time.message": "お客様の{{previousProductName}}サブスクリプションの未使用期間分のクレジットが適用され、サブスクリプション間の差額がお支払い方法に請求されます。",
+  "paddle_checkout.return_to": "{{appName}}に戻る",
+  "paddle_order_summary.billed_frequency": "{{frequency}}請求",
+  "paddle_order_summary.intro_then_recurring": "最初の{{firstPeriod}}、その後{{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "税込",
+  "paddle_order_summary.due_on": "{{date}}に請求"
 }

--- a/src/ui/localization/locale/ko.json
+++ b/src/ui/localization/locale/ko.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "일정 확인",
   "upgrade_confirm_page.on_file": "등록됨",
   "credit_for_unused_time.title": "미사용 시간에 대한 크레딧",
-  "credit_for_unused_time.message": "회원님의 결제 수단으로 구독 간의 차액이 청구되며, {{previousProductName}} 구독의 미사용 시간에 대한 크레딧이 적용됩니다."
+  "credit_for_unused_time.message": "회원님의 결제 수단으로 구독 간의 차액이 청구되며, {{previousProductName}} 구독의 미사용 시간에 대한 크레딧이 적용됩니다.",
+  "paddle_checkout.return_to": "{{appName}}(으)로 돌아가기",
+  "paddle_order_summary.billed_frequency": "{{frequency}} 청구",
+  "paddle_order_summary.intro_then_recurring": "첫 {{firstPeriod}}, 이후 {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "세금 포함",
+  "paddle_order_summary.due_on": "{{date}} 결제 예정"
 }

--- a/src/ui/localization/locale/ms.json
+++ b/src/ui/localization/locale/ms.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Sahkan jadual",
   "upgrade_confirm_page.on_file": "Dalam rekod",
   "credit_for_unused_time.title": "Kredit untuk masa tidak digunakan",
-  "credit_for_unused_time.message": "Kaedah pembayaran anda akan dicaj untuk perbezaan antara langganan, dengan kredit untuk masa tidak digunakan pada langganan {{previousProductName}} anda."
+  "credit_for_unused_time.message": "Kaedah pembayaran anda akan dicaj untuk perbezaan antara langganan, dengan kredit untuk masa tidak digunakan pada langganan {{previousProductName}} anda.",
+  "paddle_checkout.return_to": "Kembali ke {{appName}}",
+  "paddle_order_summary.billed_frequency": "dibilkan {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "{{firstPeriod}} pertama, kemudian {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "termasuk cukai",
+  "paddle_order_summary.due_on": "Perlu dibayar pada {{date}}"
 }

--- a/src/ui/localization/locale/nl.json
+++ b/src/ui/localization/locale/nl.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Planning bevestigen",
   "upgrade_confirm_page.on_file": "Geregistreerd",
   "credit_for_unused_time.title": "Tegoed voor ongebruikte tijd",
-  "credit_for_unused_time.message": "Uw betaalmethode wordt belast voor het verschil tussen abonnementen, met een tegoed voor ongebruikte tijd van uw {{previousProductName}}-abonnement."
+  "credit_for_unused_time.message": "Uw betaalmethode wordt belast voor het verschil tussen abonnementen, met een tegoed voor ongebruikte tijd van uw {{previousProductName}}-abonnement.",
+  "paddle_checkout.return_to": "Terug naar {{appName}}",
+  "paddle_order_summary.billed_frequency": "gefactureerd {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "eerste {{firstPeriod}}, daarna {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "incl. btw",
+  "paddle_order_summary.due_on": "Verschuldigd op {{date}}"
 }

--- a/src/ui/localization/locale/no.json
+++ b/src/ui/localization/locale/no.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Bekreft plan",
   "upgrade_confirm_page.on_file": "Lagret",
   "credit_for_unused_time.title": "Tilgodehavende for ubrukt tid",
-  "credit_for_unused_time.message": "Betalingsmåten din vil bli belastet for differansen mellom abonnementene, med et tilgodehavende for ubrukt tid på ditt {{previousProductName}}-abonnement."
+  "credit_for_unused_time.message": "Betalingsmåten din vil bli belastet for differansen mellom abonnementene, med et tilgodehavende for ubrukt tid på ditt {{previousProductName}}-abonnement.",
+  "paddle_checkout.return_to": "Tilbake til {{appName}}",
+  "paddle_order_summary.billed_frequency": "faktureres {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "første {{firstPeriod}}, deretter {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "inkl. mva",
+  "paddle_order_summary.due_on": "Forfaller {{date}}"
 }

--- a/src/ui/localization/locale/pl.json
+++ b/src/ui/localization/locale/pl.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Potwierdź harmonogram",
   "upgrade_confirm_page.on_file": "Zapisane",
   "credit_for_unused_time.title": "Uznanie za niewykorzystany czas",
-  "credit_for_unused_time.message": "Twoja metoda płatności zostanie obciążona za różnicę między subskrypcjami, z uwzględnieniem niewykorzystanego czasu z Twojej subskrypcji {{previousProductName}}."
+  "credit_for_unused_time.message": "Twoja metoda płatności zostanie obciążona za różnicę między subskrypcjami, z uwzględnieniem niewykorzystanego czasu z Twojej subskrypcji {{previousProductName}}.",
+  "paddle_checkout.return_to": "Powrót do {{appName}}",
+  "paddle_order_summary.billed_frequency": "rozliczane {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "pierwszy {{firstPeriod}}, następnie {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "z podatkiem",
+  "paddle_order_summary.due_on": "Płatne {{date}}"
 }

--- a/src/ui/localization/locale/pt.json
+++ b/src/ui/localization/locale/pt.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Confirmar agendamento",
   "upgrade_confirm_page.on_file": "Em arquivo",
   "credit_for_unused_time.title": "Crédito por tempo não utilizado",
-  "credit_for_unused_time.message": "Seu método de pagamento será cobrado pela diferença entre as assinaturas, com um crédito por tempo não utilizado em sua assinatura {{previousProductName}}."
+  "credit_for_unused_time.message": "Seu método de pagamento será cobrado pela diferença entre as assinaturas, com um crédito por tempo não utilizado em sua assinatura {{previousProductName}}.",
+  "paddle_checkout.return_to": "Voltar para {{appName}}",
+  "paddle_order_summary.billed_frequency": "faturado {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "primeiro {{firstPeriod}}, depois {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "impostos incl.",
+  "paddle_order_summary.due_on": "Vence em {{date}}"
 }

--- a/src/ui/localization/locale/ro.json
+++ b/src/ui/localization/locale/ro.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Confirmă programarea",
   "upgrade_confirm_page.on_file": "Înregistrat",
   "credit_for_unused_time.title": "Credit pentru timp neutilizat",
-  "credit_for_unused_time.message": "Metoda ta de plată va fi debitată pentru diferența dintre abonamente, cu un credit pentru timpul neutilizat la abonamentul tău {{previousProductName}}."
+  "credit_for_unused_time.message": "Metoda ta de plată va fi debitată pentru diferența dintre abonamente, cu un credit pentru timpul neutilizat la abonamentul tău {{previousProductName}}.",
+  "paddle_checkout.return_to": "Înapoi la {{appName}}",
+  "paddle_order_summary.billed_frequency": "facturat {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "prima {{firstPeriod}}, apoi {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "incl. taxe",
+  "paddle_order_summary.due_on": "Scadent la {{date}}"
 }

--- a/src/ui/localization/locale/ru.json
+++ b/src/ui/localization/locale/ru.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Подтвердить расписание",
   "upgrade_confirm_page.on_file": "Сохранено",
   "credit_for_unused_time.title": "Зачет за неиспользованное время",
-  "credit_for_unused_time.message": "С вашего способа оплаты будет списана сумма за разницу между подписками, с зачетом неиспользованного времени по вашей подписке {{previousProductName}}."
+  "credit_for_unused_time.message": "С вашего способа оплаты будет списана сумма за разницу между подписками, с зачетом неиспользованного времени по вашей подписке {{previousProductName}}.",
+  "paddle_checkout.return_to": "Вернуться в {{appName}}",
+  "paddle_order_summary.billed_frequency": "оплата {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "первый {{firstPeriod}}, затем {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "вкл. налог",
+  "paddle_order_summary.due_on": "К оплате {{date}}"
 }

--- a/src/ui/localization/locale/sk.json
+++ b/src/ui/localization/locale/sk.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Potvrdiť plán",
   "upgrade_confirm_page.on_file": "Uložené",
   "credit_for_unused_time.title": "Kredit za nevyužitý čas",
-  "credit_for_unused_time.message": "Vašej platobnej metóde bude účtovaný rozdiel medzi predplatnými, s kreditom za nevyužitý čas z vášho predplatného {{previousProductName}}."
+  "credit_for_unused_time.message": "Vašej platobnej metóde bude účtovaný rozdiel medzi predplatnými, s kreditom za nevyužitý čas z vášho predplatného {{previousProductName}}.",
+  "paddle_checkout.return_to": "Späť na {{appName}}",
+  "paddle_order_summary.billed_frequency": "účtované {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "prvý {{firstPeriod}}, potom {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "vr. dane",
+  "paddle_order_summary.due_on": "Splatné {{date}}"
 }

--- a/src/ui/localization/locale/sl.json
+++ b/src/ui/localization/locale/sl.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Potrdi urnik",
   "upgrade_confirm_page.on_file": "V evidenci",
   "credit_for_unused_time.title": "Dobroimetje za neizkoriščen čas",
-  "credit_for_unused_time.message": "Vašemu plačilnemu sredstvu bo zaračunana razlika med naročninami, z dobroimetjem za neizkoriščen čas vaše naročnine {{previousProductName}}."
+  "credit_for_unused_time.message": "Vašemu plačilnemu sredstvu bo zaračunana razlika med naročninami, z dobroimetjem za neizkoriščen čas vaše naročnine {{previousProductName}}.",
+  "paddle_checkout.return_to": "Nazaj na {{appName}}",
+  "paddle_order_summary.billed_frequency": "zaračunano {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "prvi {{firstPeriod}}, nato {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "z davkom",
+  "paddle_order_summary.due_on": "Zapade {{date}}"
 }

--- a/src/ui/localization/locale/sv.json
+++ b/src/ui/localization/locale/sv.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Bekräfta schema",
   "upgrade_confirm_page.on_file": "Sparad",
   "credit_for_unused_time.title": "Kredit för oanvänd tid",
-  "credit_for_unused_time.message": "Din betalningsmetod kommer att debiteras för skillnaden mellan prenumerationerna, med en kredit för oanvänd tid på din {{previousProductName}}-prenumeration."
+  "credit_for_unused_time.message": "Din betalningsmetod kommer att debiteras för skillnaden mellan prenumerationerna, med en kredit för oanvänd tid på din {{previousProductName}}-prenumeration.",
+  "paddle_checkout.return_to": "Tillbaka till {{appName}}",
+  "paddle_order_summary.billed_frequency": "faktureras {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "första {{firstPeriod}}, därefter {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "inkl. moms",
+  "paddle_order_summary.due_on": "Förfaller {{date}}"
 }

--- a/src/ui/localization/locale/th.json
+++ b/src/ui/localization/locale/th.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "ยืนยันกำหนดการ",
   "upgrade_confirm_page.on_file": "ในระบบ",
   "credit_for_unused_time.title": "เครดิตสำหรับเวลาที่ไม่ได้ใช้",
-  "credit_for_unused_time.message": "วิธีการชำระเงินของคุณจะถูกเรียกเก็บเงินสำหรับส่วนต่างระหว่างการสมัครสมาชิก พร้อมเครดิตสำหรับเวลาที่ไม่ได้ใช้ในการสมัครสมาชิก {{previousProductName}} ของคุณ"
+  "credit_for_unused_time.message": "วิธีการชำระเงินของคุณจะถูกเรียกเก็บเงินสำหรับส่วนต่างระหว่างการสมัครสมาชิก พร้อมเครดิตสำหรับเวลาที่ไม่ได้ใช้ในการสมัครสมาชิก {{previousProductName}} ของคุณ",
+  "paddle_checkout.return_to": "กลับไปที่ {{appName}}",
+  "paddle_order_summary.billed_frequency": "เรียกเก็บ{{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "{{firstPeriod}}แรก จากนั้น {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "รวมภาษี",
+  "paddle_order_summary.due_on": "ครบกำหนดวันที่ {{date}}"
 }

--- a/src/ui/localization/locale/tr.json
+++ b/src/ui/localization/locale/tr.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Planı onayla",
   "upgrade_confirm_page.on_file": "Kayıtlı",
   "credit_for_unused_time.title": "Kullanılmayan süre için kredi",
-  "credit_for_unused_time.message": "Ödeme yönteminizden, abonelikler arasındaki fark tahsil edilecek, {{previousProductName}} aboneliğinizdeki kullanılmayan süre için ise bir kredi uygulanacaktır."
+  "credit_for_unused_time.message": "Ödeme yönteminizden, abonelikler arasındaki fark tahsil edilecek, {{previousProductName}} aboneliğinizdeki kullanılmayan süre için ise bir kredi uygulanacaktır.",
+  "paddle_checkout.return_to": "{{appName}} uygulamasına dön",
+  "paddle_order_summary.billed_frequency": "{{frequency}} faturalandırılır",
+  "paddle_order_summary.intro_then_recurring": "ilk {{firstPeriod}}, ardından {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "vergi dahil",
+  "paddle_order_summary.due_on": "Son ödeme: {{date}}"
 }

--- a/src/ui/localization/locale/uk.json
+++ b/src/ui/localization/locale/uk.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Підтвердити розклад",
   "upgrade_confirm_page.on_file": "Збережено",
   "credit_for_unused_time.title": "Кредит за невикористаний час",
-  "credit_for_unused_time.message": "З вашого способу оплати буде списано різницю між підписками, з урахуванням кредиту за невикористаний час вашої підписки на {{previousProductName}}."
+  "credit_for_unused_time.message": "З вашого способу оплати буде списано різницю між підписками, з урахуванням кредиту за невикористаний час вашої підписки на {{previousProductName}}.",
+  "paddle_checkout.return_to": "Повернутися до {{appName}}",
+  "paddle_order_summary.billed_frequency": "оплата {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "перший {{firstPeriod}}, потім {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "вкл. податок",
+  "paddle_order_summary.due_on": "До сплати {{date}}"
 }

--- a/src/ui/localization/locale/vi.json
+++ b/src/ui/localization/locale/vi.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "Xác nhận lịch trình",
   "upgrade_confirm_page.on_file": "Đã lưu",
   "credit_for_unused_time.title": "Hoàn tiền cho thời gian chưa sử dụng",
-  "credit_for_unused_time.message": "Phương thức thanh toán của bạn sẽ bị tính phí cho khoản chênh lệch giữa các gói đăng ký, với khoản hoàn tiền cho thời gian chưa sử dụng trên gói đăng ký {{previousProductName}} của bạn."
+  "credit_for_unused_time.message": "Phương thức thanh toán của bạn sẽ bị tính phí cho khoản chênh lệch giữa các gói đăng ký, với khoản hoàn tiền cho thời gian chưa sử dụng trên gói đăng ký {{previousProductName}} của bạn.",
+  "paddle_checkout.return_to": "Quay lại {{appName}}",
+  "paddle_order_summary.billed_frequency": "thanh toán {{frequency}}",
+  "paddle_order_summary.intro_then_recurring": "{{firstPeriod}} đầu tiên, sau đó {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "đã gồm thuế",
+  "paddle_order_summary.due_on": "Đến hạn ngày {{date}}"
 }

--- a/src/ui/localization/locale/zh_Hans.json
+++ b/src/ui/localization/locale/zh_Hans.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "确认安排",
   "upgrade_confirm_page.on_file": "已存档",
   "credit_for_unused_time.title": "未用时长抵扣",
-  "credit_for_unused_time.message": "您的付款方式将收取订阅之间的差价，同时抵扣您{{previousProductName}}订阅的未用时长。"
+  "credit_for_unused_time.message": "您的付款方式将收取订阅之间的差价，同时抵扣您{{previousProductName}}订阅的未用时长。",
+  "paddle_checkout.return_to": "返回{{appName}}",
+  "paddle_order_summary.billed_frequency": "{{frequency}}计费",
+  "paddle_order_summary.intro_then_recurring": "首个{{firstPeriod}}，之后 {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "含税",
+  "paddle_order_summary.due_on": "{{date}}到期"
 }

--- a/src/ui/localization/locale/zh_Hant.json
+++ b/src/ui/localization/locale/zh_Hant.json
@@ -125,5 +125,10 @@
   "upgrade_confirm_page.confirm_schedule": "確認排程",
   "upgrade_confirm_page.on_file": "已存檔",
   "credit_for_unused_time.title": "未使用時間的抵用金",
-  "credit_for_unused_time.message": "您的付款方式將會收取訂閱方案之間的差額，並抵用您 {{previousProductName}} 訂閱方案上未使用的時間。"
+  "credit_for_unused_time.message": "您的付款方式將會收取訂閱方案之間的差額，並抵用您 {{previousProductName}} 訂閱方案上未使用的時間。",
+  "paddle_checkout.return_to": "返回{{appName}}",
+  "paddle_order_summary.billed_frequency": "{{frequency}}計費",
+  "paddle_order_summary.intro_then_recurring": "首個{{firstPeriod}}，之後 {{price}} {{frequency}}",
+  "paddle_order_summary.inc_tax": "含稅",
+  "paddle_order_summary.due_on": "{{date}}到期"
 }

--- a/src/ui/localization/supportedLanguages.ts
+++ b/src/ui/localization/supportedLanguages.ts
@@ -161,6 +161,11 @@ export enum LocalizationKeys {
   UpgradeConfirmPageEmail = "upgrade_confirm_page.email",
   UpgradeConfirmPagePaymentMethod = "upgrade_confirm_page.payment_method",
   UpgradeConfirmPageBillingAddress = "upgrade_confirm_page.billing_address",
+  PaddleCheckoutReturnTo = "paddle_checkout.return_to",
+  PaddleOrderSummaryBilledFrequency = "paddle_order_summary.billed_frequency",
+  PaddleOrderSummaryIntroThenRecurring = "paddle_order_summary.intro_then_recurring",
+  PaddleOrderSummaryIncTax = "paddle_order_summary.inc_tax",
+  PaddleOrderSummaryDueOn = "paddle_order_summary.due_on",
 }
 
 export const supportedLanguages: Record<

--- a/src/ui/organisms/paddle-order-summary.svelte
+++ b/src/ui/organisms/paddle-order-summary.svelte
@@ -136,8 +136,18 @@
     !billedFrequencyLabel
       ? null
       : stepsUpToRecurring && firstPeriodLabel
-        ? `first ${firstPeriodLabel}, then ${formatAmount(recurringMicros!)} ${billedFrequencyLabel}`
-        : `billed ${billedFrequencyLabel}`,
+        ? $translator.translate(
+            LocalizationKeys.PaddleOrderSummaryIntroThenRecurring,
+            {
+              firstPeriod: firstPeriodLabel,
+              price: formatAmount(recurringMicros!),
+              frequency: billedFrequencyLabel,
+            },
+          )
+        : $translator.translate(
+            LocalizationKeys.PaddleOrderSummaryBilledFrequency,
+            { frequency: billedFrequencyLabel },
+          ),
   );
 
   const productName = $derived(totals?.productName ?? productDetails.title);
@@ -173,7 +183,11 @@
     <div class="rcb-paddle-summary-amount-row">
       <span class="rcb-paddle-summary-amount">{formatAmount(totalMicros)}</span>
       {#if hasTax}
-        <span class="rcb-paddle-summary-muted">inc. tax</span>
+        <span class="rcb-paddle-summary-muted"
+          >{$translator.translate(
+            LocalizationKeys.PaddleOrderSummaryIncTax,
+          )}</span
+        >
       {/if}
     </div>
     {#if billedSummaryLabel}
@@ -228,7 +242,10 @@
       </div>
       {#if recurringMicros !== null && nextBillingLabel}
         <div class="rcb-paddle-summary-row">
-          <span class="rcb-paddle-summary-muted">Due on {nextBillingLabel}</span
+          <span class="rcb-paddle-summary-muted"
+            >{$translator.translate(LocalizationKeys.PaddleOrderSummaryDueOn, {
+              date: nextBillingLabel,
+            })}</span
           >
           <span>{formatAmount(recurringMicros)}</span>
         </div>

--- a/src/ui/paddle-inline-checkout-page.svelte
+++ b/src/ui/paddle-inline-checkout-page.svelte
@@ -71,7 +71,13 @@
         onclick={onClose}
       >
         <Icon name="back" />
-        <span>{appName ? `Return to ${appName}` : "Back"}</span>
+        <span
+          >{appName
+            ? $translator.translate(LocalizationKeys.PaddleCheckoutReturnTo, {
+                appName,
+              })
+            : $translator.translate(LocalizationKeys.NavbarBackButton)}</span
+        >
       </button>
     {/if}
   {/snippet}


### PR DESCRIPTION
## Summary

A customer running the Paddle inline checkout in French reported that "Return to", "billed" and "Due on" stayed in English while the rest of the page was translated. These strings were hardcoded English in the Paddle checkout UI, so the translator never saw them. This PR routes them (plus "inc. tax" and the intro-offer summary line, which had the same issue) through the existing localization keys and adds translations for every supported locale.

Before: `Return to Français sans Fautes` / `billed annuel` / `Due on 2 septembre 2027`
After: `Retour à Français sans Fautes` / `facturé annuel` / `Dû le 2 septembre 2027`

## Error

<img width="2068" height="1774" alt="image" src="https://github.com/user-attachments/assets/6c6eafdf-2535-4dda-99cb-299df24950ad" />


## Changes

- New keys `paddle_checkout.return_to`, `paddle_order_summary.billed_frequency`, `paddle_order_summary.intro_then_recurring`, `paddle_order_summary.inc_tax`, `paddle_order_summary.due_on` in `LocalizationKeys`, `en.json` and `keys_context.json`.
- `paddle-inline-checkout-page.svelte` and `paddle-order-summary.svelte` use `$translator.translate(...)` instead of template literals. The no-app-name fallback reuses `navbar_header.back_button`.
- Translations added to all 33 non-English locale files. These were written by hand (the Gemini key for `scripts/translate_locales.py` wasn't available), so a skim from native speakers is welcome.
- French test in `paddle-purchases-ui.test.ts` covering the "Due on" and intro-offer lines.

## Testing

`pnpm test` (884 tests), `pnpm typecheck`, `pnpm test:typecheck`, `svelte-check` and `eslint src/` pass.

<details>
<summary>AI-assisted implementation details</summary>

This change was implemented with Claude Code.

- Root cause found by grepping the Paddle UI for the reported strings: `paddle-inline-checkout-page.svelte:74` and `paddle-order-summary.svelte:139-140, 176, 231` built the labels as template literals. The Stripe checkout was unaffected because its equivalents are keyed.
- All 34 locale files already had full key parity (127 keys each) and `supportedLanguages` is typed as `Record<LocalizationKeys, string>`, so the new keys had to be added to every file rather than relying on English fallback.
- Note for reviewers: in French the intro line renders as "premier 1 semaine, puis 20,00 $ mensuel". The `1` is pre-existing behaviour of `getPeriodDurationLabel`, which only collapses the singular in English. Left as-is to keep this PR scoped to the missing translations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>