### PR TITLE
Add dependency-update action to bump purchases-ui-js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ aliases:
 parameters:
   action:
     type: enum
-    enum: [ default, bump, update_error_codes ]
+    enum: [ default, bump, update_error_codes, dependency-update ]
     default: default
   version:
     type: string
@@ -210,6 +210,21 @@ jobs:
                 --exit-once-uploaded
             fi
 
+  dependency-update:
+    description: "Opens a PR updating purchases-ui-js to the latest version published to npm"
+    docker:
+      - image: cimg/ruby:3.3.0-node
+    steps:
+      - checkout
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
+      - revenuecat/trust-github-key
+      - revenuecat/setup-git-credentials
+      - install-dependencies
+      - run:
+          name: Update purchases-ui-js to latest version
+          command: bundle exec fastlane open_pr_upgrading_dependencies
+
   test-e2e:
     docker:
       - image: mcr.microsoft.com/playwright:v1.56.1-jammy
@@ -273,6 +288,8 @@ workflows:
             equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - not:
             equal: [ update_error_codes, << pipeline.parameters.action >> ]
+        - not:
+            equal: [ dependency-update, << pipeline.parameters.action >> ]
     jobs:
       - revenuecat/danger:
           ruby_version: "3.3.0"
@@ -313,6 +330,16 @@ workflows:
                 name: Extract API
                 command: pnpm run extract-api
 
+  dependency-update:
+    when:
+      or:
+        - and:
+            - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+            - equal: [ "dependency-update", << pipeline.schedule.name >> ]
+        - equal: [ dependency-update, << pipeline.parameters.action >> ]
+    jobs:
+      - dependency-update
+
   test-deploy:
     when:
       and:
@@ -320,6 +347,8 @@ workflows:
             equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - not:
             equal: [ update_error_codes, << pipeline.parameters.action >> ]
+        - not:
+            equal: [ dependency-update, << pipeline.parameters.action >> ]
     jobs:
       - test
       - test-e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,11 +216,16 @@ jobs:
       - image: cimg/ruby:3.3.0-node
     steps:
       - checkout
+      # Not using install-dependencies on purpose: it overwrites the tracked .npmrc
+      # and creates .pnpm-store, both would trip ensure_git_status_clean in the lane.
+      # pnpm add installs what it needs. The tracked .npmrc already excludes
+      # purchases-ui-js from minimum-release-age.
+      - revenuecat/install-mise-tools:
+          tools: ruby,node
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - revenuecat/trust-github-key
       - revenuecat/setup-git-credentials
-      - install-dependencies
       - run:
           name: Update purchases-ui-js to latest version
           command: bundle exec fastlane open_pr_upgrading_dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,10 +216,7 @@ jobs:
       - image: cimg/ruby:3.3.0-node
     steps:
       - checkout
-      # Not using install-dependencies on purpose: it overwrites the tracked .npmrc
-      # and creates .pnpm-store, both would trip ensure_git_status_clean in the lane.
-      # pnpm add installs what it needs. The tracked .npmrc already excludes
-      # purchases-ui-js from minimum-release-age.
+      # No install-dependencies: it dirties the tree (.npmrc, .pnpm-store) and the lane needs it clean.
       - revenuecat/install-mise-tools:
           tools: ruby,node
       - revenuecat/install-gem-unix-dependencies:

--- a/.npmrc.SAMPLE
+++ b/.npmrc.SAMPLE
@@ -1,7 +1,3 @@
 //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
 
 minimum-release-age=1440
-
-# purchases-ui-js is our own package and gets bumped right after it is published.
-# Exclude it from the cooldown, same as the tracked .npmrc.
-minimum-release-age-exclude[]=@revenuecat/purchases-ui-js

--- a/.npmrc.SAMPLE
+++ b/.npmrc.SAMPLE
@@ -1,3 +1,7 @@
 //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
 
 minimum-release-age=1440
+
+# purchases-ui-js is our own package and gets bumped right after it is published.
+# Exclude it from the cooldown, same as the tracked .npmrc.
+minimum-release-age-exclude[]=@revenuecat/purchases-ui-js

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -7,6 +7,7 @@ files_to_update_on_latest_stable_releases = {
   './scripts/docs/index.html' => ['purchases-js-docs/{x}/']
 }
 repo_name = 'purchases-js'
