### PR TITLE
Bump purchases-ui-js to 4.8.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@eslint/js": "^9.16.0",
     "@microsoft/api-extractor": "^7.48.0",
     "@paddle/paddle-js": "^1.6.4",
-    "@revenuecat/purchases-ui-js": "4.8.21",
+    "@revenuecat/purchases-ui-js": "4.8.22",
     "@storybook/addon-essentials": "^8.6.15",
     "@storybook/addon-interactions": "^8.6.15",
     "@storybook/addon-links": "^8.6.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^1.6.4
         version: 1.6.4
       "@revenuecat/purchases-ui-js":
-        specifier: 4.8.21
-        version: 4.8.21(svelte@5.46.4)
+        specifier: 4.8.22
+        version: 4.8.22(svelte@5.46.4)
       "@storybook/addon-essentials":
         specifier: ^8.6.15
         version: 8.6.15(@types/react@19.0.10)(storybook@8.6.15(prettier@3.4.2))
@@ -698,10 +698,10 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
 
-  "@revenuecat/purchases-ui-js@4.8.21":
+  "@revenuecat/purchases-ui-js@4.8.22":
     resolution:
       {
-        integrity: sha512-RfV372rroVFOyFs6rfENy6IdNCsWzv8V4GXe/Bn2H3mM7d7o0BVyT/eofVCw3liC2NUfJ2yyRAvk4InhkI98Lw==,
+        integrity: sha512-0GmZTAEDQIqA5IoCw+aWkLpyB7iWLZ/7NldeWOU+fhHElBmMUho3mhY8CIfJEOSDItrXdQMyd34UMd5AERPzhw==,
       }
     engines: { node: ^22.18 || ^24.11 }
     peerDependencies:
@@ -6128,7 +6128,7 @@ snapshots:
 
   "@pkgr/core@0.1.1": {}
 
-  "@revenuecat/purchases-ui-js@4.8.21(svelte@5.46.4)":
+  "@revenuecat/purchases-ui-js@4.8.22(svelte@5.46.4)":
     dependencies:
       "@revenuecat/workflow-web-components-sdk": 0.1.7
       qrcode: 1.5.4


### PR DESCRIPTION
## Motivation / Description

Bumps `@revenuecat/purchases-ui-js` to 4.8.22 so the web paywall picks up two sheet fixes a few bug reports: a `navigate_back` button inside a sheet closed the whole paywall ([#383](https://github.com/RevenueCat/purchases-ui-js/pull/383)), and gradient or image backgrounds vanished outside the paywall while a sheet was open ([#384](https://github.com/RevenueCat/purchases-ui-js/pull/384)).

## Changes introduced

Dependency bump only, `package.json` and `pnpm-lock.yaml`. `pnpm build` and `pnpm test` (884 tests) pass locally.

## Linear ticket (if any)

https://linear.app/revenuecat/issue/WEB-3746

<details>
<summary>AI session context</summary>

- Branch `bump-purchases-ui-js-4.8.22`, Claude Code (Claude Fable 5.1), 2026-09-07
- Prompt: "can you bump js then? open a PR"
- Agent: edited the pin, ran `pnpm install`, reformatted the lockfile with prettier to drop 6600 lines of quote churn pnpm introduced, built and ran the suite
- Human: asked for the bump after confirming the ui-js fixes were published but not yet bundled
- Gaps: no end-to-end run against a real paywall in this repo; relies on the tests in purchases-ui-js #383 and #384

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-dependency version pin only; behavior changes are limited to bundled paywall UI fixes from the upstream package.
> 
> **Overview**
> Pins **`@revenuecat/purchases-ui-js`** from **4.8.21** to **4.8.22** in `package.json`, with matching **`pnpm-lock.yaml`** resolution updates. No application source changes in this repo.
> 
> The newer UI package brings in paywall **sheet** fixes: **`navigate_back`** inside a sheet no longer dismisses the whole paywall, and **gradient/image backgrounds** stay visible outside the paywall while a sheet is open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5012e0c51456bccc5c31f9987a312396fc7aab13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->