### PR TITLE
FUN-2346 Paddle package discounts: PricePreview and discountId at checkout

### DIFF
--- a/api-report/purchases-js.api.md
+++ b/api-report/purchases-js.api.md
@@ -508,6 +508,7 @@ export interface PurchaseParams {
     customerEmail?: string;
     defaultLocale?: string;
     discountCode?: string;
+    discountId?: string;
     externalPurchaseTokenId?: string;
     htmlTarget?: HTMLElement;
     metadata?: PurchaseMetadata;

--- a/src/entities/offerings.ts
+++ b/src/entities/offerings.ts
@@ -531,7 +531,7 @@ export interface Offerings {
  */
 export type PurchaseMetadata = Record<string, string | null>;
 
-const getPriceForCurrency = (
+export const getPriceForCurrency = (
   amountMicros: number,
   currency: string,
 ): Price => ({

--- a/src/entities/purchase-params.ts
+++ b/src/entities/purchase-params.ts
@@ -160,6 +160,14 @@ export interface PurchaseParams {
 
   /**
    * @experimental
+   * Paddle discount id (`dsc_...`) to apply at checkout. Paddle only.
+   * Takes precedence over {@link PurchaseParams.discountCode}, since Paddle
+   * Checkout accepts one or the other but not both.
+   */
+  discountId?: string;
+
+  /**
+   * @experimental
    * Called when the applied discount code changes in the Web Billing checkout.
    * This can be used by host applications to keep external state, such as the URL,
    * in sync with the checkout.

--- a/src/helpers/price-labels.ts
+++ b/src/helpers/price-labels.ts
@@ -11,7 +11,7 @@ const microsToDollars = (micros: number): number => {
 
 const fractionDigitsCache = new Map<string, number>();
 
-function getCurrencyFractionDigits(currency: string): number {
+export function getCurrencyFractionDigits(currency: string): number {
   const cached = fractionDigitsCache.get(currency);
   if (cached !== undefined) return cached;
   let digits: number;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import type {
+  DiscountPhase,
   Offering,
   Offerings,
   Package,
@@ -41,6 +42,7 @@ import {
   PurchaseOperationHelper,
 } from "./helpers/purchase-operation-helper";
 import { PaddleService } from "./paddle/paddle-service";
+import { withPaddleDiscountsOnOffering } from "./paddle/paddle-discount-preview";
 import { type LogHandler, type LogLevel } from "./entities/logging";
 import { Logger } from "./helpers/logger";
 import {
@@ -431,6 +433,75 @@ export class Purchases {
   /** @internal */
   static getPlatformInfo(): PlatformInfo | undefined {
     return Purchases._platformInfo;
+  }
+
+  /**
+   * Resolve Paddle discounts configured on paywall package components and
+   * return a copy of `offering` where those packages carry the discounted
+   * price as their `discount` phase, so {@link Purchases.buildVariablesPerPackage}
+   * and {@link Purchases.buildInfoPerPackage} surface it (`product.offer_price`,
+   * `promo_offer` condition). Uses `Paddle.PricePreview` under the hood.
+   *
+   * Returns the offering untouched for non-Paddle apps or when the map is
+   * empty. Packages whose preview fails or applies no discount are left as-is.
+   * Used to support Paywalls in Workflows.
+   * @internal
+   */
+  async applyPaddleDiscountsToOffering(
+    offering: Offering,
+    discountIdsByPackage: Record<string, string>,
+  ): Promise<Offering> {
+    const entries = Object.entries(discountIdsByPackage).filter(
+      ([packageId, discountId]) =>
+        Boolean(discountId) && offering.packagesById[packageId] !== undefined,
+    );
+    if (entries.length === 0 || !isPaddleApiKey(this._API_KEY)) {
+      return offering;
+    }
+
+    const paddleService = new PaddleService(this.backend, this.eventsTracker);
+    const [firstPackageId] = entries[0];
+    const firstProduct =
+      offering.packagesById[firstPackageId].webBillingProduct;
+    try {
+      await paddleService.initializeForPreview(
+        firstProduct.identifier,
+        firstProduct.defaultPurchaseOption,
+      );
+    } catch (error) {
+      Logger.errorLog(
+        `Could not initialize Paddle for price preview: ${error}`,
+      );
+      return offering;
+    }
+
+    const discountsByPackage: Record<string, DiscountPhase> = {};
+    await Promise.all(
+      entries.map(async ([packageId, discountId]) => {
+        const product = offering.packagesById[packageId].webBillingProduct;
+        try {
+          const discount = await paddleService.previewDiscount({
+            priceId: product.identifier,
+            discountId,
+            currencyCode: product.price.currency,
+            fallbackPeriodDuration: product.normalPeriodDuration,
+          });
+          if (discount) {
+            discountsByPackage[packageId] = discount;
+          } else {
+            Logger.debugLog(
+              `Paddle discount ${discountId} did not apply to package ${packageId}`,
+            );
+          }
+        } catch (error) {
+          Logger.errorLog(
+            `Paddle price preview failed for package ${packageId}: ${error}`,
+          );
+        }
+      }),
+    );
+
+    return withPaddleDiscountsOnOffering(offering, discountsByPackage);
   }
 
   /**
@@ -2526,6 +2597,7 @@ export class Purchases {
       purchaseOption,
       customerEmail,
       discountCode,
+      discountId,
       attributionMetadata,
       workflowPurchaseContext,
       externalPurchaseTokenId,
@@ -2625,6 +2697,7 @@ export class Purchases {
             purchaseOption: purchaseOptionToUse,
             customerEmail,
             discountCode,
+            discountId,
             attributionMetadata,
             workflowPurchaseContext,
             externalPurchaseTokenId,

--- a/src/paddle/paddle-discount-preview.ts
+++ b/src/paddle/paddle-discount-preview.ts
@@ -1,0 +1,222 @@
+import type { PricePreviewResponse } from "@paddle/paddle-js";
+import {
+  type DiscountPhase,
+  getPriceForCurrency,
+  type NonSubscriptionOption,
+  type Offering,
+  type Package,
+  type Product,
+  ProductType,
+  type SubscriptionOption,
+} from "../entities/offerings";
+import { parseISODuration, type Period } from "../helpers/duration-helper";
+import { getCurrencyFractionDigits } from "../helpers/price-labels";
+
+type PricePreviewLineItem =
+  PricePreviewResponse["data"]["details"]["lineItems"][number];
+
+/**
+ * Paddle returns amounts as strings in the currency's minor unit (e.g. "1999"
+ * for $19.99, "1500" for ¥1500). Convert to RevenueCat micros.
+ */
+export function paddleAmountToMicros(amount: string, currency: string): number {
+  const minorUnits = Number(amount);
+  if (!Number.isFinite(minorUnits)) {
+    return 0;
+  }
+  const fractionDigits = getCurrencyFractionDigits(currency);
+  return Math.round(minorUnits * 10 ** (6 - fractionDigits));
+}
+
+function toPeriod(
+  billingCycle: PricePreviewLineItem["price"]["billingCycle"],
+  fallbackPeriodDuration: string | null,
+): { period: Period | null; periodDuration: string | null } {
+  if (billingCycle) {
+    const unitLetter = { day: "D", week: "W", month: "M", year: "Y" }[
+      billingCycle.interval
+    ];
+    const periodDuration = `P${billingCycle.frequency}${unitLetter}`;
+    return { period: parseISODuration(periodDuration), periodDuration };
+  }
+  if (fallbackPeriodDuration) {
+    return {
+      period: parseISODuration(fallbackPeriodDuration),
+      periodDuration: fallbackPeriodDuration,
+    };
+  }
+  return { period: null, periodDuration: null };
+}
+
+/**
+ * Maps the first line item of a Paddle `PricePreview` response into a
+ * RevenueCat {@link DiscountPhase}. Returns `null` when Paddle did not apply
+ * any discount to the item (unknown, expired or non-applicable discount).
+ */
+export function toDiscountPhaseFromPricePreview(
+  response: PricePreviewResponse,
+  fallbackPeriodDuration: string | null,
+): DiscountPhase | null {
+  const lineItem = response.data.details.lineItems[0];
+  const applied = lineItem?.discounts?.[0];
+  if (!lineItem || !applied) {
+    return null;
+  }
+
+  const currency = response.data.currencyCode;
+  const subtotalMicros = paddleAmountToMicros(
+    lineItem.totals.subtotal,
+    currency,
+  );
+  const discountMicros = paddleAmountToMicros(
+    lineItem.totals.discount,
+    currency,
+  );
+  if (discountMicros <= 0) {
+    return null;
+  }
+  const discountedMicros = Math.max(subtotalMicros - discountMicros, 0);
+
+  const { discount } = applied;
+  const isPercentage = discount.type === "percentage";
+  const { period, periodDuration } = toPeriod(
+    lineItem.price.billingCycle,
+    fallbackPeriodDuration,
+  );
+
+  let durationMode: DiscountPhase["durationMode"] = "one_time";
+  let cycleCount = 0;
+  if (discount.recur) {
+    if (discount.maximumRecurringIntervals) {
+      durationMode = "time_window";
+      cycleCount = discount.maximumRecurringIntervals;
+    } else {
+      durationMode = "forever";
+    }
+  }
+
+  return {
+    durationMode,
+    timeWindow: durationMode === "time_window" ? periodDuration : null,
+    price: getPriceForCurrency(discountedMicros, currency),
+    name: discount.description || null,
+    periodDuration,
+    period,
+    cycleCount,
+    discountType: isPercentage ? "percentage" : "fixed_amount",
+    percentage: isPercentage ? Number(discount.amount) : null,
+    fixedAmount: isPercentage
+      ? null
+      : getPriceForCurrency(
+          paddleAmountToMicros(
+            discount.amount,
+            discount.currencyCode ?? currency,
+          ),
+          discount.currencyCode ?? currency,
+        ),
+  };
+}
+
+function withDiscountOnSubscriptionOption(
+  option: SubscriptionOption,
+  discount: DiscountPhase,
+): SubscriptionOption {
+  return { ...option, discount };
+}
+
+function withDiscountOnNonSubscriptionOption(
+  option: NonSubscriptionOption,
+  discount: DiscountPhase,
+): NonSubscriptionOption {
+  return { ...option, discount };
+}
+
+/**
+ * Returns a copy of `product` with `discount` applied to its default
+ * purchase option (and the matching entry in `subscriptionOptions`), so the
+ * existing paywall variable/package-info helpers surface it like a catalog
+ * discount.
+ */
+export function withPaddleDiscountOnProduct(
+  product: Product,
+  discount: DiscountPhase,
+): Product {
+  if (
+    product.productType === ProductType.Subscription &&
+    product.defaultSubscriptionOption
+  ) {
+    const defaultOption = withDiscountOnSubscriptionOption(
+      product.defaultSubscriptionOption,
+      discount,
+    );
+    const subscriptionOptions = { ...product.subscriptionOptions };
+    if (subscriptionOptions[defaultOption.id]) {
+      subscriptionOptions[defaultOption.id] = defaultOption;
+    }
+    return {
+      ...product,
+      defaultPurchaseOption: defaultOption,
+      defaultSubscriptionOption: defaultOption,
+      subscriptionOptions,
+      discountPhase: discount,
+    };
+  }
+
+  if (product.defaultNonSubscriptionOption) {
+    const defaultOption = withDiscountOnNonSubscriptionOption(
+      product.defaultNonSubscriptionOption,
+      discount,
+    );
+    return {
+      ...product,
+      defaultPurchaseOption: defaultOption,
+      defaultNonSubscriptionOption: defaultOption,
+      discountPhase: discount,
+    };
+  }
+
+  return product;
+}
+
+export function withPaddleDiscountOnPackage(
+  pkg: Package,
+  discount: DiscountPhase,
+): Package {
+  const product = withPaddleDiscountOnProduct(pkg.webBillingProduct, discount);
+  return { ...pkg, rcBillingProduct: product, webBillingProduct: product };
+}
+
+/**
+ * Returns a copy of `offering` where the packages in `discountsByPackage`
+ * carry the given discount phase. Packages without an entry are left as-is.
+ */
+export function withPaddleDiscountsOnOffering(
+  offering: Offering,
+  discountsByPackage: Record<string, DiscountPhase>,
+): Offering {
+  const replace = (pkg: Package | null): Package | null => {
+    if (!pkg) return null;
+    const discount = discountsByPackage[pkg.identifier];
+    return discount ? withPaddleDiscountOnPackage(pkg, discount) : pkg;
+  };
+
+  const availablePackages = offering.availablePackages.map(
+    (pkg) => replace(pkg) as Package,
+  );
+  const packagesById = Object.fromEntries(
+    availablePackages.map((pkg) => [pkg.identifier, pkg]),
+  );
+
+  return {
+    ...offering,
+    availablePackages,
+    packagesById,
+    lifetime: replace(offering.lifetime),
+    annual: replace(offering.annual),
+    sixMonth: replace(offering.sixMonth),
+    threeMonth: replace(offering.threeMonth),
+    twoMonth: replace(offering.twoMonth),
+    monthly: replace(offering.monthly),
+    weekly: replace(offering.weekly),
+  };
+}

--- a/src/paddle/paddle-service.ts
+++ b/src/paddle/paddle-service.ts
@@ -1,5 +1,6 @@
 import type {
   CheckoutOpenOptions,
+  CurrencyCode,
   DisplayMode,
   Paddle,
   PaddleEventData,
@@ -35,6 +36,8 @@ import { handleCheckoutSessionFailed } from "../helpers/checkout-error-handler";
 import type { PaddleCheckoutStartResponse } from "../networking/responses/checkout-start-response";
 import type { PaddleCheckoutSettings } from "../networking/responses/paddle-checkout-settings";
 import type { IEventsTracker } from "../behavioural-events/events-tracker";
+import type { DiscountPhase } from "../entities/offerings";
+import { toDiscountPhaseFromPricePreview } from "./paddle-discount-preview";
 
 interface PaddlePurchaseParams {
   rcPackage: Package;
@@ -44,6 +47,16 @@ interface PaddlePurchaseParams {
   customerEmail?: string;
   locale?: string;
   discountCode?: string;
+  /** Paddle discount id (`dsc_...`). Takes precedence over `discountCode`. */
+  discountId?: string;
+}
+
+interface PaddlePreviewDiscountParams {
+  /** Paddle price id (`pri_...`). For Paddle apps this is the RC product identifier. */
+  priceId: string;
+  /** Paddle discount id (`dsc_...`). */
+  discountId: string;
+  currencyCode?: string;
 }
 
 /**
@@ -92,6 +105,7 @@ interface BuildPaddleCheckoutOptionsParams {
   locale: string;
   customerEmail?: string;
   discountCode?: string;
+  discountId?: string;
   checkoutSettings?: PaddleCheckoutSettings;
   displayMode?: PaddleCheckoutDisplayMode;
   theme?: PaddleCheckoutTheme;
@@ -108,6 +122,7 @@ export function buildPaddleCheckoutOptions({
   locale,
   customerEmail,
   discountCode,
+  discountId,
   checkoutSettings = {},
   displayMode = "overlay",
   theme = "light",
@@ -141,7 +156,8 @@ export function buildPaddleCheckoutOptions({
     transactionId,
     settings,
     ...(customerEmail && { customer: { email: customerEmail } }),
-    ...(discountCode && { discountCode }),
+    // Paddle accepts either a discount id or a discount code, never both.
+    ...(discountId ? { discountId } : discountCode ? { discountCode } : {}),
   };
 }
 
@@ -256,6 +272,57 @@ export class PaddleService {
     }
   }
 
+  /**
+   * Initializes Paddle.js without starting a transaction, using the client
+   * token returned by the checkout prepare endpoint. Lets callers run price
+   * previews before any checkout exists.
+   */
+  async initializeForPreview(
+    productId: string,
+    purchaseOption: PurchaseOption,
+  ): Promise<Paddle> {
+    if (this.paddleInstance?.Initialized) {
+      return this.paddleInstance;
+    }
+    const prepareResponse = await this.backend.postCheckoutPrepare(
+      productId,
+      purchaseOption,
+    );
+    const paddleParams = prepareResponse.paddle_billing_params;
+    if (!paddleParams) {
+      throw new PurchaseFlowError(
+        PurchaseFlowErrorCode.ErrorSettingUpPurchase,
+        "Checkout prepare response has no Paddle params",
+      );
+    }
+    return this.initializePaddle(
+      paddleParams.client_side_token,
+      paddleParams.is_sandbox,
+    );
+  }
+
+  /**
+   * Runs `Paddle.PricePreview` for a single price with a discount applied and
+   * maps the result to a {@link DiscountPhase}. Resolves to `null` when Paddle
+   * applies no discount (unknown, expired or not applicable to the price).
+   */
+  async previewDiscount({
+    priceId,
+    discountId,
+    currencyCode,
+    fallbackPeriodDuration = null,
+  }: PaddlePreviewDiscountParams & {
+    fallbackPeriodDuration?: string | null;
+  }): Promise<DiscountPhase | null> {
+    const paddleInstance = this.getPaddleInstance();
+    const response = await paddleInstance.PricePreview({
+      items: [{ priceId, quantity: 1 }],
+      discountId,
+      ...(currencyCode && { currencyCode: currencyCode as CurrencyCode }),
+    });
+    return toDiscountPhaseFromPricePreview(response, fallbackPeriodDuration);
+  }
+
   async startCheckout({
     appUserId,
     productId,
@@ -323,7 +390,7 @@ export class PaddleService {
     onCheckoutCompleted,
   }: PaddlePurchase): Promise<OperationSessionSuccessfulResult> {
     const paddleInstance = this.getPaddleInstance();
-    const { customerEmail, locale = "en", discountCode } = params;
+    const { customerEmail, locale = "en", discountCode, discountId } = params;
 
     const forwardTotals = (data: PaddleEventData["data"]) => {
       if (onCheckoutTotals && data?.totals) {
@@ -401,6 +468,7 @@ export class PaddleService {
         locale,
         customerEmail,
         discountCode,
+        discountId,
         checkoutSettings,
         displayMode,
         theme,

--- a/src/tests/paddle/paddle-discount-preview.test.ts
+++ b/src/tests/paddle/paddle-discount-preview.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, test } from "vitest";
+import type { PricePreviewResponse } from "@paddle/paddle-js";
+import {
+  paddleAmountToMicros,
+  toDiscountPhaseFromPricePreview,
+  withPaddleDiscountsOnOffering,
+} from "../../paddle/paddle-discount-preview";
+import { createMonthlyPackageMock } from "../mocks/offering-mock-provider";
+import { buildOffering } from "../utils/fixtures-utils";
+import { buildVariablesPerPackage } from "../../helpers/paywall-variables-helpers";
+import { parseOfferingIntoPackageInfoPerPackage } from "../../helpers/paywall-package-info-helpers";
+import { PeriodUnit } from "../../helpers/duration-helper";
+import type { DiscountPhase } from "../../entities/offerings";
+
+type LineItem = PricePreviewResponse["data"]["details"]["lineItems"][number];
+type Discount = LineItem["discounts"][number]["discount"];
+
+const baseDiscount: Discount = {
+  id: "dsc_01test",
+  status: "active",
+  description: "Launch promo",
+  enabledForCheckout: true,
+  code: "LAUNCH",
+  type: "percentage",
+  amount: "20",
+  currencyCode: null,
+  recur: false,
+  maximumRecurringIntervals: null,
+  usageLimit: null,
+  restrictTo: null,
+  expiresAt: null,
+  timesUsed: 0,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+function buildResponse({
+  currencyCode = "USD",
+  subtotal = "300",
+  discount = "60",
+  discounts = [
+    { discount: baseDiscount, total: "60", formattedTotal: "$0.60" },
+  ],
+  billingCycle = {
+    interval: "month",
+    frequency: 1,
+  } as LineItem["price"]["billingCycle"],
+}: {
+  currencyCode?: string;
+  subtotal?: string;
+  discount?: string;
+  discounts?: LineItem["discounts"];
+  billingCycle?: LineItem["price"]["billingCycle"];
+} = {}): PricePreviewResponse {
+  const totals = {
+    subtotal,
+    discount,
+    tax: "0",
+    total: String(Number(subtotal) - Number(discount)),
+  };
+  const lineItem = {
+    price: { id: "pri_01test", billingCycle },
+    quantity: 1,
+    taxRate: "0",
+    unitTotals: totals,
+    formattedUnitTotals: totals,
+    totals,
+    formattedTotals: totals,
+    product: { id: "pro_01test", name: "Monthly" },
+    discounts,
+  } as unknown as LineItem;
+
+  return {
+    data: {
+      customerId: null,
+      addressId: null,
+      businessId: null,
+      currencyCode:
+        currencyCode as PricePreviewResponse["data"]["currencyCode"],
+      address: null,
+      customerIpAddress: null,
+      discountId: discounts.length ? discounts[0].discount.id : null,
+      details: { lineItems: [lineItem] },
+      availablePaymentMethods: [],
+    },
+    meta: { requestId: "req_01test" },
+  };
+}
+
+describe("paddleAmountToMicros", () => {
+  test("converts minor units for two-decimal currencies", () => {
+    expect(paddleAmountToMicros("1999", "USD")).toBe(19_990_000);
+  });
+
+  test("converts whole units for zero-decimal currencies", () => {
+    expect(paddleAmountToMicros("1500", "JPY")).toBe(1_500_000_000);
+  });
+
+  test("returns 0 for non numeric input", () => {
+    expect(paddleAmountToMicros("abc", "USD")).toBe(0);
+  });
+});
+
+describe("toDiscountPhaseFromPricePreview", () => {
+  test("maps a one-time percentage discount", () => {
+    const phase = toDiscountPhaseFromPricePreview(buildResponse(), "P1M");
+
+    expect(phase).toEqual<DiscountPhase>({
+      durationMode: "one_time",
+      timeWindow: null,
+      price: {
+        amount: 240,
+        amountMicros: 2_400_000,
+        currency: "USD",
+        formattedPrice: "$2.40",
+      },
+      name: "Launch promo",
+      periodDuration: "P1M",
+      period: { number: 1, unit: PeriodUnit.Month },
+      cycleCount: 0,
+      discountType: "percentage",
+      percentage: 20,
+      fixedAmount: null,
+    });
+  });
+
+  test("maps a recurring flat discount with a cycle limit", () => {
+    const response = buildResponse({
+      discount: "100",
+      discounts: [
+        {
+          discount: {
+            ...baseDiscount,
+            type: "flat",
+            amount: "100",
+            currencyCode: "USD" as Discount["currencyCode"],
+            recur: true,
+            maximumRecurringIntervals: 3,
+          },
+          total: "100",
+          formattedTotal: "$1.00",
+        },
+      ],
+    });
+
+    const phase = toDiscountPhaseFromPricePreview(response, "P1M");
+
+    expect(phase?.durationMode).toBe("time_window");
+    expect(phase?.cycleCount).toBe(3);
+    expect(phase?.timeWindow).toBe("P1M");
+    expect(phase?.discountType).toBe("fixed_amount");
+    expect(phase?.percentage).toBeNull();
+    expect(phase?.fixedAmount?.amountMicros).toBe(1_000_000);
+    expect(phase?.price.amountMicros).toBe(2_000_000);
+  });
+
+  test("maps a forever recurring discount", () => {
+    const response = buildResponse({
+      discounts: [
+        {
+          discount: { ...baseDiscount, recur: true },
+          total: "60",
+          formattedTotal: "$0.60",
+        },
+      ],
+    });
+
+    expect(toDiscountPhaseFromPricePreview(response, "P1M")?.durationMode).toBe(
+      "forever",
+    );
+  });
+
+  test("uses the fallback period when Paddle has no billing cycle", () => {
+    const phase = toDiscountPhaseFromPricePreview(
+      buildResponse({ billingCycle: null }),
+      "P1Y",
+    );
+
+    expect(phase?.periodDuration).toBe("P1Y");
+    expect(phase?.period).toEqual({ number: 1, unit: PeriodUnit.Year });
+  });
+
+  test("returns null when no discount was applied", () => {
+    expect(
+      toDiscountPhaseFromPricePreview(
+        buildResponse({ discount: "0", discounts: [] }),
+        "P1M",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("withPaddleDiscountsOnOffering", () => {
+  const discount = toDiscountPhaseFromPricePreview(buildResponse(), "P1M")!;
+
+  test("applies the discount to the matching package only", () => {
+    const monthly = createMonthlyPackageMock();
+    const other = {
+      ...createMonthlyPackageMock(),
+      identifier: "$rc_annual",
+    };
+    const offering = buildOffering([monthly, other]);
+
+    const result = withPaddleDiscountsOnOffering(offering, {
+      $rc_monthly: discount,
+    });
+
+    const patched = result.packagesById["$rc_monthly"].webBillingProduct;
+    expect(patched.defaultSubscriptionOption?.discount).toEqual(discount);
+    expect(patched.subscriptionOptions["base_option"].discount).toEqual(
+      discount,
+    );
+    expect(patched.discountPhase).toEqual(discount);
+    expect(result.monthly?.webBillingProduct.discountPhase).toEqual(discount);
+    expect(result.availablePackages[0].webBillingProduct.discountPhase).toEqual(
+      discount,
+    );
+
+    expect(
+      result.packagesById["$rc_annual"].webBillingProduct.discountPhase,
+    ).toBeNull();
+    expect(
+      offering.packagesById["$rc_monthly"].webBillingProduct.discountPhase,
+    ).toBeNull();
+  });
+
+  test("surfaces the discount through paywall variables and package info", () => {
+    const offering = withPaddleDiscountsOnOffering(
+      buildOffering([createMonthlyPackageMock()]),
+      { $rc_monthly: discount },
+    );
+
+    const variables = buildVariablesPerPackage(offering)["$rc_monthly"];
+    expect(variables["product.price"]).toBe("$3.00");
+    expect(variables["product.offer_price"]).toBe("$2.40");
+
+    const info =
+      parseOfferingIntoPackageInfoPerPackage(offering)["$rc_monthly"];
+    expect(info.hasPromoOffer).toBe(true);
+  });
+});

--- a/src/tests/paddle/paddle-service.test.ts
+++ b/src/tests/paddle/paddle-service.test.ts
@@ -248,6 +248,25 @@ describe("buildPaddleCheckoutOptions", () => {
     });
     expect(withoutDiscount).not.toHaveProperty("discountCode");
   });
+
+  test("prefers discountId over discountCode", () => {
+    const withId = buildPaddleCheckoutOptions({
+      transactionId,
+      locale: "en",
+      discountId: "dsc_01test",
+    });
+    expect(withId.discountId).toBe("dsc_01test");
+    expect(withId).not.toHaveProperty("discountCode");
+
+    const withBoth = buildPaddleCheckoutOptions({
+      transactionId,
+      locale: "en",
+      discountCode: "SAVE10",
+      discountId: "dsc_01test",
+    });
+    expect(withBoth.discountId).toBe("dsc_01test");
+    expect(withBoth).not.toHaveProperty("discountCode");
+  });
 });
 
 describe("PaddleService", () => {
@@ -408,6 +427,159 @@ describe("PaddleService", () => {
     test("is a no-op when Paddle is not initialized", () => {
       expect(() => paddleService.closeCheckout()).not.toThrow();
       expect(mockPaddleInstance.Checkout?.close).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("initializeForPreview", () => {
+    const checkoutPrepareEndpoint =
+      "http://localhost:8000/rcbilling/v1/checkout/prepare";
+    const purchaseOption = { id: "base_option", priceId: "test-price-id" };
+
+    test("initializes Paddle from the checkout prepare response", async () => {
+      vi.mocked(initPaddle).mockResolvedValue(mockPaddleInstance);
+      let capturedBody: Record<string, unknown> | undefined;
+      server.use(
+        http.post(checkoutPrepareEndpoint, async (req) => {
+          capturedBody = (await req.request.json()) as Record<string, unknown>;
+          return HttpResponse.json(
+            {
+              stripe_gateway_params: null,
+              paypal_gateway_params: null,
+              paddle_billing_params: {
+                client_side_token: "test-preview-token",
+                is_sandbox: false,
+              },
+            },
+            { status: StatusCodes.OK },
+          );
+        }),
+      );
+
+      const result = await paddleService.initializeForPreview(
+        "pri_01test",
+        purchaseOption,
+      );
+
+      expect(capturedBody).toEqual({
+        product_id: "pri_01test",
+        price_id: "test-price-id",
+      });
+      expect(initPaddle).toHaveBeenCalledWith({
+        token: "test-preview-token",
+        version: "v1",
+        environment: "production",
+      });
+      expect(result).toBe(mockPaddleInstance);
+    });
+
+    test("throws when the prepare response has no Paddle params", async () => {
+      server.use(
+        http.post(checkoutPrepareEndpoint, () =>
+          HttpResponse.json(
+            {
+              stripe_gateway_params: null,
+              paypal_gateway_params: null,
+              paddle_billing_params: null,
+            },
+            { status: StatusCodes.OK },
+          ),
+        ),
+      );
+
+      await expect(
+        paddleService.initializeForPreview("pri_01test", purchaseOption),
+      ).rejects.toThrow(
+        new PurchaseFlowError(
+          PurchaseFlowErrorCode.ErrorSettingUpPurchase,
+          "Checkout prepare response has no Paddle params",
+        ),
+      );
+    });
+
+    test("skips the network call when Paddle is already initialized", async () => {
+      vi.mocked(initPaddle).mockResolvedValue(mockPaddleInstance);
+      await paddleService.initializePaddle("test-token", true);
+      server.use(
+        http.post(checkoutPrepareEndpoint, () => {
+          throw new Error("should not be called");
+        }),
+      );
+
+      const result = await paddleService.initializeForPreview(
+        "pri_01test",
+        purchaseOption,
+      );
+
+      expect(result).toBe(mockPaddleInstance);
+    });
+  });
+
+  describe("previewDiscount", () => {
+    test("calls Paddle.PricePreview with the price, discount and currency", async () => {
+      const pricePreview = vi.fn().mockResolvedValue({
+        data: {
+          currencyCode: "USD",
+          discountId: "dsc_01test",
+          details: {
+            lineItems: [
+              {
+                price: { billingCycle: { interval: "month", frequency: 1 } },
+                totals: {
+                  subtotal: "300",
+                  discount: "60",
+                  tax: "0",
+                  total: "240",
+                },
+                discounts: [
+                  {
+                    discount: {
+                      id: "dsc_01test",
+                      description: "Launch promo",
+                      type: "percentage",
+                      amount: "20",
+                      currencyCode: null,
+                      recur: false,
+                      maximumRecurringIntervals: null,
+                    },
+                    total: "60",
+                    formattedTotal: "$0.60",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      });
+      vi.mocked(initPaddle).mockResolvedValue({
+        ...mockPaddleInstance,
+        PricePreview: pricePreview,
+      } as unknown as Paddle);
+      await paddleService.initializePaddle("test-token", true);
+
+      const phase = await paddleService.previewDiscount({
+        priceId: "pri_01test",
+        discountId: "dsc_01test",
+        currencyCode: "USD",
+        fallbackPeriodDuration: "P1M",
+      });
+
+      expect(pricePreview).toHaveBeenCalledWith({
+        items: [{ priceId: "pri_01test", quantity: 1 }],
+        discountId: "dsc_01test",
+        currencyCode: "USD",
+      });
+      expect(phase?.price.amountMicros).toBe(2_400_000);
+      expect(phase?.percentage).toBe(20);
+      expect(phase?.name).toBe("Launch promo");
+    });
+
+    test("throws when Paddle is not initialized", async () => {
+      await expect(
+        paddleService.previewDiscount({
+          priceId: "pri_01test",
+          discountId: "dsc_01test",
+        }),
+      ).rejects.toThrow("Paddle not initialized.");
     });
   });
 
@@ -653,6 +825,25 @@ describe("PaddleService", () => {
         expect.objectContaining({
           transactionId: "test-transaction-id",
           discountCode: "SAVE10",
+        }),
+      );
+
+      purchasePromise.catch(() => {});
+    });
+
+    test("passes discountId to Paddle when provided", async () => {
+      const purchasePromise = paddleService.purchase({
+        operationSessionId,
+        transactionId,
+        onCheckoutLoaded: vi.fn(),
+        onClose: vi.fn(),
+        params: { ...purchaseParams, discountId: "dsc_01test" },
+      });
+
+      expect(mockPaddleInstance.Checkout?.open).toHaveBeenCalledWith(
+        expect.objectContaining({
+          transactionId: "test-transaction-id",
+          discountId: "dsc_01test",
         }),
       );
 

--- a/src/tests/purchase.paddle-discounts.test.ts
+++ b/src/tests/purchase.paddle-discounts.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { StatusCodes } from "http-status-codes";
+import { initializePaddle as initPaddle } from "@paddle/paddle-js";
+import type { Paddle } from "@paddle/paddle-js";
+import { configurePurchases, server } from "./base.purchases_test";
+import { Purchases } from "../main";
+import { createMonthlyPackageMock } from "./mocks/offering-mock-provider";
+import { buildOffering } from "./utils/fixtures-utils";
+
+vi.mock("@paddle/paddle-js", () => ({
+  initializePaddle: vi.fn(),
+  CheckoutEventNames: {
+    CHECKOUT_LOADED: "checkout.loaded",
+    CHECKOUT_UPDATED: "checkout.updated",
+    CHECKOUT_COMPLETED: "checkout.completed",
+    CHECKOUT_CLOSED: "checkout.closed",
+  },
+}));
+
+const paddleApiKey = "pdl_test_api_key";
+const checkoutPrepareEndpoint =
+  "http://localhost:8000/rcbilling/v1/checkout/prepare";
+
+const pricePreviewResponse = {
+  data: {
+    currencyCode: "USD",
+    discountId: "dsc_01test",
+    details: {
+      lineItems: [
+        {
+          price: { billingCycle: { interval: "month", frequency: 1 } },
+          totals: { subtotal: "300", discount: "60", tax: "0", total: "240" },
+          discounts: [
+            {
+              discount: {
+                id: "dsc_01test",
+                description: "Launch promo",
+                type: "percentage",
+                amount: "20",
+                currencyCode: null,
+                recur: false,
+                maximumRecurringIntervals: null,
+              },
+              total: "60",
+              formattedTotal: "$0.60",
+            },
+          ],
+        },
+      ],
+    },
+  },
+};
+
+function mockPaddle(
+  pricePreview = vi.fn().mockResolvedValue(pricePreviewResponse),
+) {
+  const instance = {
+    Initialized: true,
+    Update: vi.fn(),
+    Checkout: { open: vi.fn(), close: vi.fn() },
+    PricePreview: pricePreview,
+  } as unknown as Paddle;
+  vi.mocked(initPaddle).mockResolvedValue(instance);
+  server.use(
+    http.post(checkoutPrepareEndpoint, () =>
+      HttpResponse.json(
+        {
+          stripe_gateway_params: null,
+          paypal_gateway_params: null,
+          paddle_billing_params: {
+            client_side_token: "test-preview-token",
+            is_sandbox: true,
+          },
+        },
+        { status: StatusCodes.OK },
+      ),
+    ),
+  );
+  return { instance, pricePreview };
+}
+
+describe("Purchases.applyPaddleDiscountsToOffering", () => {
+  const offering = buildOffering([createMonthlyPackageMock()]);
+
+  test("returns the offering untouched for non-Paddle api keys", async () => {
+    const purchases = configurePurchases();
+
+    const result = await purchases.applyPaddleDiscountsToOffering(offering, {
+      $rc_monthly: "dsc_01test",
+    });
+
+    expect(result).toBe(offering);
+    expect(initPaddle).not.toHaveBeenCalled();
+  });
+
+  test("returns the offering untouched when there is nothing to apply", async () => {
+    const purchases = configurePurchases(undefined, undefined, paddleApiKey);
+
+    expect(await purchases.applyPaddleDiscountsToOffering(offering, {})).toBe(
+      offering,
+    );
+    expect(
+      await purchases.applyPaddleDiscountsToOffering(offering, {
+        unknown_package: "dsc_01test",
+      }),
+    ).toBe(offering);
+    expect(initPaddle).not.toHaveBeenCalled();
+  });
+
+  test("applies the previewed discount to the matching package", async () => {
+    const { pricePreview } = mockPaddle();
+    const purchases = configurePurchases(undefined, undefined, paddleApiKey);
+
+    const result = await purchases.applyPaddleDiscountsToOffering(offering, {
+      $rc_monthly: "dsc_01test",
+    });
+
+    expect(initPaddle).toHaveBeenCalledWith({
+      token: "test-preview-token",
+      version: "v1",
+      environment: "sandbox",
+    });
+    expect(pricePreview).toHaveBeenCalledWith({
+      items: [{ priceId: "monthly", quantity: 1 }],
+      discountId: "dsc_01test",
+      currencyCode: "USD",
+    });
+
+    const product = result.packagesById["$rc_monthly"].webBillingProduct;
+    expect(product.discountPhase?.price.formattedPrice).toBe("$2.40");
+    expect(product.defaultSubscriptionOption?.discount?.percentage).toBe(20);
+
+    const variables = Purchases.buildVariablesPerPackage(result);
+    expect(variables["$rc_monthly"]["product.offer_price"]).toBe("$2.40");
+    expect(variables["$rc_monthly"]["product.price"]).toBe("$3.00");
+  });
+
+  test("leaves the package untouched when the preview fails", async () => {
+    mockPaddle(vi.fn().mockRejectedValue(new Error("boom")));
+    const purchases = configurePurchases(undefined, undefined, paddleApiKey);
+
+    const result = await purchases.applyPaddleDiscountsToOffering(offering, {
+      $rc_monthly: "dsc_01test",
+    });
+
+    expect(
+      result.packagesById["$rc_monthly"].webBillingProduct.discountPhase,
+    ).toBeNull();
+  });
+
+  test("returns the offering untouched when Paddle cannot be initialized", async () => {
+    server.use(
+      http.post(checkoutPrepareEndpoint, () =>
+        HttpResponse.json({}, { status: StatusCodes.INTERNAL_SERVER_ERROR }),
+      ),
+    );
+    const purchases = configurePurchases(undefined, undefined, paddleApiKey);
+
+    const result = await purchases.applyPaddleDiscountsToOffering(offering, {
+      $rc_monthly: "dsc_01test",
+    });
+
+    expect(result).toBe(offering);
+  });
+});

--- a/src/ui/paddle-purchases-ui.svelte
+++ b/src/ui/paddle-purchases-ui.svelte
@@ -49,6 +49,7 @@
     customerEmail: string | undefined;
     externalPurchaseTokenId?: string;
     discountCode?: string;
+    discountId?: string;
     metadata: PurchaseMetadata | undefined;
     attributionMetadata?: AttributionMetadata;
     workflowPurchaseContext?: WorkflowPurchaseContext;
@@ -75,6 +76,7 @@
     customerEmail,
     externalPurchaseTokenId,
     discountCode,
+    discountId,
     metadata,
     attributionMetadata,
     workflowPurchaseContext,
@@ -250,6 +252,7 @@
           customerEmail,
           locale: selectedLocale || defaultLocale,
           ...(discountCode && { discountCode }),
+          ...(discountId && { discountId }),
         },
         ...(useInlineCheckout && {
           displayMode: "inline" as const,


### PR DESCRIPTION
FUN-2346

## Motivation / Description

Funnels can now configure a Paddle discount per package component (`paddle_discount.discount_id` in the paywall JSON). The host needs two things from the SDK: the discounted price before checkout, so the paywall can render `product.offer_price` and the `promo_offer` condition, and a way to hand that discount to Paddle checkout for the selected package. Existing discount codes go through the RC backend, which knows nothing about Paddle discounts, so the preview has to come from Paddle.js.

## Changes introduced

- `PaddleService.initializeForPreview(productId, purchaseOption)` initializes Paddle.js from the `/checkout/prepare` client token, without creating a transaction.
- `PaddleService.previewDiscount({ priceId, discountId, currencyCode })` runs `Paddle.PricePreview` and maps the first line item to a `DiscountPhase` (`src/paddle/paddle-discount-preview.ts`). Minor-unit amounts convert to micros using the currency's fraction digits; `recur` / `maximumRecurringIntervals` map to `forever` / `time_window`. Returns `null` when Paddle applies no discount.
- `Purchases.applyPaddleDiscountsToOffering(offering, discountIdsByPackage)` (`@internal`, for Workflows): returns a copy of the offering where matching packages carry the previewed discount on their default option, so `buildVariablesPerPackage` / `buildInfoPerPackage` surface it unchanged. No-op for non-Paddle keys; per-package failures are logged and leave that package as fetched.
- `PurchaseParams.discountId` (`@experimental`, Paddle only) threaded through `performPaddlePurchase` -> `PaddlePurchasesUi` -> `Checkout.open`. When set it replaces `discountCode`, since Paddle accepts one or the other.
- `getCurrencyFractionDigits` and `getPriceForCurrency` exported for reuse.

Tests: `paddle-discount-preview.test.ts` (amount conversion, phase mapping, offering cloning feeding the variable helpers), `paddle-service.test.ts` (checkout options, `initializeForPreview`, `previewDiscount`), `purchase.paddle-discounts.test.ts` (`applyPaddleDiscountsToOffering` end to end with msw + mocked Paddle.js). Full suite: 943 passed. `api-report` regenerated (adds `PurchaseParams.discountId`).

## Linear ticket (if any)

FUN-2346

## Additional comments

Companion PRs: Backend API (schema), purchases-ui-js (type), dashboard (editor), rc-workflows (runtime). rc-workflows needs a release of this package to bump to.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Paddle checkout discount wiring and customer-facing offer prices; failures degrade to undiscounted packages but incorrect previews could mislead before purchase.
> 
> **Overview**
> Adds **Paddle-configured package discounts** so paywalls can show promo pricing before checkout and pass the same discount into Paddle Checkout.
> 
> A new internal **`Purchases.applyPaddleDiscountsToOffering`** uses **`Paddle.PricePreview`** (via **`initializeForPreview`** / **`previewDiscount`** on **`PaddleService`**) to build a **`DiscountPhase`** per package and clone the offering so existing paywall helpers expose **`product.offer_price`** and **`promo_offer`**. Preview math scales off the displayed catalog price so tax-inclusive totals stay aligned with checkout.
> 
> Checkout now accepts an internal **`PurchaseParams.discountId`** (`dsc_...`), threaded through the Paddle UI; **`buildPaddleCheckoutOptions`** prefers **`discountId`** over **`discountCode`** because Paddle allows only one. **`getPriceForCurrency`** and **`getCurrencyFractionDigits`** are exported for the preview mapper. Tests cover preview mapping, offering patching, service APIs, and the **`applyPaddleDiscountsToOffering`** integration path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ee5ad345cb5022895bdd7b569e614b7d8cec524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->