+PURCHASES_UI_JS_PACKAGE = '@revenuecat/purchases-ui-js'
 changelog_latest_path = './CHANGELOG.latest.md'
 changelog_path = './CHANGELOG.md'
 
@@ -129,12 +130,78 @@ lane :tag_current_branch do |options|
   push_git_tags(tag: version_number)
 end
 
+desc "Updates purchases-ui-js to the latest version published to npm and opens a PR"
+lane :open_pr_upgrading_dependencies do |options|
+  ensure_git_status_clean
+
+  dry_run = options[:dry_run]
+
+  current_version = current_purchases_ui_js_version
+  latest_version = latest_npm_version(PURCHASES_UI_JS_PACKAGE)
+
+  UI.message("ℹ️  #{PURCHASES_UI_JS_PACKAGE} current: #{current_version}, latest on npm: #{latest_version}")
+
+  if Gem::Version.new(latest_version) <= Gem::Version.new(current_version)
+    UI.success("#{PURCHASES_UI_JS_PACKAGE} is already at its latest version: #{current_version} 💪")
+    next
+  end
+
+  type_of_bump = detect_bump_type(current_version: current_version, new_version_number: latest_version)
+
+  if dry_run
+    UI.message("ℹ️  Nothing more to do since dry_run: true. Would update #{PURCHASES_UI_JS_PACKAGE} #{current_version} => #{latest_version} (#{type_of_bump})")
+    next
+  end
+
+  branch = "update-purchases-ui-js-#{latest_version}"
+  message = "[AUTOMATIC] purchases-ui-js #{current_version} => #{latest_version}"
+
+  create_or_checkout_branch(branch_name: branch)
+
+  Dir.chdir(get_root_folder) do
+    sh("pnpm", "add", "#{PURCHASES_UI_JS_PACKAGE}@#{latest_version}", "--save-exact")
+  end
+
+  commit_all_changes(commit_message: message)
+  push_to_git_remote(set_upstream: true, remote_branch: branch)
+
+  labels = ["pr:dependencies"]
+  labels << "pr:force_minor" if type_of_bump == :minor
+
+  create_pr_if_necessary(
+    title: message,
+    body: message,
+    repo_name: repo_name,
+    base_branch: "main",
+    head_branch: branch,
+    github_pr_token: ENV["GITHUB_PULL_REQUEST_API_TOKEN"],
+    labels: labels,
+    team_reviewers: []
+  )
+end
+
 ###############################################################################
 # Helper functions 🤜🤛                                                      #
 ###############################################################################
 
 def current_version_number
   File.read("../.version").strip
+end
+
+def current_purchases_ui_js_version
+  package_json = File.read(File.join(get_root_folder, "package.json"))
+  match = package_json.match(/"#{Regexp.escape(PURCHASES_UI_JS_PACKAGE)}": "([^"]+)"/)
+  UI.user_error!("Could not find #{PURCHASES_UI_JS_PACKAGE} in package.json") unless match
+  match[1]
+end
+
+def latest_npm_version(package)
+  version = Dir.chdir(get_root_folder) do
+    # npm warns on stderr about pnpm-only keys in .npmrc, keep only stdout
+    sh("pnpm view #{package} version 2>/dev/null", log: false).strip
+  end
+  UI.user_error!("Could not read latest version of #{package} from npm: '#{version}'") unless version.match?(/\A\d+\.\d+\.\d+/)
+  version
 end
 
 def get_root_folder

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -162,7 +162,7 @@ lane :open_pr_upgrading_dependencies do |options|
     sh("pnpm", "add", "#{PURCHASES_UI_JS_PACKAGE}@#{latest_version}", "--save-exact")
   end
 
-  commit_all_changes(commit_message: message)
+  commit_current_changes(commit_message: message)
   push_to_git_remote(set_upstream: true, remote_branch: branch)
 
   labels = ["pr:dependencies"]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -166,7 +166,11 @@ lane :open_pr_upgrading_dependencies do |options|
   push_to_git_remote(set_upstream: true, remote_branch: branch)
 
   labels = ["pr:dependencies"]
