### PR TITLE
Add Stripe elements loading time logging

### DIFF
--- a/src/tests/ui/pages/payment-entry-page.test.ts
+++ b/src/tests/ui/pages/payment-entry-page.test.ts
@@ -33,6 +33,7 @@ import type { ComponentProps } from "svelte";
 import type { GatewayParams } from "../../../networking/responses/stripe-elements";
 import type { CheckoutPricingResponse } from "../../../networking/responses/checkout-pricing-response";
 import { defaultPurchaseMode } from "../../../behavioural-events/event";
+import { Logger } from "../../../helpers/logger";
 
 vi.mock("../../../stripe/stripe-service", async () => {
   const actual = await vi.importActual<{
@@ -1211,5 +1212,78 @@ describe("PurchasesUI", () => {
       await fireEvent.click(screen.getByTestId("CheckoutConsentCheckbox"));
       expect(payButton.disabled).toBe(false);
     });
+  });
+
+  test("logs Stripe Element readiness relative to loading start", async () => {
+    const createElementReadyAfter = (delay: number, readyEvent?: object) => ({
+      mount: vi.fn(),
+      on: (eventType: string, callback: (event?: object) => void) => {
+        if (eventType === "ready") {
+          setTimeout(() => callback(readyEvent), delay);
+        }
+      },
+      destroy: vi.fn(),
+    });
+
+    vi.mocked(StripeService.createPaymentElement).mockReturnValue(
+      // @ts-expect-error - This is a mock
+      createElementReadyAfter(10),
+    );
+    vi.mocked(StripeService.createLinkAuthenticationElement).mockReturnValue(
+      // @ts-expect-error - This is a mock
+      createElementReadyAfter(20),
+    );
+    vi.mocked(StripeService.createExpressCheckoutElement).mockReturnValue(
+      // @ts-expect-error - This is a mock
+      createElementReadyAfter(30, {
+        availablePaymentMethods: { applePay: true },
+      }),
+    );
+    const debugLogSpy = vi
+      .spyOn(Logger, "debugLog")
+      .mockImplementation(() => undefined);
+
+    render(PaymentEntryPage, {
+      props: { ...basicProps },
+      context: defaultContext,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(debugLogSpy).toHaveBeenCalledWith(
+      "[Stripe Elements] Loading started. Elements: Link Authentication, Payment, Express Checkout.",
+    );
+    expect(debugLogSpy).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /^\[Stripe Elements\] Stripe initialized after \d+ms\.$/,
+      ),
+    );
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(debugLogSpy).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /^\[Stripe Elements\] Payment Element completed after \d+ms\.$/,
+      ),
+    );
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(debugLogSpy).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /^\[Stripe Elements\] Link Authentication Element completed after \d+ms\.$/,
+      ),
+    );
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(debugLogSpy).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /^\[Stripe Elements\] Express Checkout Element completed after \d+ms\.$/,
+      ),
+    );
+    expect(debugLogSpy).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /^\[Stripe Elements\] Loading completed after \d+ms\.$/,
+      ),
+    );
+
+    debugLogSpy.mockRestore();
   });
 });

--- a/src/ui/molecules/stripe-elements.svelte
+++ b/src/ui/molecules/stripe-elements.svelte
@@ -29,6 +29,7 @@
   } from "../../stripe/stripe-service";
   import { type Writable } from "svelte/store";
   import type { StripeExpressCheckoutConfiguration } from "../../stripe/stripe-express-checkout-configuration";