-  labels << "pr:force_minor" if type_of_bump == :minor
+  if type_of_bump == :minor
+    labels << "pr:force_minor"
+  elsif type_of_bump == :patch
+    labels << "pr:force_patch"
+  end
 
   create_pr_if_necessary(
     title: message,

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -61,6 +61,14 @@ Generate docs
 
 Tag current branch with current version number
 
+### open_pr_upgrading_dependencies
+
+```sh
+[bundle exec] fastlane open_pr_upgrading_dependencies
+```
+
+Updates purchases-ui-js to the latest version published to npm and opens a PR
+
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.


### PR DESCRIPTION
This adds support for updating purchases-ui-js from CircleCI.

Triggering the `dependency-update` action checks the latest `@revenuecat/purchases-ui-js` on npm and, if we are behind, opens a PR bumping it. Same flow and names as purchases-hybrid-common. purchases-ui-js will call it after every publish in a follow-up PR.

```
POST https://circleci.com/api/v2/project/github/RevenueCat/purchases-js/pipeline
{"branch":"main","parameters":{"action":"dependency-update"}}
```

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: #1128
- Branch: `dependency-update-purchases-ui-js`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Claude Fable 5.1)
- Session source: current conversation
- Generated: 2026-09-07, updated 2026-09-08
- Context document version: 2

## Goal

Let purchases-ui-js trigger a dependency bump in purchases-js whenever a new purchases-ui-js version is published, using the same tooling other RevenueCat SDK repos use.

## Initial Prompt

"Would it be possible to trigger an update in purchases-js repository whenever something gets merged here? We can introduce a labeling system if that helps"

## Important Follow-up Prompts

- "Let's try to find similar solutions to other repositories so tooling remains consistent"
- "Can't we call a job on circle every time? Then check there if there was a version bump" (set the trigger-and-check design)
- "Ok do 1. I think it is called bump-dependencies in other repos right?" (asked for the purchases-js PR; name was corrected to `dependency-update` after checking sibling repos)
- "Check hybrid commons" (confirm how hybrid-common handles its purchases-js npm dependency)
- "let's apply exactly what antonio suggested" (review follow-up: add `pr:force_patch` on patch bumps, same if/elsif shape as hybrid-common)

## Agent Contribution

- Surveyed CI in purchases-ui-js (Azure Pipelines), purchases-js, purchases-hybrid-common, purchases-flutter, and fastlane-plugin-revenuecat_internal to find the existing cross-repo bump pattern.
- Wrote the CircleCI job, workflow, enum value, and workflow gating.
- Wrote the fastlane lane and two helpers.
- Found that CI copies `.npmrc.SAMPLE` over `.npmrc`, dropping the cooldown exclusion present in the tracked file, and reproduced the resulting pnpm refusal.
- Ran validation listed below.
- Review follow-up: verified against the plugin's `main` and the revision locked in `Gemfile.lock` that `pr:dependencies` alone is now release-neutral, then added `pr:force_patch` for patch bumps.

## Human Decisions

- Decision: trigger from purchases-ui-js unconditionally, purchases-js decides whether to bump. Rejected: gating in Azure and passing the version; pushing a branch directly from Azure into purchases-js; Dependabot; semantic-release in purchases-ui-js.
- Decision: mirror purchases-hybrid-common naming and flow rather than invent a new one.
- Decision: apply the reviewer's `pr:force_patch` suggestion verbatim (if/elsif), matching hybrid-common's Fastfile.

## Key Implementation Decisions

- Decision: action and workflow named `dependency-update`, lane named `open_pr_upgrading_dependencies`.
  - Rationale: identical names in purchases-hybrid-common.
  - Rejected: `bump-dependencies` (not used anywhere), `upgrade-hybrid-common` (that is the downstream hybrid name).
- Decision: use `pnpm add --save-exact` instead of the plugin's text replace.
  - Rationale: `pnpm-lock.yaml` must be updated. hybrid-common gets away with text replace because its mappings package has no lockfile.
- Decision: read the latest version with `pnpm view <pkg> version 2>/dev/null` and validate it with a semver regex.
  - Rationale: npm prints warnings on stderr about pnpm-only `.npmrc` keys, and fastlane's `sh` merges stderr into stdout.
- Decision: `team_reviewers: []` on `create_pr_if_necessary`.
  - Rationale: the plugin default is the `coresdk` team. CODEOWNERS here is `@RevenueCat/sdk` and will request review anyway.
- Decision: skip `danger` and `test-deploy` when action is `dependency-update`.
  - Rationale: same gating already exists for `update_error_codes`. Avoids running e2e and redeploying the demo on every purchases-ui-js publish.
- Decision: add `pr:force_patch` when the bump is a patch.
  - Rationale: fastlane-plugin-revenuecat_internal #147 (merged 2026-07-28) moved `pr:dependencies` to the skip set. purchases-js locks the plugin at `6db1da0` (2026-08-28), which includes it, so a patch bump labeled only `pr:dependencies` would never release. hybrid-common did the same in #1781.
  - Rejected: relying on `pr:dependencies` alone (release-neutral now).
- Decision: `PURCHASES_UI_JS_PACKAGE` is a constant, not a local.
  - Rationale: Fastfile locals are not visible inside `def` helpers. Found by a failing dry run.

## Files / Symbols Touched

- `.circleci/config.yml`
  - Why: new `dependency-update` job and workflow, enum value, gating on `danger` and `test-deploy`.
  - Review relevance: confirm the `when` conditions and that no other workflow runs on the new action.
- `fastlane/Fastfile`
  - Why: lane `open_pr_upgrading_dependencies`, helpers `current_purchases_ui_js_version`, `latest_npm_version`, constant `PURCHASES_UI_JS_PACKAGE`.
  - Review relevance: idempotency when the bump branch or PR already exists, error handling around `pnpm view`.
- `.npmrc.SAMPLE`
  - Why: `minimum-release-age-exclude[]=@revenuecat/purchases-ui-js`.
  - Review relevance: this widens the cooldown exception to CI for one first-party package.

## Dependencies / Config / Migrations

- Requires `GITHUB_PULL_REQUEST_API_TOKEN` in the CircleCI project, already used by `revenuecat/automatic-bump`.
- Optional: a CircleCI scheduled pipeline named `dependency-update` as a fallback. Not created.
- Follow-up in purchases-ui-js: Azure step calling the CircleCI API, needs a `CIRCLE_TOKEN` variable there.

## Validation

- Commands run:
  - `circleci config validate .circleci/config.yml`: valid.
  - `mise exec -- bundle exec fastlane open_pr_upgrading_dependencies dry_run:true` at pin 4.8.22: "already at its latest version", exit 0. Re-run after the `pr:force_patch` change with the same result.
  - `ruby -c fastlane/Fastfile`: Syntax OK.
  - Same at temporary pin 4.8.21: "Would update @revenuecat/purchases-ui-js 4.8.21 => 4.8.22 (patch)", exit 0.
  - `pnpm add @revenuecat/purchases-ui-js@4.8.22 --save-exact` with the sample npmrc: succeeded on a same-day version. In a scratch project with only `minimum-release-age=1440`, pnpm 10.23.0 refused the same version.
- Manual verification:
  - Not run.
- CI:
  - Not captured at time of writing.

## Validation Gaps

- Branch creation, commit, push, and PR creation were not exercised locally. They use existing plugin actions already used by other lanes.
- Registry propagation lag right after publish was not tested. If `pnpm view` still returns the previous version, the lane exits 0 and the next trigger or schedule catches up.
- No automated test covers the lane. Fastfile lanes in RevenueCat repos are not unit tested; verification is the dry run above.

## Review Focus

- Is it acceptable to exclude `@revenuecat/purchases-ui-js` from the pnpm cooldown in CI as well as locally?
- Should the `dependency-update` schedule be created now, and at what cadence?
- A major bump still ends up with only `pr:dependencies`, which is release-neutral. Should it get `pr:breaking` or fail the lane loudly?

## Risks / Reviewer Notes

- Risk: a trigger arrives before the registry serves the new version.
  - Evidence: not observed, theoretical.
  - Mitigation: idempotent lane, next trigger or schedule.
- Risk: the first automatic PR could be a major bump if purchases-ui-js ships one.
  - Evidence: purchases-js CI runs the full test, Chromatic, and e2e suites on the PR.
  - Mitigation: no auto-merge is enabled.

## Non-goals / Out of Scope

- The Azure trigger in purchases-ui-js (separate PR).
- Release automation for purchases-ui-js.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>