+  import { Logger } from "../../helpers/logger";
 
   interface Props {
     stripe: Stripe | null;
@@ -119,6 +120,36 @@
   let viewport: "mobile" | "desktop" = $state("mobile");
   let resizeTimeout: number | undefined = $state(undefined);
 
+  const stripeElementsLoadingStartedAt = performance.now();
+
+  const getPendingStripeElements = () => {
+    const pendingElements: string[] = [];
+
+    if (!emailElementReadyForSubmission) {
+      pendingElements.push("Link Authentication");
+    }
+    if (!paymentElementReadyForSubmission) {
+      pendingElements.push("Payment");
+    }
+    if (!expressCheckoutElementReadyForSubmission) {
+      pendingElements.push("Express Checkout");
+    }
+    if (!addressElementReadyForSubmission) {
+      pendingElements.push("Address");
+    }
+
+    return pendingElements;
+  };
+
+  const getStripeElementsElapsedTime = () =>
+    Math.round(performance.now() - stripeElementsLoadingStartedAt);
+
+  const logStripeElementReady = (element: string) => {
+    Logger.debugLog(
+      `[Stripe Elements] ${element} completed after ${getStripeElementsElapsedTime()}ms.`,
+    );
+  };
+
   // Maybe extract this to a hook
   function updateStripeVariables() {
     const isMobile =
@@ -151,6 +182,10 @@
   }
 
   const onStripeElementsLoadingError = (error: StripeServiceError) => {
+    const pendingElements = getPendingStripeElements();
+    Logger.debugLog(
+      `[Stripe Elements] Loading failed after ${getStripeElementsElapsedTime()}ms. ${pendingElements.length > 0 ? `Elements still pending: ${pendingElements.join(", ")}.` : "No elements were pending."}`,
+    );
     onError(error);
     onLoadingComplete();
   };
@@ -162,6 +197,9 @@
       expressCheckoutElementReadyForSubmission &&
       addressElementReadyForSubmission
     ) {
+      Logger.debugLog(
+        `[Stripe Elements] Loading completed after ${getStripeElementsElapsedTime()}ms.`,
+      );
       onLoadingComplete();
     }
   };
@@ -169,6 +207,7 @@
   const onLinkAuthenticationElementReady = async () => {
     if (!emailElementReadyForSubmission) {
       emailElementReadyForSubmission = true;
+      logStripeElementReady("Link Authentication Element");
       maybeCompleteLoading();
     }
   };
@@ -176,6 +215,7 @@
   const onExpressCheckoutElementReady = async () => {
     if (!expressCheckoutElementReadyForSubmission) {
       expressCheckoutElementReadyForSubmission = true;
+      logStripeElementReady("Express Checkout Element");
       maybeCompleteLoading();
     }
   };
@@ -183,6 +223,7 @@
   const onPaymentElementReady = async () => {
     if (!paymentElementReadyForSubmission) {
       paymentElementReadyForSubmission = true;
+      logStripeElementReady("Payment Element");
       maybeCompleteLoading();
     }
   };
@@ -190,6 +231,7 @@
   const onAddressElementReady = async () => {
     if (!addressElementReadyForSubmission) {
       addressElementReadyForSubmission = true;
+      logStripeElementReady("Address Element");
       maybeCompleteLoading();
     }
   };
@@ -233,6 +275,9 @@
   });
 
   onMount(async () => {
+    Logger.debugLog(
+      `[Stripe Elements] Loading started. Elements: ${getPendingStripeElements().join(", ")}.`,
+    );
     updateStripeVariables();
 
     if (stripe) return;
@@ -254,8 +299,14 @@
       .then(({ stripe: stripeInstance, elements: elementsInstance }) => {
         stripe = stripeInstance;
         elements = elementsInstance;
+        Logger.debugLog(
+          `[Stripe Elements] Stripe initialized after ${getStripeElementsElapsedTime()}ms.`,
+        );
       })
       .catch((error) => {
+        Logger.debugLog(
+          `[Stripe Elements] Stripe initialization failed after ${getStripeElementsElapsedTime()}ms.`,
+        );
         onError(error);
       });
   });


### PR DESCRIPTION
## Motivation / Description

We've had a few instances where the Stripe Payment Element is slow to load. This commit adds structured debug logging around Stripe Elements loading (start time, per-element ready timestamps, completion, and failure diagnostics).

<img width="846" height="525" alt="Screenshot 2026-09-09 at 3 42 57 PM" src="https://github.com/user-attachments/assets/fc1bc62d-c255-419f-9e16-55881ba7cb5c" />


## Changes introduced

## Linear ticket (if any)

## Additional comments


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only `Logger.debugLog` calls on the checkout Stripe UI path; no payment or auth behavior changes.
> 
> **Overview**
> Adds **structured debug logging** in `stripe-elements.svelte` to diagnose slow Stripe Payment Element loads. A load start timestamp drives elapsed-ms messages for load start (pending element list), Stripe init success/failure, each element’s `ready` handler (Link Authentication, Payment, Express Checkout, Address), overall load completion, and load failures (including which elements were still pending).
> 
> A new **`payment-entry-page` test** stubs staggered `ready` events and asserts `Logger.debugLog` emits the expected `[Stripe Elements]` messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b520f1fb6d71dc50632b99053ca0dab49a6d8e8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->